### PR TITLE
fix: 修复表单本地持久数据获取失效问题

### DIFF
--- a/src/renderers/Form/index.tsx
+++ b/src/renderers/Form/index.tsx
@@ -827,7 +827,7 @@ export default class Form extends React.Component<FormProps, object> {
       );
     }
 
-    if (store.persistData) {
+    if (store.persistData && store.inited) {
       store.setLocalPersistData();
     }
   }

--- a/src/store/form.ts
+++ b/src/store/form.ts
@@ -588,14 +588,9 @@ export const FormStore = ServiceStore.named('FormStore')
       self.persistData = value;
     }
 
-    const setLocalPersistData = debounce(
-      () => localStorage.setItem(self.persistKey, JSON.stringify(self.data)),
-      250,
-      {
-        trailing: true,
-        leading: false
-      }
-    );
+    const setLocalPersistData = () => {
+      localStorage.setItem(self.persistKey, JSON.stringify(self.data));
+    };
 
     function getLocalPersistData() {
       let data = localStorage.getItem(self.persistKey);
@@ -639,7 +634,6 @@ export const FormStore = ServiceStore.named('FormStore')
       clearRestError,
       beforeDestroy() {
         syncOptions.cancel();
-        setLocalPersistData.cancel();
       }
     };
   });


### PR DESCRIPTION
原因是表单初始化过程中也会触发 form 的handleChange，而这个时候拿到的数据是不全的，而且会写入本地，导致原来写入的数据被删除。