### PR TITLE
fix: 修复季度范围选择器禁用bug

### DIFF
--- a/src/components/DateRangePicker.tsx
+++ b/src/components/DateRangePicker.tsx
@@ -531,8 +531,8 @@ export class DateRangePicker extends React.Component<
 
   checkStartIsValidDate(currentDate: moment.Moment) {
     let {endDate, startDate} = this.state;
-
-    let {minDate, maxDate, minDuration, maxDuration} = this.props;
+    let {minDate, maxDate, minDuration, maxDuration, viewMode} = this.props;
+    const precision = viewMode === 'quarters' ? 'quarter' : 'day';
 
     maxDate =
       maxDate && endDate
@@ -541,9 +541,9 @@ export class DateRangePicker extends React.Component<
           : endDate
         : maxDate || endDate;
 
-    if (minDate && currentDate.isBefore(minDate, 'day')) {
+    if (minDate && currentDate.isBefore(minDate, precision)) {
       return false;
-    } else if (maxDate && currentDate.isAfter(maxDate, 'day')) {
+    } else if (maxDate && currentDate.isAfter(maxDate, precision)) {
       return false;
     } else if (
       // 如果配置了 minDuration 那么 EndDate - minDuration 之后的天数也不能选
@@ -565,8 +565,8 @@ export class DateRangePicker extends React.Component<
 
   checkEndIsValidDate(currentDate: moment.Moment) {
     let {startDate} = this.state;
-
-    let {minDate, maxDate, minDuration, maxDuration} = this.props;
+    let {minDate, maxDate, minDuration, maxDuration, viewMode} = this.props;
+    const precision = viewMode === 'quarters' ? 'quarter' : 'day';
 
     minDate =
       minDate && startDate
@@ -575,9 +575,9 @@ export class DateRangePicker extends React.Component<
           : startDate
         : minDate || startDate;
 
-    if (minDate && currentDate.isBefore(minDate, 'day')) {
+    if (minDate && currentDate.isBefore(minDate, precision)) {
       return false;
-    } else if (maxDate && currentDate.isAfter(maxDate, 'day')) {
+    } else if (maxDate && currentDate.isAfter(maxDate, precision)) {
       return false;
     } else if (
       startDate &&

--- a/src/components/DateRangePicker.tsx
+++ b/src/components/DateRangePicker.tsx
@@ -532,7 +532,7 @@ export class DateRangePicker extends React.Component<
   checkStartIsValidDate(currentDate: moment.Moment) {
     let {endDate, startDate} = this.state;
     let {minDate, maxDate, minDuration, maxDuration, viewMode} = this.props;
-    const precision = viewMode === 'quarters' ? 'quarter' : 'day';
+    const precision = viewMode === 'time' ? 'hours' : viewMode || 'day';
 
     maxDate =
       maxDate && endDate
@@ -566,7 +566,7 @@ export class DateRangePicker extends React.Component<
   checkEndIsValidDate(currentDate: moment.Moment) {
     let {startDate} = this.state;
     let {minDate, maxDate, minDuration, maxDuration, viewMode} = this.props;
-    const precision = viewMode === 'quarters' ? 'quarter' : 'day';
+    const precision = viewMode === 'time' ? 'hours' : viewMode || 'day';
 
     minDate =
       minDate && startDate


### PR DESCRIPTION
季度范围选择器禁用方法比对精确到季就够用了。
修复在使用unix时间戳作为值时，禁用范围显示不正确的bug。
![1831B8843F64586979051A14BD032F27](https://user-images.githubusercontent.com/24724874/122388406-6e78e380-cfa2-11eb-8295-aba898e1d4b3.gif)
