### PR TITLE
fix: buttonToolbar 中数据同步不及时

### DIFF
--- a/src/renderers/Form/ButtonToolbar.tsx
+++ b/src/renderers/Form/ButtonToolbar.tsx
@@ -45,6 +45,7 @@ export default class ButtonToolbar extends React.Component<
 }
 
 @FormItem({
-  type: 'button-toolbar'
+  type: 'button-toolbar',
+  strictMode: false
 })
 export class ButtonToolbarRenderer extends ButtonToolbar {}


### PR DESCRIPTION
buttonToolbar 是个容器，本来不关联表单项，所以应该是 strictMode：false 。如果不是容器的话，默认关联 name，只有表单项的值变化才会更新。