### PR TITLE
docs: service组件文档示例里将dataProvider错写成func

### DIFF
--- a/docs/zh-CN/components/service.md
+++ b/docs/zh-CN/components/service.md
@@ -495,7 +495,7 @@ wsFetcher(ws, onMessage, onError) {
 ```javascript
 {
     "type": "service",
-    "func": async (data, setData) => {
+    "dataProvider": async (data, setData) => {
       const timer = setInterval(() => {
         setData({date: new Date().toString()})
       }, 1000);


### PR DESCRIPTION
虽然只是一个单词错误, 但在使用的时候会误导用户, 导致只能看源码才能确认