### PR TITLE
fix #3967: CRUD导出csv按钮文字size不统一问题

### DIFF
--- a/src/renderers/CRUD.tsx
+++ b/src/renderers/CRUD.tsx
@@ -1808,7 +1808,6 @@ export default class CRUD extends React.Component<CRUDProps, any> {
             data
           })
         }
-        size="sm"
       >
         {toolbar.label || __('CRUD.exportCSV')}
       </Button>


### PR DESCRIPTION
<img width="247" alt="image" src="https://user-images.githubusercontent.com/36724300/164971077-f7853e9c-924b-4c3e-9efe-b41b767d4fa6.png">
问题截图