### PR TITLE
为NestedSelect添加checkAll和checkAllLabel选项

### DIFF
--- a/src/renderers/Form/NestedSelect.tsx
+++ b/src/renderers/Form/NestedSelect.tsx
@@ -38,7 +38,9 @@ export default class NestedSelectControl extends React.Component<
   static defaultProps: Partial<NestedSelectProps> = {
     cascade: false,
     withChildren: false,
-    searchPromptText: '输入内容进行检索'
+    searchPromptText: '输入内容进行检索',
+    checkAll: true,
+    checkAllLabel: '全选',
   };
   target: any;
   input: HTMLInputElement;
@@ -395,6 +397,8 @@ export default class NestedSelectControl extends React.Component<
       options,
       disabled,
       searchable,
+      checkAll,
+      checkAllLabel,
       searchPromptText,
       translate: __,
       labelField
@@ -430,7 +434,7 @@ export default class NestedSelectControl extends React.Component<
         {stack.map((options, index) => (
           <div key={index} className={cx('NestedSelect-menu')}>
             {index === 0 ? searchInput : null}
-            {multiple && index === 0 ? (
+            {multiple && checkAll && index === 0 ? (
               <div
                 className={cx('NestedSelect-option', 'checkall')}
                 onMouseEnter={this.onMouseEnterAll}
@@ -440,7 +444,7 @@ export default class NestedSelectControl extends React.Component<
                   checked={partialChecked}
                   partial={partialChecked && !allChecked}
                 >
-                  全选
+                  {__(checkAllLabel)}
                 </Checkbox>
               </div>
             ) : null}


### PR DESCRIPTION
在使用NestedSelect组件的时候如果设置`searchAble: true`后，在搜索框中输入内容，然后当鼠标经过全选的时候就会触发mouseenter事件导致所有选项全部展示，从而使得搜索无效，产生交互上的bug。
所以为NestedSelect添加和select类似的checkAll和checkAllLabel选项，使得我们可以为NestedSelect设置是否展示全选框，同时可以设置全选的label。
前面场景见issues#851