### PR TITLE
fix: 修复 input-table 里的 popover 被遮挡问题 Closes #3377

### DIFF
--- a/scss/components/_table.scss
+++ b/scss/components/_table.scss
@@ -199,6 +199,7 @@
 
   &-content {
     min-height: 0.01%;
+    overflow-x: auto;
     transform: translateZ(0);
 
     th {

--- a/scss/components/_table.scss
+++ b/scss/components/_table.scss
@@ -199,7 +199,6 @@
 
   &-content {
     min-height: 0.01%;
-    overflow-x: auto;
     transform: translateZ(0);
 
     th {

--- a/src/renderers/Form/Select.tsx
+++ b/src/renderers/Form/Select.tsx
@@ -322,7 +322,7 @@ export default class SelectControl extends React.Component<SelectProps, any> {
             popOverContainer={
               mobileUI && env && env.getModalContainer
                 ? env.getModalContainer
-                : undefined
+                : rest.popOverContainer
             }
             borderMode={borderMode}
             placeholder={placeholder}


### PR DESCRIPTION
 感觉可能是之前改 popOverContainer 导致的，但没看出是哪里，而这个 overflow-x 似乎用处不大，就先这样修复了