### PR TITLE
fix #4085: 修复select onEdit/onDelete外部无法获取option

### DIFF
--- a/src/renderers/Form/Select.tsx
+++ b/src/renderers/Form/Select.tsx
@@ -198,18 +198,14 @@ export default class SelectControl extends React.Component<SelectProps, any> {
   async dispatchEvent(eventName: SelectRendererEvent, eventData: any = {}) {
     const event = 'on' + eventName.charAt(0).toUpperCase() + eventName.slice(1);
     const {dispatchEvent, options, data} = this.props;
-    // 抛出事件数据
-    let dispatchData = {
-      value: ['onEdit', 'onDelete'].includes(event)
-        ? eventData
-        : eventData && eventData.value
-    };
     // 触发渲染器事件
     const rendererEvent = await dispatchEvent(
       eventName,
       createObject(data, {
         options,
-        ...dispatchData
+        value: ['onEdit', 'onDelete'].includes(event)
+          ? eventData
+          : eventData && eventData.value
       })
     );
     if (rendererEvent?.prevented) {

--- a/src/renderers/Form/Select.tsx
+++ b/src/renderers/Form/Select.tsx
@@ -198,17 +198,24 @@ export default class SelectControl extends React.Component<SelectProps, any> {
   async dispatchEvent(eventName: SelectRendererEvent, eventData: any = {}) {
     const event = 'on' + eventName.charAt(0).toUpperCase() + eventName.slice(1);
     const {dispatchEvent, options, data} = this.props;
+    // 抛出事件数据
+    let dispatchData = {
+      value: ['onEdit', 'onDelete'].includes(event)
+        ? eventData
+        : eventData && eventData.value
+    };
     // 触发渲染器事件
     const rendererEvent = await dispatchEvent(
       eventName,
       createObject(data, {
         options,
-        ...eventData
+        ...dispatchData
       })
     );
     if (rendererEvent?.prevented) {
       return;
     }
+    // 触发外部方法
     this.props[event](eventData);
   }
 
@@ -405,12 +412,12 @@ export default class SelectControl extends React.Component<SelectProps, any> {
             creatable={creatable}
             searchable={searchable || !!autoComplete}
             onChange={this.changeValue}
-            onBlur={(e: any) => this.dispatchEvent('blur', {value: e.value})}
-            onFocus={(e: any) => this.dispatchEvent('focus', {value: e.value})}
+            onBlur={(e: any) => this.dispatchEvent('blur', e)}
+            onFocus={(e: any) => this.dispatchEvent('focus', e)}
             onAdd={() => this.dispatchEvent('add')}
-            onEdit={(item: any) => this.dispatchEvent('edit', {value: item})}
+            onEdit={(item: any) => this.dispatchEvent('edit', item)}
             onDelete={(item: any) =>
-              this.dispatchEvent('delete', {value: item})
+              this.dispatchEvent('delete', item)
             }
             loading={loading}
             noResultsText={noResultsText}


### PR DESCRIPTION
### 这个变动的性质是？
 
- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化语料改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 其他改动（是关于什么的改动？）
 
 
### 需求背景和解决方案

 
### 更新日志
 
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->
 
| 语言    | 更新描述 |
| ------- | -------- |
| 英文 |          |
| 中文 |  fix: 修复select onEdit/onDelete外部无法获取option   |
 
### 请求合并前的自查清单
 
⚠️ 请自检并全部**勾选全部选项**。⚠️
 
- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供