### PR TITLE
fix: 修复Popover弹框显示异常问题

### DIFF
--- a/src/renderers/PopOver.tsx
+++ b/src/renderers/PopOver.tsx
@@ -214,7 +214,6 @@ export const HocPopOver =
           (popOver.mode === 'dialog' || popOver.mode === 'drawer')
         ) {
           schema = {
-            type: popOver.mode,
             actions: [
               {
                 label: __('Dialog.close'),
@@ -222,7 +221,8 @@ export const HocPopOver =
                 actionType: 'cancel'
               }
             ],
-            ...popOver
+            ...popOver,
+            type: popOver.mode
           };
         } else if (typeof popOver === 'string') {
           schema = {


### PR DESCRIPTION
类似下面这种结构，mode应该覆盖掉type属性才是正常弹框
```json
{
          "name": "engine",
          "label": "渲染引擎",
          "type": "text",
          "popOver": {
            "mode": "dialog",
            "type": "form",
            "title": "查看详情",
            "body": [
              {
                "type": "tpl",
                "tpl": "内容详情",
                "inline": false
              }
            ]
          }
        }
```