### PR TITLE
fix: 修复 Select 多选时，高亮会自动选中第一项的问题

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -596,8 +596,6 @@ export class Select extends React.Component<SelectProps, SelectState> {
         break;
     }
 
-    console.log('==================', update);
-
     if (Object.keys(update).length) {
       this.setState(update);
     }

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -582,7 +582,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
         };
         break;
       case DownshiftChangeTypes.controlledPropUpdatedSelectedItem:
-
+        break;
       case DownshiftChangeTypes.changeInput:
         update.highlightedIndex = 0;
         break;
@@ -595,6 +595,8 @@ export class Select extends React.Component<SelectProps, SelectState> {
         };
         break;
     }
+
+    console.log('==================', update);
 
     if (Object.keys(update).length) {
       this.setState(update);


### PR DESCRIPTION
选中其他项，会重置高亮到第一项