### PR TITLE
fix: 非CxD主题下Toast背景颜色和ICON颜色相近问题

### DIFF
--- a/scss/_properties.scss
+++ b/scss/_properties.scss
@@ -1291,24 +1291,25 @@
   );
   --TagControl-sugTip-color: var(--info);
 
-  --Toast--danger-bgColor: var(--danger);
-  --Toast--danger-borderColor: var(--danger);
+  --Toast-color: var(--text-color);
+  --Toast--danger-bgColor: var(--background);
+  --Toast--danger-borderColor: transparent;
   --Toast--danger-color: var(--Toast-color);
-  --Toast--info-bgColor: var(--info);
-  --Toast--info-borderColor: var(--info);
+  --Toast--info-bgColor: var(--background);
+  --Toast--info-borderColor: transparent;
   --Toast--info-color: var(--Toast-color);
-  --Toast--success-bgColor: var(--success);
-  --Toast--success-borderColor: var(--success);
+  --Toast--success-bgColor: var(--background);
+  --Toast--success-borderColor: transparent;
   --Toast--success-color: var(--Toast-color);
-  --Toast--warning-bgColor: var(--warning);
-  --Toast--warning-borderColor: var(--warning);
+  --Toast--warning-bgColor: var(--background);
+  --Toast--warning-borderColor: transparent;
   --Toast--warning-color: var(--Toast-color);
+
   --Toast-border-width: 0;
-  --Toast-borderRadius: var(--borderRadiusLg);
+  --Toast-borderRadius: #{px2rem(2px)};
   --Toast-box-shadow: var(--boxShadow);
+  --Toast-close-color: var(--icon-color);
   --Toast-close--onHover-color: var(--Toast-close-color);
-  --Toast-close-color: var(--white);
-  --Toast-color: var(--white);
 
   --Toast-icon-width: #{px2rem(16px)};
   --Toast-icon-height: var(--Toast-icon-width);

--- a/scss/themes/_cxd-variables.scss
+++ b/scss/themes/_cxd-variables.scss
@@ -530,8 +530,9 @@ $L1: 0px 4px 6px 0px rgba(8, 14, 26, 0.06),
 
   // Toast size
   --Toast-width: #{px2rem(300px)};
-  --Toast-borderRadius: 0;
+  --Toast-borderRadius: #{$R3};
   --Toast-paddingL: #{px2rem(26px)};
+  --Toast-paddingX: #{px2rem(16px)};
   --Toast--info-paddingL: 0;
   --Toast-border-width: #{px2rem(1px)};
   --Toast-opacity: 1;
@@ -539,8 +540,6 @@ $L1: 0px 4px 6px 0px rgba(8, 14, 26, 0.06),
 
   // Toast color
   --Toast-color: var(--white);
-  --Toast-borderRadius: #{$R3};
-  --Toast-paddingX: #{px2rem(16px)};
 
   --Toast--danger-color: #{$G2};
   --Toast--danger-bgColor: #{$G11};


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/36724300/143821265-df70c4e5-e2f9-4536-b89c-aa897e5b8251.png)
现在AntD，Ang主题下的背景色和ICON颜色交叠，有点不太和谐。
看了下AntD官方的消息组件都采用白色背景了，所以这里统一升级一下
![image](https://user-images.githubusercontent.com/36724300/143821222-dae17d1f-f035-4942-86c7-c002b00bb64d.png)
