### PR TITLE
fix:修复 CRUD组件更改columns字段不立刻生效问题

### DIFF
--- a/packages/amis-core/src/store/crud.ts
+++ b/packages/amis-core/src/store/crud.ts
@@ -134,6 +134,7 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
         loadDataMode?: boolean;
         syncResponse2Query?: boolean;
         columns?: Array<any>;
+        isTableV2?: Boolean; // 是否是 CRUD2
       }
     ) => Promise<any> = flow(function* getInitData(
       api: Api,
@@ -336,7 +337,7 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
 
           if (Array.isArray(columns)) {
             self.columns = columns.concat();
-          } else {
+          } else if (rest.isTableV2) {
             self.columns = options.columns;
           }
 

--- a/packages/amis/src/renderers/CRUD2.tsx
+++ b/packages/amis/src/renderers/CRUD2.tsx
@@ -531,7 +531,8 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
             perPageField,
             loadDataMode,
             syncResponse2Query,
-            columns: store.columns ?? columns
+            columns: store.columns ?? columns,
+            isTableV2: true
           })
           .then(value => {
             interval &&


### PR DESCRIPTION
为了不影响 table-v2 ，我在CRUD里面传参过去的时候调整一下, 这样 store中的 crud.ts文件会运行下面
```javascript
          if (Array.isArray(columns)) {
            self.columns = columns.concat(); // 设置 store.columns 为 接口获取的值
          } else {
            self.columns = options.columns; // 设置传递进来的 columns 值， 这时候传递进来的就是  undefined
          }
```