### PR TITLE
feat: 添加 json-schema 渲染器

### DIFF
--- a/__tests__/renderers/Form/__snapshots__/options.test.tsx.snap
+++ b/__tests__/renderers/Form/__snapshots__/options.test.tsx.snap
@@ -199,7 +199,7 @@ exports[`options:linkage 2`] = `
         class="cxd-RadiosControl cxd-Form-control is-inline"
       >
         <label
-          class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full cxd-Checkbox--button--disabled--unchecked"
+          class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
         >
           <input
             disabled=""

--- a/docs/zh-CN/components/form/checkbox.md
+++ b/docs/zh-CN/components/form/checkbox.md
@@ -82,7 +82,7 @@ order: 8
             "falseValue": false,
             "optionType": "button",
             "option": "选项说明",
-            "checked": true
+            "value": true
         }
     ]
 }

--- a/docs/zh-CN/components/form/json-schema.md
+++ b/docs/zh-CN/components/form/json-schema.md
@@ -81,6 +81,7 @@ order: 61
                   type: 'object',
                   title: '日期',
                   additionalProperties: false,
+                  required: ['year', 'month', 'day'],
                   properties: {
                     year: {
                       type: 'number',

--- a/docs/zh-CN/components/form/json-schema.md
+++ b/docs/zh-CN/components/form/json-schema.md
@@ -1,0 +1,119 @@
+---
+title: JSONSchema
+description:
+type: 0
+group: null
+menuName: JSONSchema
+icon:
+order: 61
+---
+
+## 基本用法
+
+> 1.10.0 及以上版本
+
+> 此组件还在实验阶段，很多 json-schema 属性没有对应实现，使用前请先确认你要的功能满足了需求
+
+基于 json-schema 定义生成表单输入项。
+
+```schema: scope="body"
+{
+    "type": "form",
+    "api": "/api/mock2/form/saveForm",
+    debug: true,
+    "body": [
+        {
+            "type": "json-schema",
+            "name": "value",
+            "label": "字段值",
+            "schema": {
+              type: 'object',
+              properties: {
+                id: {
+                  type: 'number',
+                  title: 'ID'
+                },
+                name: {
+                  type: 'string',
+                  title: '名称'
+                },
+                description: {
+                  type: 'string',
+                  title: '描述'
+                }
+              }
+            }
+        }
+    ]
+}
+```
+
+## 复杂 case
+
+```schema: scope="body"
+{
+    "type": "form",
+    "api": "/api/mock2/form/saveForm",
+    debug: true,
+    "body": [
+        {
+            "type": "json-schema",
+            "name": "value",
+            "label": "字段值",
+            "schema": {
+              type: 'object',
+              additionalProperties: false,
+              required: ['id', 'name'],
+              properties: {
+                id: {
+                  type: 'number',
+                  title: 'ID'
+                },
+                name: {
+                  type: 'string',
+                  title: '名称'
+                },
+                description: {
+                  type: 'string',
+                  title: '描述'
+                },
+                date: {
+                  type: 'object',
+                  title: '日期',
+                  additionalProperties: false,
+                  properties: {
+                    year: {
+                      type: 'number',
+                      title: '年'
+                    },
+                    month: {
+                      type: 'number',
+                      title: '月'
+                    },
+                    day: {
+                      type: 'number',
+                      title: '日'
+                    }
+                  }
+                },
+                tag: {
+                  type: 'array',
+                  title: '个人标签',
+                  items: {
+                    type: 'string'
+                  },
+                  minContains: 2,
+                  maxContains: 10
+                }
+              }
+            }
+        }
+    ]
+}
+```
+
+## 属性表
+
+| 属性名 | 类型                 | 默认值 | 说明             |
+| ------ | -------------------- | ------ | ---------------- |
+| schema | `object` \| `string` |        | 指定 json-schema |

--- a/docs/zh-CN/components/form/json-schema.md
+++ b/docs/zh-CN/components/form/json-schema.md
@@ -113,6 +113,23 @@ order: 61
 }
 ```
 
+## 远程获取 schema
+
+```schema: scope="body"
+{
+    "type": "form",
+    debug: true,
+    "body": [
+        {
+            "type": "json-schema",
+            "name": "value",
+            "label": "字段值",
+            "schema": "/api/mock2/json-schema"
+        }
+    ]
+}
+```
+
 ## 属性表
 
 | 属性名 | 类型                 | 默认值 | 说明             |

--- a/examples/components/Components.tsx
+++ b/examples/components/Components.tsx
@@ -79,9 +79,7 @@ export const components = [
         label: 'Pagination分页',
         path: '/zh-CN/components/pagination',
         component: React.lazy(() =>
-          import('../../docs/zh-CN/components/pagination.md').then(
-            wrapDoc
-          )
+          import('../../docs/zh-CN/components/pagination.md').then(wrapDoc)
         )
       },
       {
@@ -740,6 +738,16 @@ export const components = [
         path: '/zh-CN/components/form/input-year-range',
         component: React.lazy(() =>
           import('../../docs/zh-CN/components/form/input-year-range.md').then(
+            wrapDoc
+          )
+        )
+      },
+
+      {
+        label: 'JsonSchema',
+        path: '/zh-CN/components/form/json-schema',
+        component: React.lazy(() =>
+          import('../../docs/zh-CN/components/form/json-schema.md').then(
             wrapDoc
           )
         )

--- a/mock/cfc/mock/json-schema.json
+++ b/mock/cfc/mock/json-schema.json
@@ -1,0 +1,21 @@
+{
+  "status": 0,
+  "msg": "",
+  "data": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "number",
+        "title": "ID"
+      },
+      "name": {
+        "type": "string",
+        "title": "名称"
+      },
+      "description": {
+        "type": "string",
+        "title": "描述"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "react-color": "^2.19.3",
     "react-cropper": "^2.1.8",
     "react-dropzone": "^11.4.2",
+    "react-hook-form": "7.30.0",
     "react-input-range": "1.3.0",
     "react-json-view": "1.21.3",
     "react-overlays": "5.1.1",

--- a/scss/components/_input-box.scss
+++ b/scss/components/_input-box.scss
@@ -51,4 +51,24 @@
   > a {
     cursor: pointer;
   }
+
+  &-caret {
+    transition: transform var(--animation-duration) ease-out;
+    margin: 5px;
+    display: flex;
+    color: var(--Form-select-caret-iconColor);
+    &:hover {
+      color: var(--Form-select-caret-onHover-iconColor);
+    }
+
+    > svg {
+      width: px2rem(10px);
+      height: px2rem(10px);
+      top: 0;
+    }
+  }
+
+  &.is-active &-caret {
+    transform: rotate(180deg);
+  }
 }

--- a/scss/components/_input-box.scss
+++ b/scss/components/_input-box.scss
@@ -10,7 +10,8 @@
     cursor: inherit;
   }
 
-  &.is-error {
+  &.is-error,
+  .is-error > & {
     border-color: var(--Form-input-onError-borderColor);
     background: var(--Form-input-onError-bg);
   }

--- a/scss/components/_json-schema.scss
+++ b/scss/components/_json-schema.scss
@@ -5,8 +5,9 @@
   gap: var(--gap-sm);
 
   &-key {
-    min-width: 100px;
+    min-width: 80px;
     max-width: 150px;
+    flex: 1;
 
     & > span {
       display: flex;
@@ -36,6 +37,7 @@
 
     > div {
       flex: 1;
+      flex-wrap: nowrap;
     }
   }
 

--- a/scss/components/_json-schema.scss
+++ b/scss/components/_json-schema.scss
@@ -20,6 +20,7 @@
       font-size: var(--Form-input-fontSize);
       flex-wrap: wrap;
       justify-content: flex-start;
+      align-items: center;
 
       color: var(--Form-input-color);
     }

--- a/scss/components/_json-schema.scss
+++ b/scss/components/_json-schema.scss
@@ -1,0 +1,121 @@
+.#{$ns}JSONSchemaMember {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  gap: var(--gap-sm);
+
+  &-key {
+    min-width: 100px;
+    max-width: 150px;
+
+    & > span {
+      display: flex;
+      background: var(--Form-input-bg);
+      border: var(--Form-input-borderWidth) solid var(--Form-input-borderColor);
+      border-radius: var(--Form-input-borderRadius);
+      // height: var(--Form-input-height);
+      line-height: var(--Form-input-lineHeight);
+      padding: var(--Form-input-paddingY) var(--Form-input-paddingX);
+      font-size: var(--Form-input-fontSize);
+      flex-wrap: wrap;
+      justify-content: flex-start;
+
+      color: var(--Form-input-color);
+    }
+  }
+
+  &-value {
+    flex: 1;
+    margin-left: auto;
+    display: flex;
+    gap: var(--gap-sm);
+
+    > a {
+      display: inline-block;
+    }
+
+    > div {
+      flex: 1;
+    }
+  }
+
+  & + & {
+    margin-top: var(--gap-sm);
+  }
+}
+
+.#{$ns}JSONSchemaObject {
+  &-caret {
+    display: inline-block;
+    height: px2rem(24px);
+    text-align: center;
+    line-height: px2rem(24px);
+    vertical-align: middle;
+    cursor: pointer;
+    transform: rotate(0deg);
+    transition: transform var(--animation-duration);
+    color: var(--icon-color);
+    margin-top: calc((var(--Form-input-height) - var(--Switch-height)) / 2);
+
+    > svg {
+      width: 10px;
+      height: 10px;
+      top: 0;
+    }
+  }
+
+  &-caret.is-collapsed {
+    transform: rotate(-90deg);
+  }
+
+  &.is-expanded {
+    position: relative;
+    margin-left: px2rem(20px);
+
+    &:before {
+      width: 1px;
+      content: '';
+      display: block;
+      position: absolute;
+      top: 30px;
+      bottom: 10px;
+      left: -33px;
+      border-left: dashed 1px var(--icon-color);
+    }
+
+    & .#{$ns}JSONSchemaMember {
+      position: relative;
+    }
+
+    & .#{$ns}JSONSchemaMember:before {
+      height: 1px;
+      content: '';
+      display: block;
+      position: absolute;
+      top: 17px;
+      width: 25px;
+      left: -33px;
+      border-top: dashed 1px var(--icon-color);
+    }
+
+    & .#{$ns}JSONSchemaMember:first-child:before {
+      left: -20px;
+      width: 12px;
+    }
+
+    & > button {
+      position: relative;
+
+      &:before {
+        height: 1px;
+        content: '';
+        display: block;
+        position: absolute;
+        top: 10px;
+        width: 25px;
+        left: -33px;
+        border-top: dashed 1px var(--icon-color);
+      }
+    }
+  }
+}

--- a/scss/components/form/_select.scss
+++ b/scss/components/form/_select.scss
@@ -1,5 +1,9 @@
 .#{$ns}Select {
   display: inline-flex;
+
+  &--block {
+    display: flex;
+  }
   vertical-align: middle;
   text-align: left;
   align-items: center;
@@ -395,6 +399,11 @@
     border-color: var(--Form-input-onError-borderColor);
     background: var(--Form-input-onError-bg);
   }
+}
+
+.#{$ns}Select.is-error {
+  border-color: var(--Form-input-onError-borderColor);
+  background: var(--Form-input-onError-bg);
 }
 
 // 需要能撑开

--- a/scss/themes/_common.scss
+++ b/scss/themes/_common.scss
@@ -68,6 +68,7 @@
 @import '../components/image-gallery';
 @import '../components/images';
 @import '../components/input-box';
+@import '../components/json-schema';
 @import '../components/json-schema-editor';
 @import '../components/result-box';
 @import '../components/search-box';

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -170,6 +170,7 @@ export type SchemaType =
   | 'static-image' // 这个几个跟表单项同名，再form下面用必须带前缀 static-
   | 'images'
   | 'static-images' // 这个几个跟表单项同名，再form下面用必须带前缀 static-
+  | 'json-schema'
   | 'json-schema-editor'
   | 'json'
   | 'static-json' // 这个几个跟表单项同名，再form下面用必须带前缀 static-

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -83,7 +83,8 @@ export class Checkbox extends React.Component<CheckboxProps, any> {
           [`Checkbox--${size}`]: size,
           'Checkbox--button': optionType === 'button',
           'Checkbox--button--checked': optionType === 'button' && checked,
-          'Checkbox--button--disabled--unchecked': disabled && !checked
+          'Checkbox--button--disabled--unchecked':
+            optionType === 'button' && disabled && !checked
         })}
       >
         <input

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -4,6 +4,8 @@
 import React from 'react';
 import {themeable, ThemeProps} from '../theme';
 import {useForm, UseFormReturn} from 'react-hook-form';
+import {useValidationResolver} from '../hooks/use-validation-resolver';
+import {localeable, LocaleProps} from '../locale';
 
 export type FormRef = React.MutableRefObject<
   | {
@@ -12,7 +14,7 @@ export type FormRef = React.MutableRefObject<
   | undefined
 >;
 
-export interface FormProps extends ThemeProps {
+export interface FormProps extends ThemeProps, LocaleProps {
   defaultValues: any;
   onSubmit: (value: any) => void;
   forwardRef?: FormRef;
@@ -21,7 +23,10 @@ export interface FormProps extends ThemeProps {
 
 export function Form(props: FormProps) {
   const {classnames: cx} = props;
-  const methods = useForm({defaultValues: props.defaultValues});
+  const methods = useForm({
+    defaultValues: props.defaultValues,
+    resolver: useValidationResolver(props.translate)
+  });
 
   React.useEffect(() => {
     if (props.forwardRef) {
@@ -60,8 +65,8 @@ export function Form(props: FormProps) {
   );
 }
 
-const ThemedForm = themeable(Form);
-type ThemedFormProps = Omit<FormProps, keyof ThemeProps>;
+const ThemedForm = themeable(localeable(Form));
+type ThemedFormProps = Omit<FormProps, keyof ThemeProps & LocaleProps>;
 
 export default React.forwardRef((props: ThemedFormProps, ref: FormRef) => (
   <ThemedForm {...props} forwardRef={ref} />

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,0 +1,68 @@
+/**
+ * @file 给组件用的，渲染器里面不要用这个
+ */
+import React from 'react';
+import {themeable, ThemeProps} from '../theme';
+import {useForm, UseFormReturn} from 'react-hook-form';
+
+export type FormRef = React.MutableRefObject<
+  | {
+      submit: () => void;
+    }
+  | undefined
+>;
+
+export interface FormProps extends ThemeProps {
+  defaultValues: any;
+  onSubmit: (value: any) => void;
+  forwardRef?: FormRef;
+  children?: (methods: UseFormReturn) => JSX.Element | null;
+}
+
+export function Form(props: FormProps) {
+  const {classnames: cx} = props;
+  const methods = useForm({defaultValues: props.defaultValues});
+
+  React.useEffect(() => {
+    if (props.forwardRef) {
+      props.forwardRef.current = {
+        submit: () =>
+          new Promise<any>((resolve, reject) => {
+            methods.handleSubmit(
+              values => {
+                resolve(values);
+              },
+              () => {
+                resolve(false);
+              }
+            )();
+          })
+      };
+    }
+
+    return () => {
+      if (props.forwardRef) {
+        props.forwardRef.current = undefined;
+      }
+    };
+  });
+
+  return (
+    <form
+      className={cx('Form')}
+      onSubmit={methods.handleSubmit(props.onSubmit)}
+      noValidate
+    >
+      {/* 实现回车自动提交 */}
+      <input type="submit" style={{display: 'none'}} />
+      {props.children?.(methods)}
+    </form>
+  );
+}
+
+const ThemedForm = themeable(Form);
+type ThemedFormProps = Omit<FormProps, keyof ThemeProps>;
+
+export default React.forwardRef((props: ThemedFormProps, ref: FormRef) => (
+  <ThemedForm {...props} forwardRef={ref} />
+));

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -30,16 +30,13 @@ export function Form(props: FormProps) {
 
   React.useEffect(() => {
     if (props.forwardRef) {
+      // 这个模式别的组件没见到过不知道后续会不会不允许
       props.forwardRef.current = {
         submit: () =>
           new Promise<any>((resolve, reject) => {
             methods.handleSubmit(
-              values => {
-                resolve(values);
-              },
-              () => {
-                resolve(false);
-              }
+              values => resolve(values),
+              () => resolve(false)
             )();
           })
       };
@@ -66,7 +63,7 @@ export function Form(props: FormProps) {
 }
 
 const ThemedForm = themeable(localeable(Form));
-type ThemedFormProps = Omit<FormProps, keyof ThemeProps & LocaleProps>;
+type ThemedFormProps = Omit<FormProps, keyof ThemeProps | keyof LocaleProps>;
 
 export default React.forwardRef((props: ThemedFormProps, ref: FormRef) => (
   <ThemedForm {...props} forwardRef={ref} />

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -90,7 +90,7 @@ export default ThemedFormField;
 export interface ControllerProps
   extends ReactHookFormControllerProps,
     Omit<FormFieldProps, keyof ThemeProps> {
-  rules: Omit<
+  rules?: Omit<
     RegisterOptions,
     'valueAsNumber' | 'valueAsDate' | 'setValueAs' | 'disabled'
   > & {

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -1,0 +1,113 @@
+/**
+ * @file 给组件用的，渲染器里面不要用这个
+ */
+import React from 'react';
+import {themeable, ThemeProps} from '../theme';
+import {
+  ControllerProps as ReactHookFormControllerProps,
+  Controller as ReactHookFormController
+} from 'react-hook-form';
+
+export interface FormFieldProps extends ThemeProps {
+  mode?: 'normal' | 'horizontal';
+  horizontal?: {
+    left?: number;
+    right?: number;
+    leftFixed?: boolean | number | 'xs' | 'sm' | 'md' | 'lg';
+    justify?: boolean; // 两端对齐
+  };
+  label?: string;
+  description?: string;
+  isRequired?: boolean;
+  hasError?: boolean;
+  errors?: string | Array<string>;
+  children?: JSX.Element;
+}
+
+function FormField(props: FormFieldProps) {
+  const {
+    mode,
+    children,
+    classnames: cx,
+    className,
+    hasError,
+    isRequired,
+    label,
+    description
+  } = props;
+
+  const errors = Array.isArray(props.errors)
+    ? props.errors
+    : props.errors
+    ? [props.errors]
+    : [];
+
+  if (mode === 'horizontal') {
+  }
+
+  return (
+    <div
+      data-role="form-item"
+      className={cx(`Form-item Form-item--normal`, className, {
+        'is-error': hasError,
+        [`is-required`]: isRequired
+      })}
+    >
+      {label ? (
+        <label className={cx(`Form-label`)}>
+          <span>
+            {label}
+            {isRequired && label ? (
+              <span className={cx(`Form-star`)}>*</span>
+            ) : null}
+          </span>
+        </label>
+      ) : null}
+      {children}
+
+      {hasError && errors.length ? (
+        <ul className={cx(`Form-feedback`)}>
+          {errors.map((msg: string, key: number) => (
+            <li key={key}>{msg}</li>
+          ))}
+        </ul>
+      ) : null}
+
+      {description ? (
+        <div className={cx(`Form-description`)}>{description}</div>
+      ) : null}
+    </div>
+  );
+}
+
+const ThemedFormField = themeable(FormField);
+
+export default ThemedFormField;
+
+export interface ControllerProps
+  extends ReactHookFormControllerProps,
+    Omit<FormFieldProps, keyof ThemeProps> {}
+export function Controller(props: ControllerProps) {
+  const {
+    render,
+    name,
+    rules,
+    shouldUnregister,
+    defaultValue,
+    control,
+    ...rest
+  } = props;
+
+  return (
+    <ReactHookFormController
+      name={name}
+      rules={rules}
+      shouldUnregister={shouldUnregister}
+      defaultValue={defaultValue}
+      control={control}
+      render={methods => (
+        <ThemedFormField {...rest}>{render(methods)}</ThemedFormField>
+      )}
+    />
+  );
+}

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -5,8 +5,10 @@ import React from 'react';
 import {themeable, ThemeProps} from '../theme';
 import {
   ControllerProps as ReactHookFormControllerProps,
-  Controller as ReactHookFormController
+  Controller as ReactHookFormController,
+  RegisterOptions
 } from 'react-hook-form';
+import {method} from 'lodash';
 
 export interface FormFieldProps extends ThemeProps {
   mode?: 'normal' | 'horizontal';
@@ -63,6 +65,7 @@ function FormField(props: FormFieldProps) {
           </span>
         </label>
       ) : null}
+
       {children}
 
       {hasError && errors.length ? (
@@ -86,17 +89,22 @@ export default ThemedFormField;
 
 export interface ControllerProps
   extends ReactHookFormControllerProps,
-    Omit<FormFieldProps, keyof ThemeProps> {}
+    Omit<FormFieldProps, keyof ThemeProps> {
+  rules: Omit<
+    RegisterOptions,
+    'valueAsNumber' | 'valueAsDate' | 'setValueAs' | 'disabled'
+  > & {
+    [propName: string]: any;
+  };
+}
 export function Controller(props: ControllerProps) {
-  const {
-    render,
-    name,
-    rules,
-    shouldUnregister,
-    defaultValue,
-    control,
-    ...rest
-  } = props;
+  const {render, name, shouldUnregister, defaultValue, control, ...rest} =
+    props;
+  let rules = {...props.rules};
+
+  if (rest.isRequired) {
+    rules.required = true;
+  }
 
   return (
     <ReactHookFormController
@@ -106,7 +114,13 @@ export function Controller(props: ControllerProps) {
       defaultValue={defaultValue}
       control={control}
       render={methods => (
-        <ThemedFormField {...rest}>{render(methods)}</ThemedFormField>
+        <ThemedFormField
+          {...rest}
+          hasError={!!methods.fieldState.error}
+          errors={methods.fieldState.error?.message}
+        >
+          {render(methods)}
+        </ThemedFormField>
       )}
     />
   );

--- a/src/components/InputBox.tsx
+++ b/src/components/InputBox.tsx
@@ -37,6 +37,7 @@ export class InputBox extends React.Component<InputBoxProps, InputBoxState> {
   @autobind
   clearValue(e: any) {
     e.preventDefault();
+    e.stopPropagation();
 
     const onClear = this.props.onClear;
     const onChange = this.props.onChange;
@@ -81,6 +82,7 @@ export class InputBox extends React.Component<InputBoxProps, InputBoxState> {
       prefix: result,
       children,
       borderMode,
+      onClick,
       ...rest
     } = this.props;
     const isFocused = this.state.isFocused;
@@ -91,9 +93,10 @@ export class InputBox extends React.Component<InputBoxProps, InputBoxState> {
           'is-focused': isFocused,
           'is-disabled': disabled,
           'is-error': hasError,
-          'is-clickable': rest.onClick,
+          'is-clickable': onClick,
           [`InputBox--border${ucFirst(borderMode)}`]: borderMode
         })}
+        onClick={onClick}
       >
         {result}
 

--- a/src/components/InputBoxWithSuggestion.tsx
+++ b/src/components/InputBoxWithSuggestion.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import {findDOMNode} from 'react-dom';
+import {localeable, LocaleProps} from '../locale';
+import {themeable, ThemeProps} from '../theme';
+// @ts-ignore
+import {matchSorter} from 'match-sorter';
+import PopOverContainer from './PopOverContainer';
+import SearchBox from './SearchBox';
+import ListSelection from './GroupedSelection';
+import InputBox from './InputBox';
+import {Icon} from './icons';
+
+export interface InputBoxWithSuggestionProps extends ThemeProps, LocaleProps {
+  options: Array<any>;
+  value: any;
+  onChange: (value: any) => void;
+  disabled?: boolean;
+  searchable?: boolean;
+  popOverContainer?: any;
+  hasError?: boolean;
+  placeholder?: string;
+  clearable?: boolean;
+}
+
+const option2value = (item: any) => item.value;
+
+export class InputBoxWithSuggestion extends React.Component<InputBoxWithSuggestionProps> {
+  constructor(props: InputBoxWithSuggestionProps) {
+    super(props);
+    this.state = {
+      searchText: ''
+    };
+    this.onSearch = this.onSearch.bind(this);
+    this.filterOptions = this.filterOptions.bind(this);
+  }
+
+  onSearch(text: string) {
+    let txt = text.toLowerCase();
+
+    this.setState({searchText: txt});
+  }
+
+  filterOptions(options: any[]) {
+    return matchSorter(options, this.props.value, {
+      keys: ['label', 'value']
+    });
+  }
+
+  // 选了值，还原options
+  onPopClose(e: React.MouseEvent, onClose: () => void) {
+    this.setState({searchText: ''});
+    onClose();
+  }
+
+  render() {
+    const {
+      placeholder,
+      onChange,
+      value,
+      classnames: cx,
+      disabled,
+      translate: __,
+      searchable,
+      popOverContainer,
+      clearable,
+      hasError
+    } = this.props;
+    const options = this.filterOptions(this.props.options);
+
+    return (
+      <PopOverContainer
+        popOverContainer={popOverContainer || (() => findDOMNode(this))}
+        popOverRender={({onClose}) => (
+          <>
+            {searchable ? (
+              <SearchBox mini={false} onSearch={this.onSearch} />
+            ) : null}
+            <ListSelection
+              multiple={false}
+              onClick={e => this.onPopClose(e, onClose)}
+              options={options}
+              value={[value]}
+              option2value={option2value}
+              onChange={(value: any) => {
+                onChange?.(value);
+              }}
+            />
+          </>
+        )}
+      >
+        {({onClick, ref, isOpened}) => (
+          <InputBox
+            className={cx('InputBox--sug', isOpened ? 'is-active' : '')}
+            ref={ref}
+            placeholder={placeholder}
+            disabled={disabled}
+            value={options.find(o => o.value === value)?.label ?? value}
+            onChange={onChange}
+            clearable={clearable}
+            onClick={onClick}
+            hasError={hasError}
+          >
+            <span className={cx('InputBox-caret')}>
+              <Icon icon="caret" className="icon" />
+            </span>
+          </InputBox>
+        )}
+      </PopOverContainer>
+    );
+  }
+}
+
+export default themeable(localeable(InputBoxWithSuggestion));

--- a/src/components/PickerContainer.tsx
+++ b/src/components/PickerContainer.tsx
@@ -23,7 +23,7 @@ export interface PickerContainerProps extends ThemeProps, LocaleProps {
     onChange: (value: any) => void;
     setState: (state: any) => void;
     [propName: string]: any;
-  }) => JSX.Element | nul;
+  }) => JSX.Element | null;
   value?: any;
   beforeConfirm?: (bodyRef: any) => any;
   onConfirm?: (value?: any) => void;
@@ -100,15 +100,18 @@ export class PickerContainer extends React.Component<
     const {onConfirm, beforeConfirm} = this.props;
 
     const ret = await beforeConfirm?.(this.bodyRef.current);
+    let state: any = {
+      isOpened: false
+    };
 
-    // beforeConfirm 返回 false 则组织后续动作
+    // beforeConfirm 返回 false 则阻止后续动作
     if (ret === false) {
       return;
     } else if (isObject(ret)) {
-      this.handleChange(ret);
+      state.value = ret;
     }
 
-    this.close(undefined, () => onConfirm?.(this.state.value));
+    this.setState(state, () => onConfirm?.(this.state.value));
   }
 
   @autobind

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1096,6 +1096,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
       multiple,
       valuesNoWrap,
       searchable,
+      inline,
       block,
       className,
       value,
@@ -1141,6 +1142,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
                 `Select`,
                 {
                   [`Select--multi`]: multiple,
+                  [`Select--inline`]: inline,
                   [`Select--block`]: block,
                   [`Select--searchable`]: searchable,
                   'is-opened': isOpen,

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -60,6 +60,8 @@ export interface OptionProps {
   disabled?: boolean;
   creatable?: boolean;
   pathSeparator?: string;
+  hasError?: boolean;
+  block?: boolean;
   onAdd?: (
     idx?: number | Array<number>,
     value?: any,
@@ -476,7 +478,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
     const {simpleValue} = this.props;
     const {selection} = this.state;
     const value = simpleValue ? selection.map(item => item.value) : selection;
-    
+
     this.props.disabled ||
       this.state.isOpen ||
       this.setState(
@@ -486,10 +488,11 @@ export class Select extends React.Component<SelectProps, SelectState> {
         this.focus
       );
 
-    this.props.onFocus && this.props.onFocus({
-      ...e,
-      value
-    });
+    this.props.onFocus &&
+      this.props.onFocus({
+        ...e,
+        value
+      });
   }
 
   @autobind
@@ -502,10 +505,11 @@ export class Select extends React.Component<SelectProps, SelectState> {
       isFocused: false
     });
 
-    this.props.onBlur && this.props.onBlur({
-      ...e,
-      value
-    });
+    this.props.onBlur &&
+      this.props.onBlur({
+        ...e,
+        value
+      });
   }
 
   @autobind
@@ -1092,7 +1096,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
       multiple,
       valuesNoWrap,
       searchable,
-      inline,
+      block,
       className,
       value,
       loading,
@@ -1101,7 +1105,8 @@ export class Select extends React.Component<SelectProps, SelectState> {
       disabled,
       checkAll,
       borderMode,
-      useMobileUI
+      useMobileUI,
+      hasError
     } = this.props;
 
     const selection = this.state.selection;
@@ -1136,12 +1141,13 @@ export class Select extends React.Component<SelectProps, SelectState> {
                 `Select`,
                 {
                   [`Select--multi`]: multiple,
-                  [`Select--inline`]: inline,
+                  [`Select--block`]: block,
                   [`Select--searchable`]: searchable,
                   'is-opened': isOpen,
                   'is-focused': this.state.isFocused,
                   'is-disabled': disabled,
                   'is-mobile': mobileUI,
+                  'is-error': hasError,
                   [`Select--border${ucFirst(borderMode)}`]: borderMode
                 },
                 className

--- a/src/components/Textarea.tsx
+++ b/src/components/Textarea.tsx
@@ -1,2 +1,234 @@
-import Textarea from 'react-textarea-autosize';
-export default Textarea;
+import React from 'react';
+import {findDOMNode} from 'react-dom';
+import BaseTextArea from 'react-textarea-autosize';
+import {localeable, LocaleProps} from '../locale';
+import {themeable, ThemeProps} from '../theme';
+import {autobind, ucFirst} from '../utils/helper';
+import {Icon} from './icons';
+
+export interface TextAreaProps extends ThemeProps, LocaleProps {
+  /**
+   * 最大行数
+   */
+  maxRows?: number;
+
+  /**
+   * 最小行数
+   */
+  minRows?: number;
+
+  /**
+   * 是否只读
+   */
+  readOnly?: boolean;
+
+  /**
+   * 边框模式，全边框，还是半边框，或者没边框。
+   */
+  borderMode?: 'full' | 'half' | 'none';
+
+  /**
+   * 限制文字个数
+   */
+  maxLength?: number;
+
+  /**
+   * 是否显示计数
+   */
+  showCounter?: boolean;
+
+  /**
+   * 输入内容是否可清除
+   */
+  clearable?: boolean;
+
+  /**
+   * 重置值
+   */
+  resetValue?: string;
+
+  trimContents?: boolean;
+
+  value?: any;
+  onChange?: (value: any) => void;
+
+  onFocus?: (e: any) => void;
+  onBlur?: (e: any) => void;
+
+  placeholder?: string;
+  name?: string;
+  disabled?: boolean;
+}
+
+export interface TextAreaState {
+  focused: boolean;
+}
+
+export class Textarea extends React.Component<TextAreaProps, TextAreaState> {
+  static defaultProps = {
+    minRows: 3,
+    maxRows: 20,
+    trimContents: true,
+    resetValue: '',
+    clearable: false
+  };
+
+  state = {
+    focused: false
+  };
+
+  input?: HTMLInputElement;
+  inputRef = (ref: any) => (this.input = findDOMNode(ref) as HTMLInputElement);
+
+  valueToString(value: any) {
+    return typeof value === 'undefined' || value === null
+      ? ''
+      : typeof value === 'string'
+      ? value
+      : JSON.stringify(value);
+  }
+
+  focus() {
+    if (!this.input) {
+      return;
+    }
+
+    this.setState(
+      {
+        focused: true
+      },
+      () => {
+        if (!this.input) {
+          return;
+        }
+
+        this.input.focus();
+
+        // 光标放到最后
+        const len = this.input.value.length;
+        len && this.input.setSelectionRange(len, len);
+      }
+    );
+  }
+
+  @autobind
+  handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    const {onChange} = this.props;
+    let value = e.currentTarget.value;
+
+    onChange?.(value);
+  }
+
+  @autobind
+  handleFocus(e: React.FocusEvent<HTMLTextAreaElement>) {
+    const {onFocus} = this.props;
+
+    this.setState(
+      {
+        focused: true
+      },
+      () => {
+        onFocus?.(e);
+      }
+    );
+  }
+
+  @autobind
+  handleBlur(e: React.FocusEvent<HTMLTextAreaElement>) {
+    const {onBlur, trimContents, value, onChange} = this.props;
+
+    this.setState(
+      {
+        focused: false
+      },
+      () => {
+        if (trimContents && value && typeof value === 'string') {
+          onChange?.(value.trim());
+        }
+
+        onBlur && onBlur(e);
+      }
+    );
+  }
+
+  @autobind
+  async handleClear() {
+    const {onChange, resetValue} = this.props;
+
+    onChange?.(resetValue);
+    this.focus();
+  }
+
+  render() {
+    const {
+      className,
+      classPrefix: ns,
+      value,
+      placeholder,
+      disabled,
+      minRows,
+      maxRows,
+      readOnly,
+      name,
+      borderMode,
+      classnames: cx,
+      maxLength,
+      showCounter,
+      clearable
+    } = this.props;
+    const counter = showCounter ? this.valueToString(value).length : 0;
+
+    return (
+      <div
+        className={cx(
+          `TextareaControl`,
+          {
+            [`TextareaControl--border${ucFirst(borderMode)}`]: borderMode,
+            'is-focused': this.state.focused,
+            'is-disabled': disabled
+          },
+          className
+        )}
+      >
+        <BaseTextArea
+          className={cx(`TextareaControl-input`)}
+          autoComplete="off"
+          ref={this.inputRef}
+          name={name}
+          disabled={disabled}
+          value={this.valueToString(value)}
+          placeholder={placeholder}
+          autoCorrect="off"
+          spellCheck="false"
+          readOnly={readOnly}
+          minRows={minRows || undefined}
+          maxRows={maxRows || undefined}
+          onChange={this.handleChange}
+          onFocus={this.handleFocus}
+          onBlur={this.handleBlur}
+        />
+
+        {clearable && !disabled && value ? (
+          <a onClick={this.handleClear} className={cx('TextareaControl-clear')}>
+            <Icon icon="input-clear" className="icon" />
+          </a>
+        ) : null}
+
+        {showCounter ? (
+          <span
+            className={cx('TextareaControl-counter', {
+              'is-empty': counter === 0,
+              'is-clearable': clearable && !disabled && value
+            })}
+          >
+            {`${counter}${
+              typeof maxLength === 'number' && maxLength ? `/${maxLength}` : ''
+            }`}
+          </span>
+        ) : null}
+      </div>
+    );
+  }
+}
+
+export default themeable(localeable(Textarea));

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -62,6 +62,7 @@ import Table from './table';
 import SchemaVariableListPicker from './schema-editor/SchemaVariableListPicker';
 import SchemaVariableList from './schema-editor/SchemaVariableList';
 import FormulaPicker from './formula/Picker';
+import InputJSONSchema from './json-schema';
 
 export {
   NotFound,
@@ -127,5 +128,6 @@ export {
   Table,
   SchemaVariableListPicker,
   SchemaVariableList,
-  FormulaPicker
+  FormulaPicker,
+  InputJSONSchema
 };

--- a/src/components/json-schema/Array.tsx
+++ b/src/components/json-schema/Array.tsx
@@ -18,7 +18,8 @@ export function InputJSONSchemaArray(props: InputJSONSchemaItemProps) {
     onChange,
     disabled,
     translate: __,
-    collapsable
+    collapsable,
+    renderValue
   } = props;
   const buildMembers = React.useCallback((schema: any, value) => {
     const members: Array<JSONSchemaArrayMember> = [];
@@ -156,15 +157,17 @@ export function InputJSONSchemaArray(props: InputJSONSchemaItemProps) {
         })}
       >
         {collapsed ? (
-          <InputJSONSchemaItem
-            {...props}
-            value={value}
-            onChange={onChange}
-            schema={{
-              type: 'string'
-            }}
-            placeholder={props.schema?.description}
-          />
+          renderValue ? (
+            <InputJSONSchemaItem
+              {...props}
+              value={value}
+              onChange={onChange}
+              schema={{
+                type: 'string'
+              }}
+              placeholder={props.schema?.description}
+            />
+          ) : null
         ) : (
           members.map(member => {
             return (

--- a/src/components/json-schema/Array.tsx
+++ b/src/components/json-schema/Array.tsx
@@ -18,7 +18,6 @@ export function InputJSONSchemaArray(props: InputJSONSchemaItemProps) {
     onChange,
     disabled,
     translate: __,
-    renderKey,
     collapsable
   } = props;
   const buildMembers = React.useCallback((schema: any, value) => {

--- a/src/components/json-schema/Array.tsx
+++ b/src/components/json-schema/Array.tsx
@@ -77,7 +77,7 @@ export function InputJSONSchemaArray(props: InputJSONSchemaItemProps) {
 
   React.useEffect(() => {
     setMembers(buildDefaultMembers(props.schema, props.value));
-  }, [props.schema]);
+  }, [props.schema, props.value]);
 
   const handleAdd = React.useCallback(() => {
     const m = members.concat();

--- a/src/components/json-schema/Array.tsx
+++ b/src/components/json-schema/Array.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import {guid} from '../../utils/helper';
+import Button from '../Button';
+import {Icon} from '../icons';
+import type {InputJSONSchemaItemProps} from './index';
+import {InputJSONSchemaItem} from './Item';
+
+type JSONSchemaArrayMember = {
+  key: string;
+  index: number;
+  schema?: any;
+  invalid?: boolean;
+};
+export function InputJSONSchemaArray(props: InputJSONSchemaItemProps) {
+  const {
+    classnames: cx,
+    value,
+    onChange,
+    disabled,
+    translate: __,
+    renderKey,
+    collapsable
+  } = props;
+  const buildDefaultMembers = React.useCallback((schema: any, value) => {
+    const members: Array<JSONSchemaArrayMember> = [];
+
+    let len = Array.isArray(value) ? value.length : 1;
+
+    if (typeof schema.minContains === 'number') {
+      len = Math.max(len, schema.minContains);
+    }
+
+    const maxContains =
+      typeof schema.maxContains === 'number' ? schema.maxContains : 0;
+
+    while (len--) {
+      members.push({
+        key: guid(),
+        index: members.length,
+        schema: schema.items,
+        invalid: maxContains ? maxContains < members.length : false
+      });
+    }
+
+    return members;
+  }, []);
+
+  const [members, setMembers] = React.useState<Array<JSONSchemaArrayMember>>(
+    buildDefaultMembers(props.schema, value)
+  );
+  const [collapsed, setCollapsed] = React.useState<boolean>(
+    collapsable ? true : false
+  );
+  const toggleCollapsed = () => {
+    setCollapsed(!collapsed);
+  };
+
+  const onMemberChange = (member: JSONSchemaArrayMember, memberValue: any) => {
+    const newValue = Array.isArray(props.value) ? props.value.concat() : [];
+    newValue[member.index] = memberValue;
+    onChange?.(newValue);
+  };
+  const onMemberDelete = (member: JSONSchemaArrayMember) => {
+    const idx = members.indexOf(member);
+    if (!~idx) {
+      throw new Error('member object not found');
+    }
+
+    const m = members.concat();
+    m.splice(idx, 1);
+    setMembers(m);
+
+    const newValue = Array.isArray(props.value) ? props.value.concat() : [];
+    newValue.splice(member.index, 1);
+    onChange?.(newValue);
+  };
+
+  React.useEffect(() => {
+    setMembers(buildDefaultMembers(props.schema, props.value));
+  }, [props.schema]);
+
+  const handleAdd = React.useCallback(() => {
+    const m = members.concat();
+    m.push({
+      key: guid(),
+      index: members.length,
+      schema: props.schema.items,
+      invalid: false
+    });
+    setMembers(m);
+  }, [members]);
+
+  const maxContains =
+    typeof props.schema?.maxContains === 'number'
+      ? props.schema.maxContains
+      : 0;
+
+  const minContains =
+    typeof props.schema?.minContains === 'number'
+      ? props.schema.minContains
+      : 0;
+
+  // todo additionalProperties 还有其他格式
+  const allowAdd = !maxContains || maxContains > members.length;
+  const allowDelete = !minContains || minContains < members.length;
+
+  return (
+    <>
+      {collapsable ? (
+        <a
+          className={cx('JSONSchemaObject-caret', {
+            'is-collapsed': collapsed
+          })}
+          onClick={toggleCollapsed}
+        >
+          <Icon icon="caret" className="icon" />
+        </a>
+      ) : null}
+
+      <div
+        className={cx('JSONSchemaObject', {
+          'is-expanded': collapsable && !collapsed
+        })}
+      >
+        {collapsed ? (
+          <InputJSONSchemaItem
+            {...props}
+            value={value}
+            onChange={onChange}
+            schema={{
+              type: 'string'
+            }}
+            placeholder={props.schema?.description}
+          />
+        ) : (
+          members.map(member => {
+            return (
+              <div key={member.key} className={cx('JSONSchemaMember')}>
+                <div className={cx('JSONSchemaMember-value')}>
+                  <InputJSONSchemaItem
+                    {...props}
+                    value={value?.[member.index]}
+                    onChange={onMemberChange.bind(null, member)}
+                    schema={
+                      member.schema || {
+                        type: 'string'
+                      }
+                    }
+                    collapsable
+                  />
+                </div>
+                {allowDelete ? (
+                  <Button
+                    className={cx('SchemaEditor-btn')}
+                    onClick={onMemberDelete.bind(null, member)}
+                    iconOnly
+                    disabled={disabled || !!value?.$ref}
+                  >
+                    <Icon icon="remove" className="icon" />
+                  </Button>
+                ) : null}
+              </div>
+            );
+          })
+        )}
+
+        {!collapsed ? (
+          <Button
+            level="link"
+            onClick={handleAdd}
+            size="xs"
+            disabled={disabled || !allowAdd}
+          >
+            {__('JSONSchema.add_prop')}
+          </Button>
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/src/components/json-schema/Array.tsx
+++ b/src/components/json-schema/Array.tsx
@@ -80,7 +80,7 @@ export function InputJSONSchemaArray(props: InputJSONSchemaItemProps) {
 
   React.useEffect(() => {
     setMembers(buildMembers(props.schema, props.value));
-  }, [props.schema]);
+  }, [JSON.stringify(props.schema)]);
 
   React.useEffect(() => {
     const value = props.value;
@@ -110,7 +110,7 @@ export function InputJSONSchemaArray(props: InputJSONSchemaItemProps) {
       }
       setMembers(m);
     }
-  }, [props.value]);
+  }, [JSON.stringify(props.value)]);
 
   const handleAdd = React.useCallback(() => {
     const m = members.concat();

--- a/src/components/json-schema/Item.tsx
+++ b/src/components/json-schema/Item.tsx
@@ -13,7 +13,7 @@ export function InputJSONSchemaItem(props: InputJSONSchemaItemProps) {
   } else if (schema.type === 'array') {
     return <InputJSONSchemaArray {...props} />;
   } else if (props.renderValue) {
-    return props.renderValue(props.value, props.onChange, schema);
+    return props.renderValue(props.value, props.onChange, schema, props);
   } else if (schema.type == 'number') {
     return (
       <NumberInput

--- a/src/components/json-schema/Item.tsx
+++ b/src/components/json-schema/Item.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import InputBox from '../InputBox';
+import NumberInput from '../NumberInput';
+import Switch from '../Switch';
+import {InputJSONSchemaArray} from './Array';
+import type {InputJSONSchemaItemProps} from './index';
+import {InputJSONSchemaObject} from './Object';
+
+export function InputJSONSchemaItem(props: InputJSONSchemaItemProps) {
+  const schema = props.schema;
+  if (schema.type === 'object') {
+    return <InputJSONSchemaObject {...props} />;
+  } else if (schema.type === 'array') {
+    return <InputJSONSchemaArray {...props} />;
+  } else if (props.renderValue) {
+    return props.renderValue(props.value, props.onChange, schema);
+  } else if (schema.type == 'number') {
+    return (
+      <NumberInput
+        value={props.value}
+        onChange={props.onChange}
+        placeholder={props.placeholder}
+      />
+    );
+  } else if (schema.type == 'integer') {
+    return (
+      <NumberInput
+        value={props.value}
+        onChange={props.onChange}
+        precision={0}
+        placeholder={props.placeholder}
+      />
+    );
+  } else if (schema.type == 'boolean') {
+    return (
+      <Switch value={props.value} onChange={props.onChange} className="mt-2" />
+    );
+  }
+
+  return (
+    <InputBox
+      value={props.value}
+      onChange={props.onChange}
+      placeholder={props.placeholder}
+    />
+  );
+}

--- a/src/components/json-schema/Object.tsx
+++ b/src/components/json-schema/Object.tsx
@@ -23,7 +23,7 @@ export function InputJSONSchemaObject(props: InputJSONSchemaItemProps) {
     renderKey,
     collapsable
   } = props;
-  const buildDefaultMembers = React.useCallback((schema: any) => {
+  const buildDefaultMembers = React.useCallback((schema: any, value: any) => {
     const members: Array<JSONSchemaObjectMember> = [];
 
     Object.keys(schema.properties || {}).forEach(key => {
@@ -47,13 +47,26 @@ export function InputJSONSchemaObject(props: InputJSONSchemaItemProps) {
       });
     }
 
-    // todo 外部 value 发生变化，也需要构建这个
+    const keys = Object.keys(value || {});
+    for (let key of keys) {
+      const exists = members.find(m => m.name === key);
+      if (!exists) {
+        members.push({
+          key: guid(),
+          name: key,
+          nameMutable: true,
+          schema: {
+            type: 'string'
+          }
+        });
+      }
+    }
 
     return members;
   }, []);
 
   const [members, setMembers] = React.useState<Array<JSONSchemaObjectMember>>(
-    buildDefaultMembers(props.schema)
+    buildDefaultMembers(props.schema, props.value)
   );
   const [collapsed, setCollapsed] = React.useState<boolean>(
     collapsable ? true : false
@@ -107,8 +120,8 @@ export function InputJSONSchemaObject(props: InputJSONSchemaItemProps) {
   };
 
   React.useEffect(() => {
-    setMembers(buildDefaultMembers(props.schema));
-  }, [props.schema]);
+    setMembers(buildDefaultMembers(props.schema, props.value));
+  }, [props.schema, props.value]);
 
   const handleAdd = React.useCallback(() => {
     const m = members.concat();

--- a/src/components/json-schema/Object.tsx
+++ b/src/components/json-schema/Object.tsx
@@ -100,6 +100,9 @@ export function InputJSONSchemaObject(props: InputJSONSchemaItemProps) {
       throw new Error('member object not found');
     }
 
+    const newValue = {
+      ...props.value
+    };
     const m = members.concat();
     m.splice(idx, 1, {
       ...member,
@@ -113,6 +116,10 @@ export function InputJSONSchemaObject(props: InputJSONSchemaItemProps) {
     });
 
     setMembers(m);
+
+    newValue[memberValue] = newValue[member.name];
+    delete newValue[member.name];
+    onChange?.(newValue);
   };
   const onMemberDelete = (member: JSONSchemaObjectMember) => {
     const idx = members.indexOf(member);

--- a/src/components/json-schema/Object.tsx
+++ b/src/components/json-schema/Object.tsx
@@ -129,7 +129,7 @@ export function InputJSONSchemaObject(props: InputJSONSchemaItemProps) {
 
   React.useEffect(() => {
     setMembers(buildMembers(props.schema, props.value));
-  }, [props.schema]);
+  }, [JSON.stringify(props.schema)]);
 
   React.useEffect(() => {
     const value = props.value;
@@ -151,7 +151,7 @@ export function InputJSONSchemaObject(props: InputJSONSchemaItemProps) {
     if (m.length !== membersRef.current!.length) {
       setMembers(m);
     }
-  }, [props.value]);
+  }, [JSON.stringify(props.value)]);
 
   const handleAdd = React.useCallback(() => {
     const m = members.concat();

--- a/src/components/json-schema/Object.tsx
+++ b/src/components/json-schema/Object.tsx
@@ -24,7 +24,8 @@ export function InputJSONSchemaObject(props: InputJSONSchemaItemProps) {
     disabled,
     translate: __,
     renderKey,
-    collapsable
+    collapsable,
+    renderValue
   } = props;
   const buildMembers = React.useCallback((schema: any, value: any) => {
     const members: Array<JSONSchemaObjectMember> = [];
@@ -35,7 +36,7 @@ export function InputJSONSchemaObject(props: InputJSONSchemaItemProps) {
       members.push({
         key: guid(),
         name: key,
-        nameMutable: false,
+        nameMutable: !required.includes(key),
         required: required.includes(key),
         schema: child
       });
@@ -102,6 +103,9 @@ export function InputJSONSchemaObject(props: InputJSONSchemaItemProps) {
     const m = members.concat();
     m.splice(idx, 1, {
       ...member,
+      schema: props.schema?.properties?.[memberValue] || {
+        type: 'string'
+      },
       name: memberValue,
       invalid:
         !memberValue ||
@@ -198,15 +202,17 @@ export function InputJSONSchemaObject(props: InputJSONSchemaItemProps) {
         })}
       >
         {collapsed ? (
-          <InputJSONSchemaItem
-            {...props}
-            value={value}
-            onChange={onChange}
-            schema={{
-              type: 'string'
-            }}
-            placeholder={props.schema?.description}
-          />
+          renderValue ? (
+            <InputJSONSchemaItem
+              {...props}
+              value={value}
+              onChange={onChange}
+              schema={{
+                type: 'string'
+              }}
+              placeholder={props.schema?.description}
+            />
+          ) : null
         ) : (
           members.map(member => {
             const filtedOptions = options.filter(
@@ -259,7 +265,11 @@ export function InputJSONSchemaObject(props: InputJSONSchemaItemProps) {
                     </>
                   ) : (
                     <span>
+                      {member.required ? (
+                        <span className={cx(`Form-star`)}>*</span>
+                      ) : null}
                       {member.schema?.title || member.name}
+
                       {/* {member.schema?.description ? (
                         <TooltipWrapper
                           tooltipTheme="dark"

--- a/src/components/json-schema/index.tsx
+++ b/src/components/json-schema/index.tsx
@@ -14,12 +14,14 @@ export interface InputJSONSchemaItemProps extends ThemeProps, LocaleProps {
   renderValue?: (
     value: any,
     onChange: (value: any) => void,
-    schema: any
+    schema: any,
+    props: any
   ) => JSX.Element;
   renderKey?: (
     value: any,
     onChange: (value: any) => void,
-    schema: any
+    schema: any,
+    props: any
   ) => JSX.Element;
   collapsable?: boolean;
   placeholder?: string;

--- a/src/components/json-schema/index.tsx
+++ b/src/components/json-schema/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {localeable, LocaleProps} from '../../locale';
+import {themeable, ThemeProps} from '../../theme';
+import type {JSONSchema} from '../../utils/DataScope';
+import {InputJSONSchemaItem} from './Item';
+
+export interface InputJSONSchemaItemProps extends ThemeProps, LocaleProps {
+  schema: JSONSchema & {
+    [propName: string]: any;
+  };
+  value?: any;
+  onChange?: any;
+  disabled?: boolean;
+  renderValue?: (
+    value: any,
+    onChange: (value: any) => void,
+    schema: any
+  ) => JSX.Element;
+  renderKey?: (
+    value: any,
+    onChange: (value: any) => void,
+    schema: any
+  ) => JSX.Element;
+  collapsable?: boolean;
+  placeholder?: string;
+}
+
+export interface InputJSONSchemaProps
+  extends Omit<InputJSONSchemaItemProps, 'schema'> {
+  schema?: any;
+}
+
+function InputJSONSchema(props: InputJSONSchemaProps) {
+  const schema = props.schema || {
+    type: 'object',
+    properties: {}
+  };
+
+  return <InputJSONSchemaItem {...props} schema={schema} />;
+}
+
+export default themeable(localeable(InputJSONSchema));

--- a/src/components/schema-editor/Array.tsx
+++ b/src/components/schema-editor/Array.tsx
@@ -38,7 +38,8 @@ export class SchemaEditorItemArray extends SchemaEditorItemCommon {
       disabled,
       showInfo,
       types,
-      onTypeChange
+      onTypeChange,
+      enableAdvancedSetting
     } = this.props;
     const items = value?.items || {
       type: 'string'
@@ -67,6 +68,7 @@ export class SchemaEditorItemArray extends SchemaEditorItemCommon {
           classnames={cx}
           classPrefix={classPrefix}
           disabled={disabled || !!(items as any)?.$ref}
+          enableAdvancedSetting={enableAdvancedSetting}
         />
       </div>
     );

--- a/src/components/schema-editor/Common.tsx
+++ b/src/components/schema-editor/Common.tsx
@@ -11,6 +11,7 @@ import {Icon} from '../icons';
 import InputBox from '../InputBox';
 import PickerContainer from '../PickerContainer';
 import Select from '../Select';
+import Textarea from '../Textarea';
 
 export interface SchemaEditorItemCommonProps extends LocaleProps, ThemeProps {
   value?: JSONSchema;
@@ -40,6 +41,7 @@ export interface SchemaEditorItemCommonProps extends LocaleProps, ThemeProps {
   ) => JSX.Element;
   prefix?: JSX.Element;
   affix?: JSX.Element;
+  enableAdvancedSetting?: boolean;
 }
 
 export class SchemaEditorItemCommon<
@@ -83,6 +85,7 @@ export class SchemaEditorItemCommon<
       onRequiredChange,
       renderExtraProps,
       renderModalProps,
+      enableAdvancedSetting,
       prefix,
       affix,
       types
@@ -114,46 +117,68 @@ export class SchemaEditorItemCommon<
 
         {renderExtraProps?.(value!, this.handlePropsChange)}
 
-        <PickerContainer
-          value={value}
-          bodyRender={({isOpened, value, onChange, ref}) => {
-            return isOpened ? (
-              <Form defaultValues={value} onSubmit={onChange} ref={ref}>
-                {({control}) => (
-                  <>
-                    <Controller
-                      label={__('JSONSchema.title')}
-                      name="title"
-                      control={control}
-                      rules={{isInt: true}}
-                      isRequired
-                      render={({field}) => (
-                        <InputBox
-                          {...field}
-                          disabled={disabled || !!value?.$ref}
-                        />
-                      )}
-                    />
-                  </>
-                )}
-              </Form>
-            ) : null;
-          }}
-          beforeConfirm={this.handleBeforeSubmit}
-          onConfirm={this.handlePropsChange}
-          size="md"
-          title={__('SubForm.editDetail')}
-        >
-          {({onClick}) => (
-            <Button
-              disabled={disabled}
-              className={cx('SchemaEditor-btn')}
-              onClick={onClick}
-            >
-              <Icon icon="setting" className="icon" />
-            </Button>
-          )}
-        </PickerContainer>
+        {enableAdvancedSetting ? (
+          <PickerContainer
+            value={value}
+            bodyRender={({isOpened, value, onChange, ref}) => {
+              return isOpened ? (
+                <Form defaultValues={value} onSubmit={onChange} ref={ref}>
+                  {({control, getValues, setValue}) => (
+                    <>
+                      <Controller
+                        label={__('JSONSchema.title')}
+                        name="title"
+                        control={control}
+                        rules={{maxLength: 20}}
+                        isRequired
+                        render={({field}) => (
+                          <InputBox {...field} disabled={disabled} />
+                        )}
+                      />
+
+                      <Controller
+                        label={__('JSONSchema.description')}
+                        name="description"
+                        control={control}
+                        render={({field}) => (
+                          <Textarea {...field} disabled={disabled} />
+                        )}
+                      />
+
+                      <Controller
+                        label={__('JSONSchema.default')}
+                        name="default"
+                        control={control}
+                        render={({field}) => (
+                          <InputBox {...field} disabled={disabled} />
+                        )}
+                      />
+
+                      {renderModalProps?.(getValues(), (values: any) => {
+                        Object.keys(values).forEach(key =>
+                          setValue(key, values[key])
+                        );
+                      })}
+                    </>
+                  )}
+                </Form>
+              ) : null;
+            }}
+            beforeConfirm={this.handleBeforeSubmit}
+            onConfirm={this.handlePropsChange}
+            title={__('SubForm.editDetail')}
+          >
+            {({onClick}) => (
+              <Button
+                disabled={disabled || !!value?.$ref}
+                className={cx('SchemaEditor-btn')}
+                onClick={onClick}
+              >
+                <Icon icon="setting" className="icon" />
+              </Button>
+            )}
+          </PickerContainer>
+        ) : null}
 
         {affix}
       </>

--- a/src/components/schema-editor/Common.tsx
+++ b/src/components/schema-editor/Common.tsx
@@ -119,17 +119,16 @@ export class SchemaEditorItemCommon<
           bodyRender={({isOpened, value, onChange, ref}) => {
             return isOpened ? (
               <Form defaultValues={value} onSubmit={onChange} ref={ref}>
-                {({control, formState: {errors}}) => (
+                {({control}) => (
                   <>
                     <Controller
                       label={__('JSONSchema.title')}
                       name="title"
-                      hasError={errors.title}
-                      errors={errors.title}
                       control={control}
+                      rules={{isInt: true}}
+                      isRequired
                       render={({field}) => (
                         <InputBox
-                          className={cx('SchemaEditor-title')}
                           {...field}
                           disabled={disabled || !!value?.$ref}
                         />

--- a/src/components/schema-editor/Common.tsx
+++ b/src/components/schema-editor/Common.tsx
@@ -5,6 +5,8 @@ import type {JSONSchema} from '../../utils/DataScope';
 import {autobind} from '../../utils/helper';
 import Button from '../Button';
 import Checkbox from '../Checkbox';
+import Form from '../Form';
+import FormField, {Controller} from '../FormField';
 import {Icon} from '../icons';
 import InputBox from '../InputBox';
 import PickerContainer from '../PickerContainer';
@@ -65,6 +67,11 @@ export class SchemaEditorItemCommon<
     });
   }
 
+  @autobind
+  handleBeforeSubmit(form: any) {
+    return form.submit();
+  }
+
   renderCommon() {
     const {
       value,
@@ -107,21 +114,47 @@ export class SchemaEditorItemCommon<
 
         {renderExtraProps?.(value!, this.handlePropsChange)}
 
-        {renderModalProps ? (
-          <PickerContainer
-            value={value}
-            bodyRender={renderModalProps as any}
-            onConfirm={this.handlePropsChange}
-            size="md"
-            title={__('SubForm.editDetail')}
-          >
-            {({onClick}) => (
-              <Button className={cx('SchemaEditor-btn')} onClick={onClick}>
-                <Icon icon="setting" className="icon" />
-              </Button>
-            )}
-          </PickerContainer>
-        ) : null}
+        <PickerContainer
+          value={value}
+          bodyRender={({isOpened, value, onChange, ref}) => {
+            return isOpened ? (
+              <Form defaultValues={value} onSubmit={onChange} ref={ref}>
+                {({control, formState: {errors}}) => (
+                  <>
+                    <Controller
+                      label={__('JSONSchema.title')}
+                      name="title"
+                      hasError={errors.title}
+                      errors={errors.title}
+                      control={control}
+                      render={({field}) => (
+                        <InputBox
+                          className={cx('SchemaEditor-title')}
+                          {...field}
+                          disabled={disabled || !!value?.$ref}
+                        />
+                      )}
+                    />
+                  </>
+                )}
+              </Form>
+            ) : null;
+          }}
+          beforeConfirm={this.handleBeforeSubmit}
+          onConfirm={this.handlePropsChange}
+          size="md"
+          title={__('SubForm.editDetail')}
+        >
+          {({onClick}) => (
+            <Button
+              disabled={disabled}
+              className={cx('SchemaEditor-btn')}
+              onClick={onClick}
+            >
+              <Icon icon="setting" className="icon" />
+            </Button>
+          )}
+        </PickerContainer>
 
         {affix}
       </>

--- a/src/components/schema-editor/Object.tsx
+++ b/src/components/schema-editor/Object.tsx
@@ -195,7 +195,8 @@ export class SchemaEditorItemObject extends SchemaEditorItemCommon<
       disabled,
       showInfo,
       types,
-      onTypeChange
+      onTypeChange,
+      enableAdvancedSetting
     } = this.props;
     const members = this.state.members;
 
@@ -211,6 +212,7 @@ export class SchemaEditorItemObject extends SchemaEditorItemCommon<
               key={member.id}
               types={types}
               onTypeChange={onTypeChange}
+              enableAdvancedSetting={enableAdvancedSetting}
               prefix={
                 <>
                   <InputBox

--- a/src/components/schema-editor/index.tsx
+++ b/src/components/schema-editor/index.tsx
@@ -35,7 +35,7 @@ export interface SchemaEditorProps extends LocaleProps, ThemeProps {
       type:
         | 'string'
         | 'number'
-        | 'interger'
+        | 'integer'
         | 'object'
         | 'array'
         | 'boolean'
@@ -90,8 +90,8 @@ export class SchemaEditor extends React.Component<SchemaEditorProps> {
       },
 
       {
-        label: __('SchemaType.interger'),
-        value: 'interger'
+        label: __('SchemaType.integer'),
+        value: 'integer'
       },
 
       {
@@ -173,7 +173,7 @@ export class SchemaEditor extends React.Component<SchemaEditorProps> {
           [
             'string',
             'number',
-            'interger',
+            'integer',
             'object',
             'array',
             'boolean',

--- a/src/components/schema-editor/index.tsx
+++ b/src/components/schema-editor/index.tsx
@@ -54,6 +54,11 @@ export interface SchemaEditorProps extends LocaleProps, ThemeProps {
    * 顶层类型信息是否隐藏
    */
   showRootInfo: boolean;
+
+  /**
+   * 是否开启高级配置
+   */
+  enableAdvancedSetting?: boolean;
 }
 
 export class SchemaEditor extends React.Component<SchemaEditorProps> {
@@ -145,7 +150,8 @@ export class SchemaEditor extends React.Component<SchemaEditorProps> {
       rootTypeMutable,
       showRootInfo,
       disabled,
-      definitions
+      definitions,
+      enableAdvancedSetting
     } = this.props;
     const value: JSONSchema = this.props.value || {
       type: defaultType || 'object'
@@ -202,6 +208,7 @@ export class SchemaEditor extends React.Component<SchemaEditorProps> {
           classPrefix={classPrefix}
           disabled={disabled}
           onTypeChange={this.handleTypeChange}
+          enableAdvancedSetting={enableAdvancedSetting}
         />
       </div>
     );

--- a/src/hooks/use-validation-resolver.ts
+++ b/src/hooks/use-validation-resolver.ts
@@ -1,0 +1,41 @@
+import pick from 'lodash/pick';
+import React from 'react';
+import {validateObject, validations} from '../utils/validations';
+
+function formatErrors(errors: any) {
+  const formated: any = {};
+  Object.keys(errors).forEach(key => {
+    const origin = errors[key][0];
+    if (origin) {
+      formated[key] = {
+        type: origin.rule,
+        message: origin.msg
+      };
+    }
+  });
+  return formated;
+}
+
+export function useValidationResolver(__ = (str: string) => str) {
+  return React.useCallback<any>(
+    async (values: any, context: any, config: any) => {
+      const rules: any = {};
+      const ruleKeys = Object.keys(validations);
+      for (let key of Object.keys(config.fields)) {
+        const field = config.fields[key];
+        rules[key] = pick(field, ruleKeys);
+
+        if (field.required) {
+          rules[key].isRequired = true;
+        }
+      }
+
+      const errors = validateObject(values, rules, undefined, __);
+
+      return {
+        errors: formatErrors(errors)
+      };
+    },
+    [__]
+  );
+}

--- a/src/hooks/use-validation-resolver.ts
+++ b/src/hooks/use-validation-resolver.ts
@@ -1,3 +1,6 @@
+/**
+ * @file 用 amis 内置的验证来验证 react-hook-form 里面的表单数据
+ */
 import pick from 'lodash/pick';
 import React from 'react';
 import {validateObject, validations} from '../utils/validations';
@@ -33,6 +36,7 @@ export function useValidationResolver(__ = (str: string) => str) {
       const errors = validateObject(values, rules, undefined, __);
 
       return {
+        values,
         errors: formatErrors(errors)
       };
     },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -87,6 +87,7 @@ import './renderers/Form/ChartRadios';
 import './renderers/Form/InputRating';
 import './renderers/Form/Switch';
 import './renderers/Form/Radios';
+import './renderers/Form/JSONSchema';
 import './renderers/Form/JSONSchemaEditor';
 import './renderers/Form/ListSelect';
 import './renderers/Form/LocationPicker';

--- a/src/locale/de-DE.ts
+++ b/src/locale/de-DE.ts
@@ -316,6 +316,7 @@ register('de-DE', {
   'SchemaType.null': 'Null',
   'SchemaType.any': 'Any',
   'JSONSchema.title': 'Title',
+  'JSONSchema.default': 'Default',
   'JSONSchema.description': 'Description',
   'JSONSchema.key': 'Key',
   'JSONSchema.array_items': 'Items'

--- a/src/locale/de-DE.ts
+++ b/src/locale/de-DE.ts
@@ -309,7 +309,7 @@ register('de-DE', {
   'Picker.placeholder': 'Klicken Sie rechts auf das Symbol',
   'SchemaType.string': 'String',
   'SchemaType.number': 'Number',
-  'SchemaType.interger': 'Interger',
+  'SchemaType.integer': 'integer',
   'SchemaType.object': 'Object',
   'SchemaType.array': 'Array',
   'SchemaType.boolean': 'Boolean',

--- a/src/locale/en-US.ts
+++ b/src/locale/en-US.ts
@@ -311,7 +311,7 @@ register('en-US', {
   'Picker.placeholder': 'Click icon on the right',
   'SchemaType.string': 'String',
   'SchemaType.number': 'Number',
-  'SchemaType.interger': 'Interger',
+  'SchemaType.integer': 'integer',
   'SchemaType.object': 'Object',
   'SchemaType.array': 'Array',
   'SchemaType.boolean': 'Boolean',

--- a/src/locale/en-US.ts
+++ b/src/locale/en-US.ts
@@ -318,6 +318,7 @@ register('en-US', {
   'SchemaType.any': 'Any',
   'SchemaType.null': 'Null',
   'JSONSchema.title': 'Title',
+  'JSONSchema.default': 'Default',
   'JSONSchema.description': 'Description',
   'JSONSchema.key': 'Key',
   'JSONSchema.array_items': 'Items'

--- a/src/locale/zh-CN.ts
+++ b/src/locale/zh-CN.ts
@@ -318,7 +318,7 @@ register('zh-CN', {
   'Picker.placeholder': '请点击右侧的图标',
   'SchemaType.string': '文本',
   'SchemaType.number': '数字',
-  'SchemaType.interger': '整数',
+  'SchemaType.integer': '整数',
   'SchemaType.object': '对象',
   'SchemaType.array': '数组',
   'SchemaType.boolean': '布尔',

--- a/src/locale/zh-CN.ts
+++ b/src/locale/zh-CN.ts
@@ -325,6 +325,7 @@ register('zh-CN', {
   'SchemaType.null': 'Null',
   'SchemaType.any': '任意',
   'JSONSchema.title': '名称',
+  'JSONSchema.default': '默认值',
   'JSONSchema.key': '字段名',
   'JSONSchema.description': '描述',
   'JSONSchema.add_prop': '添加属性',

--- a/src/renderers/Form/JSONSchema.tsx
+++ b/src/renderers/Form/JSONSchema.tsx
@@ -34,10 +34,10 @@ export interface JSONSchemaProps
 
 const EnhancedInputJSONSchema = withRemoteConfig({
   sourceField: 'schema',
-  injectedPropsFilter: props => {
+  injectedPropsFilter: (injectedProps, props) => {
     return {
-      schema: props.config,
-      loading: props.loading
+      schema: injectedProps.config,
+      loading: injectedProps.loading
     };
   }
 })(InputJSONSchema as any);

--- a/src/renderers/Form/JSONSchema.tsx
+++ b/src/renderers/Form/JSONSchema.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import {FormItem, FormControlProps, FormBaseControl} from './Item';
-import {autobind} from '../../utils/helper';
+import {autobind, isObjectShallowModified} from '../../utils/helper';
 import InputJSONSchema from '../../components/json-schema/index';
 import {
   isPureVariable,
   resolveVariableAndFilter
 } from '../../utils/tpl-builtin';
+import {isApiOutdated, isEffectiveApi} from '../../utils/api';
+import {withRemoteConfig} from '../../components/WithRemoteConfig';
 
 /**
  * JSON Schema
@@ -30,14 +32,20 @@ export interface JSONSchemaProps
       'type' | 'className' | 'descriptionClassName' | 'inputClassName'
     > {}
 
+const EnhancedInputJSONSchema = withRemoteConfig({
+  sourceField: 'schema',
+  injectedPropsFilter: props => {
+    return {
+      schema: props.config,
+      loading: props.loading
+    };
+  }
+})(InputJSONSchema as any);
 export default class JSONSchemaControl extends React.PureComponent<JSONSchemaProps> {
   render() {
-    const {schema, ...rest} = this.props;
-    const finalSchema = isPureVariable(schema)
-      ? resolveVariableAndFilter(schema, rest.data, '| raw')
-      : schema;
+    const {...rest} = this.props;
 
-    return <InputJSONSchema {...rest} schema={finalSchema} />;
+    return <EnhancedInputJSONSchema {...rest} />;
   }
 }
 

--- a/src/renderers/Form/JSONSchema.tsx
+++ b/src/renderers/Form/JSONSchema.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {FormItem, FormControlProps, FormBaseControl} from './Item';
+import {autobind} from '../../utils/helper';
+
+/**
+ * JSON Schema
+ * 文档：https://baidu.gitee.io/amis/docs/components/form/json-schema
+ */
+export interface JSONSchemaControlSchema extends FormBaseControl {
+  /**
+   * 指定为 JSON Schema
+   */
+  type: 'json-schema';
+
+  /**
+   * json-schema 详情，支持关联上下文数据
+   */
+  schema?: any;
+}
+
+export interface JSONSchemaProps
+  extends FormControlProps,
+    Omit<
+      JSONSchemaControlSchema,
+      'type' | 'className' | 'descriptionClassName' | 'inputClassName'
+    > {}
+
+export default class JSONSchemaControl extends React.PureComponent<JSONSchemaProps> {
+  render() {
+    const {} = this.props;
+
+    return <p>233</p>;
+  }
+}
+
+@FormItem({
+  type: 'json-schema'
+})
+export class JSONSchemaRenderer extends JSONSchemaControl {}

--- a/src/renderers/Form/JSONSchema.tsx
+++ b/src/renderers/Form/JSONSchema.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import {FormItem, FormControlProps, FormBaseControl} from './Item';
 import {autobind} from '../../utils/helper';
+import InputJSONSchema from '../../components/json-schema/index';
+import {
+  isPureVariable,
+  resolveVariableAndFilter
+} from '../../utils/tpl-builtin';
 
 /**
  * JSON Schema
@@ -27,13 +32,17 @@ export interface JSONSchemaProps
 
 export default class JSONSchemaControl extends React.PureComponent<JSONSchemaProps> {
   render() {
-    const {} = this.props;
+    const {schema, ...rest} = this.props;
+    const finalSchema = isPureVariable(schema)
+      ? resolveVariableAndFilter(schema, rest.data, '| raw')
+      : schema;
 
-    return <p>233</p>;
+    return <InputJSONSchema {...rest} schema={finalSchema} />;
   }
 }
 
 @FormItem({
-  type: 'json-schema'
+  type: 'json-schema',
+  strictMode: false
 })
 export class JSONSchemaRenderer extends JSONSchemaControl {}

--- a/src/renderers/Form/JSONSchemaEditor.tsx
+++ b/src/renderers/Form/JSONSchemaEditor.tsx
@@ -79,39 +79,21 @@ export default class JSONSchemaEditorControl extends React.PureComponent<JSONSch
     enableAdvancedSetting: false
   };
 
-  // todo 完善这块配置
-  settings: any = {
-    common: [
-      {
-        type: 'input-text',
-        name: 'title',
-        label: this.props.translate('JSONSchema.title')
-      },
-
-      {
-        type: 'textarea',
-        name: 'description',
-        label: this.props.translate('JSONSchema.description')
-      }
-    ]
-  };
-
   @autobind
-  renderModalProps({value, onChange}: any) {
+  renderModalProps(value: any, onChange: (value: any) => void) {
     const {render, advancedSettings} = this.props;
+    const fields = advancedSettings?.[value?.type] || [];
     return render(
       `modal`,
       {
         type: 'form',
         wrapWithPanel: false,
-        body: [
-          ...(this.settings[value?.type] || this.settings.common),
-          ...(advancedSettings?.[value?.type] || [])
-        ]
+        body: fields,
+        submitOnChange: true
       },
       {
         data: value,
-        onChange: (value: any) => onChange(value)
+        onSubmit: (value: any) => onChange(value)
       }
     );
   }
@@ -122,9 +104,8 @@ export default class JSONSchemaEditorControl extends React.PureComponent<JSONSch
     return (
       <JSONSchemaEditor
         {...rest}
-        renderModalProps={
-          enableAdvancedSetting ? this.renderModalProps : undefined
-        }
+        enableAdvancedSetting={enableAdvancedSetting}
+        renderModalProps={this.renderModalProps}
       />
     );
   }

--- a/src/renderers/Form/JSONSchemaEditor.tsx
+++ b/src/renderers/Form/JSONSchemaEditor.tsx
@@ -22,7 +22,7 @@ export interface JSONSchemaEditorControlSchema extends FormBaseControl {
       type:
         | 'string'
         | 'number'
-        | 'interger'
+        | 'integer'
         | 'object'
         | 'array'
         | 'boolean'

--- a/src/renderers/Form/Textarea.tsx
+++ b/src/renderers/Form/Textarea.tsx
@@ -86,60 +86,22 @@ export default class TextAreaControl extends React.Component<
     clearable: false
   };
 
-  state = {
-    focused: false
-  };
-
-  input?: HTMLInputElement;
-  inputRef = (ref: any) => (this.input = findDOMNode(ref) as HTMLInputElement);
+  inputRef = React.createRef<any>();
 
   doAction(action: ListenerAction, args: any) {
     const actionType = action?.actionType as string;
+    const onChange = this.props.onChange;
 
     if (!!~['clear', 'reset'].indexOf(actionType)) {
-      this.handleClear();
+      onChange?.(this.props.resetValue);
+      this.focus();
     } else if (actionType === 'focus') {
       this.focus();
     }
   }
 
-  valueToString(value: any) {
-    return typeof value === 'undefined' || value === null
-      ? ''
-      : typeof value === 'string'
-      ? value
-      : JSON.stringify(value);
-  }
-
   focus() {
-    if (!this.input) {
-      return;
-    }
-
-    this.setState(
-      {
-        focused: true
-      },
-      () => {
-        if (!this.input) {
-          return;
-        }
-
-        this.input.focus();
-
-        // 光标放到最后
-        const len = this.input.value.length;
-        len && this.input.setSelectionRange(len, len);
-      }
-    );
-  }
-
-  @autobind
-  handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
-    const {onChange} = this.props;
-    let value = e.currentTarget.value;
-
-    onChange?.(value);
+    this.inputRef.current?.focus();
   }
 
   @autobind
@@ -176,83 +138,11 @@ export default class TextAreaControl extends React.Component<
     );
   }
 
-  @autobind
-  async handleClear() {
-    const {onChange, resetValue} = this.props;
-
-    onChange?.(resetValue);
-    this.focus();
-  }
-
   render() {
-    const {
-      className,
-      classPrefix: ns,
-      value,
-      type,
-      placeholder,
-      disabled,
-      minRows,
-      maxRows,
-      readOnly,
-      name,
-      borderMode,
-      classnames: cx,
-      maxLength,
-      showCounter,
-      clearable
-    } = this.props;
-    const counter = showCounter ? this.valueToString(value).length : 0;
+    const {...rest} = this.props;
 
     return (
-      <div
-        className={cx(
-          `TextareaControl`,
-          {
-            [`TextareaControl--border${ucFirst(borderMode)}`]: borderMode,
-            'is-focused': this.state.focused,
-            'is-disabled': disabled
-          },
-          className
-        )}
-      >
-        <Textarea
-          className={cx(`TextareaControl-input`)}
-          autoComplete="off"
-          ref={this.inputRef}
-          name={name}
-          disabled={disabled}
-          value={this.valueToString(value)}
-          placeholder={placeholder}
-          autoCorrect="off"
-          spellCheck="false"
-          readOnly={readOnly}
-          minRows={minRows || undefined}
-          maxRows={maxRows || undefined}
-          onChange={this.handleChange}
-          onFocus={this.handleFocus}
-          onBlur={this.handleBlur}
-        />
-
-        {clearable && !disabled && value ? (
-          <a onClick={this.handleClear} className={cx('TextareaControl-clear')}>
-            <Icon icon="input-clear" className="icon" />
-          </a>
-        ) : null}
-
-        {showCounter ? (
-          <span
-            className={cx('TextareaControl-counter', {
-              'is-empty': counter === 0,
-              'is-clearable': clearable && !disabled && value
-            })}
-          >
-            {`${counter}${
-              typeof maxLength === 'number' && maxLength ? `/${maxLength}` : ''
-            }`}
-          </span>
-        ) : null}
-      </div>
+      <Textarea {...rest} onFocus={this.handleFocus} onBlur={this.handleBlur} />
     );
   }
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -307,7 +307,7 @@ export function responseAdaptor(ret: fetcherResult, api: ApiObject) {
   if (data.hasOwnProperty('errorCode')) {
     // 阿里 Java 规范
     data.status = data.errorCode;
-    data.msg = data.errorMessage;
+    data.msg = data.errorMessage || data.errorMsg;
   } else if (data.hasOwnProperty('errno')) {
     data.status = data.errno;
     data.msg = data.errmsg || data.errstr || data.msg;


### PR DESCRIPTION
 1. 添加 json-schema 渲染器，可以用来基于入参 json-schema 做数据映射
 2. 添加 react-hook-form 依赖，组件层可以更方便使用表单逻辑。原有逻辑在渲染器层实现，不方便在组件层调用。
 3. Textarea 大部分逻辑移动到 component 中，方便组件层复用。
 4. JSONSchema Editor 部分重构，支持配置默认值，弹窗详情改为由组件自身实现（而不是在渲染器中实现）