### PR TITLE
fix: 修复动态导入esm模块时，ecStat.transform.histogram为空导致图表不显示的错误

### DIFF
--- a/packages/amis/src/renderers/Chart.tsx
+++ b/packages/amis/src/renderers/Chart.tsx
@@ -264,6 +264,9 @@ export class Chart extends React.Component<ChartProps> {
         // @ts-ignore 官方没提供 type
         import('echarts/extension/bmap/bmap')
       ]).then(async ([echarts, ecStat]) => {
+        if(ecStat.default != null) {
+          ecStat = ecStat.default;
+        }
         (window as any).echarts = echarts;
         (window as any).ecStat = ecStat;
         let theme = 'default';


### PR DESCRIPTION
当模块采用`esm`时，由于动态`import` `ecStat`，但是未使用default，导致`ecStat`为模块，ecStat.transform.histogram为空，会出现如下错误导致图表无法展示：
```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'regression')
    at ChartRenderer.<anonymous> (Chart.js:147:76)
    at step (tslib.es6.js:102:23)
    at Object.next (tslib.es6.js:83:53)
    at tslib.es6.js:76:71
    at new Promise (<anonymous>)
    at __awaiter (tslib.es6.js:72:12)
    at Chart.js:128:24
```

正常代码应该为
`ecStat.default.transform.histogram`，所以在动态导入后, 添加`default`属性判断，如果`default`不为空，将`default`属性赋值给`ecStat`对象。


修改后的`react-amis-admin`示例代码，采用patch-package临时修复：
https://github.com/iceqing/react-amis-admin/tree/vite

amis `ecStat`默认未使用`default`错误示例代码, `amis-esm-demo` 项目：
https://github.com/iceqing/amis-esm-demo

![image](https://user-images.githubusercontent.com/39587710/179416599-3b1383fc-daec-4c0c-b18a-1fe136a47d1f.png)

正常的页面展示效果（分支为vite），可以参考示例网站 https://amis.iceq.cc/
