### PR TITLE
fix: 修复 isJson 校验

### DIFF
--- a/__tests__/utils/validations.test.ts
+++ b/__tests__/utils/validations.test.ts
@@ -465,6 +465,21 @@ test('validation:isJson invalid', () => {
   ).toMatchObject(['请检查 Json 格式']);
 });
 
+test('validation:isJson invalid', () => {
+  expect(
+    validate(
+      '12345',
+      {},
+      {
+        isJson: true
+      },
+      {
+        isJson: '请检查 Json 格式'
+      }
+    )
+  ).toMatchObject(['请检查 Json 格式']);
+});
+
 test('validation:isLength valid', () => {
   expect(
     validate(

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -149,7 +149,11 @@ export const validations: {
   isJson: function (values, value, minimum) {
     if (isExisty(value) && !isEmpty(value) && typeof value === 'string') {
       try {
-        JSON.parse(value);
+        const result = JSON.parse(value);
+        if (typeof result === 'object' && result) {
+          return true;
+        }
+        return false;
       } catch (e) {
         return false;
       }


### PR DESCRIPTION
单纯的依赖 `JSON.parse` 判断是否是 `json` 并不准确。

```
JSON.parse('true'); // true
JSON.parse('false'); // false
JSON.parse('123'); // 123
```
https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse

