### PR TITLE
Drawer 有 overlay 时，配置 closeOnOutside 失效

### DIFF
--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -115,16 +115,15 @@ export class Drawer extends React.Component<DrawerProps, DrawerState> {
     const isLeftButton =
       (e.button === 1 && window.event !== null) || e.button === 0;
 
-    this.isRootClosed = !!(
-      (
+    this.isRootClosed =
+      !!(
         isLeftButton &&
         closeOnOutside &&
         target &&
         this.modalDom &&
         !this.modalDom.contains(target) &&
         !target.closest('[role=dialog]')
-      ) // 干脆过滤掉来自弹框里面的点击
-    );
+      ) || target.matches('.a-Drawer-overlay.in'); // 干脆过滤掉来自弹框里面的点击
   }
 
   @autobind

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -115,15 +115,15 @@ export class Drawer extends React.Component<DrawerProps, DrawerState> {
     const isLeftButton =
       (e.button === 1 && window.event !== null) || e.button === 0;
 
-    this.isRootClosed =
-      !!(
-        isLeftButton &&
-        closeOnOutside &&
-        target &&
-        this.modalDom &&
-        !this.modalDom.contains(target) &&
-        !target.closest('[role=dialog]')
-      ) || target.matches(`.${ns}Drawer-overlay.in`); // 干脆过滤掉来自弹框里面的点击
+    this.isRootClosed = !!(
+      isLeftButton &&
+      closeOnOutside &&
+      target &&
+      this.modalDom &&
+      ((!this.modalDom.contains(target) && !target.closest('[role=dialog]')) ||
+        (target.matches(`.${ns}Drawer-overlay`) &&
+          target.parentElement === this.modalDom))
+    ); // 干脆过滤掉来自弹框里面的点击
   }
 
   @autobind

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -111,7 +111,7 @@ export class Drawer extends React.Component<DrawerProps, DrawerState> {
   @autobind
   handleRootClickCapture(e: MouseEvent) {
     const target = e.target as HTMLElement;
-    const closeOnOutside = this.props.closeOnOutside;
+    const {closeOnOutside, classPrefix: ns} = this.props;
     const isLeftButton =
       (e.button === 1 && window.event !== null) || e.button === 0;
 
@@ -123,7 +123,7 @@ export class Drawer extends React.Component<DrawerProps, DrawerState> {
         this.modalDom &&
         !this.modalDom.contains(target) &&
         !target.closest('[role=dialog]')
-      ) || target.matches('.a-Drawer-overlay.in'); // 干脆过滤掉来自弹框里面的点击
+      ) || target.matches(`.${ns}Drawer-overlay.in`); // 干脆过滤掉来自弹框里面的点击
   }
 
   @autobind


### PR DESCRIPTION
## bug场景

有`overlay`时，配置`closeOnOutside`失效

## bug原因
过滤掉来自弹框里面的点击可能漏掉了`overlay:true`的场景

## 解决方案
加个match `.${ns}Drawer-overlay.in`判断