### PR TITLE
window 通信逻辑优化

### DIFF
--- a/src/Scoped.tsx
+++ b/src/Scoped.tsx
@@ -165,7 +165,7 @@ function createScopedTools(
             ...values
           };
           const link = location.pathname + '?' + qsstringify(query);
-          env.updateLocation(link);
+          env.updateLocation(link, true);
         }
       });
     },


### PR DESCRIPTION
当联动目标为 window 时，应该用 replace 模式同步地址栏。