### PR TITLE
fixup: 容错请求错误的情况

### DIFF
--- a/src/utils/attachmentAdpator.ts
+++ b/src/utils/attachmentAdpator.ts
@@ -64,7 +64,7 @@ export default function attachmentAdpator(response: any, __: Function) {
         }
       };
     }
-  } else if (response.data.toString() === '[object Blob]') {
+  } else if (response.data && response.data.toString() === '[object Blob]') {
     return new Promise((resolve, reject) => {
       let reader = new FileReader();
       reader.addEventListener('loadend', e => {


### PR DESCRIPTION
当http code不为200的时候，response.data为null，执行`response.data.toString()`会抛错
导致无法正确执行后续的`responseAdaptor`