### PR TITLE
fix:表单开启debug后，表单项字段内容过长导致数据显示样式问题

### DIFF
--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -1548,7 +1548,9 @@ export default class Form extends React.Component<FormProps, object> {
 
         {debug ? (
           <pre>
-            <code>{JSON.stringify(store.data, null, 2)}</code>
+            <code className={cx('Form--debug')}>
+              {JSON.stringify(store.data, null, 2)}
+            </code>
           </pre>
         ) : null}
 

--- a/packages/amis-ui/scss/components/form/_form.scss
+++ b/packages/amis-ui/scss/components/form/_form.scss
@@ -387,6 +387,11 @@
   }
 }
 
+.#{$ns}Form--debug {
+  word-break: break-all;
+  white-space: pre-wrap;
+}
+
 .#{$ns}Form--quickEdit {
   min-width: var(--Form-control-widthSm);
 }

--- a/packages/amis/__tests__/event-action/renderers/form/__snapshots__/range.test.tsx.snap
+++ b/packages/amis/__tests__/event-action/renderers/form/__snapshots__/range.test.tsx.snap
@@ -223,7 +223,9 @@ exports[`EventAction:inputRange 1`] = `
                   type="submit"
                 />
                 <pre>
-                  <code>
+                  <code
+                    class="cxd-Form--debug"
+                  >
                     {
   "rangeValue": "值改变为0了",
   "rangeEvent": "触发了blur"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/chainedSelect.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/chainedSelect.test.tsx.snap
@@ -33,7 +33,9 @@ exports[`Renderer:chained-select 1`] = `
           type="submit"
         />
         <pre>
-          <code>
+          <code
+            class="cxd-Form--debug"
+          >
             {
   "select3": "a,b"
 }

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/conditionBuilder.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/conditionBuilder.test.tsx.snap
@@ -45,7 +45,9 @@ exports[`Renderer:condition-builder 1`] = `
                   type="submit"
                 />
                 <pre>
-                  <code>
+                  <code
+                    class="cxd-Form--debug"
+                  >
                     {}
                   </code>
                 </pre>

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/inputArray.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/inputArray.test.tsx.snap
@@ -45,7 +45,9 @@ exports[`Renderer:inputArray 1`] = `
                   type="submit"
                 />
                 <pre>
-                  <code>
+                  <code
+                    class="cxd-Form--debug"
+                  >
                     {
   "array": [
     "amis"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/inputFormula.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/inputFormula.test.tsx.snap
@@ -45,7 +45,9 @@ exports[`Renderer:input-formula 1`] = `
                   type="submit"
                 />
                 <pre>
-                  <code>
+                  <code
+                    class="cxd-Form--debug"
+                  >
                     {
   "formula": "SUM(1 + 2)"
 }
@@ -211,7 +213,9 @@ exports[`Renderer:input-formula button 1`] = `
                   type="submit"
                 />
                 <pre>
-                  <code>
+                  <code
+                    class="cxd-Form--debug"
+                  >
                     {
   "formula": "SUM(1 + 2)"
 }
@@ -363,7 +367,9 @@ exports[`Renderer:input-formula input-group 1`] = `
                   type="submit"
                 />
                 <pre>
-                  <code>
+                  <code
+                    class="cxd-Form--debug"
+                  >
                     {
   "formula": "SUM(1 + 2)"
 }

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
@@ -45,7 +45,9 @@ exports[`Renderer:input table 1`] = `
                   type="submit"
                 />
                 <pre>
-                  <code>
+                  <code
+                    class="cxd-Form--debug"
+                  >
                     {
   "table": [
     {

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/text.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/text.test.tsx.snap
@@ -1631,7 +1631,9 @@ exports[`Renderer:text with options 1`] = `
           type="submit"
         />
         <pre>
-          <code>
+          <code
+            class="cxd-Form--debug"
+          >
             {}
           </code>
         </pre>
@@ -1769,7 +1771,9 @@ exports[`Renderer:text with options and multiple: first option selected 1`] = `
           type="submit"
         />
         <pre>
-          <code>
+          <code
+            class="cxd-Form--debug"
+          >
             {
   "text": "a"
 }
@@ -1958,7 +1962,9 @@ exports[`Renderer:text with options and multiple: options is opened 1`] = `
           type="submit"
         />
         <pre>
-          <code>
+          <code
+            class="cxd-Form--debug"
+          >
             {}
           </code>
         </pre>
@@ -2142,7 +2148,9 @@ exports[`Renderer:text with options and multiple: options is opened again, and f
           type="submit"
         />
         <pre>
-          <code>
+          <code
+            class="cxd-Form--debug"
+          >
             {
   "text": "a"
 }
@@ -2331,7 +2339,9 @@ exports[`Renderer:text with options and multiple: second option selected 1`] = `
           type="submit"
         />
         <pre>
-          <code>
+          <code
+            class="cxd-Form--debug"
+          >
             {
   "text": "a,b"
 }
@@ -2523,7 +2533,9 @@ exports[`Renderer:text with options: options is open 1`] = `
           type="submit"
         />
         <pre>
-          <code>
+          <code
+            class="cxd-Form--debug"
+          >
             {}
           </code>
         </pre>
@@ -2687,7 +2699,9 @@ exports[`Renderer:text with options: select first option 1`] = `
           type="submit"
         />
         <pre>
-          <code>
+          <code
+            class="cxd-Form--debug"
+          >
             {
   "text": "a"
 }

--- a/packages/amis/__tests__/renderers/Form/inputTag.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/inputTag.test.tsx
@@ -160,7 +160,7 @@ describe('Renderer:InputTag', () => {
     expect(Banana).toBeNull();
 
     expect(container).toMatchSnapshot();
-  });
+  }, 6000);
 
   test('InputTag input with maxTagLength 5', async () => {
     const {container, input, queryByText} = await setupInputTag({


### PR DESCRIPTION
amis文档中即可复现，bug复现代码如下：
```javascript
{
  "type": "page",
  "body": {
    "type": "form",
    "debug": true,
    "body": [
      {
        "type": "input-text",
        "name": "name",
        "label": "姓名：",
        "value": "这是一个很长的文本，导致了开启debug后，表单数据显示的样式出现了问题，超出的内容显示在容器外了，超出的内容显示在容器外了，超出的内容显示在容器外了，超出的内容显示在容器外了"
      }
    ]
  }
}
```