### PR TITLE
fix(Audio): should not call load method at first render

### DIFF
--- a/__tests__/renderers/Audio.test.tsx
+++ b/__tests__/renderers/Audio.test.tsx
@@ -2,17 +2,25 @@ import {render} from 'react-testing-library';
 import {render as amisRender} from '../../src';
 import {makeEnv} from '../helper';
 
+let times = 0;
+
 beforeAll(() => {
   // jsdom not implemented: HTMLMediaElement.prototype.load
   // here: https://github.com/jsdom/jsdom/issues/1515
   Object.defineProperty(global.window.HTMLMediaElement.prototype, 'load', {
     get() {
-      return () => {}
+      return () => {
+        times++;
+      }
     }
   })
 });
 
-test('Renderer:alert', () => {
+afterEach(() => {
+  times = 0;
+});
+
+test('Renderer:audio', () => {
   const {container} = render(amisRender(
     {
       type: 'audio',
@@ -27,4 +35,17 @@ test('Renderer:alert', () => {
   ));
 
   expect(container).toMatchSnapshot();
+});
+
+test('should not call load method at first render phase', () => {
+  render(amisRender(
+    {
+      type: 'audio',
+      src: 'https://example.com/music.mp3'
+    },
+    {},
+    makeEnv({})
+  ));
+
+  expect(times).toBe(0);
 });

--- a/__tests__/renderers/__snapshots__/Audio.test.tsx.snap
+++ b/__tests__/renderers/__snapshots__/Audio.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Renderer:alert 1`] = `
+exports[`Renderer:audio 1`] = `
 <div>
   <div
     class="a-Audio a-Audio--inline"

--- a/src/renderers/Audio.tsx
+++ b/src/renderers/Audio.tsx
@@ -248,7 +248,6 @@ export class Audio extends React.Component<AudioProps, AudioState> {
     clearTimeout(this.durationTimeout);
     const duration = this.audio && this.audio.duration;
     if (!duration) {
-      this.audio.load();
       this.durationTimeout = setTimeout(this.onDurationCheck, 500);
     }
   }


### PR DESCRIPTION
当音频文件加载所需时间大于 500 ms 时，会发生调用 load 方法，导致 canceled 当前请求，重新发起请求的循序，无法正确加载音频文件。