### PR TITLE
chore: 调整弹框中查找子节点渲染器处理动作逻辑

### DIFF
--- a/src/renderers/Dialog.tsx
+++ b/src/renderers/Dialog.tsx
@@ -649,24 +649,17 @@ export class DialogRenderer extends Dialog {
         .getComponents()
         .filter(item => !~['drawer', 'dialog'].indexOf(item.props.type));
 
-      // 如果是纯容器组件，则进到里面去找。
-      while (
-        components.length === 1 &&
-        ~['page', 'service'].indexOf(components[0].props.type)
-      ) {
-        components = components[0].context
-          .getComponents()
-          .filter(
-            (item: any) => !~['drawer', 'dialog'].indexOf(item.props.type)
-          );
-      }
+      const pool = components.concat();
 
-      // 优先最下面的，找到一个功能组件，就交给这个功能组件。
-      for (let i = components.length - 1; i >= 0; i--) {
-        const component = components[i];
+      while (pool.length) {
+        const item = pool.shift()!;
 
-        if (~['crud', 'form', 'wizard'].indexOf(component.props.type)) {
-          targets.push(component);
+        if (~['drawer', 'dialog'].indexOf(item.props.type)) {
+          continue;
+        } else if (~['page', 'service'].indexOf(item.props.type)) {
+          pool.push.apply(pool, item.context.getComponents());
+        } else if (~['crud', 'form', 'wizard'].indexOf(item.props.type)) {
+          targets.push(item);
           break;
         }
       }

--- a/src/renderers/Drawer.tsx
+++ b/src/renderers/Drawer.tsx
@@ -707,24 +707,17 @@ export class DrawerRenderer extends Drawer {
         .getComponents()
         .filter(item => !~['drawer', 'dialog'].indexOf(item.props.type));
 
-      // 如果是纯容器组件，则进到里面去找。
-      while (
-        components.length === 1 &&
-        ~['page', 'service'].indexOf(components[0].props.type)
-      ) {
-        components = components[0].context
-          .getComponents()
-          .filter(
-            (item: any) => !~['drawer', 'dialog'].indexOf(item.props.type)
-          );
-      }
+      const pool = components.concat();
 
-      // 优先最下面的，找到一个功能组件，就交给这个功能组件。
-      for (let i = components.length - 1; i >= 0; i--) {
-        const component = components[i];
+      while (pool.length) {
+        const item = pool.shift()!;
 
-        if (~['crud', 'form', 'wizard'].indexOf(component.props.type)) {
-          targets.push(component);
+        if (~['drawer', 'dialog'].indexOf(item.props.type)) {
+          continue;
+        } else if (~['page', 'service'].indexOf(item.props.type)) {
+          pool.push.apply(pool, item.context.getComponents());
+        } else if (~['crud', 'form', 'wizard'].indexOf(item.props.type)) {
+          targets.push(item);
           break;
         }
       }


### PR DESCRIPTION
原来是有且只有一个 page 或者 service 才向下找,

现在是不管怎么组合,找不到就一直往里面找,直到找到第一个 crud 或者 form 或者 wizard 为止