### PR TITLE
fix: 表格单元格下发属性逻辑优化

### DIFF
--- a/src/renderers/Card.tsx
+++ b/src/renderers/Card.tsx
@@ -13,6 +13,7 @@ import PopOver, {SchemaPopOver} from './PopOver';
 import {TableCell} from './Table';
 import Copyable, {SchemaCopyable} from './Copyable';
 import {Icon} from '../components/icons';
+import omit = require('lodash/omit');
 import {
   BaseSchema,
   SchemaClassName,
@@ -607,7 +608,7 @@ export class CardItemFieldRenderer extends TableCell {
     let body = children
       ? children
       : render('field', schema, {
-          ...rest,
+          ...omit(rest, Object.keys(schema)),
           value,
           data
         });

--- a/src/renderers/Form/Static.tsx
+++ b/src/renderers/Form/Static.tsx
@@ -6,6 +6,7 @@ import QuickEdit, {SchemaQuickEdit} from '../QuickEdit';
 import {Renderer} from '../../factory';
 import Copyable, {SchemaCopyable} from '../Copyable';
 import {extendObject} from '../../utils/helper';
+import omit = require('lodash/omit');
 import {SchemaObject, SchemaTpl, SchemaType} from '../../Schema';
 
 /**
@@ -172,7 +173,7 @@ export class StaticFieldRenderer extends TableCell {
     let body = children
       ? children
       : render('field', schema, {
-          ...rest,
+          ...omit(rest, Object.keys(schema)),
           value,
           data
         });

--- a/src/renderers/List.tsx
+++ b/src/renderers/List.tsx
@@ -8,6 +8,7 @@ import Button from '../components/Button';
 import Checkbox from '../components/Checkbox';
 import {ListStore, IListStore, IItem} from '../store/list';
 import {observer} from 'mobx-react';
+import omit = require('lodash/omit');
 import {
   anyChanged,
   getScrollParent,
@@ -1350,7 +1351,7 @@ export class ListItemFieldRenderer extends TableCell {
     let body = children
       ? children
       : render('field', schema, {
-          ...rest,
+          ...omit(rest, Object.keys(schema)),
           value,
           data
         });

--- a/src/renderers/Table/TableCell.tsx
+++ b/src/renderers/Table/TableCell.tsx
@@ -4,6 +4,7 @@ import QuickEdit from '../QuickEdit';
 import Copyable from '../Copyable';
 import PopOverable from '../PopOver';
 import {observer} from 'mobx-react';
+import omit = require('lodash/omit');
 
 export interface TableCellProps extends RendererProps {
   wrapperComponent?: React.ReactType;
@@ -63,7 +64,7 @@ export class TableCell extends React.Component<RendererProps> {
     let body = children
       ? children
       : render('field', schema, {
-          ...rest,
+          ...omit(rest, Object.keys(schema)),
           inputOnly: true,
           value,
           data


### PR DESCRIPTION
在 schema 的配置会作为 props 下发,导致优先级提高

比如: 某个表格配置了个 service 如果 service 成员包含有配置 api 的在成员中读取的 api 始终是最外层这个表格的 service api