### PR TITLE
Fix comb repeat remote verification

### DIFF
--- a/packages/amis-core/src/store/form.ts
+++ b/packages/amis-core/src/store/form.ts
@@ -61,6 +61,27 @@ export const FormStore = ServiceStore.named('FormStore')
         return getItems();
       },
 
+      /**
+       * 相对于 items(), 只收集直接子formItem
+       * 避免 子form 表单项的重复验证
+       */
+      get directItems() {
+        const formItems: Array<IFormItemStore> = [];
+
+        // 查找孩子节点中是 formItem 的表单项
+        const pool = self.children.concat();
+        while (pool.length) {
+          const current = pool.shift()!;
+          if (current.storeType === 'FormItemStore') {
+            formItems.push(current);
+          } else if (current.storeType !== 'ComboStore') {
+            pool.push(...current.children);
+          }
+        }
+
+        return formItems;
+      },
+
       get errors() {
         let errors: {
           [propName: string]: Array<string>;
@@ -511,7 +532,7 @@ export const FormStore = ServiceStore.named('FormStore')
       forceValidate?: boolean
     ) {
       self.validated = true;
-      const items = self.items.concat();
+      const items = self.directItems.concat();
       for (let i = 0, len = items.length; i < len; i++) {
         let item = items[i] as IFormItemStore;
 

--- a/packages/amis/src/renderers/Form/Combo.tsx
+++ b/packages/amis/src/renderers/Form/Combo.tsx
@@ -728,14 +728,13 @@ export default class ComboControl extends React.Component<ComboProps> {
 
   validate(): any {
     const {
-      value,
       minLength,
       maxLength,
       messages,
       nullable,
       translate: __
     } = this.props;
-
+    const value = this.getValueAsArray();
     if (minLength && (!Array.isArray(value) || value.length < minLength)) {
       return __(
         (messages && messages.minLengthValidateFailed) || 'Combo.minLength',


### PR DESCRIPTION
### 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化语料改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 其他改动（是关于什么的改动？）


### 需求背景和解决方案

#### 问题1
1. 描述： combo 组件在值打平模式下（配置如下）,提交时校验出错
```javascript
{
    type: "combo",
    flat: true,
    joinValues: true
    // ...
}
```
2. 问题出现原因：
值打平模式下，value 为字符串`str1,str2`，会在下方代码的`!Array.isArray(value)`中被捕获，导致校验报错
```javascript
if (minLength && (!Array.isArray(value) || value.length < minLength)) {
    return __(
        (messages && messages.minLengthValidateFailed) || 'Combo.minLength',
        {minLength}
    );
}
```
3. 解决方案
在校验前，使用`this.getValueAsArray()`方法对`value`先进行转换

#### 问题2
1. 描述：当表单中有combo组件submit时，combo中的表单项会被重复校验，如果是多层combo嵌套会重复更多次，尤其是表单项中包含 远程api校验的情况，会让校验时间成倍增长，表单反应特别慢。
2. 问题出现原因：当前逻辑是校验时，会先收集包含深层子元素在内的所有formItem，循环校验结束后，再调用子表单hook校验，子表单校验时，其中的表单项被再次校验，导致了重复校验。
3. 解决方案：在收集formItem阶段，只收集验证直接子表单项就可以。


### 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 英文 | Fix some verification issues of the Combo component.  |
| 中文 | 修复combo组件的一些校验问题。 |

### 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
