### PR TITLE
升级 monaco-editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "mobx-react": "^6.1.4",
     "mobx-state-tree": "^3.7.0",
     "moment": "^2.19.3",
-    "monaco-editor": "0.21.2",
+    "monaco-editor": "0.23.0",
     "papaparse": "^5.3.0",
     "prop-types": "^15.6.1",
     "qrcode.react": "^0.8.0",


### PR DESCRIPTION
用户反馈 monaco-editor 0.21.2 会导致safari 崩溃