### PR TITLE
feat: input-formula 支持 mixedMode 支持字符串和表达式混合输入

### DIFF
--- a/docs/zh-CN/components/form/input-formula.md
+++ b/docs/zh-CN/components/form/input-formula.md
@@ -22,7 +22,7 @@ order: 21
       "name": "formula",
       "label": "公式",
       "evalMode": true,
-      "value": "SUM(1 + 2)",
+      "value": "SUM(1 , 2)",
       "variables": [
         {
           "label": "表单字段",
@@ -93,7 +93,7 @@ order: 21
       "label": "公式",
       "variableMode": "tree",
       "evalMode": false,
-      "value": "${SUM(1 + 2)}",
+      "value": "${SUM(1 , 2)}",
       "inputMode": "button",
       "variables": [
         {
@@ -163,7 +163,7 @@ order: 21
       "label": "公式",
       "variableMode": "tree",
       "evalMode": true,
-      "value": "SUM(1 + 2)",
+      "value": "SUM(1 , 2)",
       "inputMode": "input-group",
       "variables": [
         {
@@ -373,7 +373,147 @@ Tab 结构：
       "allowInput": false,
       "label": "公式",
       "evalMode": true,
-      "value": "SUM(1 + 2)",
+      "value": "SUM(1, 2)",
+      "variables": [
+        {
+          "label": "表单字段",
+          "children": [
+            {
+              "label": "文章名",
+              "value": "name",
+              "tag": "文本"
+            },
+            {
+              "label": "作者",
+              "value": "author",
+              "tag": "文本"
+            },
+            {
+              "label": "售价",
+              "value": "price",
+              "tag": "数字"
+            },
+            {
+              "label": "出版时间",
+              "value": "time",
+              "tag": "时间"
+            },
+            {
+              "label": "版本号",
+              "value": "version",
+              "tag": "数字"
+            },
+            {
+              "label": "出版社",
+              "value": "publisher",
+              "tag": "文本"
+            }
+          ]
+        },
+        {
+          "label": "流程字段",
+          "children": [
+            {
+              "label": "联系电话",
+              "value": "telphone"
+            },
+            {
+              "label": "地址",
+              "value": "addr"
+            }
+          ]
+        }
+      ],
+    }
+  ]
+}
+```
+
+## 模板模式
+
+当配置 `evalMode` 为 false 时则为模板模式，意思是说默认不当做表达式，只有 `${`和`}`包裹的部分才是表达式。
+
+```schema: scope="body"
+{
+  "type": "form",
+  "debug": true,
+  "body": [
+    {
+      "type": "input-formula",
+      "name": "formula",
+      "label": "公式",
+      "evalMode": false,
+      "value": "my name is \\${name}",
+      "variables": [
+        {
+          "label": "表单字段",
+          "children": [
+            {
+              "label": "文章名",
+              "value": "name",
+              "tag": "文本"
+            },
+            {
+              "label": "作者",
+              "value": "author",
+              "tag": "文本"
+            },
+            {
+              "label": "售价",
+              "value": "price",
+              "tag": "数字"
+            },
+            {
+              "label": "出版时间",
+              "value": "time",
+              "tag": "时间"
+            },
+            {
+              "label": "版本号",
+              "value": "version",
+              "tag": "数字"
+            },
+            {
+              "label": "出版社",
+              "value": "publisher",
+              "tag": "文本"
+            }
+          ]
+        },
+        {
+          "label": "流程字段",
+          "children": [
+            {
+              "label": "联系电话",
+              "value": "telphone"
+            },
+            {
+              "label": "地址",
+              "value": "addr"
+            }
+          ]
+        }
+      ],
+    }
+  ]
+}
+```
+
+## 混合模式
+
+混合模式的意思是支持输入文本和输入公式两种格式的值，当输入公式时值会自动用 `${` 和 `}` 包裹，如果不是这种格式则认为是输入普通的字符串。通过 `mixedMode` 为 true 启用这种模式
+
+```schema: scope="body"
+{
+  "type": "form",
+  "debug": true,
+  "body": [
+    {
+      "type": "input-formula",
+      "name": "value",
+      "label": "混合模式",
+      "mixedMode": true,
+      "value": "\\${SUM(1, 2)}",
       "variables": [
         {
           "label": "表单字段",

--- a/packages/amis-ui/src/components/formula/Picker.tsx
+++ b/packages/amis-ui/src/components/formula/Picker.tsx
@@ -27,6 +27,14 @@ export interface FormulaPickerProps extends FormulaEditorProps {
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
 
   /**
+   * 混合模式，意味着这个输入框既可以输入不同文本
+   * 也可以输入公式。
+   * 当输入公式时，值格式为 ${公式内容}
+   * 其他内容当字符串。
+   */
+  mixedMode?: boolean;
+
+  /**
    * 编辑器标题
    */
   title?: string;
@@ -130,30 +138,46 @@ export class FormulaPicker extends React.Component<
   FormulaPickerProps,
   FormulaPickerState
 > {
-  constructor(props: FormulaPickerProps) {
-    super(props);
-    this.props.onRef && this.props.onRef(this);
-  }
+  state: FormulaPickerState;
 
   static defaultProps = {
     evalMode: true
   };
 
-  state: FormulaPickerState = {
-    isOpened: false,
-    value: this.props.value!,
-    editorValue: this.props.value!,
-    isError: false
-  };
+  constructor(props: FormulaPickerProps) {
+    super(props);
+    this.props.onRef && this.props.onRef(this);
+    this.state = {
+      isOpened: false,
+      value: this.props.value!,
+      editorValue: this.value2EditorValue(this.props),
+      isError: false
+    };
+  }
 
   componentDidUpdate(prevProps: FormulaPickerProps) {
     const value = this.props.value;
     if (typeof value !== 'undefined' && value !== prevProps.value) {
       this.setState({
         value,
-        editorValue: value
+        editorValue: this.value2EditorValue(this.props)
       });
     }
+  }
+
+  value2EditorValue(props: FormulaPickerProps) {
+    if (props.mixedMode) {
+      if (
+        typeof props.value === 'string' &&
+        /^\s*\$\{(.+?)\}\s*$/.test(props.value)
+      ) {
+        return RegExp.$1;
+      } else {
+        return '';
+      }
+    }
+
+    return String(props.value || '');
   }
 
   @autobind
@@ -209,10 +233,11 @@ export class FormulaPicker extends React.Component<
   }
 
   confirm(value: string) {
+    const {mixedMode} = this.props;
     const validate = this.validate(value);
 
     if (validate === true) {
-      this.setState({value}, () => {
+      this.setState({value: mixedMode ? `\${${value}}` : value}, () => {
         this.close(undefined, () => this.handleConfirm());
       });
     } else {
@@ -224,7 +249,7 @@ export class FormulaPicker extends React.Component<
   async handleClick() {
     const state = {
       ...(await this.props.onPickerOpen?.(this.props)),
-      editorValue: this.props.value,
+      editorValue: this.value2EditorValue(this.props),
       isOpened: true
     };
 
@@ -263,7 +288,7 @@ export class FormulaPicker extends React.Component<
     try {
       value &&
         parse(value, {
-          evalMode: this.props.evalMode,
+          evalMode: this.props.mixedMode ? true : this.props.evalMode,
           allowFilter: false
         });
 
@@ -299,10 +324,11 @@ export class FormulaPicker extends React.Component<
       functions,
       children,
       variableMode,
+      mixedMode,
+      evalMode,
       ...rest
     } = this.props;
     const {isOpened, value, editorValue, isError} = this.state;
-
     const iconElement = generateIcon(cx, icon, 'Icon');
 
     return (
@@ -442,6 +468,7 @@ export class FormulaPicker extends React.Component<
           <Modal.Body>
             <Editor
               {...rest}
+              evalMode={mixedMode ? true : evalMode}
               variables={this.state.variables ?? variables}
               functions={this.state.functions ?? functions}
               variableMode={this.state.variableMode ?? variableMode}

--- a/packages/amis-ui/src/components/formula/Picker.tsx
+++ b/packages/amis-ui/src/components/formula/Picker.tsx
@@ -237,9 +237,12 @@ export class FormulaPicker extends React.Component<
     const validate = this.validate(value);
 
     if (validate === true) {
-      this.setState({value: mixedMode ? `\${${value}}` : value}, () => {
-        this.close(undefined, () => this.handleConfirm());
-      });
+      this.setState(
+        {value: mixedMode && value ? `\${${value}}` : value},
+        () => {
+          this.close(undefined, () => this.handleConfirm());
+        }
+      );
     } else {
       this.setState({isError: validate});
     }

--- a/packages/amis/src/renderers/Form/InputFormula.tsx
+++ b/packages/amis/src/renderers/Form/InputFormula.tsx
@@ -25,6 +25,14 @@ export interface InputFormulaControlSchema extends FormBaseControlSchema {
   evalMode?: boolean;
 
   /**
+   * 混合模式，意味着这个输入框既可以输入不同文本
+   * 也可以输入公式。
+   * 当输入公式时，值格式为 ${公式内容}
+   * 其他内容当字符串。
+   */
+  mixedMode?: boolean;
+
+  /**
    * 用于提示的变量集合，默认为空
    */
   variables: Array<VariableItem>;
@@ -165,6 +173,7 @@ export class InputFormulaRenderer extends React.Component<InputFormulaProps> {
       disabled,
       onChange,
       evalMode,
+      mixedMode,
       variableMode,
       header,
       label,
@@ -227,6 +236,7 @@ export class InputFormulaRenderer extends React.Component<InputFormulaProps> {
         data={data}
         onPickerOpen={onPickerOpen}
         selfVariableName={selfVariableName}
+        mixedMode={mixedMode}
       />
     );
   }


### PR DESCRIPTION
混合模式的意思是支持输入文本和输入公式两种格式的值，当输入公式时值会自动用 `${` 和 `}` 包裹，如果不是这种格式则认为是输入普通的字符串。通过 `mixedMode` 为 true 启用这种模式