### PR TITLE
修复 select 使用动态拉取时无法设置 defaultCheckAll

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -392,3 +392,14 @@
     $gap-sm;
   color: $text--muted-color;
 }
+
+@mixin label-variant($color) {
+  background-color: $color;
+
+  &[href] {
+    &:hover,
+    &:focus {
+      background-color: darken($color, 10%);
+    }
+  }
+}

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -1517,6 +1517,69 @@
   word-wrap: break-word;
 }
 
+//
+// Labels
+// --------------------------------------------------
+
+.label {
+  display: inline;
+  padding: 0.2em 0.6em 0.3em;
+  font-size: 75%;
+  font-weight: 700;
+  line-height: 1;
+  color: $label-color;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: 0.25em;
+
+  // Empty labels collapse automatically (not available in IE8)
+  &:empty {
+    display: none;
+  }
+
+  // Quick fix for labels in buttons
+  .btn & {
+    position: relative;
+    top: -1px;
+  }
+}
+a.label {
+  &:hover,
+  &:focus {
+    color: $label-link--hover-color;
+    text-decoration: none;
+    cursor: pointer;
+  }
+}
+
+// Colors
+// Contextual variations (linked labels get darker on :hover)
+
+.label-default {
+  @include label-variant($label--default-bg);
+}
+
+.label-primary {
+  @include label-variant($label--primary-bg);
+}
+
+.label-success {
+  @include label-variant($label--success-bg);
+}
+
+.label-info {
+  @include label-variant($label--info-bg);
+}
+
+.label-warning {
+  @include label-variant($label--warning-bg);
+}
+
+.label-danger {
+  @include label-variant($label--danger-bg);
+}
+
 @keyframes apearSensor {
   from {
     opacity: 0;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -138,6 +138,16 @@ $gap-lg: px2rem(30px) !default;
 $icon-color: $gray600 !default;
 $icon-onHover-color: $gray900 !default;
 
+$label--default-bg: $gray700 !default;
+$label--primary-bg: $primary !default;
+$label--success-bg: $success !default;
+$label--info-bg: $info !default;
+$label--warning-bg: $warning !default;
+$label--danger-bg: $danger !default;
+
+$label-color: #fff !default;
+$label-link--hover-color: #fff !default;
+
 // Components
 $scrollbar-width: px2rem(17px) !default;
 

--- a/scss/components/form/_nested-select.scss
+++ b/scss/components/form/_nested-select.scss
@@ -6,7 +6,7 @@
   border: $Form-select-borderWidth solid $Form-select-borderColor;
   background: $Form-select-bg;
   border-radius: $Form-select-borderRadius;
-  height: $Form-selectOption-height;
+  min-height: $Form-selectOption-height;
   $paddingY: (
       $Form-selectOption-height - $Form-input-lineHeight * $Form-input-fontSize -
         $Form-select-borderWidth * 2

--- a/scss/components/form/_nested-select.scss
+++ b/scss/components/form/_nested-select.scss
@@ -31,10 +31,8 @@
     }
   }
 
-  &.is-opened {
-    .#{$ns}Select-arrow:before {
-      transform: rotate(180deg);
-    }
+  &.is-opened .#{$ns}Select-arrow > svg {
+    transform: rotate(180deg);
   }
 
   &:not(.is-disabled):hover {

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -407,9 +407,34 @@ export class Select extends React.Component<SelectProps, SelectState> {
       props.value !== nextProps.value ||
       JSON.stringify(props.options) !== JSON.stringify(nextProps.options)
     ) {
-      this.setState({
-        selection: value2array(nextProps.value, nextProps)
-      });
+      if (
+        props.value !== nextProps.value ||
+        JSON.stringify(props.options) !== JSON.stringify(nextProps.options)
+      ) {
+        let selection;
+        if (
+          (
+            !props.options
+            || !props.options.length
+          )
+          && nextProps.options.length
+        ) {
+          const {selection: stateSelection} = this.state;
+          const {multiple, defaultCheckAll, options, onChange, simpleValue} = nextProps;
+          if (multiple && defaultCheckAll && options.length) {
+            selection = union(options, stateSelection);
+            onChange(simpleValue ? selection.map(item => item.value) : selection);
+          } else {
+            selection = value2array(nextProps.value, nextProps);
+          }
+        } else {
+          selection = value2array(nextProps.value, nextProps);
+        }
+
+        this.setState({
+          selection: selection
+        });
+      }
     }
   }
 

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -407,34 +407,29 @@ export class Select extends React.Component<SelectProps, SelectState> {
       props.value !== nextProps.value ||
       JSON.stringify(props.options) !== JSON.stringify(nextProps.options)
     ) {
+      let selection;
       if (
-        props.value !== nextProps.value ||
-        JSON.stringify(props.options) !== JSON.stringify(nextProps.options)
+        (
+          !props.options
+          || !props.options.length
+        )
+        && nextProps.options.length
       ) {
-        let selection;
-        if (
-          (
-            !props.options
-            || !props.options.length
-          )
-          && nextProps.options.length
-        ) {
-          const {selection: stateSelection} = this.state;
-          const {multiple, defaultCheckAll, options, onChange, simpleValue} = nextProps;
-          if (multiple && defaultCheckAll && options.length) {
-            selection = union(options, stateSelection);
-            onChange(simpleValue ? selection.map(item => item.value) : selection);
-          } else {
-            selection = value2array(nextProps.value, nextProps);
-          }
+        const {selection: stateSelection} = this.state;
+        const {multiple, defaultCheckAll, options, onChange, simpleValue} = nextProps;
+        if (multiple && defaultCheckAll && options.length) {
+          selection = union(options, stateSelection);
+          onChange(simpleValue ? selection.map(item => item.value) : selection);
         } else {
           selection = value2array(nextProps.value, nextProps);
         }
-
-        this.setState({
-          selection: selection
-        });
+      } else {
+        selection = value2array(nextProps.value, nextProps);
       }
+
+      this.setState({
+        selection: selection
+      });
     }
   }
 

--- a/src/renderers/Form/NestedSelect.tsx
+++ b/src/renderers/Form/NestedSelect.tsx
@@ -562,7 +562,9 @@ export default class NestedSelectControl extends React.Component<
 
           {this.renderClear()}
 
-          <span className={cx('Select-arrow')} />
+          <span className={cx('Select-arrow')}>
+            <Icon icon="caret" className="icon" />
+          </span>
         </div>
 
         {this.state.isOpened ? this.renderOuter() : null}


### PR DESCRIPTION
使用 `source` 拉取 `options` 的时候，无法设置 `defaultCheckAll` 