### PR TITLE
feat: 事件动作类型增强, 能够根据actionType自动类型提示和校验, 同时修复AjaxAction里会将adaptor/req…

### DIFF
--- a/src/actions/AjaxAction.ts
+++ b/src/actions/AjaxAction.ts
@@ -1,24 +1,25 @@
 import omit from 'lodash/omit';
-import {Api} from '../types';
-import {normalizeApiResponseData} from '../utils/api';
-import {ServerError} from '../utils/errors';
-import {createObject, isEmpty} from '../utils/helper';
-import {RendererEvent} from '../utils/renderer-event';
+import { Api } from '../types';
+import { normalizeApiResponseData } from '../utils/api';
+import { ServerError } from '../utils/errors';
+import { createObject, isEmpty } from '../utils/helper';
+import { RendererEvent } from '../utils/renderer-event';
 import {
   RendererAction,
-  ListenerAction,
+  IListenerAction,
   ListenerContext,
   registerAction
 } from './Action';
 
-export interface IAjaxAction extends ListenerAction {
+export interface IAjaxAction extends IListenerAction {
+  action: 'ajax';
   args: {
     api: Api;
-    messages: {
+    messages?: {
       success: string;
       failed: string;
     };
-    options: object;
+    options?: Record<string, any>
     [propName: string]: any;
   };
 }
@@ -56,8 +57,8 @@ export class AjaxAction implements RendererAction {
             event.data,
             action.outputVar
               ? {
-                  [`${action.outputVar}`]: responseData
-                }
+                [`${action.outputVar}`]: responseData
+              }
               : responseData
           )
         );
@@ -76,9 +77,9 @@ export class AjaxAction implements RendererAction {
             msg,
             result.msgTimeout !== undefined
               ? {
-                  closeButton: true,
-                  timeout: result.msgTimeout
-                }
+                closeButton: true,
+                timeout: result.msgTimeout
+              }
               : undefined
           );
       }
@@ -92,9 +93,9 @@ export class AjaxAction implements RendererAction {
           e.message,
           result.msgTimeout !== undefined
             ? {
-                closeButton: true,
-                timeout: result.msgTimeout
-              }
+              closeButton: true,
+              timeout: result.msgTimeout
+            }
             : undefined
         );
       } else {

--- a/src/actions/BreakAction.ts
+++ b/src/actions/BreakAction.ts
@@ -1,11 +1,15 @@
-import {RendererEvent} from '../utils/renderer-event';
+import { RendererEvent } from '../utils/renderer-event';
 import {
   RendererAction,
-  ListenerAction,
   ListenerContext,
   LoopStatus,
-  registerAction
+  registerAction,
+  ILogicAction
 } from './Action';
+
+export interface IBreakAction extends ILogicAction {
+  actionType: 'break';
+}
 
 /**
  * breach
@@ -16,7 +20,7 @@ import {
  */
 export class BreakAction implements RendererAction {
   async run(
-    action: ListenerAction,
+    action: IBreakAction,
     renderer: ListenerContext,
     event: RendererEvent<any>
   ) {

--- a/src/actions/BroadcastAction.ts
+++ b/src/actions/BroadcastAction.ts
@@ -1,14 +1,15 @@
-import {RendererProps} from '../factory';
-import {createObject} from '../utils/helper';
-import {RendererEvent, dispatchEvent} from '../utils/renderer-event';
+import { RendererProps } from '../factory';
+import { createObject } from '../utils/helper';
+import { RendererEvent, dispatchEvent } from '../utils/renderer-event';
 import {
   RendererAction,
-  ListenerAction,
+  IListenerAction,
   ListenerContext,
   registerAction
 } from './Action';
 
-export interface IBroadcastAction extends ListenerAction {
+export interface IBroadcastAction extends IListenerAction {
+  actionType: 'broadcast';
   eventName: string; // 事件名称，actionType: broadcast
 }
 

--- a/src/actions/CmptAction.ts
+++ b/src/actions/CmptAction.ts
@@ -1,15 +1,16 @@
-import {RendererEvent} from '../utils/renderer-event';
-import {dataMapping} from '../utils/tpl-builtin';
+import { RendererEvent } from '../utils/renderer-event';
 import {
   RendererAction,
-  ListenerAction,
+  IListenerAction,
   ListenerContext,
-  LoopStatus,
   registerAction
 } from './Action';
 
-export interface ICmptAction extends ListenerAction {
-  value?: string | {[key: string]: string};
+export interface ICmptAction extends IListenerAction {
+  actionType: 'setValue' | 'show' | 'hidden' | 'enabled' | 'disabled' | 'reload';
+  args: {
+    value?: string | { [key: string]: string };
+  }
 }
 
 /**

--- a/src/actions/ContinueAction.ts
+++ b/src/actions/ContinueAction.ts
@@ -1,11 +1,15 @@
-import {RendererEvent} from '../utils/renderer-event';
+import { RendererEvent } from '../utils/renderer-event';
 import {
   RendererAction,
-  ListenerAction,
   ListenerContext,
   LoopStatus,
-  registerAction
+  registerAction,
+  ILogicAction
 } from './Action';
+
+export interface IContinueAction extends ILogicAction {
+  actionType: 'continue';
+}
 
 /**
  * continue
@@ -16,7 +20,7 @@ import {
  */
 export class ContinueAction implements RendererAction {
   async run(
-    action: ListenerAction,
+    action: IContinueAction,
     renderer: ListenerContext,
     event: RendererEvent<any>
   ) {

--- a/src/actions/CopyAction.ts
+++ b/src/actions/CopyAction.ts
@@ -1,13 +1,13 @@
-import {RendererEvent} from '../utils/renderer-event';
-import {filter} from '../utils/tpl';
+import { RendererEvent } from '../utils/renderer-event';
 import {
   RendererAction,
-  ListenerAction,
+  IListenerAction,
   ListenerContext,
   registerAction
 } from './Action';
 
-export interface ICopyAction extends ListenerAction {
+export interface ICopyAction extends IListenerAction {
+  actionType: 'copy';
   args: {
     content: string;
     copyFormat?: string;

--- a/src/actions/CustomAction.ts
+++ b/src/actions/CustomAction.ts
@@ -1,14 +1,21 @@
-import {RendererEvent} from '../utils/renderer-event';
+import { Action } from '../types';
+import { RendererEvent } from '../utils/renderer-event';
 import {
   RendererAction,
-  ListenerAction,
+  IListenerAction,
   ListenerContext,
-  LoopStatus,
-  registerAction
+  registerAction,
+  ListenerAction
 } from './Action';
 
-export interface ICustomAction extends ListenerAction {
-  script: string; // 自定义JS，actionType: custom
+export interface ICustomAction extends IListenerAction {
+  actionType: 'custom';
+  script: string | ((
+    renderer: any,
+    doAction: (action: Action, data: Record<string, any>) => void,
+    event: RendererEvent<any>,
+    action: ListenerAction,
+  ) => void); // 自定义JS，actionType: custom
 }
 
 /**
@@ -42,7 +49,7 @@ export class CustomAction implements RendererAction {
       null,
       renderer,
       renderer.props.onAction?.bind(renderer, event.context.nativeEvent) ||
-        renderer.doAction?.bind(renderer),
+      renderer.doAction?.bind(renderer),
       event,
       action
     );

--- a/src/actions/DialogAction.ts
+++ b/src/actions/DialogAction.ts
@@ -1,20 +1,23 @@
-import {SchemaNode} from '../types';
-import {RendererEvent} from '../utils/renderer-event';
+import { SchemaNode } from '../types';
+import { RendererEvent } from '../utils/renderer-event';
 import {
   RendererAction,
   ListenerAction,
+  IListenerAction,
   ListenerContext,
   registerAction
 } from './Action';
 
-export interface IAlertAction extends ListenerAction {
+export interface IAlertAction extends IListenerAction {
+  actionType: 'alert';
   args: {
     msg: string;
     [propName: string]: any;
   };
 }
 
-export interface IConfirmAction extends ListenerAction {
+export interface IConfirmAction extends IListenerAction {
+  actionType: 'confirm';
   args: {
     title: string;
     msg: string;
@@ -22,7 +25,8 @@ export interface IConfirmAction extends ListenerAction {
   };
 }
 
-export interface IDialogAction extends ListenerAction {
+export interface IDialogAction extends IListenerAction {
+  actionType: 'dialog';
   dialog: SchemaNode;
 }
 
@@ -41,6 +45,10 @@ export class DialogAction implements RendererAction {
   ) {
     renderer.props.onAction?.(event, action, action.args);
   }
+}
+
+export interface ICloseDialogAction extends IListenerAction {
+  actionType: 'closeDialog';
 }
 
 /**

--- a/src/actions/DrawerAction.ts
+++ b/src/actions/DrawerAction.ts
@@ -1,13 +1,15 @@
-import {SchemaNode} from '../types';
-import {RendererEvent} from '../utils/renderer-event';
+import { SchemaNode } from '../types';
+import { RendererEvent } from '../utils/renderer-event';
 import {
   RendererAction,
+  IListenerAction,
   ListenerAction,
   ListenerContext,
   registerAction
 } from './Action';
 
-export interface IDrawerAction extends ListenerAction {
+export interface IDrawerAction extends IListenerAction {
+  actionType: 'drawer';
   drawer: SchemaNode;
 }
 
@@ -27,6 +29,11 @@ export class DrawerAction implements RendererAction {
     renderer.props.onAction?.(event, action, action.args);
   }
 }
+
+export interface ICloseDrawerAction extends IListenerAction {
+  actionType: 'closeDrawer';
+}
+
 
 /**
  * 关闭抽屉动作

--- a/src/actions/EmailAction.ts
+++ b/src/actions/EmailAction.ts
@@ -1,16 +1,15 @@
-import {RendererEvent} from '../utils/renderer-event';
-import {filter} from '../utils/tpl';
+import { RendererEvent } from '../utils/renderer-event';
 import pick from 'lodash/pick';
-import mapValues from 'lodash/mapValues';
 import qs from 'qs';
 import {
   RendererAction,
-  ListenerAction,
   ListenerContext,
-  registerAction
+  registerAction,
+  IListenerAction
 } from './Action';
 
-export interface IEmailAction extends ListenerAction {
+export interface IEmailAction extends IListenerAction {
+  actionType: 'email';
   args: {
     to: string;
     cc: string;

--- a/src/actions/LinkAction.ts
+++ b/src/actions/LinkAction.ts
@@ -1,32 +1,18 @@
-import {Action} from '../types';
-import {buildApi} from '../utils/api';
-import {isEmpty, isObject, qsstringify} from '../utils/helper';
-import {RendererEvent} from '../utils/renderer-event';
-import {filter} from '../utils/tpl';
+import { buildApi } from '../utils/api';
+import { RendererEvent } from '../utils/renderer-event';
 import omit from 'lodash/omit';
 import {
   RendererAction,
-  ListenerAction,
   ListenerContext,
-  registerAction
+  registerAction,
+  IListenerAction
 } from './Action';
 
-export interface ILinkAction extends ListenerAction {
+export interface ILinkAction extends IListenerAction {
+  actionType: 'link' | 'url' | 'jump';
   args: {
-    link: string;
+    link?: string;
     url?: never;
-    blank?: boolean;
-    params?: {
-      [key: string]: string;
-    };
-    [propName: string]: any;
-  };
-}
-
-export interface IUrlAction extends ListenerAction {
-  args: {
-    url: string;
-    link?: never;
     blank?: boolean;
     params?: {
       [key: string]: string;
@@ -44,7 +30,7 @@ export interface IUrlAction extends ListenerAction {
  */
 export class LinkAction implements RendererAction {
   async run(
-    action: ListenerAction,
+    action: ILinkAction,
     renderer: ListenerContext,
     event: RendererEvent<any>
   ) {
@@ -71,6 +57,7 @@ export class LinkAction implements RendererAction {
       urlObj.url,
       {
         actionType: action.actionType,
+        type: 'button',
         ...action.args
       },
       action.args

--- a/src/actions/LoopAction.ts
+++ b/src/actions/LoopAction.ts
@@ -1,18 +1,17 @@
-import {RendererEvent} from '../utils/renderer-event';
-import {createObject} from '../utils/helper';
+import { RendererEvent } from '../utils/renderer-event';
+import { createObject } from '../utils/helper';
 import {
   RendererAction,
-  ListenerAction,
   ListenerContext,
-  LogicAction,
   LoopStatus,
   registerAction,
-  runAction,
-  runActions
+  runActions,
+  ILogicAction
 } from './Action';
-import {resolveVariable} from '../utils/tpl-builtin';
+import { resolveVariable } from '../utils/tpl-builtin';
 
-export interface ILoopAction extends ListenerAction, LogicAction {
+export interface ILoopAction extends ILogicAction {
+  actionType: 'loop';
   args: {
     loopName: string;
     [propName: string]: any;

--- a/src/actions/PageAction.ts
+++ b/src/actions/PageAction.ts
@@ -1,12 +1,13 @@
-import {RendererEvent} from '../utils/renderer-event';
+import { RendererEvent } from '../utils/renderer-event';
 import {
   RendererAction,
-  ListenerAction,
+  IListenerAction,
   ListenerContext,
   registerAction
 } from './Action';
 
-export interface IPageGoAction extends ListenerAction {
+export interface IPageGoAction extends IListenerAction {
+  actionType: 'goBack' | 'refresh' | 'goPage';
   args: {
     delta?: number;
     [propName: string]: any;
@@ -22,7 +23,7 @@ export interface IPageGoAction extends ListenerAction {
  */
 export class PageGoBackAction implements RendererAction {
   async run(
-    action: ListenerAction,
+    action: IPageGoAction,
     renderer: ListenerContext,
     event: RendererEvent<any>
   ) {
@@ -56,7 +57,7 @@ export class PageGoAction implements RendererAction {
  */
 export class PageRefreshAction implements RendererAction {
   async run(
-    action: ListenerAction,
+    action: IPageGoAction,
     renderer: ListenerContext,
     event: RendererEvent<any>
   ) {

--- a/src/actions/ParallelAction.ts
+++ b/src/actions/ParallelAction.ts
@@ -1,14 +1,16 @@
-import {RendererEvent} from '../utils/renderer-event';
+import { RendererEvent } from '../utils/renderer-event';
 import {
   RendererAction,
-  ListenerAction,
   ListenerContext,
+  ILogicAction,
   LogicAction,
   registerAction,
   runActions
 } from './Action';
 
-export interface IParallelAction extends ListenerAction, LogicAction {}
+export interface IParallelAction extends ILogicAction {
+  actionType: 'parallel';
+}
 
 export class ParallelAction implements RendererAction {
   async run(

--- a/src/actions/SwitchAction.ts
+++ b/src/actions/SwitchAction.ts
@@ -1,16 +1,16 @@
-import {inflate} from 'zlib';
-import {RendererEvent} from '../utils/renderer-event';
-import {evalExpression} from '../utils/tpl';
+import { RendererEvent } from '../utils/renderer-event';
+import { evalExpression } from '../utils/tpl';
 import {
   RendererAction,
-  ListenerAction,
   ListenerContext,
-  LogicAction,
   registerAction,
-  runActions
+  runActions,
+  ILogicAction
 } from './Action';
 
-export interface ISwitchAction extends ListenerAction, LogicAction {}
+export interface ISwitchAction extends ILogicAction {
+  actionType: 'switch';
+}
 
 /**
  * 排他动作

--- a/src/actions/ToastAction.ts
+++ b/src/actions/ToastAction.ts
@@ -1,16 +1,17 @@
-import {RendererEvent} from '../utils/renderer-event';
+import { RendererEvent } from '../utils/renderer-event';
 import {
   RendererAction,
-  ListenerAction,
   ListenerContext,
-  registerAction
+  registerAction,
+  IListenerAction
 } from './Action';
-import {resolveVariableAndFilter} from '../utils/tpl-builtin';
 
-export interface IToastAction extends ListenerAction {
-  msg: string;
-  msgType?: string;
-  position?:
+export interface IToastAction extends IListenerAction {
+  actionType: 'toast';
+  args: {
+    msg: string;
+    msgType?: string;
+    position?:
     | 'top-right'
     | 'top-center'
     | 'top-left'
@@ -18,9 +19,10 @@ export interface IToastAction extends ListenerAction {
     | 'bottom-left'
     | 'bottom-right'
     | 'center';
-  closeButton?: boolean;
-  showIcon?: boolean;
-  timeout?: number;
+    closeButton?: boolean;
+    showIcon?: boolean;
+    timeout?: number;
+  }
 }
 
 /**


### PR DESCRIPTION
主要解决如下几个问题: 
1. AjaxAction动作严重bug, 在经过dataMapping后, 会将adaptor/requestAdaptor/responseAdaptor转换成对象, 直接报错
2. ListenAction不是多种事件动作的联合类型, 而是写死的, 导致在ts编程的时候没有提示和校验
3. action下的多个事件里没用清晰声明它的actionType, 只能去代码里找, 现在通过类型声明后更加明了
