### PR TITLE
修复字符串形式配置正则时异常

### DIFF
--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -314,7 +314,7 @@ export function str2rules(
           if (~idx) {
             validateMethod = validation.substring(0, idx);
             args = /^matchRegexp/.test(validateMethod)
-              ? [validation]
+              ? [validation.substring(idx + 1).trim()]
               : validation
                   .substring(idx + 1)
                   .split(',')


### PR DESCRIPTION
## bug场景
在配置如下形式的验证格式时，验证会失效
```
{
    validations: 'matchRegexp: /。$/',
    validationErrors: {
        matchRegexp: '必须以中文。结尾'
    }
}
```

## bug原因
解析正则部分，未将`matchRegexp: `部分去掉

而[这次提交](https://github.com/baidu/amis/pull/533/files#diff-92d10af68ec8cbb847370aa5cb07f057R7  )，加上了开始和结束匹配，得以发现该问题

## 解决方案
看代码
