### PR TITLE
feat: 支持fontawesome v5/v6 等版本 & 添加icon示例

### DIFF
--- a/docs/zh-CN/components/icon.md
+++ b/docs/zh-CN/components/icon.md
@@ -51,10 +51,158 @@ icon 还可以使用 URL 地址，可以从 [iconfont](https://www.iconfont.cn/)
 }
 ```
 
+## 使用 v5/v6 版本的 fontawesome
+
+`icon`默认支持[fontawesome v4](https://fontawesome.com/v4/icons/)，如果想要支持 v5 以及 v6 版本的 fontawesome 请设置`vendor`为空字符串。
+
+### fontawesome v5 版本
+
+v5 用 far/fas 等表示前缀，可参考官网[示例](https://fontawesome.com/v5/search?m=free)
+
+```schema
+{
+    "type":"page",
+    "body":[
+        {
+            "type":"icon",
+            "icon":"far fa-address-book",
+            "vendor":""
+        },
+        {
+            "type":"icon",
+            "icon":"fas fa-address-book",
+            "vendor":""
+        },
+        {
+            "type":"icon",
+            "icon":"far fa-address-book",
+            "vendor":"",
+            "className": "text-info text-xl"
+        },
+        {
+            "type":"icon",
+            "icon":"fas fa-address-book",
+            "vendor":"",
+            "className": "text-info text-xl"
+        },
+        {
+          type: "divider",
+        },
+        {
+            "type":"icon",
+            "icon":"far fa-bell",
+            "vendor":""
+        },
+        {
+            "type":"icon",
+            "icon":"fas fa-bell",
+            "vendor":""
+        },
+        {
+            "type":"icon",
+            "icon":"far fa-bell",
+            "vendor":"",
+            "className": "text-info text-xl"
+        },
+        {
+            "type":"icon",
+            "icon":"fas fa-bell",
+            "vendor":"",
+            "className": "text-info text-xl"
+        },
+        {
+          type: "divider",
+        },
+        {
+            "type":"icon",
+            "icon":"far fa-plus",
+            "vendor":""
+        },
+        {
+            "type":"icon",
+            "icon":"fas fa-plus",
+            "vendor":""
+        },
+        {
+            "type":"icon",
+            "icon":"far fa-plus",
+            "vendor":"",
+            "className": "text-info text-xl"
+        },
+        {
+            "type":"icon",
+            "icon":"fas fa-plus",
+            "vendor":"",
+            "className": "text-info text-xl"
+        },
+        {
+          type: "divider",
+        },
+        {
+            "type":"icon",
+            "icon":"far fa-question-circle",
+            "vendor":""
+        },
+        {
+            "type":"icon",
+            "icon":"fas fa-question-circle",
+            "vendor":""
+        },
+        {
+            "type":"icon",
+            "icon":"far fa-question-circle",
+            "vendor":"",
+            "className": "text-info text-xl"
+        },
+        {
+            "type":"icon",
+            "icon":"fas fa-question-circle",
+            "vendor":"",
+            "className": "text-info text-xl"
+        }
+    ]
+}
+```
+
+### fontawesome v6 版本
+
+v6 用 fa-regular / fa-solid 等表示前缀，可参考官网[示例](https://fontawesome.com/search?m=free)
+
+```schema
+{
+    "type":"page",
+    "body":[
+        {
+            "type":"icon",
+            "icon":"fa-regular fa-address-book",
+            "vendor":""
+        },
+        {
+            "type":"icon",
+            "icon":"fa-solid fa-address-book",
+            "vendor":""
+        },
+        {
+            "type":"icon",
+            "icon":"fa-regular fa-address-book",
+            "vendor":"",
+            "className": "text-info text-xl"
+        },
+        {
+            "type":"icon",
+            "icon":"fa-solid fa-address-book",
+            "vendor":"",
+            "className": "text-info text-xl"
+        }
+    ]
+}
+```
+
 ## 属性表
 
-| 属性名    | 类型     | 默认值 | 说明                                    |
-| --------- | -------- | ------ | --------------------------------------- |
-| type      | `string` | `icon` | 指定组件类型                            |
-| className | `string` |        | 外层 CSS 类名                           |
-| icon      | `string` |        | icon 名，支持 fontawesome v4 或使用 url |
+| 属性名    | 类型     | 默认值 | 说明                                                                                                                      |
+| --------- | -------- | ------ | ------------------------------------------------------------------------------------------------------------------------- |
+| type      | `string` | `icon` | 指定组件类型                                                                                                              |
+| className | `string` |        | 外层 CSS 类名                                                                                                             |
+| icon      | `string` |        | icon 名称，支持 [fontawesome v4](https://fontawesome.com/v4/icons/) 或使用 url                                            |
+| vendor    | `string` |        | icon 类型，默认为`fa`, 表示 fontawesome v4。也支持 iconfont, 如果是 fontawesome v5 以上版本或者其他框架可以设置为空字符串 |

--- a/src/renderers/Icon.tsx
+++ b/src/renderers/Icon.tsx
@@ -41,13 +41,12 @@ export class Icon extends React.Component<IconProps, object> {
     if (vendor === 'iconfont') {
       iconPrefix = `iconfont icon-${icon}`;
     } else if (vendor === 'fa') {
-      //默认是fontawesome v4，兼容之前配置，如果是设置ventor为空，则不拼接
+      //默认是fontawesome v4，兼容之前配置
       iconPrefix = `${vendor} ${vendor}-${icon}`;
     } else {
       // 如果vendor为空，则不设置前缀,这样可以支持fontawesome v5、fontawesome v6或者其他框架
       iconPrefix = `${icon}`;
     }
-    console.log('iconPrefix', iconPrefix);
     return isURLIcon ? (
       <img className={cx('Icon')} src={icon} />
     ) : (

--- a/src/renderers/Icon.tsx
+++ b/src/renderers/Icon.tsx
@@ -15,7 +15,7 @@ export interface IconSchema extends BaseSchema {
    */
   icon: string;
 
-  vendor?: 'iconfont' | 'fa';
+  vendor?: 'iconfont' | 'fa' | '';
 
   /**
    * 角标
@@ -37,17 +37,21 @@ export class Icon extends React.Component<IconProps, object> {
     const {icon, vendor, classnames: cx, className} = this.props;
 
     const isURLIcon = icon?.indexOf('.') !== -1;
+    let iconPrefix = '';
+    if (vendor === 'iconfont') {
+      iconPrefix = `iconfont icon-${icon}`;
+    } else if (vendor === 'fa') {
+      //默认是fontawesome v4，兼容之前配置，如果是设置ventor为空，则不拼接
+      iconPrefix = `${vendor} ${vendor}-${icon}`;
+    } else {
+      // 如果vendor为空，则不设置前缀,这样可以支持fontawesome v5、fontawesome v6或者其他框架
+      iconPrefix = `${icon}`;
+    }
+    console.log('iconPrefix', iconPrefix);
     return isURLIcon ? (
       <img className={cx('Icon')} src={icon} />
     ) : (
-      <i
-        className={cx(
-          vendor === 'iconfont'
-            ? `iconfont icon-${icon}`
-            : `${vendor} ${vendor}-${icon}`,
-          className
-        )}
-      />
+      <i className={cx(iconPrefix, className)} />
     );
   }
 }


### PR DESCRIPTION
由于升级fontawesome到v5/v6等版本后, 无法正常展示, 排查发现是由于字符串拼接的问题，修复后效果如下

<img width="1076" alt="image" src="https://user-images.githubusercontent.com/39587710/160161656-1757a941-22a8-4643-8002-a10bb06ef256.png">

示例amis代码：

```schema
{
    "type":"page",
    "body":[
        {
            "type":"icon",
            "icon":"far fa-address-book",
            "vendor":""
        },
     ]
}
```