### PR TITLE
filter notIn优化

### DIFF
--- a/src/utils/tpl-builtin.ts
+++ b/src/utils/tpl-builtin.ts
@@ -247,7 +247,7 @@ export const filters: {
       fn = value => !!~list.indexOf(value);
     } else if (directive === 'notIn') {
       let list: Array<any> = arg1 ? getStrOrVariable(arg1, this) : [];
-      list = Array.isArray(list) ? list : [];
+      list = Array.isArray(list) ? list : [list];
       fn = value => !~list.indexOf(value);
     } else {
       if (directive !== 'match') {


### PR DESCRIPTION
像下面这种形式，`"user"`和`"id"`应该list为["user"]和["id"]，而不是`[]`

```
'${fields|filter:type:notIn:"user"|filter:key:notIn:"id"|pick:value~key,label~name}'
```