### PR TITLE
fix:修复flex布局传递给 flexItem的disabled属性bug问题

### DIFF
--- a/packages/amis/src/renderers/Flex.tsx
+++ b/packages/amis/src/renderers/Flex.tsx
@@ -117,7 +117,7 @@ export default class Flex extends React.Component<FlexProps, object> {
           (item, key) =>
             render(`flexItem/${key}`, item, {
               key: `flexItem/${key}`,
-              disabled
+              disabled: item?.disabled ?? disabled
             })
         )}
       </div>


### PR DESCRIPTION
以下代码存在bug，因为flex布局向下传递的 disabled 会一直覆盖 items中每项的 disabled属性
```javascript
{
  "type": "page",
  "body": [
    {
      "type": "flex",
      "justify": "space-around",
      "alignItems": "center",
      "direction": "row",
      "style": {
        "width": 350,
        "height": 30
      },
      "items": [
        {
          "type": "tooltip-wrapper",
          "content": "提示文字",
          "body": "hover 激活文字提示",
          "className": "mb-1",
          "disabled": true  // 此属性设置不生效
        }
      ]
    }
  ]
}
```