### PR TITLE
feat: 月度选择器支持年份选择切换

### DIFF
--- a/src/components/DateRangePicker.tsx
+++ b/src/components/DateRangePicker.tsx
@@ -55,7 +55,7 @@ export interface DateRangePickerState {
   endDate?: moment.Moment;
 }
 
-const availableRanges: {[propName: string]: any} = {
+export const availableRanges: {[propName: string]: any} = {
   'today': {
     label: 'Date.today',
     startDate: (now: moment.Moment) => {

--- a/src/components/MonthRangePicker.tsx
+++ b/src/components/MonthRangePicker.tsx
@@ -20,6 +20,7 @@ import {DateRangePicker} from './DateRangePicker';
 import capitalize from 'lodash/capitalize';
 import {ShortCuts, ShortCutDateRange} from './DatePicker';
 import {availableRanges} from './DateRangePicker';
+
 export interface MonthRangePickerProps extends ThemeProps, LocaleProps {
   className?: string;
   popoverClassName?: string;

--- a/src/components/MonthRangePicker.tsx
+++ b/src/components/MonthRangePicker.tsx
@@ -21,7 +21,6 @@ import capitalize from 'lodash/capitalize';
 import {ShortCuts, ShortCutDateRange} from './DatePicker';
 import {availableRanges} from './DateRangePicker';
 
-
 export interface MonthRangePickerProps extends ThemeProps, LocaleProps {
   className?: string;
   popoverClassName?: string;

--- a/src/components/MonthRangePicker.tsx
+++ b/src/components/MonthRangePicker.tsx
@@ -20,7 +20,6 @@ import {DateRangePicker} from './DateRangePicker';
 import capitalize from 'lodash/capitalize';
 import {ShortCuts, ShortCutDateRange} from './DatePicker';
 import {availableRanges} from './DateRangePicker';
-
 export interface MonthRangePickerProps extends ThemeProps, LocaleProps {
   className?: string;
   popoverClassName?: string;
@@ -29,6 +28,7 @@ export interface MonthRangePickerProps extends ThemeProps, LocaleProps {
   format: string;
   utc?: boolean;
   inputFormat?: string;
+  timeFormat?: string;
   ranges?: string | Array<ShortCuts>;
   clearable?: boolean;
   minDate?: moment.Moment;
@@ -439,7 +439,7 @@ export class MonthRangePicker extends React.Component<
   }
 
   renderCalendar() {
-    const {classPrefix: ns, classnames: cx, locale, embed, ranges} = this.props;
+    const {classPrefix: ns, classnames: cx, locale, embed, ranges, inputFormat, timeFormat} = this.props;
     const __ = this.props.translate;
     const viewMode: 'months' = 'months';
     const dateFormat = 'YYYY-MM';
@@ -454,6 +454,8 @@ export class MonthRangePicker extends React.Component<
           onChange={this.handleStartChange}
           requiredConfirm={false}
           dateFormat={dateFormat}
+          inputFormat={inputFormat}
+          timeFormat={timeFormat}
           isValidDate={this.checkStartIsValidDate}
           viewMode={viewMode}
           input={false}
@@ -471,6 +473,8 @@ export class MonthRangePicker extends React.Component<
           onChange={this.handleEndChange}
           requiredConfirm={false}
           dateFormat={dateFormat}
+          inputFormat={inputFormat}
+          timeFormat={timeFormat}
           viewDate={this.nextMonth}
           isEndDate
           isValidDate={this.checkEndIsValidDate}


### PR DESCRIPTION
年份选择切换是根据/yy/i.test(this.props.inputFormat || '')判断的，给它传一下inputFormat让它支持切换