### PR TITLE
fix：图片集支持 string 类型

### DIFF
--- a/src/renderers/Images.tsx
+++ b/src/renderers/Images.tsx
@@ -171,7 +171,10 @@ export class ImagesField extends React.Component<ImagesProps> {
 
     if (typeof source === 'string' && isPureVariable(source)) {
       list = resolveVariableAndFilter(source, data, '| raw') || undefined;
-    } else if (Array.isArray((value = getPropValue(this.props)))) {
+    } else if (
+      Array.isArray((value = getPropValue(this.props))) ||
+      typeof value === 'string'
+    ) {
       list = value;
     } else if (Array.isArray(options)) {
       list = options;


### PR DESCRIPTION
之前的改动引入的 bug ，变成无法支持 "images": "https://internal-amis-res.cdn.bcebos.com/images/2020-1/1578395692722/4f3cb4202335.jpeg,https://internal-amis-res.cdn.bcebos.com/images/2020-1/1578395692722/4f3cb4202335.jpeg" 这样子逗号分隔的字符串了