### PR TITLE
fix: combo 组件 Tabs 模式下值丢失的 bug

### DIFF
--- a/src/renderers/Form/Combo.tsx
+++ b/src/renderers/Form/Combo.tsx
@@ -598,7 +598,7 @@ export default class ComboControl extends React.Component<ComboProps> {
 
     if (
       syncDefaultValue === false ||
-      this.subFormDefaultValues.length !== this.subForms.length
+      this.subFormDefaultValues.length !== this.subForms.filter(item => item !== undefined).length
     ) {
       return;
     }


### PR DESCRIPTION
在 Tabs 模式下, `makeFormRef`函数 要在选中对应的 Tab 之后才会执行。
如果新增了多个，先选中之后的 Tab，则 `this.subForms` 会类似  `[FormRenderer, empty, FormRenderer]`。
导致 `this.subFormDefaultValues.length !== this.subForms.length` 为true，之后的 init 没有执行。
而在最后一次初始化的时候，就会有很多 subFormDefaultValue 的 setted 为 `false`，值被重置

相关问题请看 issue 中的视频：https://github.com/baidu/amis/issues/3511