### PR TITLE
fix:ChainedSelect针对后端接口返回内容不规范导致报错处理

### DIFF
--- a/docs/zh-CN/components/form/chain-select.md
+++ b/docs/zh-CN/components/form/chain-select.md
@@ -21,7 +21,7 @@ order: 7
         {
             "name": "select3",
             "type": "chained-select",
-            "label": "级联下拉",
+            "label": "链式下拉",
             "source": "/api/mock2/options/chainedOptions?waitSeconds=1&parentId=$parentId&level=$level&maxLevel=4",
             "value": "a,b"
         }

--- a/packages/amis/src/renderers/Form/ChainedSelect.tsx
+++ b/packages/amis/src/renderers/Form/ChainedSelect.tsx
@@ -14,7 +14,7 @@ import {ActionObject} from 'amis-core';
 import {FormOptionsSchema} from '../../Schema';
 
 /**
- * 级联选择框
+ * 链式下拉框
  * 文档：https://baidu.gitee.io/amis/docs/components/form/chained-select
  */
 export interface ChainedSelectControlSchema extends FormOptionsSchema {
@@ -167,7 +167,12 @@ export default class ChainedSelectControl extends React.Component<
 
             const stack = this.state.stack.concat();
             const remoteValue = ret.data ? ret.data.value : undefined;
-            let options = (ret.data && (ret.data as any).options) || ret.data;
+            let options =
+              ret?.data?.options ||
+              ret?.data?.items ||
+              ret?.data?.rows ||
+              ret.data ||
+              [];
 
             stack.splice(idx, stack.length - idx);
 
@@ -287,7 +292,7 @@ export default class ChainedSelectControl extends React.Component<
           }
           classPrefix={ns}
           key="base"
-          options={options}
+          options={Array.isArray(options) ? options : []}
           value={arr[0]}
           onChange={this.handleChange.bind(this, 0)}
           loading={loading}
@@ -306,7 +311,7 @@ export default class ChainedSelectControl extends React.Component<
               }
               classPrefix={ns}
               key={`x-${index + 1}`}
-              options={options}
+              options={Array.isArray(options) ? options : []}
               value={arr[index + 1]}
               onChange={this.handleChange.bind(this, index + 1)}
               loading={loading}


### PR DESCRIPTION
在后端接口不符合规范的情况下，导致页面报错，例如下面接口返回：
```javascript

{
  "status": 0,
  "data": {
    "items": [ // 这里应该使用 options ， 或者整个data字段是个 Array
      {
        "engine": "aute nulla incididunt mollit",
        "id": "sunt"
      },
      {
        "engine": "deserunt",
        "id": "nulla ullamco fugiat labore"
      },
      {
        "engine": "ullamco laboris reprehenderit",
        "id": "sunt do id"
      }
    ]
  }
}
```
在 amis 中可复现此bug，代码如下：
```javascript
{
  "type": "page",
  "body": {
    "type": "form",
    "debug": true,
    "api": "/api/mock2/form/saveForm",
    "body": [
      {
        "name": "select3",
        "type": "chained-select",
        "label": "链式下拉",
        "source": "https://yapi.baidu-int.com/mock/29236/selectabc/test/a",
        "labelField": "engine",
        "valueField": "id"
      }
    ]
  }
}
```
