### PR TITLE
修复Options正则

### DIFF
--- a/src/renderers/Drawer.tsx
+++ b/src/renderers/Drawer.tsx
@@ -148,8 +148,7 @@ export default class Drawer extends React.Component<DrawerProps, object> {
 
   handleAction(e: React.UIEvent<any>, action: Action, data: object) {
     const {onClose, onAction} = this.props;
-
-    if (action.actionType === 'close') {
+    if (action.actionType === 'close' || action.actionType === 'cancel') {
       onClose();
     } else if (onAction) {
       onAction(e, action, data);
@@ -642,7 +641,7 @@ export class DrawerRenderer extends Drawer {
 
     const scoped = this.context as IScopedContext;
 
-    if (action.actionType === 'close') {
+    if (action.actionType === 'close' || action.actionType === 'cancel') {
       store.setCurrentAction(action);
       onClose();
     } else if (action.actionType === 'confirm') {

--- a/src/renderers/Form/Options.tsx
+++ b/src/renderers/Form/Options.tsx
@@ -819,7 +819,7 @@ export function highlight(
 
   text = String(text);
   const reg = new RegExp(
-    input.replace(/([\$\^\*\+\-\?\.\(\)\|\[\]\\])/, '\\$1'),
+    input.replace(/([\$\^\*\+\-\?\.\(\)\|\[\]\\])/g, '\\$1'),
     'i'
   );
   if (!reg.test(text)) {


### PR DESCRIPTION
## bug场景
![image](https://user-images.githubusercontent.com/19327810/79948681-e20a8800-84a6-11ea-89da-f1f16678ffa7.png)
![image](https://user-images.githubusercontent.com/19327810/79948676-e040c480-84a6-11ea-9906-62be82a48725.png)
输入 `xxx(xxx)`形式的字符串会报错

## bug原因
```js
input.replace(/([\$\^\*\+\-\?\.\(\)\|\[\]\\])/, '\\$1')

// 这里没加 g 标识，所以只会replace第一个，如下：
// aaa(bbb) --> aaa\(bbb)
```

`aaa\(bbb)` 在 `new RegExp` 时会报错

## 解决方案
补充标识符
