### PR TITLE
inputTree的icon显示修复

### DIFF
--- a/docs/zh-CN/components/form/input-tree.md
+++ b/docs/zh-CN/components/form/input-tree.md
@@ -746,6 +746,7 @@ true        false        true       [{label: 'A/B/C', value: 'a/b/c'},{label: 'A
 | delimeter              | `string`                                     | `false`          | [拼接符](./options#%E6%8B%BC%E6%8E%A5%E7%AC%A6-delimiter)                                                           |
 | labelField             | `string`                                     | `"label"`        | [选项标签字段](./options#%E9%80%89%E9%A1%B9%E6%A0%87%E7%AD%BE%E5%AD%97%E6%AE%B5-labelfield)                         |
 | valueField             | `string`                                     | `"value"`        | [选项值字段](./options#%E9%80%89%E9%A1%B9%E5%80%BC%E5%AD%97%E6%AE%B5-valuefield)                                    |
+| iconField              | `string`                                     | `"icon"`         | 图标值字段                                                                                                            |
 | joinValues             | `boolean`                                    | `true`           | [拼接值](./options#%E6%8B%BC%E6%8E%A5%E5%80%BC-joinvalues)                                                          |
 | extractValue           | `boolean`                                    | `false`          | [提取值](./options#%E6%8F%90%E5%8F%96%E5%A4%9A%E9%80%89%E5%80%BC-extractvalue)                                      |
 | creatable              | `boolean`                                    | `false`          | [新增选项](./options#%E5%89%8D%E7%AB%AF%E6%96%B0%E5%A2%9E-creatable)                                                |

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -765,12 +765,10 @@ export class TreeSelector extends React.Component<
                       : this.handleSelect(item))
                   }
                 >
-                  {item[iconField] ? null : (
-                    <Icon
-                      icon={childrenItems ? 'folder' : 'file'}
-                      className="icon"
-                    />
-                  )}
+                  <Icon
+                    icon={item[iconField] || (childrenItems ? 'folder' : 'file')}
+                    className="icon"
+                  />
                 </i>
               ) : null}
 

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -19,7 +19,7 @@ import {
 import {Option, Options, value2array} from './Select';
 import {ClassNamesFn, themeable, ThemeProps} from '../theme';
 import {highlight} from '../renderers/Form/Options';
-import {Icon} from './icons';
+import {Icon, getIcon} from './icons';
 import Checkbox from './Checkbox';
 import {LocaleProps, localeable} from '../locale';
 import Spinner from './Spinner';
@@ -710,6 +710,8 @@ export class TreeSelector extends React.Component<
       const isLeaf =
         (!item.children || !item.children.length) && !item.placeholder;
 
+      const iconValue = item[iconField] || (childrenItems ? 'folder' : 'file');
+
       return (
         <li
           key={key}
@@ -764,10 +766,9 @@ export class TreeSelector extends React.Component<
                       : this.handleSelect(item))
                   }
                 >
-                  <Icon
-                    icon={item[iconField] || (childrenItems ? 'folder' : 'file')}
-                    className="icon"
-                  />
+                  {getIcon(iconValue)
+                    ? <Icon icon={iconValue} className="icon"/>
+                    : <i className={iconValue}></i>}
                 </i>
               ) : null}
 

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -754,7 +754,6 @@ export class TreeSelector extends React.Component<
                 <i
                   className={cx(
                     `Tree-itemIcon ${
-                      item[iconField] ||
                       (childrenItems ? 'Tree-folderIcon' : 'Tree-leafIcon')
                     }`
                   )}


### PR DESCRIPTION
之前为了使用组件内提供的svg所以这么修复了。

但是这样子就不支持iconfont等，所以重新进行了容错