### PR TITLE
Revert "inputTree的icon显示修复;并补充文档"

### DIFF
--- a/docs/zh-CN/components/form/input-tree.md
+++ b/docs/zh-CN/components/form/input-tree.md
@@ -746,7 +746,6 @@ true        false        true       [{label: 'A/B/C', value: 'a/b/c'},{label: 'A
 | delimeter              | `string`                                     | `false`          | [拼接符](./options#%E6%8B%BC%E6%8E%A5%E7%AC%A6-delimiter)                                                           |
 | labelField             | `string`                                     | `"label"`        | [选项标签字段](./options#%E9%80%89%E9%A1%B9%E6%A0%87%E7%AD%BE%E5%AD%97%E6%AE%B5-labelfield)                         |
 | valueField             | `string`                                     | `"value"`        | [选项值字段](./options#%E9%80%89%E9%A1%B9%E5%80%BC%E5%AD%97%E6%AE%B5-valuefield)                                    |
-| iconField              | `string`                                     | `"icon"`         | 图标值字段                                                                                                            |
 | joinValues             | `boolean`                                    | `true`           | [拼接值](./options#%E6%8B%BC%E6%8E%A5%E5%80%BC-joinvalues)                                                          |
 | extractValue           | `boolean`                                    | `false`          | [提取值](./options#%E6%8F%90%E5%8F%96%E5%A4%9A%E9%80%89%E5%80%BC-extractvalue)                                      |
 | creatable              | `boolean`                                    | `false`          | [新增选项](./options#%E5%89%8D%E7%AB%AF%E6%96%B0%E5%A2%9E-creatable)                                                |

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -765,10 +765,12 @@ export class TreeSelector extends React.Component<
                       : this.handleSelect(item))
                   }
                 >
-                  <Icon
-                    icon={item[iconField] || (childrenItems ? 'folder' : 'file')}
-                    className="icon"
-                  />
+                  {item[iconField] ? null : (
+                    <Icon
+                      icon={childrenItems ? 'folder' : 'file'}
+                      className="icon"
+                    />
+                  )}
                 </i>
               ) : null}
 


### PR DESCRIPTION
大概了解了，你们组件内使用icon和icon组件功能还不太一样；

我是为了使用组件内提供的svg所以这么修复了。

但是这样子就不太支持iconfont和外部链接(外部链接倒是本来就不支持)

我重新处理下，准备将`components/icons.tsx`在没有找到icon的情况下使用Icon组件进行Icon渲染