### PR TITLE
fix:表单开启debug后，表单项字段内容过长导致数据显示样式问题

### DIFF
--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -1548,7 +1548,9 @@ export default class Form extends React.Component<FormProps, object> {
 
         {debug ? (
           <pre>
-            <code>{JSON.stringify(store.data, null, 2)}</code>
+            <code className={cx('Form--debug')}>
+              {JSON.stringify(store.data, null, 2)}
+            </code>
           </pre>
         ) : null}
 

--- a/packages/amis-ui/scss/components/form/_form.scss
+++ b/packages/amis-ui/scss/components/form/_form.scss
@@ -387,6 +387,11 @@
   }
 }
 
+.#{$ns}Form--debug {
+  word-break: break-all;
+  white-space: pre-wrap;
+}
+
 .#{$ns}Form--quickEdit {
   min-width: var(--Form-control-widthSm);
 }


### PR DESCRIPTION
amis文档中即可复现，bug复现代码如下：
```javascript
{
  "type": "page",
  "body": {
    "type": "form",
    "debug": true,
    "body": [
      {
        "type": "input-text",
        "name": "name",
        "label": "姓名：",
        "value": "这是一个很长的文本，导致了开启debug后，表单数据显示的样式出现了问题，超出的内容显示在容器外了，超出的内容显示在容器外了，超出的内容显示在容器外了，超出的内容显示在容器外了"
      }
    ]
  }
}
```