### PR TITLE
api data 支持对象外的其他格式,比如数组

### DIFF
--- a/src/utils/tpl-builtin.ts
+++ b/src/utils/tpl-builtin.ts
@@ -769,14 +769,15 @@ export function dataMapping(
   from: PlainObject,
   ignoreFunction: boolean | ((key: string, value: any) => boolean) = false
 ): any {
-  let ret = {};
-
   if (Array.isArray(to)) {
     return to.map(item => dataMapping(item, from, ignoreFunction));
-  } else if (!to) {
-    return ret;
+  } else if (typeof to === 'string') {
+    return resolveMapping(to, from);
+  } else if (!isPlainObject(to)) {
+    return to;
   }
 
+  let ret = {};
   Object.keys(to).forEach(key => {
     const value = to[key];
     let keys: Array<string>;


### PR DESCRIPTION
目前 api.data 支持对象形式的数据映射，如果想配置成发送数组格式，同时支持数据映射则不支持