### PR TITLE
fix(Table): handleOutterScroll trailing

### DIFF
--- a/src/renderers/Table/index.tsx
+++ b/src/renderers/Table/index.tsx
@@ -839,7 +839,7 @@ export default class Table extends React.Component<TableProps, object> {
 
     this.lastScrollLeft = scrollLeft;
     let leading = scrollLeft === 0;
-    let trailing = scrollLeft + this.outterWidth === this.totalWidth;
+    let trailing = Math.ceil(scrollLeft) + this.outterWidth >= this.totalWidth;
     // console.log(scrollLeft, store.outterWidth, store.totalWidth, (scrollLeft + store.outterWidth) === store.totalWidth);
     // store.setLeading(leading);
     // store.setTrailing(trailing);


### PR DESCRIPTION
页面缩放会导致判断错误
![}2){D3R{3 I0E1NL_MNIHR9](https://user-images.githubusercontent.com/31752986/99207954-39cd5f80-27fa-11eb-8154-ad9483e0fe84.png)
![GKR3C}Q()}2JEEJP0W(MT F](https://user-images.githubusercontent.com/31752986/99208009-579ac480-27fa-11eb-89c0-f8d9324f563d.png)
