### PR TITLE
整理 autoFill

### DIFF
--- a/src/renderers/Form/ButtonGroup.tsx
+++ b/src/renderers/Form/ButtonGroup.tsx
@@ -42,13 +42,6 @@ export default class ButtonGroupControl extends React.Component<
   @autobind
   handleToggle(option: Option) {
     const {onToggle, multiple, autoFill, onBulkChange} = this.props;
-
-    const sendTo =
-      !multiple &&
-      autoFill &&
-      !isEmpty(autoFill) &&
-      dataMapping(autoFill, option as Option);
-    sendTo && onBulkChange(sendTo);
     onToggle(option);
   }
 

--- a/src/renderers/Form/Control.tsx
+++ b/src/renderers/Form/Control.tsx
@@ -97,7 +97,8 @@ export default class FormControl extends React.PureComponent<
         labelField,
         joinValues,
         extractValue,
-        selectFirst
+        selectFirst,
+        autoFill
       }
     } = this.props;
 
@@ -136,7 +137,8 @@ export default class FormControl extends React.PureComponent<
       labelField,
       joinValues,
       extractValue,
-      selectFirst
+      selectFirst,
+      autoFill
     });
 
     if (this.model.unique && form.parentStore?.storeType === ComboStore.name) {
@@ -243,7 +245,9 @@ export default class FormControl extends React.PureComponent<
           'valueField',
           'labelField',
           'joinValues',
-          'extractValue'
+          'extractValue',
+          'selectFirst',
+          'autoFill'
         ],
         props.control,
         nextProps.control
@@ -261,7 +265,9 @@ export default class FormControl extends React.PureComponent<
         labelField: nextProps.control.labelField,
         joinValues: nextProps.control.joinValues,
         extractValue: nextProps.control.extractValue,
-        messages: nextProps.control.validationErrors
+        messages: nextProps.control.validationErrors,
+        selectFirst: nextProps.control.selectFirst,
+        autoFill: nextProps.control.autoFill
       });
     }
   }

--- a/src/renderers/Form/File.tsx
+++ b/src/renderers/Form/File.tsx
@@ -595,6 +595,7 @@ export default class FileControl extends React.Component<FileProps, FileState> {
                   files: files
                 },
                 () => {
+                  // todo 这个逻辑应该移到 onChange 里面去，因为这个时候并不一定修改了表单项的值。
                   const sendTo =
                     !multiple &&
                     autoFill &&

--- a/src/renderers/Form/Image.tsx
+++ b/src/renderers/Form/Image.tsx
@@ -600,6 +600,7 @@ export default class ImageControl extends React.Component<
                 env.notify('error', error || __('图片上传失败，请重试'));
               } else {
                 newFile = {
+                  name: file.name,
                   ...obj,
                   preview: file.preview
                 } as FileValue;
@@ -611,11 +612,12 @@ export default class ImageControl extends React.Component<
                   files: (this.files = files)
                 },
                 () => {
+                  // todo 这个逻辑应该移到 onChange 里面去，因为这个时候并不一定修改了表单项的值。
                   const sendTo =
                     !multiple &&
                     autoFill &&
                     !isEmpty(autoFill) &&
-                    dataMapping(autoFill, obj || {});
+                    dataMapping(autoFill, newFile || {});
                   sendTo && onBulkChange(sendTo);
 
                   this.tick();

--- a/src/renderers/Form/List.tsx
+++ b/src/renderers/Form/List.tsx
@@ -57,14 +57,7 @@ export default class ListControl extends React.Component<ListProps, any> {
       return;
     }
 
-    const {onToggle, multiple, autoFill, onBulkChange} = this.props;
-
-    const sendTo =
-      !multiple &&
-      autoFill &&
-      !isEmpty(autoFill) &&
-      dataMapping(autoFill, option as Option);
-    sendTo && onBulkChange(sendTo);
+    const {onToggle} = this.props;
 
     onToggle(option);
   }

--- a/src/renderers/Form/NestedSelect.tsx
+++ b/src/renderers/Form/NestedSelect.tsx
@@ -184,9 +184,7 @@ export default class NestedSelectControl extends React.Component<
       onChange,
       joinValues,
       extractValue,
-      valueField,
-      autoFill,
-      onBulkChange
+      valueField
     } = this.props;
 
     if (multiple) {
@@ -194,13 +192,6 @@ export default class NestedSelectControl extends React.Component<
     }
 
     e.stopPropagation();
-
-    const sendTo =
-      !multiple &&
-      autoFill &&
-      !isEmpty(autoFill) &&
-      dataMapping(autoFill, option);
-    sendTo && onBulkChange(sendTo);
 
     onChange(
       joinValues

--- a/src/renderers/Form/Picker.tsx
+++ b/src/renderers/Form/Picker.tsx
@@ -249,9 +249,7 @@ export default class PickerControl extends React.PureComponent<
       multiple,
       options,
       setOptions,
-      onChange,
-      autoFill,
-      onBulkChange
+      onChange
     } = this.props;
 
     let value: any = items;
@@ -281,12 +279,6 @@ export default class PickerControl extends React.PureComponent<
     });
 
     additionalOptions.length && setOptions(options.concat(additionalOptions));
-    const sendTo =
-      !multiple &&
-      autoFill &&
-      !isEmpty(autoFill) &&
-      dataMapping(autoFill, value as Option);
-    sendTo && onBulkChange(sendTo);
     onChange(value);
   }
 

--- a/src/renderers/Form/Radios.tsx
+++ b/src/renderers/Form/Radios.tsx
@@ -38,18 +38,7 @@ export default class RadiosControl extends React.Component<RadiosProps, any> {
 
   @autobind
   handleChange(option: Option) {
-    const {
-      joinValues,
-      extractValue,
-      valueField,
-      onChange,
-      autoFill,
-      onBulkChange
-    } = this.props;
-
-    const sendTo =
-      autoFill && !isEmpty(autoFill) && dataMapping(autoFill, option);
-    sendTo && onBulkChange && onBulkChange(sendTo);
+    const {joinValues, extractValue, valueField, onChange} = this.props;
 
     if (option && (joinValues || extractValue)) {
       option = option[valueField || 'value'];

--- a/src/renderers/Form/Select.tsx
+++ b/src/renderers/Form/Select.tsx
@@ -83,9 +83,7 @@ export default class SelectControl extends React.Component<SelectProps, any> {
       valueField,
       onChange,
       setOptions,
-      options,
-      autoFill,
-      onBulkChange
+      options
     } = this.props;
 
     let newValue: string | Option | Array<Option> | void = value;
@@ -129,12 +127,6 @@ export default class SelectControl extends React.Component<SelectProps, any> {
     // 不设置没法回显
     additonalOptions.length && setOptions(options.concat(additonalOptions));
 
-    const sendTo =
-      !multiple &&
-      autoFill &&
-      !isEmpty(autoFill) &&
-      dataMapping(autoFill, value as Option);
-    sendTo && onBulkChange(sendTo);
     onChange(newValue);
   }
 


### PR DESCRIPTION
将表单项的 autoFill 修改成 store 层实现，不是只有点击才会同步出去，而是只要有值变动就会同步，包括初始选中。

image & file 相关autoFill 逻辑保留在原处，不过应该是有问题，先记录了 todo。