### PR TITLE
修复弹框中feedback，confirm关闭弹框逻辑

### DIFF
--- a/src/renderers/Form/index.tsx
+++ b/src/renderers/Form/index.tsx
@@ -644,10 +644,13 @@ export default class Form extends React.Component<FormProps, object> {
 
                 // submit 也支持 feedback
                 if (action.feedback && isVisible(action.feedback, store.data)) {
-                  await this.openFeedback(action.feedback, store.data);
+                  const confirmed = await this.openFeedback(
+                    action.feedback,
+                    store.data
+                  );
 
                   // 如果 feedback 配置了，取消就跳过原有逻辑。
-                  if (action.feedback.skipRestOnCancel) {
+                  if (action.feedback.skipRestOnCancel && !confirmed) {
                     throw new SkipOperation();
                   }
                 }


### PR DESCRIPTION
## bug场景
`dialog`的`confirm`按钮中，配置`feedback`，然后`feedback`配置`skipRestOnCancel:true`,`feedback`点击`confirm`后，不会关掉上层的`dialog`
![image](https://user-images.githubusercontent.com/19327810/79945573-a40a6580-84a0-11ea-9141-900328ce09cd.png)


## bug原因
漏写部分逻辑判断

## 解决方案
see code