### PR TITLE
feat: 表单展示态编辑态切换

### DIFF
--- a/examples/components/Example.jsx
+++ b/examples/components/Example.jsx
@@ -13,6 +13,7 @@ import ReactionFormSchema from './Form/Reaction';
 import ValidationFormSchema from './Form/Validation';
 import FullFormSchema from './Form/Full';
 import StaticFormSchema from './Form/Static';
+import SwitchFormDisplay from './Form/SwitchDisplay';
 import HintFormSchema from './Form/Hint';
 import FieldSetInTabsFormSchema from './Form/FieldSetInTabs';
 import ComboFormSchema from './Form/Combo';
@@ -171,6 +172,12 @@ export const examples = [
             label: '静态展示',
             path: '/examples/form/static',
             component: makeSchemaRenderer(StaticFormSchema)
+          },
+
+          {
+            label: '编辑态、展示态切换',
+            path: '/examples/form/switchDisplay',
+            component: makeSchemaRenderer(SwitchFormDisplay)
           },
 
           {

--- a/examples/components/Form/SwitchDisplay.jsx
+++ b/examples/components/Form/SwitchDisplay.jsx
@@ -1,0 +1,1535 @@
+export default {
+  "title": "表单及表单项切换编辑态展示态",
+  "data": {
+    "id": 1
+  },
+  "body": [
+    {
+      "type": "form",
+      "title": "整个表单状态切换",
+      "mode": "horizontal",
+      "labelWidth": 150,
+      "id": "allFormSwitch",
+      "body": [
+        {
+          "type": "input-text",
+          "name": "var1",
+          "label": "输入框",
+          "value": "text"
+        },
+        {
+          "type": "input-color",
+          "name": "var2",
+          "label": "颜色选择",
+          "value": "#F0F"
+        },
+        {
+          "type": "switch",
+          "name": "switch",
+          "label": "开关",
+          "value": true
+        },
+        {
+          "type": "checkboxes",
+          "name": "checkboxes",
+          "label": "多选框",
+          "value": "1,2",
+          "multiple": true,
+          "options": [
+            {
+              "label": "选项1",
+              "value": 1
+            },
+            {
+              "label": "选项2",
+              "value": 2
+            },
+            {
+              "label": "选项3",
+              "value": 3
+            }
+          ]
+        },
+        {
+          "type": "select",
+          "name": "type",
+          "label": "下拉单选",
+          "inline": true,
+          "value": 1,
+          "options": [
+            {
+              "label": "选项1",
+              "value": 1
+            },
+            {
+              "label": "选项2",
+              "value": 2
+            },
+            {
+              "label": "内容很长很长的选项，内容很长很长的选项",
+              "value": 3
+            }
+          ]
+        },
+        {
+          type: 'button-toolbar',
+          name: 'button-toolbar',
+          buttons: [
+            {
+              "type": "button",
+              "label": "提交",
+              "level": "primary",
+              "onEvent": {
+                "click": {
+                  "actions": [
+                    {
+                      "actionType": "static",
+                      "componentId": "allFormSwitch"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "button",
+              "label": "编辑",
+              "level": "primary",
+              "onEvent": {
+                "click": {
+                  "actions": [
+                    {
+                      "actionType": "nonstatic",
+                      "componentId": "allFormSwitch"
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          className: 'show'
+        },
+      ],
+      "actions": []
+    },
+
+    {
+      "type": "form",
+      "title": "单个表单项状态切换",
+      "mode": "horizontal",
+      "labelWidth": 150,
+      "body": [
+        {
+          "type": "input-text",
+          "id": "formItemSwitch",
+          "name": "var1",
+          "label": "使用事件动作状态切换",
+          "value": "text"
+        },
+        {
+          type: 'button-toolbar',
+          name: 'button-toolbar',
+          buttons: [
+            {
+              "type": "button",
+              "label": "编辑态",
+              "level": "primary",
+              "onEvent": {
+                "click": {
+                  "actions": [
+                    {
+                      "actionType": "nonstatic",
+                      "componentId": "formItemSwitch"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "button",
+              "label": "展示态",
+              "level": "primary",
+              "onEvent": {
+                "click": {
+                  "actions": [
+                    {
+                      "actionType": "static",
+                      "componentId": "formItemSwitch"
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          className: 'show'
+        },
+      ],
+      "actions": []
+    },
+    {
+      "type": "form",
+      "title": "表单项展示态属性",
+      "mode": "horizontal",
+      "labelWidth": 150,
+      "body": [
+        {
+          "type": "input-text",
+          "id": "formItemInputText",
+          "name": "var1",
+          "label": "编辑态<br />不设置<br />或static: false",
+          "value": "text",
+          "static": false,
+          "desc": "使用staticOn 支持表达式控制，用法类似"
+        },
+        {
+          "type": "input-text",
+          "id": "formItemInputText",
+          "name": "var1",
+          "label": "展示态<br />static: true",
+          "value": "text",
+          "static": true
+        },
+        {
+          "type": "input-text",
+          "id": "formItemInputText",
+          "name": "var2",
+          "label": "空值时的占位 staticPlaceholder",
+          "staticPlaceholder": "空值占位符，默认为 -",
+          "static": true
+        },
+        {
+          "type": "input-text",
+          "name": "var3",
+          "label": "自定义展示态schema",
+          "value": "表单项value",
+          "desc": "通过\\${name}可获取到当前值",
+          "static": true,
+          "staticSchema": [
+            "自定义前缀 | ",
+            {
+              "type": "tpl",
+              "tpl": "${var3}"
+            },
+            " | 自定义后缀",
+          ]
+        }
+      ],
+      "actions": []
+    },
+    {
+      "type": "form",
+      "api": "/api/mock2/saveForm?waitSeconds=2",
+      "id": "myform",
+      "mode": "horizontal",
+      "autoFocus": true,
+      "panel": false,
+      "debug": false,
+      "title": "目前支持编辑态展示态切换的表单项",
+      "labelWidth": 150,
+      "staticClassName": "now-is-static",
+      "body": [
+        {
+          "type": "button-toolbar",
+          "name": "button-toolbar",
+          "buttons": [
+            {
+              "type": "button",
+              "label": "切换为编辑态",
+              "level": "primary",
+              "visibleOn": "${static}",
+              "onEvent": {
+                "click": {
+                  "actions": [
+                    {
+                      "actionType": "nonstatic",
+                      "componentId": "myform"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "button",
+              "label": "切换为展示态",
+              "level": "primary",
+              "visibleOn": "${!static}",
+              "onEvent": {
+                "click": {
+                  "actions": [
+                    {
+                      "actionType": "static",
+                      "componentId": "myform"
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "className": "show"
+        },
+        {
+          "type": "input-text",
+          "name": "var1",
+          "label": "文本",
+          "value": "text",
+          "desc": "这是一段描述文字",
+          "id": "my-input-text"
+        },
+        {
+          "type": "input-password",
+          "name": "password",
+          "label": "密码",
+          "inline": true,
+          "value": "123456"
+        },
+        {
+          "type": "input-email",
+          "validations": "isEmail",
+          "label": "邮箱",
+          "name": "email",
+          "value": "hello@baidu.com"
+        },
+        {
+          "type": "input-url",
+          "validations": "isUrl",
+          "label": "url",
+          "name": "url",
+          "value": "https://www.baidu.com"
+        },
+        {
+          "type": "input-number",
+          "name": "number",
+          "label": "数字",
+          "placeholder": "",
+          "inline": true,
+          "value": 5,
+          "min": 1,
+          "max": 10
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "native-date",
+          "name": "native-date",
+          "label": "native日期选择",
+          "value": "2022-08-18"
+        },
+        {
+          "type": "native-time",
+          "name": "native-time",
+          "label": "native时间选择",
+          "value": "16:10"
+        },
+        {
+          "type": "native-number",
+          "name": "native-number",
+          "label": "native数字输入",
+          "value": "6"
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "input-tag",
+          "name": "tag",
+          "label": "标签",
+          "placeholder": "",
+          "clearable": true,
+          "value": "zhugeliang,caocao",
+          "options": [
+            {
+              "label": "诸葛亮",
+              "value": "zhugeliang"
+            },
+            {
+              "label": "曹操",
+              "value": "caocao"
+            },
+            {
+              "label": "钟无艳",
+              "value": "zhongwuyan"
+            },
+            {
+              "label": "野核",
+              "children": [
+                {
+                  "label": "李白",
+                  "value": "libai"
+                },
+                {
+                  "label": "韩信",
+                  "value": "hanxin"
+                },
+                {
+                  "label": "云中君",
+                  "value": "yunzhongjun"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "checkboxes",
+          "name": "checkboxes",
+          "label": "多选框",
+          "value": "1,2",
+          "options": [
+            {
+              "label": "选项1",
+              "value": 1
+            },
+            {
+              "label": "选项2",
+              "value": 2
+            },
+            {
+              "label": "选项3",
+              "value": 3
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "radios",
+          "name": "radios",
+          "label": "单选",
+          "value": 3,
+          "options": [
+            {
+              "label": "选项1",
+              "value": 1
+            },
+            {
+              "label": "选项2",
+              "value": 2
+            },
+            {
+              "label": "选项3",
+              "value": 3
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "button-group-select",
+          "name": "btn-group",
+          "label": "按钮组",
+          "description": "类似于单选效果",
+          "value": 1,
+          "options": [
+            {
+              "label": "选项 A",
+              "value": 1
+            },
+            {
+              "label": "选项 B",
+              "value": 2
+            },
+            {
+              "label": "选项 C",
+              "value": 3
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "list-select",
+          "name": "List",
+          "label": "List",
+          "desc": "也差不多，只是展示方式不一样",
+          "value": 3,
+          "options": [
+            {
+              "label": "选项 A",
+              "value": 1
+            },
+            {
+              "label": "选项 B",
+              "value": 2
+            },
+            {
+              "label": "选项 C",
+              "value": 3
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "list-select",
+          "name": "list2",
+          "label": "List",
+          "desc": "可多选",
+          "multiple": true,
+          "value": "1,2",
+          "options": [
+            {
+              "label": "选项 A",
+              "value": 1
+            },
+            {
+              "label": "选项 B",
+              "value": 2
+            },
+            {
+              "label": "选项 C",
+              "value": 3
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "list-select",
+          "name": "list4",
+          "label": "List",
+          "imageClassName": "thumb-lg",
+          "desc": "支持放张图片",
+          "value": 1,
+          "options": [
+            {
+              "image": "/examples/static/photo/3893101144.jpg",
+              "value": 1,
+              "label": "图片1"
+            },
+            {
+              "image": "/examples/static/photo/3893101144.jpg",
+              "value": 2,
+              "label": "图片2"
+            },
+            {
+              "image": "/examples/static/photo/3893101144.jpg",
+              "value": 3,
+              "label": "图片3"
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "list-select",
+          "name": "list5",
+          "label": "List",
+          "desc": "支持文字排版",
+          "value": 1,
+          "options": [
+            {
+              "value": 1,
+              "body": "<div class=\"m-l-sm m-r-sm m-b-sm m-t-xs\">\n                                  <div class=\"text-md p-b-xs b-inherit b-b m-b-xs\">套餐：C01</div>\n                                  <div class=\"text-sm\">CPU：22核</div>\n                                  <div class=\"text-sm\">内存：10GB</div>\n                                  <div class=\"text-sm\">SSD盘：1024GB</div>\n                              </div>"
+            },
+            {
+              "value": 2,
+              "body": "<div class=\"m-l-sm m-r-sm  m-b-sm m-t-xs\">\n                              <div class=\"text-md p-b-xs b-inherit b-b m-b-xs\">套餐：C02</div>\n                              <div class=\"text-sm\">CPU：23核</div>\n                              <div class=\"text-sm\">内存：11GB</div>\n                              <div class=\"text-sm\">SSD盘：1025GB</div>\n                              </div>"
+            },
+            {
+              "value": 3,
+              "disabled": true,
+              "body": "<div class=\"m-l-sm m-r-sm  m-b-sm m-t-xs\">\n                              <div class=\"text-md p-b-xs b-inherit b-b m-b-xs\">套餐：C03</div>\n                              <div class=\"text-sm\">CPU：24核</div>\n                              <div class=\"text-sm\">内存：12GB</div>\n                              <div class=\"text-sm\">SSD盘：1026GB</div>\n                              </div>"
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "input-rating",
+          "count": 5,
+          "value": 4,
+          "label": "评分",
+          "name": "rating",
+          "half": false
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "switch",
+          "name": "switch",
+          "label": "开关",
+          "value": true
+        },
+        {
+          "type": "switch",
+          "name": "switch4",
+          "value": true,
+          "onText": "开启",
+          "offText": "关闭",
+          "label": "开关文字"
+        },
+        {
+          "type": "switch",
+          "name": "switch5",
+          "value": true,
+          "onText": {
+            "type": "icon",
+            "icon": "fa fa-check-circle"
+          },
+          "offText": {
+            "type": "icon",
+            "icon": "fa fa-times-circle"
+          },
+          "label": "开关icon"
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "checkbox",
+          "name": "checkbox",
+          "label": "勾选框",
+          "options": "勾选说明",
+          "value": true
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "select",
+          "name": "type",
+          "label": "下拉单选",
+          "inline": true,
+          "value": 1,
+          "options": [
+            {
+              "label": "选项1",
+              "value": 1
+            },
+            {
+              "label": "选项2",
+              "value": 2
+            },
+            {
+              "label": "内容很长很长的选项，内容很长很长的选项",
+              "value": 3
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "select",
+          "name": "type2",
+          "label": "多选",
+          "multiple": true,
+          "inline": true,
+          "value": "1,2",
+          "options": [
+            {
+              "label": "选项1",
+              "value": 1
+            },
+            {
+              "label": "选项2",
+              "value": 2
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "input-color",
+          "name": "color",
+          "label": "Color",
+          "value": "#dc1717"
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "input-date",
+          "name": "date",
+          "label": "日期",
+          "value": "1591326307"
+        },
+        {
+          "type": "input-datetime",
+          "name": "datetime",
+          "label": "日期+时间",
+          "value": "1591326307"
+        },
+        {
+          "type": "input-time",
+          "name": "time",
+          "label": "时间",
+          "value": "1591326307"
+        },
+        {
+          "type": "input-month",
+          "name": "year-month",
+          "label": "年月",
+          "value": "1591326307"
+        },
+        {
+          "type": "input-month",
+          "name": "month",
+          "label": "月份",
+          "value": "1591326307"
+        },
+        {
+          "type": "input-year",
+          "name": "year",
+          "label": "年份",
+          "value": "1591326307"
+        },
+        {
+          "type": "input-quarter",
+          "name": "quarter",
+          "label": "季度",
+          "value": "1591326307"
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "input-date-range",
+          "name": "input-date-range",
+          "label": "日期范围",
+          "value": "1661961600,1664553599"
+        },
+        {
+          "type": "input-datetime-range",
+          "name": "input-datetime-range",
+          "label": "日期时间范围",
+          "value": "1659283200,1661961599"
+        },
+        {
+          "type": "input-time-range",
+          "name": "input-time-range",
+          "label": "时间范围",
+          "value": "15:00,23:27"
+        },
+        {
+          "type": "input-month-range",
+          "name": "input-month-range",
+          "label": "月份范围",
+          "value": "1643644800,1651420799"
+        },
+        {
+          "type": "input-year-range",
+          "name": "input-year-range",
+          "label": "年份范围",
+          "value": "1693497600,1790870399"
+        },
+        {
+          "type": "input-quarter-range",
+          "name": "input-quarter-range",
+          "label": "季度范围",
+          "value": "1640966400,1664639999"
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "input-group",
+          "size": "sm",
+          "inline": true,
+          "label": "组合",
+          "body": [
+            {
+              "type": "input-text",
+              "placeholder": "搜索作业ID/名称",
+              "inputClassName": "b-l-none p-l-none",
+              "name": "jobName",
+              "value": "作业"
+            },
+            {
+              "type": "input-text",
+              "placeholder": "搜索作业ID/名称",
+              "inputClassName": "b-l-none p-l-none",
+              "name": "jobName",
+              "value": "家庭作业"
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "input-group",
+          "label": "各种组合",
+          "inline": true,
+          "body": [
+            {
+              "type": "select",
+              "name": "memoryUnits",
+              "options": [
+                {
+                  "label": "Gi",
+                  "value": "Gi"
+                },
+                {
+                  "label": "Mi",
+                  "value": "Mi"
+                },
+                {
+                  "label": "Ki",
+                  "value": "Ki"
+                }
+              ],
+              "value": "Gi"
+            },
+            {
+              "type": "input-text",
+              "name": "memory",
+              "value": "memory"
+            },
+            {
+              "type": "select",
+              "name": "memoryUnits2",
+              "options": [
+                {
+                  "label": "Gi",
+                  "value": "Gi"
+                },
+                {
+                  "label": "Mi",
+                  "value": "Mi"
+                },
+                {
+                  "label": "Ki",
+                  "value": "Ki"
+                }
+              ],
+              "value": "Gi"
+            },
+            {
+              "type": "button",
+              "label": "Go"
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "textarea",
+          "name": "textarea",
+          "label": "多行文本",
+          "value": "这是一段多行文本文字\n第二行内容"
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "label": "穿梭器",
+          "name": "a",
+          "type": "transfer",
+          "source": "/api/mock2/form/getOptions?waitSeconds=1",
+          "searchable": true,
+          "searchApi": "/api/mock2/options/autoComplete2?term=$term",
+          "selectMode": "list",
+          "sortable": true,
+          "inline": true,
+          "value": "A,B,C"
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "input-tree",
+          "name": "tree",
+          "label": "树",
+          "iconField": "icon",
+          "value": "2",
+          "options": [
+            {
+              "label": "Folder A",
+              "value": 1,
+              "icon": "fa fa-bookmark",
+              "children": [
+                {
+                  "label": "file A",
+                  "value": 2,
+                  "icon": "fa fa-star"
+                },
+                {
+                  "label": "file B",
+                  "value": 3
+                }
+              ]
+            },
+            {
+              "label": "file C",
+              "value": 4
+            },
+            {
+              "label": "file D",
+              "value": 5
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "input-tree",
+          "name": "trees",
+          "label": "树多选",
+          "multiple": true,
+          "value": "1-2,5",
+          "options": [
+            {
+              "label": "Folder A",
+              "value": 1,
+              "children": [
+                {
+                  "label": "file A",
+                  "value": 2
+                },
+                {
+                  "label": "file B",
+                  "value": 3
+                }
+              ]
+            },
+            {
+              "label": "file C",
+              "value": 4
+            },
+            {
+              "label": "file D",
+              "value": 5
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "tree-select",
+          "name": "selecttree",
+          "label": "树选择器",
+          "value": "5",
+          "options": [
+            {
+              "label": "Folder A",
+              "value": 1,
+              "children": [
+                {
+                  "label": "file A",
+                  "value": 2
+                },
+                {
+                  "label": "file B",
+                  "value": 3
+                }
+              ]
+            },
+            {
+              "label": "file C",
+              "value": 4
+            },
+            {
+              "label": "file D",
+              "value": 5
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "tree-select",
+          "name": "selecttrees",
+          "label": "树多选选择器",
+          "multiple": true,
+          "value": "1-2,5",
+          "options": [
+            {
+              "label": "Folder A",
+              "value": 1,
+              "children": [
+                {
+                  "label": "file A",
+                  "value": 2
+                },
+                {
+                  "label": "file B",
+                  "value": 3
+                }
+              ]
+            },
+            {
+              "label": "file C",
+              "value": 4
+            },
+            {
+              "label": "file D",
+              "value": 5
+            }
+          ]
+        },
+        {
+          "type": "nested-select",
+          "name": "nestedSelect",
+          "label": "级联选择器",
+          "value": "definitions",
+          "options": [
+            {
+              "label": "概念",
+              "value": "concepts",
+              "children": [
+                {
+                  "label": "配置与组件",
+                  "value": "schema"
+                },
+                {
+                  "label": "数据域与数据链",
+                  "value": "scope"
+                },
+                {
+                  "label": "模板",
+                  "value": "template"
+                },
+                {
+                  "label": "数据映射",
+                  "value": "data-mapping"
+                },
+                {
+                  "label": "表达式",
+                  "value": "expression"
+                },
+                {
+                  "label": "联动",
+                  "value": "linkage"
+                },
+                {
+                  "label": "行为",
+                  "value": "action"
+                },
+                {
+                  "label": "样式",
+                  "value": "style"
+                }
+              ]
+            },
+            {
+              "label": "类型",
+              "value": "types",
+              "children": [
+                {
+                  "label": "SchemaNode",
+                  "value": "schemanode"
+                },
+                {
+                  "label": "API",
+                  "value": "api"
+                },
+                {
+                  "label": "Definitions",
+                  "value": "definitions"
+                }
+              ]
+            },
+            {
+              "label": "组件",
+              "value": "zujian",
+              "children": [
+                {
+                  "label": "布局",
+                  "value": "buju",
+                  "children": [
+                    {
+                      "label": "Page 页面",
+                      "value": "page"
+                    },
+                    {
+                      "label": "Container 容器",
+                      "value": "container"
+                    },
+                    {
+                      "label": "Collapse 折叠器",
+                      "value": "Collapse"
+                    }
+                  ]
+                },
+                {
+                  "label": "功能",
+                  "value": "gongneng",
+                  "children": [
+                    {
+                      "label": "Action 行为按钮",
+                      "value": "action-type"
+                    },
+                    {
+                      "label": "App 多页应用",
+                      "value": "app"
+                    },
+                    {
+                      "label": "Button 按钮",
+                      "value": "button"
+                    }
+                  ]
+                },
+                {
+                  "label": "数据输入",
+                  "value": "shujushuru",
+                  "children": [
+                    {
+                      "label": "Form 表单",
+                      "value": "form"
+                    },
+                    {
+                      "label": "FormItem 表单项",
+                      "value": "formitem"
+                    },
+                    {
+                      "label": "Options 选择器表单项",
+                      "value": "options"
+                    }
+                  ]
+                },
+                {
+                  "label": "数据展示",
+                  "value": "shujuzhanshi",
+                  "children": [
+                    {
+                      "label": "CRUD 增删改查",
+                      "value": "crud"
+                    },
+                    {
+                      "label": "Table 表格",
+                      "value": "table"
+                    },
+                    {
+                      "label": "Card 卡片",
+                      "value": "card"
+                    }
+                  ]
+                },
+                {
+                  "label": "反馈",
+                  "value": "fankui"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "nested-select",
+          "name": "nestedSelectMul",
+          "label": "级联选择器多选",
+          "multiple": true,
+          "checkAll": false,
+          "value": "definitions",
+          "options": [
+            {
+              "label": "概念",
+              "value": "concepts",
+              "children": [
+                {
+                  "label": "配置与组件",
+                  "value": "schema"
+                },
+                {
+                  "label": "数据域与数据链",
+                  "value": "scope"
+                },
+                {
+                  "label": "模板",
+                  "value": "template"
+                },
+                {
+                  "label": "数据映射",
+                  "value": "data-mapping"
+                },
+                {
+                  "label": "表达式",
+                  "value": "expression"
+                },
+                {
+                  "label": "联动",
+                  "value": "linkage"
+                },
+                {
+                  "label": "行为",
+                  "value": "action"
+                },
+                {
+                  "label": "样式",
+                  "value": "style"
+                }
+              ]
+            },
+            {
+              "label": "类型",
+              "value": "types",
+              "children": [
+                {
+                  "label": "SchemaNode",
+                  "value": "schemanode"
+                },
+                {
+                  "label": "API",
+                  "value": "api"
+                },
+                {
+                  "label": "Definitions",
+                  "value": "definitions"
+                }
+              ]
+            },
+            {
+              "label": "组件",
+              "value": "zujian",
+              "children": [
+                {
+                  "label": "布局",
+                  "value": "buju",
+                  "children": [
+                    {
+                      "label": "Page 页面",
+                      "value": "page"
+                    },
+                    {
+                      "label": "Container 容器",
+                      "value": "container"
+                    },
+                    {
+                      "label": "Collapse 折叠器",
+                      "value": "Collapse"
+                    }
+                  ]
+                },
+                {
+                  "label": "功能",
+                  "value": "gongneng",
+                  "children": [
+                    {
+                      "label": "Action 行为按钮",
+                      "value": "action-type"
+                    },
+                    {
+                      "label": "App 多页应用",
+                      "value": "app"
+                    },
+                    {
+                      "label": "Button 按钮",
+                      "value": "button"
+                    }
+                  ]
+                },
+                {
+                  "label": "数据输入",
+                  "value": "shujushuru",
+                  "children": [
+                    {
+                      "label": "Form 表单",
+                      "value": "form"
+                    },
+                    {
+                      "label": "FormItem 表单项",
+                      "value": "formitem"
+                    },
+                    {
+                      "label": "Options 选择器表单项",
+                      "value": "options"
+                    }
+                  ]
+                },
+                {
+                  "label": "数据展示",
+                  "value": "shujuzhanshi",
+                  "children": [
+                    {
+                      "label": "CRUD 增删改查",
+                      "value": "crud"
+                    },
+                    {
+                      "label": "Table 表格",
+                      "value": "table"
+                    },
+                    {
+                      "label": "Card 卡片",
+                      "value": "card"
+                    }
+                  ]
+                },
+                {
+                  "label": "反馈",
+                  "value": "fankui"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "matrix-checkboxes",
+          "name": "matrix",
+          "label": "矩阵开关",
+          "rowLabel": "行标题说明",
+          "value": [
+            [
+              {
+                "label": "列1",
+                "checked": true
+              },
+              {
+                "label": "列1",
+                "checked": false
+              }
+            ],
+            [
+              {
+                "label": "列2",
+                "checked": false
+              },
+              {
+                "label": "列2",
+                "checked": true
+              }
+            ],
+          ],
+          "columns": [
+            {
+              "label": "列1"
+            },
+            {
+              "label": "列2"
+            }
+          ],
+          "rows": [
+            {
+              "label": "行1"
+            },
+            {
+              "label": "行2"
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "combo",
+          "name": "combo",
+          "label": "组合单条",
+          "value": {
+            "a": 1,
+            "b": "a"
+          },
+          "items": [
+            {
+              "name": "a",
+              "label": "名称",
+              "type": "input-text",
+              "placeholder": "A"
+            },
+            {
+              "name": "b",
+              "label": "信息",
+              "type": "select",
+              "options": [
+                "a",
+                "b",
+                "c"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "combo",
+          "name": "combo2",
+          "label": "组合多条",
+          "multiple": true,
+          "value": [
+            {
+              "a": 1,
+              "b": "a"
+            },
+            {
+              "a": 2,
+              "b": "b"
+            },
+          ],
+          "items": [
+            {
+              "name": "a",
+              "label": "名称：",
+              "type": "input-text",
+              "placeholder": "A"
+            },
+            {
+              "name": "b",
+              "label": "信息：",
+              "type": "select",
+              "options": [
+                "a",
+                "b",
+                "c"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "array",
+          "label": "颜色集合",
+          "type": "input-array",
+          "value": [
+            "red",
+            "blue",
+            "green"
+          ],
+          "inline": true,
+          "items": {
+            "type": "input-color",
+            "clearable": false
+          }
+        },
+        {
+          "type": "input-kv",
+          "name": "kv",
+          "label": "键值对",
+          "valueType": "input-number",
+          "value": {
+            "count1": 2,
+            "count2": 4
+          }
+        },
+        {
+          "type": "input-kvs",
+          "name": "dataModel",
+          "label": "可嵌套键值对象",
+          "addButtonText": "新增表",
+          "keyItem": {
+            "label": "表名",
+            "mode": "horizontal",
+            "type": "select",
+            "options": [
+              "table1",
+              "table2",
+              "table3"
+            ]
+          },
+          "valueItems": [
+            {
+              "type": "input-kvs",
+              "addButtonText": "新增字段",
+              "name": "column",
+              "keyItem": {
+                "label": "字段名",
+                "mode": "horizontal",
+                "type": "select",
+                "options": [
+                  "id",
+                  "title",
+                  "content"
+                ]
+              },
+              "valueItems": [
+                {
+                  "type": "switch",
+                  "name": "primary",
+                  "mode": "horizontal",
+                  "label": "是否是主键"
+                },
+                {
+                  "type": "select",
+                  "name": "type",
+                  "label": "字段类型",
+                  "mode": "horizontal",
+                  "options": [
+                    "text",
+                    "int",
+                    "float"
+                  ]
+                }
+              ]
+            }
+          ],
+          "value": {
+            "table1": {
+              "column": {
+                "id": {
+                  "primary": false,
+                  "type": "text"
+                },
+                "title": {
+                  "type": "text"
+                }
+              }
+            },
+            "table2": {
+              "column": {
+                "title": {
+                  "type": "int"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "input-range",
+          "name": "range",
+          "label": "范围",
+          "value": "50"
+        },
+        {
+          "type": "button-toolbar",
+          "name": "button-toolbar",
+          "buttons": [
+            {
+              "type": "button",
+              "label": "切换为编辑态",
+              "level": "primary",
+              "visibleOn": "${static}",
+              "onEvent": {
+                "click": {
+                  "actions": [
+                    {
+                      "actionType": "nonstatic",
+                      "componentId": "myform"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "button",
+              "label": "切换为展示态",
+              "level": "primary",
+              "visibleOn": "${!static}",
+              "onEvent": {
+                "click": {
+                  "actions": [
+                    {
+                      "actionType": "static",
+                      "componentId": "myform"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "actions": []
+    }
+  ]
+};

--- a/packages/amis-core/src/SchemaRenderer.tsx
+++ b/packages/amis-core/src/SchemaRenderer.tsx
@@ -86,6 +86,8 @@ export class SchemaRenderer extends React.Component<SchemaRendererProps, any> {
       () =>
         `${props.topStore.visibleState[props.schema.id || props.$path]}${
           props.topStore.disableState[props.schema.id || props.$path]
+        }${
+          props.topStore.staticState[props.schema.id || props.$path]
         }`,
       () => this.forceUpdate()
     );
@@ -274,6 +276,9 @@ export class SchemaRenderer extends React.Component<SchemaRendererProps, any> {
     const disable = isAlive(topStore)
       ? topStore.disableState[schema.id || $path]
       : undefined;
+    const isStatic = isAlive(topStore)
+      ? topStore.staticState[schema.id || $path]
+      : undefined;
 
     if (
       visible === false ||
@@ -420,6 +425,10 @@ export class SchemaRenderer extends React.Component<SchemaRendererProps, any> {
 
     if (disable !== undefined) {
       (props as any).disabled = disable;
+    }
+
+    if (isStatic !== undefined) {
+      (props as any).static = isStatic;
     }
 
     // 自动解析变量模式，主要是方便直接引入第三方组件库，无需为了支持变量封装一层

--- a/packages/amis-core/src/actions/CmptAction.ts
+++ b/packages/amis-core/src/actions/CmptAction.ts
@@ -9,6 +9,8 @@ import {
 export interface ICmptAction extends ListenerAction {
   actionType:
     | 'setValue'
+    | 'static'
+    | 'nonstatic'
     | 'show'
     | 'hidden'
     | 'enabled'
@@ -47,6 +49,11 @@ export class CmptAction implements RendererAction {
       return renderer.props.topStore.setVisible(
         action.componentId,
         action.actionType === 'show'
+      );
+    } else if (['static', 'nonstatic'].includes(action.actionType)) {
+      return renderer.props.topStore.setStatic(
+        action.componentId,
+        action.actionType === 'static'
       );
     } else if (['enabled', 'disabled'].includes(action.actionType)) {
       return renderer.props.topStore.setDisable(

--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -330,6 +330,11 @@ export interface FormSchemaBase {
    * label自定义宽度，默认单位为px
    */
   labelWidth?: number | string;
+
+  /**
+   * 展示态时的className
+   */
+  staticClassName?: string;
 }
 
 export type FormGroup = FormSchemaBase & {
@@ -1506,7 +1511,8 @@ export default class Form extends React.Component<FormProps, object> {
       formLazyChange,
       dispatchEvent,
       labelAlign,
-      labelWidth
+      labelWidth,
+      static: isStatic = false
     } = props;
 
     const subProps = {
@@ -1523,6 +1529,7 @@ export default class Form extends React.Component<FormProps, object> {
       formLabelWidth: labelWidth,
       controlWidth,
       disabled: disabled || (control as Schema).disabled || form.loading,
+      static: (control as Schema).static ?? isStatic,
       btnDisabled: disabled || form.loading || form.validating,
       onAction: this.handleAction,
       onQuery: this.handleQuery,
@@ -1565,7 +1572,9 @@ export default class Form extends React.Component<FormProps, object> {
       $path,
       store,
       columnCount,
-      render
+      render,
+      staticClassName,
+      static: isStatic = false
     } = this.props;
 
     const {restError} = store;
@@ -1592,7 +1601,9 @@ export default class Form extends React.Component<FormProps, object> {
           `Form`,
           `Form--${mode || 'normal'}`,
           columnCount ? `Form--column Form--column-${columnCount}` : null,
-          className
+          className,
+          isStatic ? 'Form--isStatic' : null,
+          staticClassName && isStatic ? staticClassName : null
         )}
         onSubmit={this.handleFormSubmit}
         noValidate
@@ -1694,6 +1705,7 @@ export default class Form extends React.Component<FormProps, object> {
       lazyLoad,
       translate: __,
       footer,
+      static: isStatic = false,
       formStore
     } = this.props;
 

--- a/packages/amis-core/src/renderers/Item.tsx
+++ b/packages/amis-core/src/renderers/Item.tsx
@@ -464,6 +464,12 @@ export interface FormItemProps extends RendererProps {
   // error string
   error?: string;
   showErrorMsg?: boolean;
+  // 展示态 相关
+  static?: boolean;
+  staticPlaceholder?: string;
+  staticClassName?: string;
+  staticLabelClassName?: string;
+  staticValueClassName?: string;
 }
 
 // 下发下去的属性
@@ -916,7 +922,11 @@ export class FormItemWrap extends React.Component<FormItemProps> {
         data,
         showErrorMsg,
         useMobileUI,
-        translate: __
+        translate: __,
+        static: isStatic,
+        staticClassName,
+        staticLabelClassName,
+        staticValueClassName
       } = props;
 
       // 强制不渲染 label 的话
@@ -942,6 +952,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
               [`is-error`]: model && !model.valid,
               [`is-required`]: required
             },
+            isStatic && staticClassName,
             model?.errClassNames
           )}
         >
@@ -958,7 +969,8 @@ export class FormItemWrap extends React.Component<FormItemProps> {
                   [`Form-itemColumn--${left}`]: !horizontal.leftFixed,
                   'Form-label--left': labelAlign === 'left'
                 },
-                labelClassName
+                labelClassName,
+                isStatic && staticLabelClassName,
               )}
               style={labelWidth != null ? {width: labelWidth} : undefined}
             >
@@ -991,11 +1003,14 @@ export class FormItemWrap extends React.Component<FormItemProps> {
           ) : null}
 
           <div
-            className={cx(`Form-value`, {
-              // [`Form-itemColumn--offset${getWidthRate(horizontal.offset)}`]: !label && label !== false,
-              [`Form-itemColumn--${right}`]:
-                !horizontal.leftFixed && !!right && right !== 12 - left
-            })}
+            className={cx(`Form-value`,
+              isStatic && staticValueClassName,
+              {
+                // [`Form-itemColumn--offset${getWidthRate(horizontal.offset)}`]: !label && label !== false,
+                [`Form-itemColumn--${right}`]:
+                  !horizontal.leftFixed && !!right && right !== 12 - left
+              }
+            )}
           >
             {renderControl()}
 
@@ -1070,7 +1085,9 @@ export class FormItemWrap extends React.Component<FormItemProps> {
         data,
         showErrorMsg,
         useMobileUI,
-        translate: __
+        translate: __,
+        static: isStatic,
+        staticLabelClassName
       } = props;
 
       description = description || desc;
@@ -1089,7 +1106,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
           )}
         >
           {label && renderLabel !== false ? (
-            <label className={cx(`Form-label`, labelClassName)}>
+            <label className={cx(`Form-label`, labelClassName, isStatic && staticLabelClassName)}>
               <span>
                 {label
                   ? render(
@@ -1189,6 +1206,9 @@ export class FormItemWrap extends React.Component<FormItemProps> {
         data,
         showErrorMsg,
         useMobileUI,
+        static: isStatic,
+        staticLabelClassName,
+        staticValueClassName,
         translate: __
       } = props;
       const labelWidth = props.labelWidth || props.formLabelWidth;
@@ -1209,7 +1229,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
         >
           {label && renderLabel !== false ? (
             <label
-              className={cx(`Form-label`, labelClassName)}
+              className={cx(`Form-label`, labelClassName, isStatic && staticLabelClassName)}
               style={labelWidth != null ? {width: labelWidth} : undefined}
             >
               <span>
@@ -1240,7 +1260,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
             </label>
           ) : null}
 
-          <div className={cx(`Form-value`)}>
+          <div className={cx(`Form-value`, isStatic && staticValueClassName)}>
             {renderControl()}
 
             {caption
@@ -1314,6 +1334,8 @@ export class FormItemWrap extends React.Component<FormItemProps> {
         data,
         showErrorMsg,
         useMobileUI,
+        static: isStatic,
+        staticLabelClassName,
         translate: __
       } = props;
       const labelWidth = props.labelWidth || props.formLabelWidth;
@@ -1335,7 +1357,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
           <div className={cx('Form-rowInner')}>
             {label && renderLabel !== false ? (
               <label
-                className={cx(`Form-label`, labelClassName)}
+                className={cx(`Form-label`, labelClassName, isStatic && staticLabelClassName)}
                 style={labelWidth != null ? {width: labelWidth} : undefined}
               >
                 <span>
@@ -1470,6 +1492,7 @@ export const detectProps = [
   'desc',
   'description',
   'disabled',
+  'static',
   'draggable',
   'editable',
   'editButtonClassName',

--- a/packages/amis-core/src/store/root.ts
+++ b/packages/amis-core/src/store/root.ts
@@ -8,7 +8,8 @@ export const RootStore = ServiceStore.named('RootStore')
     runtimeErrorStack: types.frozen(),
     query: types.frozen(),
     visibleState: types.optional(types.frozen(), {}),
-    disableState: types.optional(types.frozen(), {})
+    disableState: types.optional(types.frozen(), {}),
+    staticState: types.optional(types.frozen(), {})
   })
   .views(self => ({
     get downStream() {
@@ -53,6 +54,13 @@ export const RootStore = ServiceStore.named('RootStore')
         [id]: value
       };
       self.disableState = state;
+    },
+    setStatic(id: string, value: boolean) {
+      const state = {
+        ...self.staticState,
+        [id]: value
+      };
+      self.staticState = state;
     }
   }));
 

--- a/packages/amis-core/src/types.ts
+++ b/packages/amis-core/src/types.ts
@@ -259,9 +259,11 @@ export interface Schema {
   visibleOn?: string;
   hiddenOn?: string;
   disabledOn?: string;
+  staticOn?: string;
   visible?: boolean;
   hidden?: boolean;
   disabled?: boolean;
+  static?: boolean;
   children?: JSX.Element | ((props: any, schema?: any) => JSX.Element) | null;
   definitions?: Definitions;
   [propName: string]: any;

--- a/packages/amis-ui/scss/components/form/_checks.scss
+++ b/packages/amis-ui/scss/components/form/_checks.scss
@@ -474,6 +474,18 @@
   }
 }
 
+.#{$ns}Form-static .#{$ns}Checkbox {
+  input {
+    &[disabled]:checked + i {
+      background: var(--Checkbox-onHover-bg);
+      &:before {
+        background: var(--Checkbox-onHover-bg);
+        border-color: var(--Checkbox-onHover-bg);
+      }
+    }
+  }
+}
+
 .#{$ns}CheckboxControl,
 .#{$ns}RadiosControl,
 .#{$ns}CheckboxesControl {

--- a/packages/amis-ui/scss/components/form/_form.scss
+++ b/packages/amis-ui/scss/components/form/_form.scss
@@ -25,8 +25,10 @@
 
 .#{$ns}Form-static {
   min-height: var(--Form-input-height);
-  padding-top: var(--Form-label-paddingTop);
-  padding-bottom: var(--Form-label-paddingTop);
+  &:not(.is-noPaddingY-static) {
+    padding-top: var(--Form-label-paddingTop);
+    padding-bottom: var(--Form-label-paddingTop);
+  }
   margin-bottom: 0;
   word-break: break-word;
 

--- a/packages/amis-ui/scss/components/form/_input-group.scss
+++ b/packages/amis-ui/scss/components/form/_input-group.scss
@@ -143,6 +143,9 @@
       color: var(--primary);
     }
   }
+  .#{$ns}Form-static {
+    margin-right: var(--gap-xs);
+  }
 }
 
 .#{$ns}InputGroup:not(.is-inline) {

--- a/packages/amis-ui/scss/components/form/_list.scss
+++ b/packages/amis-ui/scss/components/form/_list.scss
@@ -120,3 +120,15 @@
     color: var(--Form-input-placeholderColor);
   }
 }
+
+.#{$ns}Form-static {
+  .#{$ns}ListControl-item.is-disabled {
+    opacity: 1;
+    background: var(--ListControl-item-onActive-bg);
+    border-color: var(--ListControl-item-onDisabled-borderColor);
+    color: var(--ListControl-item-color);
+    &::before, &::before {
+      display: none;
+    }
+  }
+}

--- a/packages/amis/src/renderers/Color.tsx
+++ b/packages/amis/src/renderers/Color.tsx
@@ -49,7 +49,7 @@ export class ColorField extends React.Component<ColorProps, object> {
           style={{backgroundColor: color || defaultColor}}
         />
         {showValue ? (
-          <span className={cx('ColorField-value')}>{color}</span>
+          <span className={cx('ColorField-value')}>{color || defaultColor}</span>
         ) : null}
       </div>
     );

--- a/packages/amis/src/renderers/Form/InputColor.tsx
+++ b/packages/amis/src/renderers/Form/InputColor.tsx
@@ -1,10 +1,11 @@
 import React, {Suspense} from 'react';
 import cx from 'classnames';
 
-import {FormItem, FormControlProps, FormBaseControl} from 'amis-core';
+import {FormItem, FormControlProps} from 'amis-core';
 import type {PresetColor} from 'amis-ui';
 import {isMobile} from 'amis-core';
 import {FormBaseControlSchema} from '../../Schema';
+import renderStaticHoc from './StaticHoc';
 
 // todo amis-ui 里面组件直接改成按需加载
 export const ColorPicker = React.lazy(
@@ -70,33 +71,47 @@ export default class ColorControl extends React.PureComponent<
     open: false
   };
 
+  @renderStaticHoc()
+  renderStatic() {
+    return this.props.render(
+      'static-color',
+      {type: 'color'},
+      this.props
+    );
+  }
+
   render() {
     const {
       className,
       classPrefix: ns,
       value,
       env,
+      static: isStatic,
       useMobileUI,
       ...rest
     } = this.props;
     const mobileUI = useMobileUI && isMobile();
     return (
       <div className={cx(`${ns}ColorControl`, className)}>
-        <Suspense fallback={<div>...</div>}>
-          <ColorPicker
-            classPrefix={ns}
-            {...rest}
-            useMobileUI={useMobileUI}
-            popOverContainer={
-              mobileUI && env && env.getModalContainer
-                ? env.getModalContainer
-                : mobileUI
-                ? undefined
-                : rest.popOverContainer
-            }
-            value={value || ''}
-          />
-        </Suspense>
+        {
+          isStatic
+            ? this.renderStatic()
+            : <Suspense fallback={<div>...</div>}>
+                <ColorPicker
+                  classPrefix={ns}
+                  {...rest}
+                  useMobileUI={useMobileUI}
+                  popOverContainer={
+                    mobileUI && env && env.getModalContainer
+                      ? env.getModalContainer
+                      : mobileUI
+                      ? undefined
+                      : rest.popOverContainer
+                  }
+                  value={value || ''}
+                />
+              </Suspense>
+        }
       </div>
     );
   }

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import {
   OptionsControl,
   OptionsControlProps,
-  highlight,
-  FormOptionsControl
+  highlight
 } from 'amis-core';
 import {ActionObject} from 'amis-core';
 import Downshift, {StateChangeOptions} from 'downshift';
@@ -20,6 +19,7 @@ import {ActionSchema} from '../Action';
 import {FormOptionsSchema, SchemaApi} from '../../Schema';
 import {generateIcon} from 'amis-core';
 import {rendererEventDispatcher, bindRendererEvent} from 'amis-core';
+import renderStaticHoc from './StaticHoc';
 
 import type {Option} from 'amis-core';
 import type {ListenerAction} from 'amis-core';
@@ -892,6 +892,19 @@ export default class TextControl extends React.PureComponent<
     );
   }
 
+  @renderStaticHoc()
+  renderStatic(displayValue = '-'): JSX.Element {
+    return (
+      <>
+        {
+          this.props.type === 'input-password'
+          ? '********'
+          : displayValue
+        }
+      </>
+    );
+  }
+
   render(): JSX.Element {
     const {
       classnames: cx,
@@ -904,7 +917,8 @@ export default class TextControl extends React.PureComponent<
       render,
       data,
       disabled,
-      inputOnly
+      inputOnly,
+      static: isStatic
     } = this.props;
 
     const addOn: any =
@@ -915,14 +929,15 @@ export default class TextControl extends React.PureComponent<
           }
         : addOnRaw;
 
-    let input =
-      autoComplete !== false && (source || options.length || autoComplete)
+    let input = isStatic
+      ? this.renderStatic()
+      : autoComplete !== false && (source || options?.length || autoComplete)
         ? this.renderSugestMode()
         : this.renderNormal();
 
     const iconElement = generateIcon(cx, addOn?.icon, 'Icon');
 
-    let addOnDom = addOn ? (
+    let addOnDom = addOn && !isStatic ? (
       addOn.actionType ||
       ~['button', 'submit', 'reset', 'action'].indexOf(addOn.type) ? (
         <div className={cx(`${ns}TextControl-button`, addOn.className)}>

--- a/packages/amis/src/renderers/Form/StaticHoc.tsx
+++ b/packages/amis/src/renderers/Form/StaticHoc.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import {getPropValue, FormControlProps} from "amis-core";
+
+export interface renderStaticHocProps {
+  /**
+   * 展示态时，是否去掉paddingY
+   * 大多数都需要，个别表单项不需要
+   */
+  staticNoPaddingY?: boolean;
+}
+
+/**
+ * 表单项目类成员展示态装饰器
+ */
+export default function renderStaticHoc<T extends FormControlProps>(
+  hocProps:renderStaticHocProps = {
+    staticNoPaddingY: false
+  }
+) {
+  const {staticNoPaddingY} = hocProps;
+  return function (
+    target: any,
+    name: string,
+    descriptor: TypedPropertyDescriptor<any>
+  ) {
+    const original = descriptor.value;
+    descriptor.value = function (...args: any[]) {
+      const props = (this as TypedPropertyDescriptor<any> & {props: T}).props;
+      const {
+        staticSchema,
+        render,
+        classPrefix: ns,
+        classnames: cx,
+        staticPlaceholder = '-'
+      } = props;
+
+      const displayValue = getPropValue(props) || staticPlaceholder;
+      const body = staticSchema
+        // 外部传入自定义展示态schema
+        ? render('form-static-schema', staticSchema, props)
+        // 预置展示态
+        : original.apply(this, [...args, displayValue]);
+
+      return <div className={cx(`${ns}Form-static`, {
+        'is-noPaddingY-static': staticNoPaddingY
+      })}>
+        {body}
+      </div>
+    }
+    return descriptor;
+  }
+}

--- a/packages/amis/src/renderers/Form/Switch.tsx
+++ b/packages/amis/src/renderers/Form/Switch.tsx
@@ -5,6 +5,7 @@ import {createObject, autobind, isObject} from 'amis-core';
 import {generateIcon} from 'amis-core';
 import {IconSchema} from '../Icon';
 import {FormBaseControlSchema} from '../../Schema';
+import renderStaticHoc from './StaticHoc';
 
 /**
  * Switch
@@ -78,6 +79,19 @@ export default class SwitchControl extends React.Component<SwitchProps, any> {
     onChange && onChange(checked);
   }
 
+  @renderStaticHoc({
+    staticNoPaddingY: true
+  })
+  renderStatic() {
+    const {
+      value,
+      trueValue,
+      on = '开',
+      off = '关'
+    } = this.props;
+    return <>{value === trueValue ? on : off}</>;
+  }
+
   render() {
     const {
       size,
@@ -92,7 +106,8 @@ export default class SwitchControl extends React.Component<SwitchProps, any> {
       option,
       onChange,
       disabled,
-      optionAtLeft
+      optionAtLeft,
+      static: isStatic
     } = this.props;
 
     const on = isObject(onText)
@@ -108,17 +123,21 @@ export default class SwitchControl extends React.Component<SwitchProps, any> {
           <span className={cx('Switch-option')}>{option}</span>
         ) : null}
 
-        <Switch
-          classPrefix={ns}
-          value={value}
-          trueValue={trueValue}
-          falseValue={falseValue}
-          onText={on}
-          offText={off}
-          disabled={disabled}
-          onChange={this.handleChange}
-          size={size as any}
-        />
+        {
+          isStatic
+            ? this.renderStatic()
+            : <Switch
+                classPrefix={ns}
+                value={value}
+                trueValue={trueValue}
+                falseValue={falseValue}
+                onText={on}
+                offText={off}
+                disabled={disabled}
+                onChange={this.handleChange}
+                size={size as any}
+              />
+        }
 
         {optionAtLeft ? null : (
           <span className={cx('Switch-option')}>{option}</span>

--- a/packages/amis/src/renderers/QuickEdit.tsx
+++ b/packages/amis/src/renderers/QuickEdit.tsx
@@ -471,6 +471,7 @@ export const HocQuickEdit =
           >
             {render('quick-edit-form', this.buildSchema(), {
               value: undefined,
+              static: false,
               onSubmit: this.handleSubmit,
               onAction: this.handleAction,
               onChange: null,
@@ -518,7 +519,8 @@ export const HocQuickEdit =
           render,
           noHoc,
           canAccessSuperData,
-          disabled
+          disabled,
+          readOnly
         } = this.props;
 
         if (
@@ -526,7 +528,8 @@ export const HocQuickEdit =
           !onQuickChange ||
           quickEditEnabled === false ||
           noHoc ||
-          disabled
+          disabled ||
+          readOnly
         ) {
           return <Component {...this.props} />;
         }


### PR DESCRIPTION
### 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化语料改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 其他改动（是关于什么的改动？）


### 需求背景和解决方案

[Form支持编辑态、展示态切换](https://ku.baidu-int.com/knowledge/HFVrC7hq1Q/tQvrZcAEPS/GxsYWwEpj5/CB1YWGgjJB3DYZ)

### 更新日志
 
1. `Form` 新增`static、staticOn、staticClassName`属性，支持通过`static`切换编辑态展示态；
2. `FormItem` 新增`static、staticOn、staticSchema、staticPlaceholder、staticClassName`属性，支持通过`static`切换编辑态展示态；
3. 新增`static`、`nonstatic`动作，用以切换`Form`和`FormItem` 的编辑态展示态；

### 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供