### PR TITLE
fix: 数据同步导致接口数据丢失问题

### DIFF
--- a/src/WithStore.tsx
+++ b/src/WithStore.tsx
@@ -194,7 +194,17 @@ export function HocStoreFactory(renderer: {
               )
             );
           } else if (props.data && (props.data as any).__super) {
-            store.initData(extendObject(props.data));
+            store.initData(
+              extendObject(
+                props.data,
+                store.hasRemoteData
+                  ? {
+                      ...store.data,
+                      ...props.data
+                    }
+                  : undefined
+              )
+            );
           } else {
             store.initData(createObject(props.scope, props.data));
           }


### PR DESCRIPTION
主要解决以下场景

crud 中有一栏为 service, service 通过接口拉取接口数据, 当切换页面的时候,如果没有构成接口重新加载的条件, service 的接口不会重新拉取, 但是因为行数据变化,导致了 service 的数据丢失.

解决办法是, 当有远程数据时, 只做 merge ,而不是完全替换