### PR TITLE
feat: 调整Tabs、Carousel、InputTree组件触发动作索引值，从1开始递增

### DIFF
--- a/docs/zh-CN/components/form/input-tree.md
+++ b/docs/zh-CN/components/form/input-tree.md
@@ -545,9 +545,9 @@ order: 59
 }
 ```
 
-如果层级较多，也可以配置`unfoldedLevel`指定展开的层级数。
+如果层级较多，也可以配置`unfoldedLevel`指定展开的层级数，默认展开第 1 层
 
-下例中设置`"unfoldedLevel": 1`，默认展开第 1 层
+下例中设置`"unfoldedLevel": 2`，表示展开第 2 层
 
 ```schema: scope="body"
 {
@@ -560,7 +560,7 @@ order: 59
       "name": "tree1",
       "label": "默认不自动带上子节点的值",
       "initiallyOpen": false,
-      "unfoldedLevel": 1,
+      "unfoldedLevel": 2,
       "options": [
         {
           "label": "A",
@@ -909,7 +909,7 @@ true        false        true       [{label: 'A/B/C', value: 'a/b/c'},{label: 'A
 | showRadio              | `boolean`                                    | `false`          | 是否显示单选按钮，`multiple` 为 `false` 是有效。                                                                                     |
 | showOutline            | `boolean`                                    | `false`          | 是否显示树层级展开线                                                                                                                 |
 | initiallyOpen          | `boolean`                                    | `true`           | 设置是否默认展开所有层级。                                                                                                           |
-| unfoldedLevel          | `number`                                     | `0`              | 设置默认展开的级数，只有`initiallyOpen`不是`true`时生效。                                                                            |
+| unfoldedLevel          | `number`                                     | `1`              | 设置默认展开的级数，只有`initiallyOpen`不是`true`时生效。                                                                            |
 | autoCheckChildren      | `boolean`                                    | `true`           | 当选中父节点时级联选择子节点。                                                                                                       |
 | cascade                | `boolean`                                    | `false`          | autoCheckChildren 为 true 时生效；默认行为：子节点禁用，值只包含父节点值；设置为 true 时，子节点可反选，值包含父子节点值。           |
 | withChildren           | `boolean`                                    | `false`          | cascade 为 false 时生效，选中父节点时，值里面将包含父子节点的值，否则只会保留父节点的值。                                            |

--- a/examples/components/EventAction/CarouselEvent.jsx
+++ b/examples/components/EventAction/CarouselEvent.jsx
@@ -3,7 +3,7 @@ export default {
   title: '轮播图组件事件',
   regions: ['body', 'toolbar', 'header'],
   data: {
-    index: 2
+    index: 3
   },
   body: [
     {

--- a/examples/components/EventAction/InputTreeEvent.jsx
+++ b/examples/components/EventAction/InputTreeEvent.jsx
@@ -46,7 +46,7 @@ export default {
         {
           name: 'input-tree-expand',
           type: 'action',
-          label: 'expand触发器（openLevel: 1）',
+          label: 'expand触发器（openLevel: 2）',
           level: 'primary',
           className: 'mr-3',
           onEvent: {
@@ -57,7 +57,7 @@ export default {
                   componentId: 'input-tree-action',
                   description: '点击展开',
                   args: {
-                    openLevel: 1
+                    openLevel: 2
                   }
                 }
               ]
@@ -91,7 +91,7 @@ export default {
           removable: true,
           editable: true,
           initiallyOpen: false,
-          unfoldedLevel: 0,
+          unfoldedLevel: 1,
           deferApi: '/api/mock2/form/deferOptions?label=${label}&waitSeconds=2',
           options: [
             {

--- a/examples/components/EventAction/TabsEvent.jsx
+++ b/examples/components/EventAction/TabsEvent.jsx
@@ -17,7 +17,7 @@ export default {
               actionType: 'changeActiveKey',
               componentId: 'tabs-change-receiver',
               args: {
-                activeKey: 0
+                activeKey: 1
               }
             }
           ]
@@ -38,7 +38,7 @@ export default {
               actionType: 'changeActiveKey',
               componentId: 'tabs-change-receiver',
               args: {
-                activeKey: 1
+                activeKey: 2
               }
             }
           ]
@@ -59,7 +59,7 @@ export default {
               actionType: 'changeActiveKey',
               componentId: 'tabs-change-receiver',
               args: {
-                activeKey: 2
+                activeKey: 3
               }
             }
           ]
@@ -92,7 +92,7 @@ export default {
               actionType: 'toast',
               args: {
                 msgType: 'info',
-                msg: '更新至${event.data.value}'
+                msg: '切换至选项卡${event.data.value}'
               }
             }
           ]

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -146,7 +146,7 @@ export class TreeSelector extends React.Component<
     showIcon: true,
     showOutline: false,
     initiallyOpen: true,
-    unfoldedLevel: 0,
+    unfoldedLevel: 1,
     showRadio: false,
     multiple: false,
     disabled: false,
@@ -260,10 +260,11 @@ export class TreeSelector extends React.Component<
     onExpandTree?.(nodePathArr);
   }
 
-  syncUnFolded(props: TreeSelectorProps, unfoldedLevel?: Number) {
+  syncUnFolded(props: TreeSelectorProps, unfoldedLevel?: number) {
     // 传入默认展开层级需要重新初始化unfolded
     let initFoldedLevel = typeof unfoldedLevel !== 'undefined';
-    let expandLevel = initFoldedLevel ? unfoldedLevel : props.unfoldedLevel;
+    let expandLevel = Number(initFoldedLevel ? unfoldedLevel : props.unfoldedLevel) - 1;
+
     // 初始化树节点的展开状态
     let unfolded = this.unfolded;
     const {foldedField, unfoldedField} = this.props;

--- a/src/renderers/Carousel.tsx
+++ b/src/renderers/Carousel.tsx
@@ -199,7 +199,7 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
     if (!!~['next', 'prev'].indexOf(actionType)) {
       this.autoSlide(actionType);
     } else if (actionType === 'goto-image') {
-      this.changeSlide((args as any).activeIndex);
+      this.changeSlide((args as any)?.activeIndex - 1);
     }
   }
 
@@ -258,7 +258,7 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
     const rendererEvent = await dispatchEvent(
       'change',
       createObject(data, {
-        activeIndex: current,
+        activeIndex: current + 1,
         prevIndex
       })
     );

--- a/src/renderers/Form/InputTree.tsx
+++ b/src/renderers/Form/InputTree.tsx
@@ -125,9 +125,9 @@ export default class TreeControl extends React.Component<TreeProps> {
     } else if (actionType === 'reset') {
       onChange?.(resetValue ?? '');
     } else if (action.actionType === 'expand') {
-      this.treeRef.syncUnFolded(this.props, action.args.openLevel);
+      this.treeRef.syncUnFolded(this.props, action.args?.openLevel);
     } else if (action.actionType === 'collapse') {
-      this.treeRef.syncUnFolded(this.props, 0);
+      this.treeRef.syncUnFolded(this.props, 1);
     }
   }
 

--- a/src/renderers/Tabs.tsx
+++ b/src/renderers/Tabs.tsx
@@ -568,6 +568,7 @@ export default class Tabs extends React.Component<TabsProps, TabsState> {
   @autobind
   async handleSelect(key: any) {
     const {dispatchEvent, data, env, onSelect, id} = this.props;
+    const {localTabs} = this.state;
 
     env.tracker?.({
       eventType: 'tabChange',
@@ -576,11 +577,13 @@ export default class Tabs extends React.Component<TabsProps, TabsState> {
         key
       }
     });
+    // 获取激活元素项
+    const tab = localTabs?.find((item, index) => key === (item.hash ? item.hash : index));
 
     const rendererEvent = await dispatchEvent(
       'change',
       createObject(data, {
-        value: key
+        value: tab?.hash ? tab?.hash : key + 1
       })
     );
     if (rendererEvent?.prevented) {
@@ -612,7 +615,11 @@ export default class Tabs extends React.Component<TabsProps, TabsState> {
    */
   doAction(action: Action, args: any) {
     const actionType = action?.actionType as string;
-    const activeKey = args?.activeKey as number;
+    let activeKey = args?.activeKey as number;
+    // 处理非用户自定义key
+    if (typeof args?.activeKey !== 'string') {
+      activeKey--;
+    }
     if (actionType === 'changeActiveKey') {
       this.handleSelect(activeKey);
     }


### PR DESCRIPTION
### 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化语料改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 其他改动（是关于什么的改动？）


### 需求背景和解决方案
https://console.cloud.baidu-int.com/devops/icafe/issue/amis-saas-4174/show?source=drawer-header

| 语言    | 更新描述 |
| ------- | -------- |
| 英文 |          |
| 中文 |      标签组件："changeActiveKey'"动作，标签项索引默认值从1开始，自定义tab hash不受影响 <br> 轮播图组件："goto-image"动作，索引默认从1开始 <br>树组件框，"expand"动作，展开层级默认从1开始    |

### 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供