### PR TITLE
修复搜索框 clear-and-submit 时有多级属性时的错误行为

### DIFF
--- a/src/store/form.ts
+++ b/src/store/form.ts
@@ -557,7 +557,7 @@ export const FormStore = ServiceStore.named('FormStore')
       const toClear: any = {};
       self.items.forEach(item => {
         if (item.name && item.type !== 'hidden') {
-          toClear[item.name] = item.resetValue;
+          setVariable(toClear, item.name, item.resetValue);
         }
       });
       setValues(toClear);


### PR DESCRIPTION
原先行为：
![1624789381995](https://user-images.githubusercontent.com/34802622/123572635-1db58600-d7ff-11eb-911f-9bc53246686e.png)

也就是 `item.name` 可能是 `data.appId` 这样的多级属性

关联 [mr](https://github.com/baidu/amis/pull/1549)