### PR TITLE
fix-726 支持自定义请求协议

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -253,7 +253,10 @@ export function isApiOutdated(
 }
 
 export function isValidApi(api: string) {
-  return api && /^(?:https?:\/\/[^\/]+)?(\/[^\s\/\?]*){1,}(\?.*)?$/.test(api);
+  return (
+    api &&
+    /^(?:(https?|wss?|taf):\/\/[^\/]+)?(\/[^\s\/\?]*){1,}(\?.*)?$/.test(api)
+  );
 }
 
 export function isEffectiveApi(


### PR DESCRIPTION
fix #726

1. 支持自定义请求协议进行变量替换，如 ws://, wss://, taf://，去掉 `isValidApi` 的校验（自定义协议会在 fetcher 函数做处理，没有必要校验 URL 的准确性，遵循浏览器自己的协议）
2. 增加 fis3 编译依赖的包

