### PR TITLE
unRegisterComponent 无法被调用到

### DIFF
--- a/src/renderers/Form/wrapControl.tsx
+++ b/src/renderers/Form/wrapControl.tsx
@@ -401,10 +401,6 @@ export function wrapControl<
             this.control = control;
             const scoped = this.context as IScopedContext;
 
-            if (!this.control) {
-              return;
-            }
-
             if (control) {
               scoped.registerComponent(this.control);
             } else {


### PR DESCRIPTION
unRegisterComponent 无效，从而导致getComponentById返回错误的引用 #4004 