### PR TITLE
修复图片放大功能读取图片地址错误问题

### DIFF
--- a/src/renderers/Table/TableRow.tsx
+++ b/src/renderers/Table/TableRow.tsx
@@ -165,7 +165,7 @@ export class TableRow extends React.Component<TableRowProps> {
                             ...rest,
                             width: null,
                             rowIndex: itemIndex,
-                            colIndex: column.rawIndex,
+                            colIndex: column.index,
                             key: column.index,
                             onAction: this.handleAction,
                             onQuickChange: this.handleQuickChange
@@ -208,7 +208,7 @@ export class TableRow extends React.Component<TableRowProps> {
           renderCell(`${itemIndex}/${column.index}`, column, item, {
             ...rest,
             rowIndex: itemIndex,
-            colIndex: column.rawIndex,
+            colIndex: column.index,
             key: column.index,
             onAction: this.handleAction,
             onQuickChange: this.handleQuickChange

--- a/src/renderers/Table/index.tsx
+++ b/src/renderers/Table/index.tsx
@@ -1084,7 +1084,7 @@ export default class Table extends React.Component<TableProps, object> {
 
     // 从列表中收集所有图片，然后作为一个图片集合派送出去。
     const store = this.props.store;
-    const column = store.filteredColumns[target.colIndex].pristine;
+    const column = store.columns[target.colIndex].pristine;
 
     let index = target.rowIndex;
     const list: Array<any> = [];


### PR DESCRIPTION
 当有批量操作按钮时，根据 index 读取原始数据列信息没对上。