### PR TITLE
fix: 修复数据映射复杂写法没有正确返回原始数据的问题

### DIFF
--- a/packages/amis-core/src/utils/isPureVariable.ts
+++ b/packages/amis-core/src/utils/isPureVariable.ts
@@ -1,5 +1,15 @@
+import {parse} from 'amis-formula';
+
 export function isPureVariable(path?: any): path is string {
-  return typeof path === 'string'
-    ? /^\$(?:((?:\w+\:)?[a-z0-9_.][a-z0-9_.\[\]]*)|{[^}{]+})$/i.test(path)
-    : false;
+  if (typeof path === 'string') {
+    try {
+      const ast = parse(path);
+      // 只有一个成员说明是纯表达式模式
+      return ast.body.length === 1;
+    } catch (err) {
+      return false;
+    }
+  }
+
+  return false;
 }


### PR DESCRIPTION
比如 

```
{
  "a": "${ARRAYMAP(items, item => {a: item.a, b: item.b})}"
}
```

会被处理成 ['[object Object]', '[object Object]']

应该是返回: [{a: xxx, b: xxx}, {a: xxx, b: xxxx}]