### PR TITLE
合并单元格，对象类型的对比优化

### DIFF
--- a/src/store/table.ts
+++ b/src/store/table.ts
@@ -557,7 +557,7 @@ export const TableStore = iRendererStore
       let value = resolveVariable(key, row.data);
       for (let i = 1, len = arr.length; i < len; i++) {
         const current = arr[i];
-        if (resolveVariable(key, current.data) == value) {
+        if (isEqual(resolveVariable(key, current.data), value)) {
           row.rowSpans[key] += 1;
           current.rowSpans[key] = 0;
         } else {


### PR DESCRIPTION
## bug场景
合并单元格里，对象类型的比较时会有问题

## 原因
对象类型时`==`不相等

## 解决办法
`lodash.isEqual`