### PR TITLE
feat: 自定义组件不在 form 当前层级也需要支持自动包裹 formItem 功能

### DIFF
--- a/src/renderers/Form/index.tsx
+++ b/src/renderers/Form/index.tsx
@@ -332,18 +332,6 @@ export interface FormProps
   lazyChange?: boolean; // 表单项的
   formLazyChange?: boolean; // 表单的
 }
-
-class PlaceholderComponent extends React.Component {
-  render() {
-    const {renderChildren, ...rest} = this.props as any;
-
-    if (typeof renderChildren === 'function') {
-      return renderChildren(rest);
-    }
-
-    return null;
-  }
-}
 export default class Form extends React.Component<FormProps, object> {
   static defaultProps = {
     title: 'Form.title',
@@ -417,7 +405,6 @@ export default class Form extends React.Component<FormProps, object> {
     trailing: true,
     leading: false
   });
-  componentCache: SimpleMap = new SimpleMap();
   unBlockRouting?: () => void;
   constructor(props: FormProps) {
     super(props);
@@ -597,7 +584,6 @@ export default class Form extends React.Component<FormProps, object> {
     this.asyncCancel && this.asyncCancel();
     this.disposeOnValidate && this.disposeOnValidate();
     this.disposeRulesValidate && this.disposeRulesValidate();
-    this.componentCache.dispose();
     window.removeEventListener('beforeunload', this.beforePageUnload);
     this.unBlockRouting?.();
   }
@@ -1412,40 +1398,6 @@ export default class Form extends React.Component<FormProps, object> {
         ...resolveDefinitions(subSchema.$ref),
         ...subSchema
       };
-    }
-
-    // 自定义组件如果在节点设置了 label name 什么的，就用 formItem 包一层
-    // 至少自动支持了 valdiations, label, description 等逻辑。
-    if (
-      subSchema.children &&
-      !subSchema.component &&
-      (subSchema.formItemConfig ||
-        subSchema.name ||
-        subSchema.hasOwnProperty('label'))
-    ) {
-      subSchema.component = PlaceholderComponent;
-      subSchema.renderChildren = subSchema.children;
-      delete subSchema.children;
-    }
-
-    if (
-      subSchema.component &&
-      (subSchema.formItemConfig ||
-        subSchema.name ||
-        subSchema.hasOwnProperty('label'))
-    ) {
-      const cache = this.componentCache.get(subSchema.component);
-
-      if (cache) {
-        subSchema.component = cache;
-      } else {
-        const cache = asFormItem({
-          strictMode: false,
-          ...subSchema.formItemConfig
-        })(subSchema.component);
-        this.componentCache.set(subSchema.component, cache);
-        subSchema.component = cache;
-      }
     }
 
     lazyChange === false && (subSchema.changeImmediately = true);

--- a/src/renderers/Form/wrapControl.tsx
+++ b/src/renderers/Form/wrapControl.tsx
@@ -349,6 +349,7 @@ export function wrapControl<
 
               rootStore.removeStore(this.model);
             }
+            delete this.model;
           }
 
           controlRef(control: any) {
@@ -501,16 +502,16 @@ export function wrapControl<
             ) {
               return;
             }
+            const validated = this.model.validated;
             onChange?.(value, name!, submitOnChange === true);
 
             if (
               validateOnChange === true ||
-              (validateOnChange !== false &&
-                (formSubmited || this.model.validated))
+              (validateOnChange !== false && (formSubmited || validated))
             ) {
               this.validate();
             } else if (validateOnChange === false) {
-              this.model.reset();
+              this.model?.reset();
             }
           }
 


### PR DESCRIPTION
原来  {component: ReactComponent} 用法只能在 form 的 boy（或者 controls）下生效，如果层级较多，比如在 fieldset 中则无效。此次调整后多少层级都能支持。