### PR TITLE
fix: 修复固定列和超级表头结合导致的样式问题

### DIFF
--- a/scss/components/_table.scss
+++ b/scss/components/_table.scss
@@ -217,6 +217,23 @@
     border-collapse: collapse;
     border: var(--Table-borderWidth) solid var(--Table-borderColor);
 
+    & th,
+    & td {
+      text-align: left;
+    }
+
+    & th.text-center,
+    & td.text-center,
+    & th[colspan],
+    & td[colspan] {
+      text-align: center;
+    }
+
+    & th.text-right,
+    & td.text-right {
+      text-align: right;
+    }
+
     &--withCombine {
       > thead > tr > th,
       > tbody > tr > td {
@@ -254,12 +271,6 @@
     > thead > tr {
       > th {
         background: var(--Table-thead-bg);
-
-        text-align: left;
-        &[colspan] {
-          text-align: center;
-        }
-
         padding: var(--TableCell-paddingY) var(--TableCell-paddingX);
 
         &:first-child {
@@ -310,7 +321,6 @@
       }
 
       > th {
-        text-align: left;
         background: var(--Table-thead-bg);
         // font-size: var(--Table-thead-fontSize);
         color: var(--Table-thead-color);

--- a/src/renderers/Form/InputTable.tsx
+++ b/src/renderers/Form/InputTable.tsx
@@ -779,15 +779,25 @@ export default class FormTable extends React.Component<TableProps, TableState> {
     }
 
     if (btns.length) {
-      columns.push({
-        type: 'operation',
-        buttons: btns,
-        label: __('Table.operation'),
-        className: 'v-middle nowrap',
-        fixed: 'right',
-        width: '1%',
-        innerClassName: 'm-n'
-      });
+      let operation = columns.find(item => item.type === 'operation');
+
+      if (!operation) {
+        operation = {
+          type: 'operation',
+          buttons: [],
+          label: __('Table.operation'),
+          className: 'v-middle nowrap',
+          fixed: 'right',
+          width: '1%',
+          innerClassName: 'm-n'
+        };
+        columns.push(operation);
+      }
+
+      operation.buttons = Array.isArray(operation.buttons)
+        ? operation.buttons.concat()
+        : [];
+      operation.buttons.unshift.apply(operation.buttons, btns);
     }
 
     if (showIndex) {

--- a/src/renderers/Table/TableContent.tsx
+++ b/src/renderers/Table/TableContent.tsx
@@ -14,6 +14,7 @@ export interface TableContentProps extends LocaleProps {
     label: string;
     index: number;
     colSpan: number;
+    rowSpan: number;
     has: Array<any>;
   }>;
   rows: Array<IRow>;
@@ -97,6 +98,7 @@ export class TableContent extends React.Component<TableContentProps> {
                     key={index}
                     data-index={item.index}
                     colSpan={item.colSpan}
+                    rowSpan={item.rowSpan}
                   >
                     {item.label ? render('tpl', item.label) : null}
                   </th>
@@ -105,10 +107,13 @@ export class TableContent extends React.Component<TableContentProps> {
             ) : null}
             <tr className={hideHeader ? 'fake-hide' : ''}>
               {columns.map(column =>
-                renderHeadCell(column, {
-                  'data-index': column.index,
-                  'key': column.index
-                })
+                columnsGroup.find(group => ~group.has.indexOf(column))
+                  ?.rowSpan === 2
+                  ? null
+                  : renderHeadCell(column, {
+                      'data-index': column.index,
+                      'key': column.index
+                    })
               )}
             </tr>
           </thead>

--- a/src/renderers/Table/index.tsx
+++ b/src/renderers/Table/index.tsx
@@ -868,10 +868,12 @@ export default class Table extends React.Component<TableProps, object> {
       [propName: string]: number;
     } = (this.heights = {});
 
-    heights.header ||
-      (heights.header = table
-        .querySelector('thead')!
-        .getBoundingClientRect().height);
+    heights.header = table
+      .querySelector('thead>tr:last-child')!
+      .getBoundingClientRect().height;
+    heights.header2 = table
+      .querySelector('thead>tr:first-child')!
+      .getBoundingClientRect().height;
 
     forEach(
       table.querySelectorAll('thead>tr:last-child>th'),
@@ -918,7 +920,7 @@ export default class Table extends React.Component<TableProps, object> {
           table.querySelectorAll('thead>tr:first-child>th'),
           (item: HTMLElement) => {
             const width = widths2[item.getAttribute('data-index') as string];
-            item.style.cssText += `width: ${width}px; height: ${heights.header}px`;
+            item.style.cssText += `width: ${width}px; height: ${heights.header2}px`;
             totalWidth2 += width;
           }
         );
@@ -935,9 +937,10 @@ export default class Table extends React.Component<TableProps, object> {
           }
         );
 
-        table.style.cssText += `width: ${
-          totalWidth || totalWidth2
-        }px;table-layout: fixed;`;
+        table.style.cssText += `width: ${Math.max(
+          totalWidth,
+          totalWidth2
+        )}px;table-layout: fixed;`;
       }
     );
 

--- a/src/renderers/Table/index.tsx
+++ b/src/renderers/Table/index.tsx
@@ -940,7 +940,7 @@ export default class Table extends React.Component<TableProps, object> {
         table.style.cssText += `width: ${Math.max(
           totalWidth,
           totalWidth2
-        )}px;table-layout: fixed;`;
+        )}px;table-layout: auto;`;
       }
     );
 

--- a/src/store/table.ts
+++ b/src/store/table.ts
@@ -434,60 +434,69 @@ export const TableStore = iRendererStore
       return self.columns.findIndex(column => !column.toggled) !== -1;
     }
 
-    function getColumnGroup(): Array<{
-      label: string;
-      index: number;
-      colSpan: number;
-      has: Array<any>;
-    }> {
-      const columsn = getFilteredColumns();
-      const len = columsn.length;
+    function getColumnGroup() {
+      const columns = getFilteredColumns();
+      const len = columns.length;
 
       if (!len) {
         return [];
       }
 
-      const result: Array<{
+      const groups: Array<{
         label: string;
         index: number;
         colSpan: number;
+        rowSpan: number;
         has: Array<any>;
       }> = [
         {
-          label: columsn[0].groupName,
+          label: columns[0].groupName,
           colSpan: 1,
-          index: columsn[0].index,
-          has: [columsn[0]]
+          rowSpan: 1,
+          index: columns[0].index,
+          has: [columns[0]]
         }
       ];
 
       //  如果是勾选栏，让它和下一列合并。
-      if (columsn[0].type === '__checkme' && columsn[1]) {
-        result[0].label = columsn[1].groupName;
+      if (columns[0].type === '__checkme' && columns[1]) {
+        groups[0].label = columns[1].groupName;
       }
 
       for (let i = 1; i < len; i++) {
-        let prev = result[result.length - 1];
-        const current = columsn[i];
+        let prev = groups[groups.length - 1];
+        const current = columns[i];
 
         if (current.groupName === prev.label) {
           prev.colSpan++;
           prev.has.push(current);
         } else {
-          result.push({
+          groups.push({
             label: current.groupName,
             colSpan: 1,
+            rowSpan: 1,
             index: current.index,
             has: [current]
           });
         }
       }
 
-      if (result.length === 1 && !result[0].label) {
-        result.pop();
+      if (groups.length === 1 && !groups[0].label) {
+        groups.pop();
       }
 
-      return result;
+      return groups.map(item => {
+        const rowSpan =
+          !item.label ||
+          (item.has.length === 1 && item.label === item.has[0].label)
+            ? 2
+            : 1;
+        return {
+          ...item,
+          rowSpan,
+          label: rowSpan === 2 ? item.label || item.has[0].label : item.label
+        };
+      });
     }
 
     return {


### PR DESCRIPTION
1. 修复固定列和超级表头结合导致的样式问题
2. 超级表头如果 label 值一样，自动合并单元格
3. inputTable 共用 operation 栏
4. th td 可以通过配置 text-center 或者text-right 来实现居中和居右