### PR TITLE
option value为0时，回显问题

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -122,7 +122,7 @@ export function expandValue(
     value &&
     value.hasOwnProperty(valueField || 'value')
   ) {
-    value = (value as Option)[valueField || 'value'] || '';
+    value = (value as Option)[valueField || 'value'] ?? '';
   }
 
   return findTree(
@@ -279,6 +279,8 @@ export class Select extends React.Component<SelectProps, SelectState> {
     this.handleAddClick = this.handleAddClick.bind(this);
     this.handleEditClick = this.handleEditClick.bind(this);
     this.handleDeleteClick = this.handleDeleteClick.bind(this);
+
+    // console.log('props.value', props.value);
 
     this.state = {
       isOpen: props.defaultOpen || false,
@@ -547,6 +549,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
     } = this.props;
 
     const selection = this.state.selection;
+    // console.log('selection', selection);
 
     if (!selection.length) {
       return (


### PR DESCRIPTION
## bug 场景

当`select`中配置了`value`为`0`的`options`时，回显异常

![image](https://user-images.githubusercontent.com/19327810/82210556-e3ae5b00-9941-11ea-816b-839d17d45a99.png)

![image](https://user-images.githubusercontent.com/19327810/82210598-f2950d80-9941-11ea-82ac-17edb5448c9f.png)

## bug 原因

`value`为`0`，这里逻辑会有问题

![image](https://user-images.githubusercontent.com/19327810/82210756-3d168a00-9942-11ea-91b2-5f0db752f5e8.png)

## 解决方案
`||` 判断符号更换为 `??`