### PR TITLE
修复两个 jssdk 用法问题

### DIFF
--- a/examples/embed.tsx
+++ b/examples/embed.tsx
@@ -157,7 +157,9 @@ export function embed(
         closeButton={false}
         timeout={5000}
       />
-      <AlertComponent container={env?.getModalContainer || container} />
+      <AlertComponent
+        container={() => env?.getModalContainer?.() || container}
+      />
 
       {renderAmis(
         schema,

--- a/examples/embed.tsx
+++ b/examples/embed.tsx
@@ -155,10 +155,9 @@ export function embed(
       <ToastComponent
         position={(env && env.toastPosition) || 'top-right'}
         closeButton={false}
-        timeOut={5000}
-        extendedTimeOut={3000}
+        timeout={5000}
       />
-      <AlertComponent container={container} />
+      <AlertComponent container={env?.getModalContainer || container} />
 
       {renderAmis(
         schema,

--- a/examples/loadMonacoEditor.ts
+++ b/examples/loadMonacoEditor.ts
@@ -180,6 +180,9 @@ function onLoad(req: any, callback: (result: any) => void) {
       // 'vs/editor/contrib/suggest/media/String_16x.svg': __uri('monaco-editor/min/vs/editor/contrib/suggest/media/String_16x.svg'),
       // 'vs/editor/contrib/suggest/media/String_inverse_16x.svg': __uri('monaco-editor/min/vs/editor/contrib/suggest/media/String_inverse_16x.svg'),
       // 'vs/editor/standalone/browser/quickOpen/symbol-sprite.svg': __uri('monaco-editor/min/vs/editor/standalone/browser/quickOpen/symbol-sprite.svg'),
+      'vs/base/browser/ui/codicons/codicon/codicon.ttf': __uri(
+        'monaco-editor/min/vs/base/browser/ui/codicons/codicon/codicon.ttf'
+      ),
       'vs/language/typescript/tsMode': __uri(
         'monaco-editor/min/vs/language/typescript/tsMode.js'
       ),


### PR DESCRIPTION
1. alert confirm 弹框 getModalContainer 设置无效问题
2. monaco-editor/min/vs/base/browser/ui/codicons/codicon/codicon.ttf 文件缺失问题