### PR TITLE
fix: input-number圆角显示可能不完整，数字颜色跟随主题

### DIFF
--- a/scss/components/form/_number.scss
+++ b/scss/components/form/_number.scss
@@ -9,6 +9,7 @@
   background: var(--Number-bg);
   border: var(--Number-borderWidth) solid var(--Number-borderColor);
   border-radius: var(--Number-borderRadius);
+  overflow: hidden;
 
   @include input-border();
   &.no-steps > &-handler-wrap {
@@ -73,6 +74,7 @@
     transition: all var(--animation-duration) ease;
     border: 0;
     border-radius: var(--Form-input-borderRadius);
+    color: var(--Form-input-color);
     padding: 0 var(--Form-input-paddingX);
   }
 


### PR DESCRIPTION
input-number圆角显示可能不完整，云舍主题下比较明显；
dark主题下数字颜色是黑色，改成跟随主题。