### PR TITLE
fix(components): 修复monaco-editor加载json worker报错问题

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -16,7 +16,7 @@ function filterUrl(url: string) {
 }
 
 (window as any).MonacoEnvironment = {
-  getWorkerUrl: function(moduleId: string, label: string) {
+  getWorkerUrl: function (moduleId: string, label: string) {
     let url = '/pkg/editor.worker.js';
 
     if (label === 'json') {
@@ -202,7 +202,7 @@ export class Editor extends React.Component<EditorProps, any> {
     });
 
     // json 默认开启验证。
-    monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+    monaco.languages.json?.jsonDefaults.setDiagnosticsOptions({
       enableSchemaRequest: true,
       validate: true,
       allowComments: true


### PR DESCRIPTION
使用monaco-editor编辑json文件，且开启json验证时，有可能因为加载不到json worker,
monaco.languages对象下会没有json属性，会报undefined错误，进而导致整个编辑器无法使用