### PR TITLE
fix: 去掉 select 中的无用代码

### DIFF
--- a/packages/amis-ui/src/components/Select.tsx
+++ b/packages/amis-ui/src/components/Select.tsx
@@ -729,13 +729,6 @@ export class Select extends React.Component<SelectProps, SelectState> {
     onDelete && onDelete(item);
   }
 
-  @autobind
-  menuItemRef(ref: any) {
-    if (ref && typeof ref.offsetHeight === 'number' && ref > 0) {
-      this.setState({itemHeight: ref.offsetHeight});
-    }
-  }
-
   renderValue({inputValue, isOpen}: ControllerStateAndHelpers<any>) {
     const {
       classnames: cx,
@@ -1166,14 +1159,6 @@ export class Select extends React.Component<SelectProps, SelectState> {
             </Checkbox>
           </div>
         ) : null}
-
-        <div ref={this.menuItemRef} className={cx('Select-option hidden')}>
-          {multiple ? (
-            <Checkbox size="sm">Placeholder</Checkbox>
-          ) : (
-            <span>Placeholder</span>
-          )}
-        </div>
 
         {creatable && !disabled ? (
           <a className={cx('Select-addBtn')} onClick={this.handleAddClick}>

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/repeat.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/repeat.test.tsx.snap
@@ -220,13 +220,6 @@ exports[`Renderer:repeat 1`] = `
                       class="cxd-Select-menu"
                     >
                       <div
-                        class="cxd-Select-option hidden"
-                      >
-                        <span>
-                          Placeholder
-                        </span>
-                      </div>
-                      <div
                         aria-selected="false"
                         class="cxd-Select-option"
                         id="downshift-0-item-0"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/select.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/select.test.tsx.snap
@@ -1664,13 +1664,6 @@ exports[`Renderer:select virtual 1`] = `
                   class="cxd-Select-menu cxd-Select--longlist"
                 >
                   <div
-                    class="cxd-Select-option hidden"
-                  >
-                    <span>
-                      Placeholder
-                    </span>
-                  </div>
-                  <div
                     style="overflow: auto; will-change: transform; height: 266px; width: 100%;"
                   >
                     <div


### PR DESCRIPTION
.hidden 样式是 `display: none`，所以这个区块的 offsetHeight 肯定为 0，导致其实这个区块实际上即不显示，对应的 ref 也没有效果，其实是无用代码