### PR TITLE
修复 Select 多选+autoComplete 时，重新拉取的问题

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -453,9 +453,9 @@ export class Select extends React.Component<SelectProps, SelectState> {
   }
 
   handleStateChange(changes: any) {
-    const {multiple, checkAll} = this.props;
+    const {multiple, checkAll, loadOptions} = this.props;
+    let {inputValue} = this.state;
     let update: any = {};
-    const loadOptions = this.props.loadOptions;
     let doLoad = false;
 
     switch (changes.type) {
@@ -464,9 +464,10 @@ export class Select extends React.Component<SelectProps, SelectState> {
         update = {
           ...update,
           isOpen: multiple ? true : false,
-          isFocused: multiple && checkAll ? true : false
+          isFocused: multiple && checkAll ? true : false,
+          inputValue: !multiple ? '' : inputValue
         };
-        doLoad = true;
+        doLoad = !multiple;
         break;
       case DownshiftChangeTypes.changeInput:
         update.highlightedIndex = 0;


### PR DESCRIPTION
## Bug 场景
在Select 配置`multiple`+`autoComplete` 时，输入搜索内容触发`autoComplete`后，勾选任意项，会再次触发`autoComplete`并清空`term`参数值，导致当前`options`变化。

## Bug 原因
`handleStateChange`中判断勾选项后，拉取
![image](https://user-images.githubusercontent.com/19327810/78099503-a7b44a80-7414-11ea-8428-2bec4357182a.png)

## 解决方案
- 单选时清空`term`是有意义的
- 所以只判断：在多选的时候，保持当前`options`，不重新拉取
![image](https://user-images.githubusercontent.com/19327810/78099583-eea24000-7414-11ea-9982-4cb2be005b60.png)

