### PR TITLE
chore: 事件动作中 dialog 动作关闭自动个刷新, 由配置决定是否刷新目标

### DIFF
--- a/packages/amis-core/src/actions/DialogAction.ts
+++ b/packages/amis-core/src/actions/DialogAction.ts
@@ -42,7 +42,14 @@ export class DialogAction implements RendererAction {
     renderer: ListenerContext,
     event: RendererEvent<any>
   ) {
-    renderer.props.onAction?.(event, action, action.args);
+    renderer.props.onAction?.(
+      event,
+      {
+        ...action,
+        reload: 'none'
+      },
+      action.args
+    );
   }
 }
 


### PR DESCRIPTION
dialogAction 是新版事件动作，要刷新什么由用户配置决定，不需要自动刷新机制，所以复用原来的弹窗逻辑时指定不刷新任何目标