### PR TITLE
修复button-group is-acitve时不显示重叠的border的问题

### DIFF
--- a/scss/components/_button-group.scss
+++ b/scss/components/_button-group.scss
@@ -16,7 +16,8 @@
 
             &:focus,
             &:active,
-            &.active {
+            &.active,
+            &.is-active {
                 z-index: 1;
             }
         }


### PR DESCRIPTION
在button-group active时不填充背景色的theme中，acitve但不:active的状态：

修复前：
![image](https://user-images.githubusercontent.com/19756301/59160284-be488880-8b06-11e9-94ea-02518f125220.png)

修复后：
![image](https://user-images.githubusercontent.com/19756301/59160297-ec2dcd00-8b06-11e9-9ccd-ad58fe505185.png)

