### PR TITLE
支持第三方云存储 API 鉴权

### DIFF
--- a/src/renderers/Form/File.tsx
+++ b/src/renderers/Form/File.tsx
@@ -810,6 +810,7 @@ export default class FileControl extends React.Component<FileProps, FileState> {
         fd.append(parts[0], decodeURIComponent(parts[1]));
       });
 
+    // Note: File类型字段放在后面，可以支持第三方云存储鉴权
     fd.append(config.fieldName || 'file', file);
 
     return this._send(api, fd, {}, onProgress);
@@ -947,6 +948,8 @@ export default class FileControl extends React.Component<FileProps, FileState> {
           fd.append('uploadId', state.uploadId);
           fd.append('partNumber', task.partNumber.toString());
           fd.append('partSize', task.partSize.toString());
+
+          // Note: File类型字段放在后面，可以支持第三方云存储鉴权
           fd.append(config.fieldName || 'file', blob, file.name);
 
           return self

--- a/src/renderers/Form/Image.tsx
+++ b/src/renderers/Form/Image.tsx
@@ -982,7 +982,6 @@ export default class ImageControl extends React.Component<
       method: 'post'
     });
     const fileField = this.props.fileField || 'file';
-    fd.append(fileField, file, (file as File).name);
 
     const idx = api.url.indexOf('?');
 
@@ -1004,6 +1003,9 @@ export default class ImageControl extends React.Component<
           fd.append(parts[0], decodeURIComponent(parts[1]));
         });
     }
+
+    // Note: File类型字段放在后面，可以支持第三方云存储鉴权
+    fd.append(fileField, file, (file as File).name);
 
     const env = this.props.env;
 

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1186,18 +1186,20 @@ export function object2formData(
   },
   fd: FormData = new FormData()
 ): any {
+  let fileObjects: any = [];
   let others: any = {};
+
   Object.keys(data).forEach(key => {
     const value = data[key];
 
     if (value instanceof File) {
-      fd.append(key, value, value.name);
+      fileObjects.push([key, value]);
     } else if (
       Array.isArray(value) &&
       value.length &&
       value[0] instanceof File
     ) {
-      value.forEach(value => fd.append(`${key}[]`, value, value.name));
+      value.forEach(value => fileObjects.push([`${key}[]`, value]));
     } else {
       others[key] = value;
     }
@@ -1211,6 +1213,10 @@ export function object2formData(
       // form-data/multipart 是不需要 encode 值的。
       parts[0] && fd.append(parts[0], decodeURIComponent(parts[1]));
     });
+
+  // Note: File类型字段放在后面，可以支持第三方云存储鉴权
+  fileObjects.forEach((fileObject: any[]) => fd.append(fileObject[0], fileObject[1], fileObject[1].name));
+
   return fd;
 }
 


### PR DESCRIPTION
用于支持第三方云存储（百度云、腾讯云、阿里云、AWS 等厂商）的 `PostObject` 接口

比如百度云文档：https://cloud.baidu.com/doc/BOS/s/akc5orrn5#%E8%AF%B7%E6%B1%82%E5%8F%82%E6%95%B0

![image](https://user-images.githubusercontent.com/53265646/94222283-85ad0800-ff1f-11ea-8b26-d406a263814e.png)