### PR TITLE
优化 Modal 弹出, 只有在弹出的那一下才创建 Portal 组件事例

### DIFF
--- a/examples/embed.tsx
+++ b/examples/embed.tsx
@@ -171,7 +171,8 @@ export function embed(
           scopeRef: (ref: any) => (scoped = ref)
         },
         {
-          getModalContainer: () => document.querySelector('.amis-scope'),
+          getModalContainer: () =>
+            env?.getModalContainer?.() || document.querySelector('.amis-scope'),
           notify: (type: string, msg: string) =>
             toast[type]
               ? toast[type](msg, type === 'error' ? '系统错误' : '系统消息')

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -189,18 +189,17 @@ export class Modal extends React.Component<ModalProps, ModalState> {
     } = this.props;
 
     return (
-      // @ts-ignore
-      <Portal container={container}>
-        <Transition
-          mountOnEnter
-          unmountOnExit
-          in={show}
-          timeout={500}
-          onEnter={this.handleEnter}
-          onExited={this.handleExited}
-          onEntered={this.handleEntered}
-        >
-          {(status: string) => (
+      <Transition
+        mountOnEnter
+        unmountOnExit
+        in={show}
+        timeout={500}
+        onEnter={this.handleEnter}
+        onExited={this.handleExited}
+        onEntered={this.handleEntered}
+      >
+        {(status: string) => (
+          <Portal container={container}>
             <div
               ref={this.modalRef}
               role="dialog"
@@ -225,9 +224,9 @@ export class Modal extends React.Component<ModalProps, ModalState> {
                 {children}
               </div>
             </div>
-          )}
-        </Transition>
-      </Portal>
+          </Portal>
+        )}
+      </Transition>
     );
   }
 }


### PR DESCRIPTION
相关 issue https://github.com/baidu/amis/issues/1245

原来是复用 Portal 的，所以 env.getModalContainer 是复用的，有可能不是最新的。现在改成弹出的时候才创建。保证及时性