### PR TITLE
docs(action): added `info` level in action.md

### DIFF
--- a/docs/zh-CN/components/action.md
+++ b/docs/zh-CN/components/action.md
@@ -88,6 +88,11 @@ Action 行为按钮，是触发页面行为的主要方法之一
     },
     {
       "type": "button",
+      "label": "信息",
+      "level": "info"
+    },
+    {
+      "type": "button",
       "label": "成功",
       "level": "success"
     },


### PR DESCRIPTION
docs(action): added `info` level in action.md

文档缺少对`level=info`的展示效果，这里补充了info级别展示


官网文档描述如下：
```
level: 按钮样式，支持：link、primary、secondary、info、success、warning、danger、light、dark、default。
```

原始展示：
![image](https://user-images.githubusercontent.com/39587710/125048305-5b08f600-e0d2-11eb-8af4-94d22046d57e.png)
