### PR TITLE
fix:修复存在侧边栏的情况下，设置pullRefresh.disabled为 false情况下，内容区展示异常问题

### DIFF
--- a/packages/amis-ui/scss/components/_page.scss
+++ b/packages/amis-ui/scss/components/_page.scss
@@ -136,7 +136,8 @@
     flex-direction: row;
     align-items: stretch;
 
-    > .#{$ns}Page-content {
+    > .#{$ns}Page-content,
+    .#{$ns}PullRefresh {
       width: 0;
       flex-grow: 1;
     }


### PR DESCRIPTION
bug复现的 json配置如下
```json
{
  "type": "page",
  "pullRefresh": {
    "disabled": false
  },
  "aside": [
    {
      "type": "tpl",
      "tpl": "这是侧边栏部分"
    }
  ],
  "body": [
    {
      "type": "input-text",
      "label": "66666666"
    }
  ]
}
```
导致内容区的外层元素宽度没有设置 flex-flow:1 而没有撑开