### PR TITLE
fix: 单选框/复选框/Options动作无效修复&注册Scoped

### DIFF
--- a/src/renderers/Form/Checkbox.tsx
+++ b/src/renderers/Form/Checkbox.tsx
@@ -5,6 +5,7 @@ import Checkbox from '../../components/Checkbox';
 import {withBadge, BadgeSchema} from '../../components/Badge';
 import {autobind, createObject} from '../../utils/helper';
 import {Action} from '../../types';
+import {ScopedContext, IScopedContext} from '../../Scoped';
 
 /**
  * Checkbox 勾选框。
@@ -55,6 +56,7 @@ export default class CheckboxControl extends React.Component<
     trueValue: true,
     falseValue: false
   };
+  static contextType = ScopedContext;
 
   doAction(action: Action, data: object, throwErrors: boolean) {
     const {resetValue, onChange} = this.props;
@@ -124,4 +126,19 @@ export default class CheckboxControl extends React.Component<
 })
 // @ts-ignore
 @withBadge
-export class CheckboxControlRenderer extends CheckboxControl {}
+export class CheckboxControlRenderer extends CheckboxControl {
+  static contextType = ScopedContext;
+
+  constructor(props: CheckboxProps, context: IScopedContext) {
+    super(props);
+
+    const scoped = context;
+    scoped.registerComponent(this);
+  }
+
+  componentWillUnmount() {
+    super.componentWillUnmount?.();
+    const scoped = this.context as IScopedContext;
+    scoped.unRegisterComponent(this);
+  }
+}

--- a/src/renderers/Form/Checkboxes.tsx
+++ b/src/renderers/Form/Checkboxes.tsx
@@ -12,6 +12,11 @@ import {Icon} from '../../components/icons';
 import {Api} from '../../types';
 import {autobind, hasAbility} from '../../utils/helper';
 import {columnsSplit} from '../../utils/columnsSplit';
+import Scoped, {
+  ScopedContext,
+  IScopedContext,
+  ScopedComponentType
+} from '../../Scoped';
 
 /**
  * 复选框
@@ -343,4 +348,19 @@ export default class CheckboxesControl extends React.Component<
   type: 'checkboxes',
   sizeMutable: false
 })
-export class CheckboxesControlRenderer extends CheckboxesControl {}
+export class CheckboxesControlRenderer extends CheckboxesControl {
+  static contextType = ScopedContext;
+
+  constructor(props: CheckboxesProps, context: IScopedContext) {
+    super(props);
+
+    const scoped = context;
+    scoped.registerComponent(this);
+  }
+
+  componentWillUnmount() {
+    super.componentWillUnmount?.();
+    const scoped = this.context as IScopedContext;
+    scoped.unRegisterComponent(this);
+  }
+}

--- a/src/renderers/Form/Options.tsx
+++ b/src/renderers/Form/Options.tsx
@@ -26,6 +26,7 @@ import {
   FormBaseControl
 } from './Item';
 import {IFormItemStore} from '../../store/formItem';
+import {ScopedContext, IScopedContext} from '../../Scoped';
 
 export type OptionsControlComponent = React.ComponentType<FormControlProps>;
 
@@ -258,6 +259,7 @@ export function registerOptionsControl(config: OptionsConfig) {
 
   class FormOptionsItem extends React.Component<OptionsProps, any> {
     static displayName = `OptionsControl(${config.type})`;
+    static contextType = ScopedContext;
     static defaultProps = {
       delimiter: ',',
       labelField: 'label',
@@ -280,8 +282,11 @@ export function registerOptionsControl(config: OptionsConfig) {
     input: any;
     mounted = false;
 
-    constructor(props: OptionsProps) {
+    constructor(props: OptionsProps, context: IScopedContext) {
       super(props);
+
+      const scoped = context;
+      scoped.registerComponent(this);
 
       const {
         initFetch,
@@ -450,6 +455,9 @@ export function registerOptionsControl(config: OptionsConfig) {
     }
 
     componentWillUnmount() {
+      super.componentWillUnmount?.();
+      const scoped = this.context as IScopedContext;
+      scoped.unRegisterComponent(this);
       this.props.removeHook?.(this.reload, 'init');
       this.toDispose.forEach(fn => fn());
       this.toDispose = [];


### PR DESCRIPTION
### 这个变动的性质是？
 
- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化语料改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 其他改动（是关于什么的改动？）
 
 
### 需求背景和解决方案

 
### 更新日志
 
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->
 
| 语言    | 更新描述 |
| ------- | -------- |
| 英文 |          |
| 中文 |    单选框/复选框/Options动作无效修复&注册Scoped   |
 
### 请求合并前的自查清单
 
⚠️ 请自检并全部**勾选全部选项**。⚠️
 
- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供