### PR TITLE
fix: fix doc parse error caused by vulnerable example.

### DIFF
--- a/packages/amis-formula/src/evalutor.ts
+++ b/packages/amis-formula/src/evalutor.ts
@@ -1831,7 +1831,7 @@ export class Evaluator {
    *
    * 示例：
    *
-   * JOIN(['a', 'b', 'c'], '~') 得到 'a~b~c'
+   * JOIN(['a', 'b', 'c'], '=') 得到 'a=b=c'
    *
    * @param {Array<any>} arr 数组
    * @param { String} separator 分隔符


### PR DESCRIPTION
## 修改示例，修复 markwodn 文档解析错误

### 引发原因

示例中使用了 `~` 符号，和 markdown 的语法产生冲突，造成文档解析异常

### 解决方案

修正示例符号，解决 markdown 的语法冲突。

### 错误详情

<img width="458" alt="image" src="https://user-images.githubusercontent.com/53367348/182996176-578ac9ee-8a44-4afb-840b-c98556fc4a5f.png">

<img width="483" alt="image" src="https://user-images.githubusercontent.com/53367348/182996232-6539b151-6800-4d80-bf72-667512fe985d.png">
