### PR TITLE
fix: bultin 语法检测,不检测带转义了的用法

### DIFF
--- a/src/utils/tpl-builtin.ts
+++ b/src/utils/tpl-builtin.ts
@@ -453,7 +453,9 @@ export const filters: {
     keys = keys.split(/\s*,\s*/);
     return input.filter((item: any) =>
       // 当keys为*时从item中获取key
-      (isAsterisk ? Object.keys(item) : keys).some((key: string) => fn(resolveVariable(key, item), key, item))
+      (isAsterisk ? Object.keys(item) : keys).some((key: string) =>
+        fn(resolveVariable(key, item), key, item)
+      )
     );
   },
   base64Encode(str) {
@@ -960,7 +962,7 @@ export function dataMapping(
 export function register(): Enginer & {name: string} {
   return {
     name: 'builtin',
-    test: (str: string) => !!~str.indexOf('$'),
+    test: (str: string) => typeof str === 'string' && /(?<!\\)\$\S/.test(str),
     compile: (str: string, data: object, defaultFilter = '| html') =>
       tokenize(str, data, defaultFilter)
   };


### PR DESCRIPTION
以下模板实际上是 lodash 模板语法，但是被检测成了内置模板。因为 $XXX 用法是加了转义的，不应该生效


`"abc \\${{ varname }}，<%- data.a ? '1' : '2' %>" `