### PR TITLE
fix:select组件选中项很长的情况下，输入框内容的label显示问题 & 同样移动端也是存在显示问题

### DIFF
--- a/packages/amis-ui/scss/components/form/_form.scss
+++ b/packages/amis-ui/scss/components/form/_form.scss
@@ -526,6 +526,9 @@
           background: transparent;
         }
       }
+      .#{$ns}SelectControl.#{$ns}Form-control {
+        overflow: hidden;
+      }
 
       .#{$ns}Form-hint,
       .#{$ns}Form-remark,

--- a/packages/amis-ui/scss/components/form/_select.scss
+++ b/packages/amis-ui/scss/components/form/_select.scss
@@ -106,6 +106,7 @@
     line-height: 1;
     // width: 0;
     max-width: 100%;
+    overflow: hidden;
   }
   &-valuesNoWrap {
     white-space: nowrap;


### PR DESCRIPTION
复现schema
```javascript
{
  "type": "page",
  "body": {
    "type": "form",
    "body": [
      {
        "label": "选项",
        "type": "select",
        "name": "select",
        "options": [
          {
            "label": "Adsafasfdsadasdasdasdasdasdfsacsacewdwadawdasdasdasfasfasfasdfasdasdasdasdsadfasfasfascsaxewfhtrjytkuyikuynfdvascfasdasd",
            "value": "a"
          },
          {
            "label": "B",
            "value": "b"
          },
          {
            "label": "C",
            "value": "c"
          }
        ]
      }
    ]
  }
}
```