### PR TITLE
docs(date.md): 修复date在Form表单中文档与代码不一致的问题

### DIFF
--- a/docs/zh-CN/components/date.md
+++ b/docs/zh-CN/components/date.md
@@ -70,13 +70,14 @@ List 的内容、Card 卡片的内容配置同上
 {
     "type": "form",
     "data": {
-        "color": "#108cee"
+        "now": "1591322307"
     },
     "body": [
         {
-            "type": "static-color",
-            "name": "color",
-            "label": "颜色"
+            "type": "static-date",
+            "name": "now",
+            "label": "日期",
+            "format": "YYYY年MM月DD日 HH时mm分ss秒"
         }
     ]
 }


### PR DESCRIPTION
docs(date.md): 修复date在Form表单中文档与代码不一致的问题
`static-color`应该为`static-date`

参考：
https://aisuda.github.io/amis-1.1.7/zh-CN/components/date#form-%E4%B8%AD%E9%9D%99%E6%80%81%E5%B1%95%E7%A4%BA