### PR TITLE
优化Modal的minHeight

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -215,7 +215,7 @@ $Modal-bg: $background !default;
 $Modal-overlay-bg: rgba(0, 0, 0, 0.6) !default;
 $Modal-content-startMarginTop: px2rem(60px) !default;
 $Modal-content-stepMarginTop: px2rem(30px) !default;
-$Modal-content-minHeight: px2rem(200px) !default;
+$Modal-content-minHeight: unset !default;
 $Modal-content-borderWidth: $borderWidth !default;
 $Modal-content-borderColor: $borderColor !default;
 $Modal-content-borderRadius: $borderRadius !default;


### PR DESCRIPTION
优化样式，设置variables的$Modal-content-minHeight为unset