### PR TITLE
feat: 评分组件 texts、colors 过滤非数字key， 如：$$id

### DIFF
--- a/src/components/Rating.tsx
+++ b/src/components/Rating.tsx
@@ -138,9 +138,12 @@ export class Rating extends React.Component<RatingProps, any> {
       const showKey = keys.filter(item => Number(item) < value).length;
 
       const showColor = keys[showKey] !== undefined && colors[keys[showKey]];
+      
+      // 取最大 key 的颜色，避免如下情况：colors 只设置了 1-4，value 为 5，导致取不到颜色而无法显示
+      const lastColor = keys.length && colors[keys[keys.length - 1]];
 
       this.setState({
-        showColor: showColor || ''
+        showColor: showColor || lastColor || ''
       });
     } else if (colors && typeof colors === 'string') {
       this.setState({

--- a/src/components/Rating.tsx
+++ b/src/components/Rating.tsx
@@ -9,6 +9,9 @@ import cx from 'classnames';
 import {ClassNamesFn, themeable} from '../theme';
 
 import {isObject} from '../utils/helper';
+import {
+  validations
+} from '../utils/validations';
 import {Icon} from './icons';
 
 export type textPositionType = 'left' | 'right';
@@ -113,7 +116,7 @@ export class Rating extends React.Component<RatingProps, any> {
 
   sortKeys(map: {[propName: number]: string}) {
     // 需验证 key 是否是数字，需要过滤掉非数字key，如 $$id
-    return Object.keys(map).filter(item => !isNaN(Number(item))).sort(
+    return Object.keys(map).filter(item => validations.isNumeric({}, item)).sort(
       (a: number | string, b: number | string) => Number(a) - Number(b)
     );
   }

--- a/src/components/Rating.tsx
+++ b/src/components/Rating.tsx
@@ -112,7 +112,8 @@ export class Rating extends React.Component<RatingProps, any> {
   }
 
   sortKeys(map: {[propName: number]: string}) {
-    return Object.keys(map).sort(
+    // 需验证 key 是否是数字，需要过滤掉非数字key，如 $$id
+    return Object.keys(map).filter(item => !isNaN(Number(item))).sort(
       (a: number | string, b: number | string) => Number(a) - Number(b)
     );
   }
@@ -137,10 +138,10 @@ export class Rating extends React.Component<RatingProps, any> {
       const showKey = keys.filter(item => Number(item) < value).length;
 
       const showColor = keys[showKey] !== undefined && colors[keys[showKey]];
-      showColor &&
-        this.setState({
-          showColor
-        });
+
+      this.setState({
+        showColor: showColor || ''
+      });
     } else if (colors && typeof colors === 'string') {
       this.setState({
         showColor: colors
@@ -153,10 +154,10 @@ export class Rating extends React.Component<RatingProps, any> {
       const showText =
         keys[showKey] !== undefined &&
         texts[keys[showKey] as keyof typeof texts];
-      showText &&
-        this.setState({
-          showText
-        });
+
+      this.setState({
+        showText: showText || ''
+      });
     }
   }
 


### PR DESCRIPTION
<img width="546" alt="image" src="https://user-images.githubusercontent.com/42135895/163547963-9981e73f-cd00-4c9f-aa1a-3e20daffef77.png">
editor 中该字段会有影响，所以需要过滤下