### PR TITLE
fix: 修复弹窗中的表单提交不自动关闭弹窗的问题

### DIFF
--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -942,20 +942,24 @@ export default class Form extends React.Component<FormProps, object> {
   }
 
   handleFormSubmit(e: React.UIEvent<any>) {
-    const {preventEnterSubmit} = this.props;
+    const {preventEnterSubmit, onActionSensor} = this.props;
 
     e.preventDefault();
     if (preventEnterSubmit) {
       return false;
     }
 
-    return this.handleAction(
+    const sensor: any = this.handleAction(
       e,
       {
         type: 'submit'
       },
       this.props.store.data
     );
+
+    // 让外层可以监控这个动作执行结果
+    onActionSensor?.(sensor);
+    return sensor;
   }
 
   handleReset(action: any) {

--- a/packages/amis/src/renderers/Action.tsx
+++ b/packages/amis/src/renderers/Action.tsx
@@ -568,6 +568,8 @@ export interface ActionProps
     e: React.MouseEvent<any> | void | null,
     action: ActionSchema
   ) => void;
+  // 可以用来监控这个动作的执行结果，包括成功与失败。
+  onActionSensor?: (promise?: Promise<any>) => void;
   isCurrentUrl?: (link: string) => boolean;
   onClick?:
     | ((e: React.MouseEvent<any>, props: any) => void)
@@ -629,7 +631,7 @@ export class Action extends React.Component<ActionProps, ActionState> {
 
   @autobind
   async handleAction(e: React.MouseEvent<any>) {
-    const {onAction, disabled, countDown, env} = this.props;
+    const {onAction, onActionSensor, disabled, countDown, env} = this.props;
     // https://reactjs.org/docs/legacy-event-pooling.html
     e.persist(); // 等 react 17之后去掉 event pooling 了，这个应该就没用了
     let onClick = this.props.onClick;
@@ -677,7 +679,12 @@ export class Action extends React.Component<ActionProps, ActionState> {
       (action as AjaxActionSchema).api = api;
     }
 
-    await onAction(e, action);
+    const sensor: any = onAction(e, action);
+    if (sensor?.then) {
+      onActionSensor?.(sensor);
+      await sensor;
+    }
+
     if (countDown) {
       const countDownEnd = Date.now() + countDown * 1000;
       this.setState({

--- a/packages/amis/src/renderers/Dialog.tsx
+++ b/packages/amis/src/renderers/Dialog.tsx
@@ -889,7 +889,12 @@ export class DialogRenderer extends Dialog {
     const scoped = this.context as IScopedContext;
     const components = scoped
       .getComponents()
-      .filter((item: any) => !~['drawer', 'dialog'].indexOf(item.props.type));
+      .filter(
+        (item: any) =>
+          !~['drawer', 'dialog', 'action', 'button', 'submit', 'reset'].indexOf(
+            item.props.type
+          )
+      );
     const onConfirm = this.props.onConfirm;
     const onClose = this.props.onClose;
 

--- a/packages/amis/src/renderers/Drawer.tsx
+++ b/packages/amis/src/renderers/Drawer.tsx
@@ -860,7 +860,12 @@ export class DrawerRenderer extends Drawer {
     const scoped = this.context as IScopedContext;
     const components = scoped
       .getComponents()
-      .filter((item: any) => !~['drawer', 'dialog'].indexOf(item.props.type));
+      .filter(
+        (item: any) =>
+          !~['drawer', 'dialog', 'action', 'button', 'submit', 'reset'].indexOf(
+            item.props.type
+          )
+      );
     const onConfirm = this.props.onConfirm;
 
     if (

--- a/packages/amis/src/renderers/Drawer.tsx
+++ b/packages/amis/src/renderers/Drawer.tsx
@@ -212,6 +212,7 @@ export default class Drawer extends React.Component<DrawerProps> {
     props.store.setEntered(!!props.show);
     this.handleSelfClose = this.handleSelfClose.bind(this);
     this.handleAction = this.handleAction.bind(this);
+    this.handleActionSensor = this.handleActionSensor.bind(this);
     this.handleDrawerConfirm = this.handleDrawerConfirm.bind(this);
     this.handleDrawerClose = this.handleDrawerClose.bind(this);
     this.handleDialogConfirm = this.handleDialogConfirm.bind(this);
@@ -281,6 +282,21 @@ export default class Drawer extends React.Component<DrawerProps> {
     // clear error
     store.updateMessage();
     onClose();
+  }
+
+  handleActionSensor(p: Promise<any>) {
+    const {store} = this.props;
+
+    store.markBusying(true);
+    // clear error
+    store.updateMessage();
+
+    p.then(() => {
+      store.markBusying(false);
+    }).catch(e => {
+      store.updateMessage(e.message, true);
+      store.markBusying(false);
+    });
   }
 
   handleAction(e: React.UIEvent<any>, action: ActionObject, data: object) {
@@ -441,6 +457,7 @@ export default class Drawer extends React.Component<DrawerProps> {
       onChange: this.handleFormChange,
       onInit: this.handleFormInit,
       onSaved: this.handleFormSaved,
+      onActionSensor: this.handleActionSensor,
       syncLocation: false
     };
 
@@ -713,9 +730,6 @@ export class DrawerRenderer extends Drawer {
     }
 
     if (targets.length) {
-      store.markBusying(true);
-      store.updateMessage();
-
       Promise.all(
         targets.map(target =>
           target.doAction(
@@ -727,26 +741,20 @@ export class DrawerRenderer extends Drawer {
             true
           )
         )
-      )
-        .then(values => {
-          if (
-            (action.type === 'submit' ||
-              action.actionType === 'submit' ||
-              action.actionType === 'confirm') &&
-            action.close !== false
-          ) {
-            onConfirm && onConfirm(values, rawAction || action, ctx, targets);
-          } else if (action.close) {
-            action.close === true
-              ? this.handleSelfClose()
-              : this.closeTarget(action.close);
-          }
-          store.markBusying(false);
-        })
-        .catch(reason => {
-          store.updateMessage(reason.message, true);
-          store.markBusying(false);
-        });
+      ).then(values => {
+        if (
+          (action.type === 'submit' ||
+            action.actionType === 'submit' ||
+            action.actionType === 'confirm') &&
+          action.close !== false
+        ) {
+          onConfirm && onConfirm(values, rawAction || action, ctx, targets);
+        } else if (action.close) {
+          action.close === true
+            ? this.handleSelfClose()
+            : this.closeTarget(action.close);
+        }
+      });
 
       return true;
     }


### PR DESCRIPTION
1. 正常通过点击弹窗的确认按钮可以提交表单并关闭，但是如果不是通过点击弹窗的按钮触发的表单提交目前无法自动关闭，比如按 enter，或者 form 内的提交按钮
2. dialog 中表单提交如果不是dialog 里面的按钮触发的，目前 dialog 不会出现 loading 态，导致可以重复提交，目前的解法是，onAction 的基础上加了 onActionSensor ， 通过这个来监控内部动作的结果，过程中让整个 dialog 不可点。