### PR TITLE
fix: 修复 filterTree 深层级过滤失效的问题

### DIFF
--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -915,11 +915,7 @@ export function filterTree<T extends TreeItem>(
           depthFirst
         );
 
-        if (
-          Array.isArray(children) &&
-          Array.isArray(item.children) &&
-          children.length !== item.children.length
-        ) {
+        if (Array.isArray(children) && Array.isArray(item.children)) {
           item = {...item, children: children};
         }
       }
@@ -1593,13 +1589,12 @@ export function JSONTraverse(
   });
 }
 
-
 export function convertDateArrayToDate(
   value: number[],
   types: string[],
   date: moment.Moment
 ): moment.Moment | null {
-  if (value.length === 0) return date
+  if (value.length === 0) return date;
   for (let i = 0; i < types.length; i++) {
     const type = types[i];
     // @ts-ignore
@@ -1622,7 +1617,7 @@ export function convertDateToObject(value: moment.Moment) {
 export function getRange(min: number, max: number, step: number = 1) {
   const arr = [];
   for (let i = min; i <= max; i += step) {
-      arr.push(i);
+    arr.push(i);
   }
   return arr;
-};
+}

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -891,11 +891,7 @@ export function filterTree<T extends TreeItem>(
           ? filterTree(item.children, iterator, level + 1, depthFirst)
           : undefined;
 
-        if (
-          Array.isArray(children) &&
-          Array.isArray(item.children) &&
-          children.length !== item.children.length
-        ) {
+        if (Array.isArray(children) && Array.isArray(item.children)) {
           item = {...item, children: children};
         }
 


### PR DESCRIPTION
如果判断 `children.length !== item.children.length`，这样如果当前层级长度没变，那么下一层级的children过滤结果就不会正确返回。

如下：
```
const nav = [
  {
    label: '1',
    readable: true,
    children: [
      {
        label: '2',
        readable: true,
        children: [
          {
            label: '3',
            readable: false
          }
        ]
      }
    ]
  }
];
```

正常过滤后，应该结果是
```
[
  {
    label: '1',
    readable: true,
    children: [
      {
        label: '2',
        readable: true,
        children: []
      }
    ]
  }
]
```

但因为第二层长度没变，又会返回原来的item，导致第三层还是原始值