### PR TITLE
开关/选项卡组件事件 & 动作扩充

### DIFF
--- a/examples/components/EventAction/SwitchEvent.jsx
+++ b/examples/components/EventAction/SwitchEvent.jsx
@@ -1,0 +1,35 @@
+export default {
+  type: 'page',
+  title: '开关组件事件',
+  regions: ['body', 'toolbar', 'header'],
+  body: [
+    {
+      type: 'tpl',
+      tpl: 'Switch组件',
+      inline: false,
+      wrapperComponent: 'h2'
+    },
+    {
+      type: 'form',
+      debug: true,
+      body: [
+        {
+          name: "switch",
+          type: "switch",
+          option: "开关事件",
+          onEvent: {
+            change: {
+              actions: [
+                {
+                  actionType: 'toast',
+                  msgType: 'info',
+                  msg: '派发change事件'
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+};

--- a/examples/components/EventAction/TabsEvent.jsx
+++ b/examples/components/EventAction/TabsEvent.jsx
@@ -1,0 +1,95 @@
+export default {
+  type: 'page',
+  title: '标签页组件事件',
+  regions: ['body', 'toolbar', 'header'],
+  body: [
+    {
+      name: 'trigger1',
+      id: 'trigger1',
+      type: 'action',
+      label: '选项卡1',
+      level: 'primary',
+      className: 'mr-3 mb-3',
+      onEvent: {
+        click: {
+          actions: [
+            {
+              actionType: 'changeActiveKey',
+              componentId: 'tabs-change-receiver',
+              activeKey: 0
+            }
+          ]
+        }
+      }
+    },
+    {
+      name: 'trigger2',
+      id: 'trigger2',
+      type: 'action',
+      label: '选项卡2',
+      level: 'primary',
+      className: 'mr-3 mb-3',
+      onEvent: {
+        click: {
+          actions: [
+            {
+              actionType: 'changeActiveKey',
+              componentId: 'tabs-change-receiver',
+              activeKey: 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      name: 'trigger3',
+      id: 'trigger3',
+      type: 'action',
+      label: '选项卡3',
+      level: 'primary',
+      className: 'mr-3 mb-3',
+      onEvent: {
+        click: {
+          actions: [
+            {
+              actionType: 'changeActiveKey',
+              componentId: 'tabs-change-receiver',
+              activeKey: 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      name: 'tabs-change-receiver',
+      id: 'tabs-change-receiver',
+      type: 'tabs',
+      mode: 'line',
+      tabs: [
+        {
+          title: '选项卡1',
+          body: '选项卡内容1'
+        },
+        {
+          title: '选项卡2',
+          body: '选项卡内容2'
+        },
+        {
+          title: '选项卡3',
+          body: '选项卡内容3'
+        }
+      ],
+      onEvent: {
+        change: {
+          actions: [
+            {
+              actionType: 'toast',
+              msgType: 'info',
+              msg: '派发change事件'
+            }
+          ]
+        }
+      }
+    }
+  ]
+};

--- a/examples/components/Example.jsx
+++ b/examples/components/Example.jsx
@@ -75,6 +75,8 @@ import StopEventActionSchema from './EventAction/Stop';
 import DataFlowEventActionSchema from './EventAction/DataFlow';
 import InputEventSchema from './EventAction/InputEvent';
 import DateEventSchema from './EventAction/DateEvent';
+import SwitchEventSchema from './EventAction/SwitchEvent';
+import TabsEventSchema from './EventAction/TabsEvent';
 import UploadEventSchema from './EventAction/UploadEvent';
 import SelectEventActionSchema from './EventAction/SelectEvent';
 import WizardSchema from './Wizard';
@@ -550,6 +552,16 @@ export const examples = [
                 label: '时间类组件',
                 path: 'examples/event/date',
                 component: makeSchemaRenderer(DateEventSchema)
+              },
+              {
+                label: '开关组件',
+                path: 'examples/event/switch',
+                component: makeSchemaRenderer(SwitchEventSchema)
+              },
+              {
+                label: '标签页组件',
+                path: 'examples/event/tabs',
+                component: makeSchemaRenderer(TabsEventSchema)
               }
             ]
           },

--- a/src/renderers/Form/Switch.tsx
+++ b/src/renderers/Form/Switch.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {FormItem, FormControlProps, FormBaseControl} from './Item';
 import Switch from '../../components/Switch';
+import {createObject, autobind} from '../../utils/helper';
 
 /**
  * Switch
@@ -50,6 +51,20 @@ export default class SwitchControl extends React.Component<SwitchProps, any> {
     falseValue: false,
     optionAtLeft: false
   };
+
+  @autobind
+  async handleChange(checked: string | number | boolean) {
+    const {dispatchEvent, data, onChange} = this.props;
+    const rendererEvent = await dispatchEvent('change', createObject(data, {
+      value: checked,
+    }));
+    if (rendererEvent?.prevented) {
+      return;
+    }
+
+    onChange && onChange(checked);
+  }
+
   render() {
     const {
       className,
@@ -80,7 +95,7 @@ export default class SwitchControl extends React.Component<SwitchProps, any> {
           onText={onText}
           offText={offText}
           disabled={disabled}
-          onChange={onChange}
+          onChange={this.handleChange}
         />
 
         {optionAtLeft ? null : (

--- a/src/renderers/Form/Switch.tsx
+++ b/src/renderers/Form/Switch.tsx
@@ -45,6 +45,8 @@ export interface SwitchProps extends FormControlProps {
   falseValue?: any;
 }
 
+export type SwitchRendererEvent = 'change';
+
 export default class SwitchControl extends React.Component<SwitchProps, any> {
   static defaultProps = {
     trueValue: true,

--- a/src/renderers/Tabs.tsx
+++ b/src/renderers/Tabs.tsx
@@ -168,6 +168,9 @@ export interface TabsState {
   prevKey: any;
 }
 
+export type TabsRendererEvent = 'change';
+export type TabsRendererAction = 'changeActiveKey';
+
 export default class Tabs extends React.Component<TabsProps, TabsState> {
   static defaultProps: Partial<TabsProps> = {
     className: '',
@@ -176,16 +179,11 @@ export default class Tabs extends React.Component<TabsProps, TabsState> {
     unmountOnExit: false
   };
 
-  static contextType = ScopedContext;
-
   renderTab?: (tab: TabSchema, props: TabsProps, index: number) => JSX.Element;
   activeKey: any;
 
-  constructor(props: TabsProps, context: IScopedContext) {
+  constructor(props: TabsProps) {
     super(props);
-
-    const scoped = context;
-    scoped.registerComponent(this);
 
     const location = props.location || window.location;
     const tabs = props.tabs;
@@ -322,11 +320,6 @@ export default class Tabs extends React.Component<TabsProps, TabsState> {
         this.handleChange((tab as any).value ?? tab.title, name);
       }
     }
-  }
-
-  componentWillUnmount() {
-    const scoped = this.context as IScopedContext;
-    scoped.unRegisterComponent(this);
   }
 
   resolveTabByKey(key: any) {
@@ -616,7 +609,6 @@ export default class Tabs extends React.Component<TabsProps, TabsState> {
   }
 }
 @Renderer({
-  type: 'tabs',
-  isolateScope: true,
+  type: 'tabs'
 })
 export class TabsRenderer extends Tabs {}


### PR DESCRIPTION
### 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化语料改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [x] 其他改动（开关/选项卡组件事件 & 动作扩充）


### 需求背景和解决方案

https://ku.baidu-int.com/knowledge/HFVrC7hq1Q/pKzJfZczuc/GxsYWwEpj5/FqxJ7_8Hkof-ed
https://ku.baidu-int.com/knowledge/HFVrC7hq1Q/pKzJfZczuc/GxsYWwEpj5/8riCsF-a-98HYl

### 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 英文 |          |
| 中文 |    1. Switch，Tabs组件添加'change'事件 <br> 2. Tabs组件添加'ChangeActiveKey'动作      |

### 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供