### PR TITLE
feat: ConditionBuilder组件左侧选项支持树形结构

### DIFF
--- a/docs/zh-CN/components/form/condition-builder.md
+++ b/docs/zh-CN/components/form/condition-builder.md
@@ -497,6 +497,8 @@ type Value = ValueGroup;
 
 ## 字段选项类型
 
+> 2.3.0 及以上版本
+
 通过 selectMode 配置组合条件左侧选项类型，可配置项为`list`、`tree`，默认为`list`。两者数据格式相同，只是下拉框展示方式不同，当存在多层 children 嵌套时，建议使用`tree`。
 
 selectMode 为`list`时

--- a/docs/zh-CN/components/form/condition-builder.md
+++ b/docs/zh-CN/components/form/condition-builder.md
@@ -495,6 +495,137 @@ type Value = ValueGroup;
 }
 ```
 
+## 字段选项类型
+
+通过 selectMode 配置组合条件左侧选项类型，可配置项为`list`、`tree`，默认为`list`。两者数据格式相同，只是下拉框展示方式不同，当存在多层 children 嵌套时，建议使用`tree`。
+
+selectMode 为`list`时
+
+```schema: scope="body"
+{
+    "type": "form",
+    "debug": true,
+    "body": [
+        {
+          "type": "condition-builder",
+          "label": "条件组件",
+          "name": "conditions",
+          "description": "适合让用户自己拼查询条件，然后后端根据数据生成 query where",
+          "fields": [
+            {
+              "label": "文本",
+              "type": "text",
+              "name": "text"
+            },
+            {
+              "label": "数字",
+              "type": "number",
+              "name": "number"
+            },
+            {
+              "label": "布尔",
+              "type": "boolean",
+              "name": "boolean"
+            },
+            {
+              "label": "选项",
+              "type": "select",
+              "name": "select",
+              "options": [
+                {
+                  "label": "A",
+                  "value": "a"
+                },
+                {
+                  "label": "B",
+                  "value": "b"
+                },
+                {
+                  "label": "C",
+                  "value": "c"
+                },
+                {
+                  "label": "D",
+                  "value": "d"
+                },
+                {
+                  "label": "E",
+                  "value": "e"
+                }
+              ]
+            }
+          ]
+        }
+    ]
+}
+```
+
+selectMode 为`tree`时
+
+```schema: scope="body"
+{
+    "type": "form",
+    "debug": true,
+    "body": [
+        {
+          "type": "condition-builder",
+          "label": "条件组件",
+          "name": "conditions",
+          "selectMode": "tree",
+          "description": "适合让用户自己拼查询条件，然后后端根据数据生成 query where",
+          "fields": [
+            {
+              "label": "文本",
+              "type": "text",
+              "name": "text"
+            },
+            {
+              "label": "数字",
+              "type": "number",
+              "name": "number"
+            },
+            {
+              "label": "布尔",
+              "type": "boolean",
+              "name": "boolean"
+            },
+            {
+              "label": "树形结构",
+              "type": "tree",
+              "name": "tree",
+              children: [
+                {
+                  "label": "Folder A",
+                  "value": 1,
+                  "children": [
+                    {
+                      "label": "file A",
+                      "value": 2
+                    },
+                    {
+                      "label": "Folder B",
+                      "value": 3,
+                      "children": [
+                        {
+                          "label": "file b1",
+                          "value": 3.1
+                        },
+                        {
+                          "label": "file b2",
+                          "value": 3.2
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+    ]
+}
+```
+
 ## 简易模式
 
 通过 builderMode 配置为简易模式，在这个模式下将不开启树形分组功能，输出结果只有一层，方便后端实现简单的 SQL 生成。
@@ -768,14 +899,15 @@ type Value = ValueGroup;
 
 ## 属性表
 
-| 属性名         | 类型      | 默认值 | 说明                           |
-| -------------- | --------- | ------ | ------------------------------ |
-| className      | `string`  |        | 外层 dom 类名                  |
-| fieldClassName | `string`  |        | 输入字段的类名                 |
-| source         | `string`  |        | 通过远程拉取配置项             |
-| embed          | `boolean` | true   | 内嵌展示                       |
-| title          | `string`  |        | 弹窗配置的顶部标题             |
-| fields         |           |        | 字段配置                       |
-| showANDOR      | `boolean` |        | 用于 simple 模式下显示切换按钮 |
-| showNot        | `boolean` |        | 是否显示「非」按钮             |
-| searchable     | `boolean` |        | 字段是否可搜索                 |
+| 属性名         | 类型               | 默认值   | 说明                           |
+| -------------- | ------------------ | -------- | ------------------------------ |
+| className      | `string`           |          | 外层 dom 类名                  |
+| fieldClassName | `string`           |          | 输入字段的类名                 |
+| source         | `string`           |          | 通过远程拉取配置项             |
+| embed          | `boolean`          | true     | 内嵌展示                       |
+| title          | `string`           |          | 弹窗配置的顶部标题             |
+| fields         |                    |          | 字段配置                       |
+| showANDOR      | `boolean`          |          | 用于 simple 模式下显示切换按钮 |
+| showNot        | `boolean`          |          | 是否显示「非」按钮             |
+| searchable     | `boolean`          |          | 字段是否可搜索                 |
+| selectMode     | `'list'`、`'tree'` | `'list'` | 组合条件左侧选项类型           |

--- a/packages/amis-ui/scss/components/form/_selection.scss
+++ b/packages/amis-ui/scss/components/form/_selection.scss
@@ -173,8 +173,13 @@
     bottom: 0;
   }
 
-  &-item.is-disabled {
+  &-item.is-disabled > .#{$ns}TreeSelection-itemInner {
+    cursor: not-allowed;
     color: var(--text--muted-color);
+  }
+
+  &-item .#{$ns}TreeSelection-itemLabel {
+    white-space: nowrap;
   }
 
   &-itemInner {

--- a/packages/amis-ui/src/components/condition-builder/Expression.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Expression.tsx
@@ -54,6 +54,7 @@ export interface ExpressionProps extends ThemeProps, LocaleProps {
   formula?: FormulaPickerProps;
   popOverContainer?: any;
   renderEtrValue?: any;
+  selectMode?: 'list' | 'tree';
 }
 
 const fieldMap = {
@@ -150,6 +151,7 @@ export class Expression extends React.Component<ExpressionProps> {
       searchable,
       formula,
       popOverContainer,
+      selectMode,
       renderEtrValue
     } = this.props;
     const inputType =
@@ -194,6 +196,7 @@ export class Expression extends React.Component<ExpressionProps> {
             disabled={disabled}
             searchable={searchable}
             popOverContainer={popOverContainer}
+            selectMode={selectMode}
             options={
               valueField
                 ? filterTree(

--- a/packages/amis-ui/src/components/condition-builder/Field.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Field.tsx
@@ -15,6 +15,7 @@ import {
 } from 'amis-core';
 import {Icon} from '../icons';
 import SearchBox from '../SearchBox';
+import TreeSelection from '../TreeSelection';
 
 export interface ConditionFieldProps extends ThemeProps, LocaleProps {
   options: Array<any>;
@@ -24,6 +25,7 @@ export interface ConditionFieldProps extends ThemeProps, LocaleProps {
   fieldClassName?: string;
   searchable?: boolean;
   popOverContainer?: any;
+  selectMode?: 'list' | 'tree';
 }
 
 export interface ConditionFieldState {
@@ -96,7 +98,8 @@ export class ConditionField extends React.Component<
       disabled,
       translate: __,
       searchable,
-      popOverContainer
+      popOverContainer,
+      selectMode = 'list'
     } = this.props;
 
     return (
@@ -107,16 +110,29 @@ export class ConditionField extends React.Component<
             {searchable ? (
               <SearchBox mini={false} onSearch={this.onSearch} />
             ) : null}
-            <ListSelection
-              multiple={false}
-              onClick={(e: any) => this.onPopClose(e, onClose)}
-              options={this.filterOptions(this.props.options)}
-              value={[value]}
-              option2value={option2value}
-              onChange={(value: any) =>
-                onChange(Array.isArray(value) ? value[0] : value)
-              }
-            />
+            {selectMode === 'tree' ? (
+              <TreeSelection
+                className={'is-scrollable'}
+                multiple={false}
+                options={this.filterOptions(this.props.options)}
+                value={value}
+                onChange={(value: any) => {
+                  this.onPopClose(null, onClose);
+                  onChange(value.name);
+                }}
+              />
+            ) : (
+              <ListSelection
+                multiple={false}
+                onClick={(e: any) => this.onPopClose(e, onClose)}
+                options={this.filterOptions(this.props.options)}
+                value={[value]}
+                option2value={option2value}
+                onChange={(value: any) =>
+                  onChange(Array.isArray(value) ? value[0] : value)
+                }
+              />
+            )}
           </>
         )}
       >

--- a/packages/amis-ui/src/components/condition-builder/Group.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Group.tsx
@@ -38,6 +38,7 @@ export interface ConditionGroupProps extends ThemeProps, LocaleProps {
   formula?: FormulaPickerProps;
   popOverContainer?: any;
   renderEtrValue?: any;
+  selectMode?: 'list' | 'tree';
 }
 
 export class ConditionGroup extends React.Component<ConditionGroupProps> {
@@ -148,6 +149,7 @@ export class ConditionGroup extends React.Component<ConditionGroupProps> {
       translate: __,
       formula,
       popOverContainer,
+      selectMode,
       renderEtrValue
     } = this.props;
     return (
@@ -205,6 +207,7 @@ export class ConditionGroup extends React.Component<ConditionGroupProps> {
                 formula={formula}
                 popOverContainer={popOverContainer}
                 renderEtrValue={renderEtrValue}
+                selectMode={selectMode}
               />
             ))
           ) : (

--- a/packages/amis-ui/src/components/condition-builder/GroupOrItem.tsx
+++ b/packages/amis-ui/src/components/condition-builder/GroupOrItem.tsx
@@ -32,6 +32,7 @@ export interface CBGroupOrItemProps extends ThemeProps {
   formula?: FormulaPickerProps;
   popOverContainer?: any;
   renderEtrValue?: any;
+  selectMode?: 'list' | 'tree';
 }
 
 export class CBGroupOrItem extends React.Component<CBGroupOrItemProps> {
@@ -79,6 +80,7 @@ export class CBGroupOrItem extends React.Component<CBGroupOrItemProps> {
       onDragStart,
       formula,
       popOverContainer,
+      selectMode,
       renderEtrValue
     } = this.props;
 
@@ -148,6 +150,7 @@ export class CBGroupOrItem extends React.Component<CBGroupOrItemProps> {
                 formula={formula}
                 popOverContainer={popOverContainer}
                 renderEtrValue={renderEtrValue}
+                selectMode={selectMode}
               />
               <Button
                 className={cx('CBDelete')}

--- a/packages/amis-ui/src/components/condition-builder/Item.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Item.tsx
@@ -48,6 +48,7 @@ export interface ConditionItemProps extends ThemeProps, LocaleProps {
   formula?: FormulaPickerProps;
   popOverContainer?: any;
   renderEtrValue?: any;
+  selectMode?: 'list' | 'tree';
 }
 
 export class ConditionItem extends React.Component<ConditionItemProps> {
@@ -131,7 +132,8 @@ export class ConditionItem extends React.Component<ConditionItemProps> {
       disabled,
       fieldClassName,
       searchable,
-      popOverContainer
+      popOverContainer,
+      selectMode
     } = this.props;
     return (
       <Expression
@@ -144,6 +146,7 @@ export class ConditionItem extends React.Component<ConditionItemProps> {
         disabled={disabled}
         searchable={searchable}
         popOverContainer={popOverContainer}
+        selectMode={selectMode}
         allowedTypes={
           ['field', 'func'].filter(
             type => type === 'field' || type === 'func'

--- a/packages/amis-ui/src/components/condition-builder/index.tsx
+++ b/packages/amis-ui/src/components/condition-builder/index.tsx
@@ -45,6 +45,7 @@ export interface ConditionBuilderProps extends ThemeProps, LocaleProps {
   formula?: FormulaPickerProps;
   popOverContainer?: any;
   renderEtrValue?: any;
+  selectMode?: 'list' | 'tree';
 }
 
 export interface ConditionBuilderState {
@@ -251,7 +252,8 @@ export class QueryBuilder extends React.Component<
       searchable,
       builderMode,
       formula,
-      renderEtrValue
+      renderEtrValue,
+      selectMode
     } = this.props;
 
     const normalizedValue = Array.isArray(value?.children)
@@ -290,6 +292,7 @@ export class QueryBuilder extends React.Component<
         formula={formula}
         renderEtrValue={renderEtrValue}
         popOverContainer={popOverContainer}
+        selectMode={selectMode}
       />
     );
   }


### PR DESCRIPTION
### 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化语料改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 其他改动（是关于什么的改动？）


### 需求背景和解决方案
ConditionBuilder组件，左侧选择框对于多层嵌套的属性结构支持不友好，增加属性配置，支持树形结构

### 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 英文 |          |
| 中文 |    ConditionBuilder组件左侧选项支持树形结构      |

### 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供