### PR TITLE
fix: 修复 table 获取滚动的父元素不准确的问题

### DIFF
--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -630,25 +630,7 @@ export default class Table extends React.Component<TableProps, object> {
 
   componentDidMount() {
     const currentNode = findDOMNode(this) as HTMLElement;
-    // 获取小于所有子元素高度之和的父元素
-    let parent: HTMLElement | Window | null = getScrollParent(
-      currentNode,
-      parent => {
-        if (parent.getAttribute('role') === 'dialog') {
-          /**
-           *
-           * * 兼容在 Dialog 中的场景,
-           * ! 有时 dialog 内容并没有撑出滚动条，这里需要做一下特殊处理
-           * TODO 有没有一种更好的方式来判断
-           */
-          return true;
-        }
-        // * 具备 overflow-*:auto 的父元素的高度小于当前元素
-        return (
-          parent.offsetHeight > 0 && parent.offsetHeight < parent.scrollHeight
-        );
-      }
-    );
+    let parent: HTMLElement | Window | null = getScrollParent(currentNode);
 
     if (!parent || parent === document.body) {
       parent = window;


### PR DESCRIPTION
之前 revert 遗留的问题，因为 `Modal` 在展开后已经不具备 `transform` 属性，之前去判断 `height` 和 `scrollHeight` 的方法已经没有必要了