### PR TITLE
Select 在有已选项时，autoComplete 不显示已选项

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -597,12 +597,12 @@ export class Select extends React.Component<SelectProps, SelectState> {
 
     let checkedAll = false;
     let checkedPartial = false;
-    let filtedOptions: Array<Option> =
-      inputValue && isOpen && !loadOptions
-        ? matchSorter(options, inputValue, {
-            keys: [labelField || 'label', valueField || 'value']
-          })
-        : options.concat();
+    let filtedOptions: Array<Option> = (inputValue && isOpen && !loadOptions
+      ? matchSorter(options, inputValue, {
+          keys: [labelField || 'label', valueField || 'value']
+        })
+      : options.concat()
+    ).filter((option: Option) => !option.hidden && option.visible !== false);
 
     const selectionValues = selection.map(select => select[valueField]);
     if (multiple && checkAll) {

--- a/src/renderers/Form/Select.tsx
+++ b/src/renderers/Form/Select.tsx
@@ -166,7 +166,10 @@ export default class SelectControl extends React.Component<SelectProps, any> {
         if (
           !find(combinedOptions, (item: Option) => item.value == option.value)
         ) {
-          combinedOptions.push(option);
+          combinedOptions.push({
+            ...option,
+            hidden: true
+          });
         }
       });
     }


### PR DESCRIPTION
## Bug场景
之前当配置`multiple`+`autoComplete`，选中部分项之后，输入新的关键字搜索`新的options`时，也显示`已选择的options`

## Bug原因
重新拉取`autoComplete`后，会把`已选项`和`新拉取的项`进行`merge`

## 解决方案
保持`merge`，因为需要映射input中的label值，只在已选项中添加`hidden:true`，并在`select`输出显示时做次过滤