### PR TITLE
fix: InputImage 上传时 formdata 不添加空元素

### DIFF
--- a/src/renderers/Form/InputImage.tsx
+++ b/src/renderers/Form/InputImage.tsx
@@ -1043,6 +1043,7 @@ export default class ImageControl extends React.Component<
     if (api.data) {
       qsstringify(api.data)
         .split('&')
+        .filter(item => item !== '')
         .forEach(item => {
           let parts = item.split('=');
           fd.append(parts[0], decodeURIComponent(parts[1]));


### PR DESCRIPTION
qsstringify 空对象会出来一个空字符串，然后 split 会得到一个 [""]，然后被添加到 formData 里面了