### PR TITLE
style: fix close button hide delay

### DIFF
--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -225,12 +225,14 @@ export class Drawer extends React.Component<DrawerProps, DrawerState> {
                     fadeStyles[status]
                   )}
                 >
-                  <a
-                    onClick={disabled ? undefined : onHide}
-                    className={`${ns}Drawer-close`}
-                  >
-                    <Icon icon="close" className="icon" />
-                  </a>
+                  {show ? (
+                    <a
+                      onClick={disabled ? undefined : onHide}
+                      className={`${ns}Drawer-close`}
+                    >
+                      <Icon icon="close" className="icon" />
+                    </a>
+                  ) : null}
                   {status === EXITED ? null : children}
                 </div>
               </div>


### PR DESCRIPTION
# 组件

`Drawer`

# 问题描述

当该组件消失时，动画结束后，图标按钮(`Close`)并没有消失，`dark`主题下可浮现

# 解决

根据组件`props.show`动态渲染图标按钮(`Close`)，来避免延时问题
