### PR TITLE
1.2.x 兼容性问题修复

### DIFF
--- a/__tests__/renderers/Form/__snapshots__/fieldSet.test.tsx.snap
+++ b/__tests__/renderers/Form/__snapshots__/fieldSet.test.tsx.snap
@@ -38,23 +38,32 @@ exports[`Renderer:fieldSet 1`] = `
               class="a-Form--horizontal"
             >
               <div
-                class="a-Form-item a-Form-item--normal"
+                class="a-Form-item a-Form-item--horizontal"
                 data-role="form-item"
               >
+                <label
+                  class="a-Form-label a-Form-itemColumn--normal"
+                >
+                  <span />
+                </label>
                 <div
-                  class="a-Form-control a-TextControl"
+                  class="a-Form-value"
                 >
                   <div
-                    class="a-TextControl-input"
+                    class="a-Form-control a-TextControl"
                   >
-                    <input
-                      autocomplete="off"
-                      name="text"
-                      placeholder=""
-                      size="10"
-                      type="text"
-                      value=""
-                    />
+                    <div
+                      class="a-TextControl-input"
+                    >
+                      <input
+                        autocomplete="off"
+                        name="text"
+                        placeholder=""
+                        size="10"
+                        type="text"
+                        value=""
+                      />
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/SchemaRenderer.tsx
+++ b/src/SchemaRenderer.tsx
@@ -41,7 +41,8 @@ const defaultOmitList = [
   'defaultData',
   'required',
   'requiredOn',
-  'syncSuperStore'
+  'syncSuperStore',
+  'mode'
 ];
 
 export class SchemaRenderer extends React.Component<SchemaRendererProps, any> {

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -363,6 +363,8 @@ function wrapControl(item: any) {
     className,
     inputClassName,
     columnClassName,
+    visibleOn,
+    visible,
     ...rest
   } = item;
 
@@ -394,6 +396,8 @@ function wrapControl(item: any) {
     horizontal,
     className,
     columnClassName,
+    visibleOn,
+    visible,
     body: rest
   };
 }

--- a/src/renderers/Form/Item.tsx
+++ b/src/renderers/Form/Item.tsx
@@ -643,7 +643,6 @@ export class FormItemWrap extends React.Component<FormItemProps> {
       renderLabel,
       renderDescription,
       hint,
-      formMode,
       data,
       showErrorMsg
     } = this.props;
@@ -855,7 +854,6 @@ export class FormItemWrap extends React.Component<FormItemProps> {
       renderLabel,
       renderDescription,
       hint,
-      formMode,
       data,
       showErrorMsg
     } = this.props;
@@ -865,7 +863,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
     return (
       <div
         data-role="form-item"
-        className={cx(`Form-item Form-item--${formMode}`, className, {
+        className={cx(`Form-item Form-item--row`, className, {
           'is-error': model && !model.valid,
           [`is-required`]: required
         })}
@@ -945,6 +943,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
 
   render() {
     const {formMode, inputOnly, wrap, render, formItem: model} = this.props;
+    const mode = this.props.mode || formMode;
 
     if (wrap === false || inputOnly) {
       return this.renderControl();
@@ -952,11 +951,11 @@ export class FormItemWrap extends React.Component<FormItemProps> {
 
     return (
       <>
-        {formMode === 'inline'
+        {mode === 'inline'
           ? this.renderInline()
-          : formMode === 'horizontal'
+          : mode === 'horizontal'
           ? this.renderHorizontal()
-          : formMode === 'row'
+          : mode === 'row'
           ? this.renderRow()
           : this.renderNormal()}
         {model

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -101,7 +101,12 @@ export function syncDataFromSuper(
         .map(item => `${item.name}`.replace(/\..*$/, ''))
         .concat(Object.keys(obj))
     );
-  } else if (force) {
+  } else if (
+    force ||
+    (store &&
+      store.storeType === 'ServiceStore' &&
+      store.parentStore.storeType === 'FormStore')
+  ) {
     keys = Object.keys(obj);
   }
 


### PR DESCRIPTION
 1. 原有 controls 下非表单项的 visibleOn 逻辑表现不一致
 2. form 下面的 service 如果有字段跟 form 下字段同名，form 数据便跟不会下发到 service
 3. 部分没有走 formItem 的表单项设置 mode 展示模式无效