### PR TITLE
fix:配置指定某个字段的值校验情况，导致校验可能出错

### DIFF
--- a/packages/amis-core/src/store/form.ts
+++ b/packages/amis-core/src/store/form.ts
@@ -545,6 +545,7 @@ export const FormStore = ServiceStore.named('FormStore')
         if (
           !item.validated ||
           item.rules.equals ||
+          item.rules.equalsField ||
           item.unique ||
           forceValidate ||
           !!item.validateApi

--- a/packages/amis-core/src/store/form.ts
+++ b/packages/amis-core/src/store/form.ts
@@ -544,6 +544,7 @@ export const FormStore = ServiceStore.named('FormStore')
         // 验证过，或者是 unique 的表单项，或者强制验证，或者有远端校验api
         if (
           !item.validated ||
+          item.rules.equals ||
           item.unique ||
           forceValidate ||
           !!item.validateApi


### PR DESCRIPTION
下面代码可在 amis 中复现bug
```javascript
{
    "type": "page",
    "title": "test-tree",
    "body": [{
        "type": "form",
        "title": "表单",
        "body": [{
            "type": "input-text",
            "label": "文本",
            "name": "text",
        },
        {
            "type": "input-password",
            "label": "密码",
            "name": "pas",
            "showCounter": false,
            "validations": {
                "equals": "${text}"
            },
            "validationErrors": {
                "equals": "密码nononno"
            },
            "validateOnChange": false
        }],
        "apiFromAPICenter": false,
        "id": "u:7cff08516ae7",
        "initApiFromAPICenter": false,
        "debug": true,
        "api": "111"
    }]
}
```
bug复现逻辑为：
1、先在 文本中输入 12
2、在在 密码中输入 12
3、然后 点击提交可正常触发提交逻辑
4、更改文本内容为 123时
5、再次点击提交可正常触发提交逻辑，不符合预期