### PR TITLE
调整 data-mapping 对 null undefined 值的处理.

### DIFF
--- a/src/utils/tpl-builtin.ts
+++ b/src/utils/tpl-builtin.ts
@@ -272,7 +272,7 @@ export const filters: {
   url_encode: input => encodeURIComponent(input),
   url_decode: input => decodeURIComponent(input),
   default: (input, defaultValue) =>
-    input ||
+    input ??
     (() => {
       try {
         if (defaultValue === 'undefined') {
@@ -636,7 +636,8 @@ export const isPureVariable = (path?: any) =>
 export const resolveVariableAndFilter = (
   path?: string,
   data: object = {},
-  defaultFilter: string = '| html'
+  defaultFilter: string = '| html',
+  fallbackValue = (value: any) => value
 ): any => {
   if (!path) {
     return undefined;
@@ -683,7 +684,7 @@ export const resolveVariableAndFilter = (
   return ret == null &&
     !~originalKey.indexOf('default') &&
     !~originalKey.indexOf('now')
-    ? ret
+    ? fallbackValue(ret)
     : paths.reduce((input, filter) => {
         let params = filter
           .replace(
@@ -757,7 +758,7 @@ function resolveMapping(
   defaultFilter = '| raw'
 ) {
   return typeof value === 'string' && isPureVariable(value)
-    ? resolveVariableAndFilter(value, data, defaultFilter)
+    ? resolveVariableAndFilter(value, data, defaultFilter, () => '')
     : typeof value === 'string' && ~value.indexOf('$')
     ? tokenize(value, data, defaultFilter)
     : value;


### PR DESCRIPTION
最开始如果为 null 或 undefined dataMapping 后变成了空字符.

后来改动后变成原始值,也就是说如果是 undefined 就还会是 undefined. 这样的话发送 api 就不会发送这个 key 了.导致了大量已有业务可能不兼容报错.

所以...

还原原来的逻辑, dataMapping 如果目标值是 undefined 或者 null 就继续是空字符.除非这么配置就不发送了. ${xxx|default:undefined}