### PR TITLE
fix: tinymce 图片上传结果解析不正确

### DIFF
--- a/docs/zh-CN/components/form/input-rich-text.md
+++ b/docs/zh-CN/components/form/input-rich-text.md
@@ -26,7 +26,33 @@ order: 47
 }
 ```
 
-### tinymce 自定义配置
+## 图片上传
+
+通过设置 `receiver` 来支持文件上传，它的返回值类似如下：
+
+```json
+{
+  "link": "https://xxx.png"
+}
+```
+
+下面是个示例，但不会真正上传，每次都返回同一张图片
+
+```schema: scope="body"
+{
+    "type": "form",
+    "body": [
+        {
+            "type": "input-rich-text",
+            "receiver": "/api/mock2/sample/mirror?json={%22value%22:%22/amis/static/logo_c812f54.png%22}",
+            "name": "rich",
+            "label": "Rich Text"
+        }
+    ]
+}
+```
+
+## tinymce 自定义配置
 
 可以设置 options 属性来自定义编辑器的展现，详细配置项请参考[官方文档](https://www.tiny.cloud/docs/general-configuration-guide/basic-setup/)。
 

--- a/docs/zh-CN/components/form/input-rich-text.md
+++ b/docs/zh-CN/components/form/input-rich-text.md
@@ -36,6 +36,17 @@ order: 47
 }
 ```
 
+也可以是
+
+```json
+{
+  "status": 0,
+  "data": {
+    "link": "https://xxx.png"
+  }
+}
+```
+
 下面是个示例，但不会真正上传，每次都返回同一张图片
 
 ```schema: scope="body"

--- a/src/renderers/Form/InputRichText.tsx
+++ b/src/renderers/Form/InputRichText.tsx
@@ -187,7 +187,6 @@ export default class RichTextControl extends React.Component<
       const fetcher = props.env.fetcher;
       this.config = {
         ...props.options,
-        images_upload_url: props.receiver,
         images_upload_handler: async (
           blobInfo: any,
           ok: (locaiton: string) => void,
@@ -203,18 +202,24 @@ export default class RichTextControl extends React.Component<
                   data: payload
                 };
               },
-              ...normalizeApi(props.receiver)
+              ...normalizeApi(props.receiver, 'post')
             };
             const response = await fetcher(receiver, formData, {
               method: 'post'
             });
             if (response.ok) {
-              ok(
+              const location =
                 response.data?.link ||
-                  response.data?.url ||
-                  response.data?.value ||
-                  (response as any).link
-              );
+                response.data?.url ||
+                response.data?.value ||
+                response.data?.data?.link ||
+                response.data?.data?.url ||
+                response.data?.data?.value;
+              if (location) {
+                ok(location);
+              } else {
+                console.warn('must have return value');
+              }
             }
           } catch (e) {
             fail(e);


### PR DESCRIPTION
之前不支持 amis 标准的 api 返回格式，response.data 是返回内容

```
{
  "status": 0,
  "data": {
    "link": "https://xxx.png"
  }
}
```