### PR TITLE
修复邮箱地址重复填写的问题

### DIFF
--- a/src/actions/EmailAction.ts
+++ b/src/actions/EmailAction.ts
@@ -25,7 +25,7 @@ export class EmailAction implements Action {
   ) {
     const mailTo = filter(action.to, action.args);
     const mailInfo = mapValues(
-      pick(action, 'to', 'cc', 'bcc', 'subject', 'body'),
+      pick(action, 'cc', 'bcc', 'subject', 'body'),
       val => filter(val, action.args)
     );
     const mailStr = qs.stringify(mailInfo);


### PR DESCRIPTION
修复前：

`mailto:amis@baidu.com?to=amis%40baidu.com&cc=&bcc=&subject=&body=`

修复后：

`mailto:amis@baidu.com?cc=&bcc=&subject=&body=`