### PR TITLE
修复动态修改 affixOffsetTop 时的异常情况

### DIFF
--- a/src/renderers/CRUD.tsx
+++ b/src/renderers/CRUD.tsx
@@ -1013,7 +1013,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       pageField,
       perPageField,
       autoJumpToTopOnPagerChange,
-      affixOffsetTop,
+      affixOffsetTop
     } = this.props;
 
     let query: any = {
@@ -1026,9 +1026,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
 
     store.updateQuery(
       query,
-      syncLocation && env && env.updateLocation
-        ? env.updateLocation
-        : undefined,
+      syncLocation && env?.updateLocation ? env.updateLocation : undefined,
       pageField,
       perPageField
     );
@@ -1038,7 +1036,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     if (autoJumpToTopOnPagerChange && this.control) {
       (findDOMNode(this.control) as HTMLElement).scrollIntoView();
       const scrolledY = window.scrollY;
-      const offsetTop = affixOffsetTop ? affixOffsetTop : env && env.affixOffsetTop ? env.affixOffsetTop : 50
+      const offsetTop = affixOffsetTop ?? env?.affixOffsetTop ?? 50;
       scrolledY && window.scroll(0, scrolledY - offsetTop);
     }
   }

--- a/src/renderers/CRUD.tsx
+++ b/src/renderers/CRUD.tsx
@@ -1012,7 +1012,8 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       env,
       pageField,
       perPageField,
-      autoJumpToTopOnPagerChange
+      autoJumpToTopOnPagerChange,
+      affixOffsetTop,
     } = this.props;
 
     let query: any = {
@@ -1037,7 +1038,8 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     if (autoJumpToTopOnPagerChange && this.control) {
       (findDOMNode(this.control) as HTMLElement).scrollIntoView();
       const scrolledY = window.scrollY;
-      scrolledY && window.scroll(0, scrolledY - 50);
+      const offsetTop = affixOffsetTop ? affixOffsetTop : env && env.affixOffsetTop ? env.affixOffsetTop : 50
+      scrolledY && window.scroll(0, scrolledY - offsetTop);
     }
   }
 

--- a/src/renderers/Cards.tsx
+++ b/src/renderers/Cards.tsx
@@ -375,7 +375,8 @@ export default class Cards extends React.Component<GridProps, object> {
     const ns = this.props.classPrefix;
     const dom = findDOMNode(this) as HTMLElement;
     const clip = (this.body as HTMLElement).getBoundingClientRect();
-    const offsetY = this.props.env.affixOffsetTop || 0;
+    const offsetY =
+      this.props.affixOffsetTop || this.props.env.affixOffsetTop || 0;
     const affixed = clip.top < offsetY && clip.top + clip.height - 40 > offsetY;
     const afixedDom = dom.querySelector(`.${ns}Cards-fixedTop`) as HTMLElement;
 

--- a/src/renderers/Cards.tsx
+++ b/src/renderers/Cards.tsx
@@ -376,7 +376,7 @@ export default class Cards extends React.Component<GridProps, object> {
     const dom = findDOMNode(this) as HTMLElement;
     const clip = (this.body as HTMLElement).getBoundingClientRect();
     const offsetY =
-      this.props.affixOffsetTop || this.props.env.affixOffsetTop || 0;
+      this.props.affixOffsetTop ?? this.props.env.affixOffsetTop ?? 0;
     const affixed = clip.top < offsetY && clip.top + clip.height - 40 > offsetY;
     const afixedDom = dom.querySelector(`.${ns}Cards-fixedTop`) as HTMLElement;
 

--- a/src/renderers/List.tsx
+++ b/src/renderers/List.tsx
@@ -417,7 +417,8 @@ export default class List extends React.Component<ListProps, object> {
     }
 
     const clip = (this.body as HTMLElement).getBoundingClientRect();
-    const offsetY = this.props.env.affixOffsetTop || 0;
+    const offsetY =
+      this.props.affixOffsetTop || this.props.env.affixOffsetTop || 0;
     const affixed = clip.top < offsetY && clip.top + clip.height - 40 > offsetY;
 
     this.body.offsetWidth &&

--- a/src/renderers/List.tsx
+++ b/src/renderers/List.tsx
@@ -418,7 +418,7 @@ export default class List extends React.Component<ListProps, object> {
 
     const clip = (this.body as HTMLElement).getBoundingClientRect();
     const offsetY =
-      this.props.affixOffsetTop || this.props.env.affixOffsetTop || 0;
+      this.props.affixOffsetTop ?? this.props.env.affixOffsetTop ?? 0;
     const affixed = clip.top < offsetY && clip.top + clip.height - 40 > offsetY;
 
     this.body.offsetWidth &&

--- a/src/renderers/Table/index.tsx
+++ b/src/renderers/Table/index.tsx
@@ -712,7 +712,7 @@ export default class Table extends React.Component<TableProps, object> {
     const dom = findDOMNode(this) as HTMLElement;
     const clip = (this.table as HTMLElement).getBoundingClientRect();
     const offsetY =
-      this.props.affixOffsetTop || this.props.env.affixOffsetTop || 0;
+      this.props.affixOffsetTop ?? this.props.env.affixOffsetTop ?? 0;
     const affixed = clip.top < offsetY && clip.top + clip.height - 40 > offsetY;
     const affixedDom = dom.querySelector(`.${ns}Table-fixedTop`) as HTMLElement;
 


### PR DESCRIPTION
这边 因为要调整 `Layout` 组件整体布局，需要动态修改 render时传入的 `affixOffsetTop`。但是发现在 `Table` 分页切换时，被悬浮固定的Toolbar并没有消失掉。是因为切换页面后，滚动条回滚的位置，是写死的默认值 50，这边简单修复了下。我这边应用场景是没有问题了。

另外将其他的几个吸顶Header的 `affixOffsetTop`,参照 `renderers/Table` 代码，统一了下，支持动态修改。