### PR TITLE
style(table): fixed table box-shadow

### DIFF
--- a/scss/components/_table.scss
+++ b/scss/components/_table.scss
@@ -14,21 +14,24 @@
     position: absolute;
     background: $Table-bg;
     z-index: 5;
-    top: -999999px;
-
-    &.in {
-      top: auto;
-    }
+    top: auto;
+    box-shadow: none;
   }
 
   &-fixedLeft {
-    box-shadow: $Table-fixedLeft-boxShadow;
     left: 0;
+
+    &.in {
+      box-shadow: $Table-fixedLeft-boxShadow;
+    }
   }
 
   &-fixedRight {
-    box-shadow: $Table-fixedRight-boxShadow;
     right: 0;
+
+    &.in {
+      box-shadow: $Table-fixedRight-boxShadow;
+    }
 
     .#{$ns}Table-table > thead > tr > th:first-child,
     .#{$ns}Table-table > tbody > tr > td:first-child {

--- a/scss/components/_table.scss
+++ b/scss/components/_table.scss
@@ -24,6 +24,10 @@
     &.in {
       box-shadow: $Table-fixedLeft-boxShadow;
     }
+
+    .#{$ns}Table-table > thead > tr > th:last-child {
+      border-right: $Table-thead-borderWidth solid $Table-thead-borderColor;
+    }
   }
 
   &-fixedRight {
@@ -33,9 +37,15 @@
       box-shadow: $Table-fixedRight-boxShadow;
     }
 
-    .#{$ns}Table-table > thead > tr > th:first-child,
-    .#{$ns}Table-table > tbody > tr > td:first-child {
-      padding-left: $TableCell-paddingX;
+    .#{$ns}Table-table {
+      > thead > tr > th:first-child,
+      > tbody > tr > td:first-child {
+        padding-left: $TableCell-paddingX;
+      }
+
+      > thead > tr > th:first-child {
+        border-left: $Table-thead-borderWidth solid $Table-thead-borderColor;
+      }
     }
   }
 


### PR DESCRIPTION
固定表头列样式优化，固定表头列一直在顶部显示，只改变 box-shadow 显隐，这样滚动体验好一点