### PR TITLE
修复 image 添加 autoFill，导致表单提交一直 loading 的问题

### DIFF
--- a/src/renderers/Form/Image.tsx
+++ b/src/renderers/Form/Image.tsx
@@ -334,6 +334,7 @@ export default class ImageControl extends React.Component<
 
   startUpload(retry: boolean = false) {
     if (this.state.uploading) {
+      this.resolve && this.resolve(null);
       return;
     }
 

--- a/src/renderers/Form/Image.tsx
+++ b/src/renderers/Form/Image.tsx
@@ -334,7 +334,6 @@ export default class ImageControl extends React.Component<
 
   startUpload(retry: boolean = false) {
     if (this.state.uploading) {
-      this.resolve && this.resolve(null);
       return;
     }
 
@@ -370,6 +369,7 @@ export default class ImageControl extends React.Component<
   }
 
   tick() {
+    const {multiple, autoFill, onBulkChange} = this.props;
     if (this.current || !this.state.uploading) {
       return;
     }
@@ -429,7 +429,16 @@ export default class ImageControl extends React.Component<
                 {
                   files: this.files = files
                 },
-                this.tick
+                () => {
+                  const sendTo =
+                    !multiple &&
+                    autoFill &&
+                    !isEmpty(autoFill) &&
+                    dataMapping(autoFill, obj || {});
+                  sendTo && onBulkChange(sendTo);
+
+                  this.tick();
+                }
               );
             },
             progress => {
@@ -777,13 +786,6 @@ export default class ImageControl extends React.Component<
           state: 'uploaded'
         };
         obj.value = obj.value || obj.url;
-
-        const sendTo =
-          !multiple &&
-          autoFill &&
-          !isEmpty(autoFill) &&
-          dataMapping(autoFill, obj);
-        sendTo && onBulkChange(sendTo);
 
         cb(null, file, obj);
       })


### PR DESCRIPTION
## bug场景

```json
{
  "label": "作者头像",
  "name": "portrait",
  "type": "image",
  "multiple": false,
  "reciever": "/api/mock2/form/saveForm",
  "autoUpload": true,
  "compress": false,
  "autoFill": {
    "portrait": "$url"
  }
}
```

上传完图片，再点击提交，表单会一直显示loading，无法操作

## bug原因

如上配置，如果成功上传了图片之后，再次提交表单时，验证触发`image`的`validate`，

![image](https://user-images.githubusercontent.com/19327810/89778049-67da3e00-db3f-11ea-8ce5-9051bdb4f851.png)

`this.state.uploading`这里仍然是`true`

![image](https://user-images.githubusercontent.com/19327810/89778850-c81daf80-db40-11ea-86af-d0583faf4bcd.png)

会因为没有`resolve`所以`form`一直显示`loading`

## 解决方案

调整autofill的位置，放在`tick`后的`setState`的回调中，防止`onBulkChange`触发`componentWillReceiveProps`导致`state`混乱
