### PR TITLE
fix: combo 组件中的动态 select 不应该受 unique 影响，导致 addable 按钮消失

### DIFF
--- a/src/store/combo.ts
+++ b/src/store/combo.ts
@@ -57,7 +57,11 @@ export const ComboStore = iRendererStore
         if (self.uniques.size) {
           let isFull = false;
           self.uniques.forEach(item => {
-            if (isFull || !item.items.length) {
+            if (
+              isFull ||
+              !item.items.length ||
+              item.items[0].type === 'select'
+            ) {
               return;
             }
 


### PR DESCRIPTION
当同时存在两个 select， 且第二个 select 依赖于第一个 select 的时候。由于第二个 select 在某个第一个 select 下的可选情况已经满了，导致 新增按钮消失，这是不对的。  

为了简单起见，这里对于 select 直接返回了，考虑到会 filter 掉 select 具体的 options，应该不是问题。 附图如下：

![image](https://user-images.githubusercontent.com/34802622/116675355-550ede80-a9d8-11eb-9c25-fb31cc812f40.png)

