### PR TITLE
fix(Range): 完善滑块刻度标记展示，避免显示多余元素

### DIFF
--- a/src/components/Range.tsx
+++ b/src/components/Range.tsx
@@ -530,13 +530,20 @@ export class Range extends React.Component<RangeItemProps, any> {
           {/* 刻度标记 */}
           {marks && (
             <div className={cx('InputRange-marks')}>
-              {keys(marks).map((key: keyof MarksType) => (
-                <div key={key} style={{left: this.getOffsetLeft(key)}}>
-                  <span style={(marks[key] as any)?.style}>
-                    {(marks[key] as any)?.label || marks[key]}
-                  </span>
-                </div>
-              ))}
+              {keys(marks).map((key: keyof MarksType) => {
+                const offsetLeft = this.getOffsetLeft(key);
+                if (/^\d+%$/.test(offsetLeft)) {
+                  return (
+                    <div key={key} style={{left: offsetLeft}}>
+                      <span style={(marks[key] as any)?.style}>
+                        {(marks[key] as any)?.label || marks[key]}
+                      </span>
+                    </div>
+                  )
+                } else {
+                  return null;
+                }
+              })}
             </div>
           )}
         </div>


### PR DESCRIPTION
amis-editor端会出现如下多余元素：
![image](https://user-images.githubusercontent.com/11958920/172114247-891d9cd0-d84f-4ad0-8226-acda4f9fdd8b.png)
