### PR TITLE
Tree-Select label 修复

### DIFF
--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -804,15 +804,21 @@ export class TreeSelector extends React.Component<
 export function findAncestorsWithValue(
   ancestors: any[],
   options: any[],
-  value: any
+  value: any,
+  valueField = 'value'
 ) {
   for (let option of options) {
-    if (option.value === value) {
+    if (option[valueField] === value) {
       return true;
     }
     // 如果没有就在 children 中查找
     if (option.children) {
-      const inChild = findAncestorsWithValue(ancestors, option.children, value);
+      const inChild = findAncestorsWithValue(
+        ancestors,
+        option.children,
+        value,
+        valueField
+      );
       if (inChild) {
         ancestors.unshift(option);
         return true;

--- a/src/renderers/Form/TreeSelect.tsx
+++ b/src/renderers/Form/TreeSelect.tsx
@@ -410,10 +410,15 @@ export default class TreeSelectControl extends React.Component<
 
   @autobind
   renderItem(item: Option) {
-    const {labelField} = this.props;
+    const {labelField, valueField} = this.props;
     // 将所有祖先节点也展现出来
     const ancestors: any[] = [];
-    findAncestorsWithValue(ancestors, this.props.options, item.value);
+    findAncestorsWithValue(
+      ancestors,
+      this.props.options,
+      item[valueField || 'value'],
+      valueField
+    );
     let ancestorsLabel = '';
     if (ancestors.length) {
       ancestorsLabel =


### PR DESCRIPTION
Tree-Select 里使用 `labelField` 和 `valueField` 时，`label` 显示不全问题