### PR TITLE
fix: 修复弹窗第一次获取不到值的问题

### DIFF
--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -8,7 +8,8 @@ import React from 'react';
 import Transition, {
   ENTERED,
   ENTERING,
-  EXITING
+  EXITING,
+  EXITED
 } from 'react-transition-group/Transition';
 import Portal from 'react-overlays/Portal';
 import {Icon} from './icons';
@@ -230,7 +231,7 @@ export class Drawer extends React.Component<DrawerProps, DrawerState> {
                   >
                     <Icon icon="close" className="icon" />
                   </a>
-                  {children}
+                  {status === EXITED ? null : children}
                 </div>
               </div>
             );

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -8,7 +8,8 @@ import React from 'react';
 import Transition, {
   ENTERED,
   ENTERING,
-  EXITING
+  EXITING,
+  EXITED
 } from 'react-transition-group/Transition';
 import Portal from 'react-overlays/Portal';
 import {current, addModal, removeModal} from './ModalManager';
@@ -264,7 +265,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
                   fadeStyles[status]
                 )}
               >
-                {children}
+                {status === EXITED ? null : children}
               </div>
             </div>
           </Portal>

--- a/src/renderers/Dialog.tsx
+++ b/src/renderers/Dialog.tsx
@@ -318,7 +318,7 @@ export default class Dialog extends React.Component<DialogProps> {
   handleExited() {
     const {lazySchema, store} = this.props;
     if (isAlive(store)) {
-      store.setFormData({});
+      store.reset();
       store.setEntered(false);
       if (typeof lazySchema === 'function') {
         store.setSchema('');

--- a/src/store/modal.ts
+++ b/src/store/modal.ts
@@ -24,6 +24,10 @@ export const ModalStore = ServiceStore.named('ModalStore')
       setFormData(obj: any) {
         self.form = obj;
       },
+      reset() {
+        self.form = {};
+        self.reInitData({}, true);
+      },
 
       setResizeCoord(value: number) {
         self.resizeCoord = value;


### PR DESCRIPTION
可以修复：

https://github.com/baidu/amis/issues/2704
https://github.com/baidu/amis/issues/2750
https://github.com/baidu/amis/issues/2742

旧版本中可以的原因是，之前是用的 willRecieveProps ，新版本中改成了 didUpdate，所以 dialog 在弹出瞬间的初始值其实是旧的，需要等待 didUpdate 后才会刷新过来，所以首次获取值是旧的，解决办法是，关闭态不渲染成员节点，打开以及打开动画中才渲染。