### PR TITLE
feat: 级联多选支持仅子节点

### DIFF
--- a/docs/zh-CN/components/form/nestedselect.md
+++ b/docs/zh-CN/components/form/nestedselect.md
@@ -173,6 +173,52 @@ order: 31
 }
 ```
 
+在多选时，也可以通过 `onlyLeaf` 来设置只允许选择叶子节点，即便分支节点有 `value` 也不会有选中动作。
+
+```schema: scope="body"
+{
+  "type": "form",
+  "api": "/api/mock2/form/saveForm",
+  "body": [
+    {
+      "type": "nested-select",
+      "name": "nestedSelect",
+      "label": "级联选择器",
+      "onlyLeaf": true,
+      "multiple": true,
+      "options": [
+        {
+          "label": "A",
+          "value": "a"
+        },
+        {
+          "label": "B",
+          "value": "b",
+          "children": [
+            {
+              "label": "B-1",
+              "value": "b-1"
+            },
+            {
+              "label": "B-2",
+              "value": "b-2"
+            },
+            {
+              "label": "B-3",
+              "value": "b-3"
+            }
+          ]
+        },
+        {
+          "label": "C",
+          "value": "c"
+        }
+      ]
+    }
+  ]
+}
+```
+
 ## 选中父节点是否自动选中子节点
 
 默认选中父节点会自动选中子节点，可以设置`"cascade": true`，不自动选中子节点
@@ -567,7 +613,8 @@ order: 31
 | searchPromptText  | `string`                                  | `"输入内容进行检索"` | 搜索框占位文本                                                                              |
 | noResultsText     | `string`                                  | `"未找到任何结果"`   | 无结果时的文本                                                                              |
 | multiple          | `boolean`                                 | `false`              | 可否多选                                                                                    |
-| hideNodePathLabel | `boolean`                                 | `false`              | 是否隐藏选择框中已选择节点的路径 label 信息                                                 |
+| hideNodePathLabel | `boolean`                                 | `false`              | 是否隐藏选择框中已选择节点的路径 label 信息    
+| onlyLeaf | `boolean`                                 | `false`              | 只允许选择叶子节点                                                 |
 
 ## 事件表
 

--- a/src/renderers/Form/NestedSelect.tsx
+++ b/src/renderers/Form/NestedSelect.tsx
@@ -62,7 +62,7 @@ export interface NestedSelectControlSchema extends FormOptionsControl {
   onlyChildren?: boolean;
 
   /**
-   * 单选时只允许选择叶子节点
+   * 只允许选择叶子节点
    */
   onlyLeaf?: boolean;
 
@@ -300,11 +300,20 @@ export default class NestedSelectControl extends React.Component<
       withChildren,
       onlyChildren,
       cascade,
-      options
+      options,
+      onlyLeaf
     } = this.props;
     const {stack} = this.state;
 
     let valueField = this.props.valueField || 'value';
+    
+    if (
+      onlyLeaf
+      && !Array.isArray(option)
+      && option.children
+    ) {
+      return;
+    }
 
     if (
       !Array.isArray(option) &&


### PR DESCRIPTION
### 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [X] 站点、文档改进
- [X] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [X] 功能增强
- [ ] 国际化语料改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 其他改动（是关于什么的改动？）


### 需求背景和解决方案

<!-- 附上设计文档和自测CASE文档的链接 -->

### 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 英文 |          |
| 中文 |       增加级联多选仅允许选择子节点及文档说明   |

### 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供