### PR TITLE
优化 Tree 父子选中逻辑

### DIFF
--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -284,19 +284,28 @@ export class TreeSelector extends React.Component<
             }
           }
 
-          const parent = getTreeParent(props.options, item);
-          if (parent?.value) {
-            // 如果所有孩子节点都勾选了，应该自动勾选父级。
+          let toCheck = item;
 
-            if (parent.children.every((child: any) => ~value.indexOf(child))) {
-              parent.children.forEach((child: any) => {
-                const index = value.indexOf(child);
-                if (~index) {
-                  value.splice(index, 1);
-                }
-              });
-              value.push(parent);
+          while (true) {
+            const parent = getTreeParent(props.options, toCheck);
+            if (parent?.value) {
+              // 如果所有孩子节点都勾选了，应该自动勾选父级。
+
+              if (
+                parent.children.every((child: any) => ~value.indexOf(child))
+              ) {
+                parent.children.forEach((child: any) => {
+                  const index = value.indexOf(child);
+                  if (~index) {
+                    value.splice(index, 1);
+                  }
+                });
+                value.push(parent);
+                toCheck = parent;
+                continue;
+              }
             }
+            break;
           }
         }
       }
@@ -557,7 +566,7 @@ export class TreeSelector extends React.Component<
         <Checkbox
           size="sm"
           disabled={nodeDisabled}
-          checked={selfChecked || selfChildrenChecked}
+          checked={selfChecked || (!cascade && selfChildrenChecked)}
           partial={!selfChecked}
           onChange={this.handleCheck.bind(this, item, !selfChecked)}
         />

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -517,7 +517,7 @@ export class TreeSelector extends React.Component<
       let selfChecked = !!uncheckable || checked;
 
       let childrenItems = null;
-      let tmpChildrenChecked = false;
+      let selfChildrenChecked = false;
       if (item.children && item.children.length) {
         childrenItems = this.renderList(
           item.children,
@@ -528,7 +528,7 @@ export class TreeSelector extends React.Component<
                 (selfDisabledAffectChildren ? selfDisabled : false) ||
                 (multiple && checked)
         );
-        tmpChildrenChecked = !!childrenItems.childrenChecked;
+        selfChildrenChecked = !!childrenItems.childrenChecked;
         if (
           !selfChecked &&
           onlyChildren &&
@@ -539,7 +539,7 @@ export class TreeSelector extends React.Component<
         childrenItems = childrenItems.dom;
       }
 
-      if (tmpChildrenChecked || checked) {
+      if ((onlyChildren ? selfChecked : selfChildrenChecked) || checked) {
         childrenChecked++;
       }
 
@@ -557,7 +557,8 @@ export class TreeSelector extends React.Component<
         <Checkbox
           size="sm"
           disabled={nodeDisabled}
-          checked={selfChecked}
+          checked={selfChecked || selfChildrenChecked}
+          partial={!selfChecked}
           onChange={this.handleCheck.bind(this, item, !selfChecked)}
         />
       ) : showRadio ? (
@@ -585,7 +586,7 @@ export class TreeSelector extends React.Component<
             <div
               className={cx('Tree-itemLabel', {
                 'is-children-checked':
-                  multiple && !cascade && tmpChildrenChecked && !nodeDisabled,
+                  multiple && !cascade && selfChildrenChecked && !nodeDisabled,
                 'is-checked': checked,
                 'is-disabled': nodeDisabled
               })}

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -11,7 +11,8 @@ import {
   autobind,
   findTreeIndex,
   hasAbility,
-  createObject
+  createObject,
+  getTreeParent
 } from '../utils/helper';
 import {Option, Options, value2array} from './Select';
 import {ClassNamesFn, themeable, ThemeProps} from '../theme';
@@ -241,10 +242,12 @@ export class TreeSelector extends React.Component<
     const props = this.props;
     const value = this.state.value.concat();
     const idx = value.indexOf(item);
-    const onlyChildren = this.props.onlyChildren;
+    const onlyChildren = props.onlyChildren;
 
     if (checked) {
       ~idx || value.push(item);
+
+      // cascade 为 true 表示父节点跟子节点没有级联关系。
       if (!props.cascade) {
         const children = item.children ? item.children.concat([]) : [];
 
@@ -256,12 +259,10 @@ export class TreeSelector extends React.Component<
             let child = children.shift();
             let index = value.indexOf(child);
 
-            if (!~index && child.value !== 'undefined') {
-              value.push(child);
-            }
-
             if (child.children) {
               children.push.apply(children, child.children);
+            } else if (!~index && child.value !== 'undefined') {
+              value.push(child);
             }
           }
         } else {
@@ -280,6 +281,21 @@ export class TreeSelector extends React.Component<
 
             if (child.children && child.children.length) {
               children.push.apply(children, child.children);
+            }
+          }
+
+          const parent = getTreeParent(props.options, item);
+          if (parent?.value) {
+            // 如果所有孩子节点都勾选了，应该自动勾选父级。
+
+            if (parent.children.every((child: any) => ~value.indexOf(child))) {
+              parent.children.forEach((child: any) => {
+                const index = value.indexOf(child);
+                if (~index) {
+                  value.splice(index, 1);
+                }
+              });
+              value.push(parent);
             }
           }
         }
@@ -315,7 +331,7 @@ export class TreeSelector extends React.Component<
           valueField,
           delimiter,
           onChange
-        } = this.props;
+        } = props;
 
         onChange(
           joinValues
@@ -541,7 +557,7 @@ export class TreeSelector extends React.Component<
         <Checkbox
           size="sm"
           disabled={nodeDisabled}
-          checked={checked}
+          checked={selfChecked}
           onChange={this.handleCheck.bind(this, item, !selfChecked)}
         />
       ) : showRadio ? (
@@ -793,39 +809,6 @@ export class TreeSelector extends React.Component<
       </div>
     );
   }
-}
-
-/**
- * 查找某个值的所有祖先节点
- * @param ancestors
- * @param options
- * @param value
- */
-export function findAncestorsWithValue(
-  ancestors: any[],
-  options: any[],
-  value: any,
-  valueField = 'value'
-) {
-  for (let option of options) {
-    if (option[valueField] === value) {
-      return true;
-    }
-    // 如果没有就在 children 中查找
-    if (option.children) {
-      const inChild = findAncestorsWithValue(
-        ancestors,
-        option.children,
-        value,
-        valueField
-      );
-      if (inChild) {
-        ancestors.unshift(option);
-        return true;
-      }
-    }
-  }
-  return false;
 }
 
 export default themeable(localeable(TreeSelector));

--- a/src/renderers/Form/TreeSelect.tsx
+++ b/src/renderers/Form/TreeSelect.tsx
@@ -11,7 +11,6 @@ import {
 } from './Options';
 import {Icon} from '../../components/icons';
 import TreeSelector from '../../components/Tree';
-import {findAncestorsWithValue} from '../../components/Tree';
 // @ts-ignore
 import matchSorter from 'match-sorter';
 import debouce from 'lodash/debounce';
@@ -20,7 +19,7 @@ import {Api} from '../../types';
 import {isEffectiveApi} from '../../utils/api';
 import Spinner from '../../components/Spinner';
 import ResultBox from '../../components/ResultBox';
-import {autobind} from '../../utils/helper';
+import {autobind, getTreeAncestors} from '../../utils/helper';
 import {findDOMNode} from 'react-dom';
 
 /**
@@ -410,23 +409,15 @@ export default class TreeSelectControl extends React.Component<
 
   @autobind
   renderItem(item: Option) {
-    const {labelField, valueField} = this.props;
+    const {labelField, options} = this.props;
+
     // 将所有祖先节点也展现出来
-    const ancestors: any[] = [];
-    findAncestorsWithValue(
-      ancestors,
-      this.props.options,
-      item[valueField || 'value'],
-      valueField
-    );
-    let ancestorsLabel = '';
-    if (ancestors.length) {
-      ancestorsLabel =
-        ancestors
-          .map((option: any) => option[labelField || 'label'])
-          .join(' / ') + ' / ';
-    }
-    return ancestorsLabel + item[labelField || 'label'];
+    const ancestors = getTreeAncestors(options, item, true);
+    return `${
+      ancestors
+        ? ancestors.map(item => `${item[labelField || 'label']}`).join(' / ')
+        : item[labelField || 'label']
+    }`;
   }
 
   renderOuter() {

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1107,6 +1107,16 @@ export function getTreeAncestors<T extends TreeItem>(
   return ancestors;
 }
 
+/**
+ * 从树中获取某个值的上级
+ * @param tree
+ * @param value
+ */
+export function getTreeParent<T extends TreeItem>(tree: Array<T>, value: T) {
+  const ancestors = getTreeAncestors(tree, value);
+  return ancestors?.length ? ancestors[ancestors.length - 1] : null;
+}
+
 export function ucFirst(str?: string) {
   return str ? str.substring(0, 1).toUpperCase() + str.substring(1) : '';
 }


### PR DESCRIPTION
1. treeSelect 显示值复用 `getTreeAncestors` 方法。
2. 非 onChildren 模式，当所有孩子节点都选中时，父级自动选中，并且所有子节点选中不可勾选状态。
3. onlyChildren 模式时，所有子节点都选中，父级节点自动选中，并且所有子节点保持选中，但是可取消勾选状态。取消后父级自动变成不勾选状态。
4. cascade 模式不受影响。
5. 添加了半选展示，即当有其中某个孩子点选了，父级就处于半选状态。

![image](https://user-images.githubusercontent.com/2698393/106881790-edb6fa80-6718-11eb-948c-83b2aac0b4af.png)

![image](https://user-images.githubusercontent.com/2698393/106881834-fc051680-6718-11eb-9b74-b30216fe11ef.png)
