### PR TITLE
form中容器组件中配置form时，修改内层的form会自动触发上层form的提交操作

### DIFF
--- a/src/renderers/Form/Container.tsx
+++ b/src/renderers/Form/Container.tsx
@@ -12,6 +12,8 @@ export interface ContainerProps extends FormControlProps {}
   sizeMutable: false
 })
 export class ContainerControlRenderer extends Container<ContainerProps> {
+  static propsList: Array<string> = ['onChange'];
+
   renderBody(): JSX.Element | null {
     const {
       renderFormItems,

--- a/src/renderers/Form/Grid.tsx
+++ b/src/renderers/Form/Grid.tsx
@@ -20,7 +20,7 @@ const defaultHorizontal = {
   sizeMutable: false
 })
 export class GridRenderer extends Grid<GridProps> {
-  static propsList: Array<string> = ['columns'];
+  static propsList: Array<string> = ['columns', 'onChange'];
   static defaultProps = {};
 
   renderChild(region: string, node: Schema, key: number, length: number) {

--- a/src/renderers/Form/HBox.tsx
+++ b/src/renderers/Form/HBox.tsx
@@ -16,7 +16,7 @@ interface HBoxProps extends FormControlProps {
   sizeMutable: false
 })
 export class HBoxRenderer extends React.Component<HBoxProps, any> {
-  static propsList: Array<string> = ['columns'];
+  static propsList: Array<string> = ['columns', 'onChange'];
   static defaultProps: Partial<HBoxProps> = {};
 
   renderColumn(column: any, key: number, length: number) {

--- a/src/renderers/Form/Panel.tsx
+++ b/src/renderers/Form/Panel.tsx
@@ -10,6 +10,7 @@ import cx from 'classnames';
   name: 'panel-control'
 })
 export class PanelRenderer extends Panel {
+  static propsList: Array<string> = ['onChange'];
   renderBody(): JSX.Element | null {
     const {
       render,

--- a/src/renderers/Form/Service.tsx
+++ b/src/renderers/Form/Service.tsx
@@ -15,6 +15,7 @@ import {ServiceStore, IServiceStore} from '../../store/service';
   name: 'service-control'
 })
 export class ServiceRenderer extends BasicService {
+  static propsList: Array<string> = ['onChange'];
   static contextType = ScopedContext;
 
   componentWillMount() {

--- a/src/renderers/Form/Tabs.tsx
+++ b/src/renderers/Form/Tabs.tsx
@@ -14,6 +14,7 @@ export class TabsRenderer extends Tabs {
   static defaultProps = {
     mountOnEnter: false // form 中的不按需渲染
   };
+  static propsList: Array<string> = ['onChange', 'tabs'];
 
   renderTab = (tab: any, props: any, key: number) => {
     const {


### PR DESCRIPTION
## bug场景
`form`中配置`tabs`等容器组件，该容器组件内部配置`另一个form`，修改`内部form`的表单项值
会自动提交`外部form`

```
{
  type: 'page',
  body: {
    type: 'form',
    api: '/api/mock2/form/saveForm?pushCode',
    controls: [
      {
        type: 'tabs',
        tabs: [
          {
            title: 'json编辑器',
            body: {
              type: 'form',
              controls: [
                {
                  name: 'json',
                  type: 'editor',
                  language: 'json'
                }
              ]
            }
          }
        ]
      }
    ]
  }
}
```

## bug原因
`内部form`在`handleChange`时，会调用`上层form`的`OnChange`，导致逻辑异常

## 解决方案
`propList`中添加`onChange`从而`omit`掉
