### PR TITLE
fix: 多层Form嵌套情况下Editor无法完整显示问题

### DIFF
--- a/scss/components/form/_editor.scss
+++ b/scss/components/form/_editor.scss
@@ -4,7 +4,8 @@
 
   > .#{$ns}MonacoEditor,
   > .#{$ns}MonacoEditor > .monaco-diff-editor {
-    min-height: px2rem(198px);
+    // 解决多层Form嵌套情况下Editor无法完整显示的问题
+    min-height: inherit;
   }
 
   overflow: visible;


### PR DESCRIPTION
问题情况：
<img width="1815" alt="image" src="https://user-images.githubusercontent.com/36724300/157018222-2725ec38-660b-43ce-9bba-36e3e7bdb1bc.png">
