### PR TITLE
fix: 修复在使用App路由时, Tabs组件页面跳转其他路由出现白屏 #3636

### DIFF
--- a/src/renderers/Tabs.tsx
+++ b/src/renderers/Tabs.tsx
@@ -335,7 +335,7 @@ export default class Tabs extends React.Component<TabsProps, TabsState> {
       localTabs = newLocalTabs;
     }
 
-    if (props.location && props.location.hash !== preProps.location.hash) {
+    if (props.location && preProps.location && props.location.hash !== preProps.location.hash) {
       const hash = props.location.hash.substring(1);
       if (!hash) {
         return;


### PR DESCRIPTION
改动一行代码, 对preProps.location做了空值保护