### PR TITLE
chore: 优化 inputRange 中间值位置

### DIFF
--- a/__tests__/renderers/Form/__snapshots__/range.test.tsx.snap
+++ b/__tests__/renderers/Form/__snapshots__/range.test.tsx.snap
@@ -74,7 +74,6 @@ exports[`Renderer:number 1`] = `
                 >
                   <span
                     class="a-InputRange-label a-InputRange-label--value"
-                    style="left: calc(50% - 0px);"
                   >
                     <span
                       class="a-InputRange-labelContainer"
@@ -105,12 +104,13 @@ exports[`Renderer:number 1`] = `
             </div>
             <span
               class="a-InputRange-label a-InputRange-label--mid"
-              style="left: calc(50% - 60px);"
+              style="left: 50%;"
             >
               <span
                 class="a-InputRange-labelContainer"
               >
                 10
+                
               </span>
             </span>
             <div
@@ -256,7 +256,6 @@ exports[`Renderer:range:multiple 1`] = `
                 >
                   <span
                     class="a-InputRange-label a-InputRange-label--value"
-                    style="left: calc(50% - 0px);"
                   >
                     <span
                       class="a-InputRange-labelContainer"
@@ -310,12 +309,13 @@ exports[`Renderer:range:multiple 1`] = `
             </div>
             <span
               class="a-InputRange-label a-InputRange-label--mid"
-              style="left: calc(50% - 60px);"
+              style="left: 50%;"
             >
               <span
                 class="a-InputRange-labelContainer"
               >
                 10
+                
               </span>
             </span>
             <div

--- a/scss/_properties.scss
+++ b/scss/_properties.scss
@@ -751,7 +751,7 @@
 
   --InputRange-label--value-display: block;
   --InputRange-label--value-positionTop: #{px2rem(-36px)};
-  --InputRange-label--value-positionLeft: #{px2rem(-3px)};
+  --InputRange-label--value-positionLeft: #{px2rem(-6px)};
   --InputRange-label-color: var(--InputRange-neutralColor);
   --InputRange-label-fontSize: 0.8rem;
   --InputRange-label-positionBottom: -1.4rem;

--- a/scss/components/form/_range.scss
+++ b/scss/components/form/_range.scss
@@ -138,6 +138,7 @@
   &-label--mid {
     left: 50%;
     bottom: calc(var(--gap-xs) * -1);
+    transform: translateX(-50%);
   }
 
   &-label--max {

--- a/src/renderers/Form/InputRange.tsx
+++ b/src/renderers/Form/InputRange.tsx
@@ -188,16 +188,14 @@ export default class RangeControl extends React.PureComponent<
   }
 
   updateStyle() {
-    const {showInput, classPrefix: ns} = this.props;
+    const {showInput, classPrefix: ns, max, min} = this.props;
 
     let offsetWidth = (this.midLabel as HTMLSpanElement).offsetWidth;
-    let left = `calc(50% - ${offsetWidth / 2}px)`;
-    (document.querySelector(
-      `.${ns}InputRange-label--value`
-    ) as HTMLSpanElement).style.left = left;
-    if (showInput) {
-      left = `calc(50% - ${offsetWidth / 2 + 60}px)`;
-    }
+    const midValue = parseFloat(
+      ((max! + min! - 0.000001) / 2).toFixed(this.getStepPrecision())
+    );
+
+    let left = `${100 * ((midValue - min!) / (max! - min!))}%`;
     (this.midLabel as HTMLSpanElement).style.left = left;
   }
 
@@ -404,6 +402,9 @@ export default class RangeControl extends React.PureComponent<
       classnames: cx,
       classPrefix: ns
     } = this.props as PropsWithDefaults;
+    const midValue = ((max + min - 0.000001) / 2).toFixed(
+      this.getStepPrecision()
+    );
 
     return (
       <div
@@ -435,7 +436,8 @@ export default class RangeControl extends React.PureComponent<
           ref={this.midLabelRef}
         >
           <span className={cx('InputRange-labelContainer')}>
-            {((max + min) / 2).toFixed(this.getStepPrecision()) + unit}
+            {midValue}
+            {unit}
           </span>
         </span>
 


### PR DESCRIPTION
之前：
![image](https://user-images.githubusercontent.com/2698393/128878452-24387d3b-8ed8-4ece-875d-c966d47dc091.png)


之后：

![image](https://user-images.githubusercontent.com/2698393/128878347-84c5e519-80e0-4626-b96e-2b627c70775f.png)
