### PR TITLE
chore: 优化日期范围input宽度

### DIFF
--- a/scss/components/form/_date-range.scss
+++ b/scss/components/form/_date-range.scss
@@ -37,6 +37,7 @@
     outline: none;
     padding: 0;
     background: 0;
+    flex: 1;
   }
 
   .#{$ns}DateRangePicker-input.isActive {


### PR DESCRIPTION
input框未设置宽度，所以第一次渲染的的时候，宽度是合适的。
但拖动浏览器宽度后，就会发现input小了或者过长了。加上flex:1的属性后可以自动伸缩