### PR TITLE
fix: 日历日程在其他主题下样式修复 & 日程点击事件点击区域修改

### DIFF
--- a/scss/_properties.scss
+++ b/scss/_properties.scss
@@ -402,6 +402,15 @@
   --Calendar-shortcuts-height: #{px2rem(30px)};
   --Calendar-wLabel-color: #999;
 
+  --Calendar-icon-bottom: #{px2rem(-4px)};
+  --Calendar-icon-width: #{px2rem(10px)};
+  --Calendar-icon-height: #{px2rem(10px)};
+  --Calendar-borderWidth: #{px2rem(1px)};
+  --Calendar-rdt-day: #{px2rem(100px)};
+  --Calendar-schedule-content-padding: 0 #{px2rem(4px)};
+  --Calendar-schedule-content-height: #{px2rem(20px)};
+  --Calendar-schedule-content-color: #{$white};
+
   --Card-actions-borderColor: #{lighten($borderColor, 5%)};
   --Card-actions-fontSize: var(--fontSizeBase);
   --Card-actions-onChecked-onHover-bg: #{darken(#d9f3fb, 5%)};

--- a/src/components/calendar/DaysView.tsx
+++ b/src/components/calendar/DaysView.tsx
@@ -185,11 +185,12 @@ export class CustomDaysView extends DaysView {
             const width = item.width || Math.min(moment(item.endTime).diff(moment(item.startTime), 'days') + 1, 7 - moment(item.startTime).weekday());
             return <div key={props.key + 'content' + index}
               className={cx('ScheduleCalendar-large-schedule-content', item.className)}
-              style={{width: width + '00%'}}>
+              style={{width: width + '00%'}}
+              onClick={() => this.props.onScheduleClick && this.props.onScheduleClick(scheduleData)}>
                 <div className={cx('ScheduleCalendar-text-overflow')}>{item.content}</div>
             </div>;
           });
-          return <td {...props} onClick={() => this.props.onScheduleClick && this.props.onScheduleClick(scheduleData)}>
+          return <td {...props}>
               <div className={cx('ScheduleCalendar-large-day-wrap')}>
                 <div className={cx('ScheduleCalendar-large-schedule-header')}>{currentDate.date()}</div>
                 {scheduleDiv}
@@ -199,8 +200,9 @@ export class CustomDaysView extends DaysView {
         }
 
         // 正常模式
-        const ScheduleIcon = <span className={cx('ScheduleCalendar-icon', schedule[0].className)}></span>;
-        return <td {...props} onClick={() => this.props.onScheduleClick && this.props.onScheduleClick(scheduleData)}>
+        const ScheduleIcon = <span className={cx('ScheduleCalendar-icon', schedule[0].className)}
+           onClick={() => this.props.onScheduleClick && this.props.onScheduleClick(scheduleData)}></span>;
+        return <td {...props}>
           {currentDate.date()}
           {ScheduleIcon}
         </td>;


### PR DESCRIPTION
### 这个变动的性质是？
 
- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ √] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化语料改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 其他改动（是关于什么的改动？）
 
 
### 需求背景和解决方案
 
<!-- 附上设计文档和自测CASE文档的链接 -->
 
### 更新日志
 
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->
 
| 语言    | 更新描述 |
| ------- | -------- |
| 英文 |   Calendar schedule component style fixed under other themes & Schedule click event Click area modification      |
| 中文 |    日历日程在其他主题下样式修复&日程点击事件点击区域修改      |
 
### 请求合并前的自查清单
 
⚠️ 请自检并全部**勾选全部选项**。⚠️
 
- [ √] 文档已补充或无须补充
- [ √] 代码演示已提供或无须提供
- [ √] TypeScript 定义已补充或无须补充
- [ √] Changelog 已提供或无须提供