### PR TITLE
fix: 修复 autoGenerateFilter 导致 crud 加载两次问题

### DIFF
--- a/src/renderers/CRUD.tsx
+++ b/src/renderers/CRUD.tsx
@@ -465,13 +465,16 @@ export default class CRUD extends React.Component<CRUDProps, any> {
   }
 
   componentDidMount() {
-    const store = this.props.store;
+    const {store, autoGenerateFilter} = this.props;
 
     if (this.props.perPage) {
       store.changePage(store.page, this.props.perPage);
     }
 
-    if (!this.props.filter || (store.filterTogggable && !store.filterVisible)) {
+    if (
+      (!this.props.filter || (store.filterTogggable && !store.filterVisible)) &&
+      !autoGenerateFilter
+    ) {
       this.handleFilterInit({});
     }
 


### PR DESCRIPTION
测试例子是

```javascript
export default {
  type: 'page',
  title: '列表',
  body: [
    {
      type: 'crud',
      name: 'datalist',
      autoGenerateFilter: true,
      api: '/api/mock2/sample',
      columns: [
        {
          type: 'text',
          name: 'id',
          label: 'ID',
          searchable: {
            type: 'input-text',
            name: 'id',
            label: 'ID',
            placeholder: '请输入ID',
            mode: 'horizontal'
          }
        }
      ]
    }
  ]
};

```