### PR TITLE
fix: inputTree的icon显示修复

### DIFF
--- a/examples/components/Form/Full.jsx
+++ b/examples/components/Form/Full.jsx
@@ -985,14 +985,17 @@ export default {
           type: 'input-tree',
           name: 'tree',
           label: '树',
+          iconField: 'icon',
           options: [
             {
               label: 'Folder A',
               value: 1,
+              icon: 'fa fa-bookmark',
               children: [
                 {
                   label: 'file A',
-                  value: 2
+                  value: 2,
+                  icon: 'fa fa-star'
                 },
                 {
                   label: 'file B',

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -765,10 +765,12 @@ export class TreeSelector extends React.Component<
                       : this.handleSelect(item))
                   }
                 >
-                  <Icon
-                    icon={childrenItems ? 'folder' : 'file'}
-                    className="icon"
-                  />
+                  {item[iconField] ? null : (
+                    <Icon
+                      icon={childrenItems ? 'folder' : 'file'}
+                      className="icon"
+                    />
+                  )}
                 </i>
               ) : null}
 

--- a/src/renderers/Form/InputTree.tsx
+++ b/src/renderers/Form/InputTree.tsx
@@ -147,6 +147,7 @@ export default class TreeControl extends React.Component<TreeProps> {
       rootCreatable,
       rootCreateTip,
       labelField,
+      iconField,
       nodePath,
       deferLoad,
       expandTreeOptions,
@@ -163,6 +164,7 @@ export default class TreeControl extends React.Component<TreeProps> {
             classPrefix={ns}
             labelField={labelField}
             valueField={valueField}
+            iconField={iconField}
             disabled={disabled}
             onChange={onChange}
             joinValues={joinValues}


### PR DESCRIPTION
{
type: 'input-tree',
name: 'tree',
label: '树',
showIcon: true
iconField: 'icon',
option:[
{
label: 'Folder A',
value: 1,
icon: 'fa fa-bookmark',
children:[
{
label: 'file A',
value: 2,
icon: 'fa fa-star'
}]}]
}

显示 iconField 对应的 icon；
之前的会出现 iconFied 的 icon 和 内部的 folder/file icon 同时显示的情况