### PR TITLE
fix: 2.1.0 及以上版本升级到tinymce 6上传图片不兼容的问题

### DIFF
--- a/packages/amis/src/renderers/Form/InputRichText.tsx
+++ b/packages/amis/src/renderers/Form/InputRichText.tsx
@@ -159,50 +159,47 @@ export default class RichTextControl extends React.Component<
       const fetcher = props.env.fetcher;
       this.config = {
         ...props.options,
-        images_upload_handler: async (
-          blobInfo: any,
-          ok: (locaiton: string) => void,
-          fail: (reason: string) => void
-        ) => {
-          const formData = new FormData();
-          formData.append(
-            props.fileField,
-            blobInfo.blob(),
-            blobInfo.filename()
-          );
+        images_upload_handler: (blobInfo: any, progress: any) =>
+          new Promise(async (resolve, reject) => {
+            const formData = new FormData();
+            formData.append(
+              props.fileField,
+              blobInfo.blob(),
+              blobInfo.filename()
+            );
 
-          try {
-            const receiver = {
-              adaptor: (payload: object) => {
-                return {
-                  ...payload,
-                  data: payload
-                };
-              },
-              ...normalizeApi(tokenize(props.receiver, props.data), 'post')
-            };
+            try {
+              const receiver = {
+                adaptor: (payload: object) => {
+                  return {
+                    ...payload,
+                    data: payload
+                  };
+                },
+                ...normalizeApi(tokenize(props.receiver, props.data), 'post')
+              };
 
-            const response = await fetcher(receiver, formData, {
-              method: 'post'
-            });
-            if (response.ok) {
-              const location =
-                response.data?.link ||
-                response.data?.url ||
-                response.data?.value ||
-                response.data?.data?.link ||
-                response.data?.data?.url ||
-                response.data?.data?.value;
-              if (location) {
-                ok(location);
-              } else {
-                console.warn('must have return value');
+              const response = await fetcher(receiver, formData, {
+                method: 'post'
+              });
+              if (response.ok) {
+                const location =
+                  response.data?.link ||
+                  response.data?.url ||
+                  response.data?.value ||
+                  response.data?.data?.link ||
+                  response.data?.data?.url ||
+                  response.data?.data?.value;
+                if (location) {
+                  resolve(location);
+                } else {
+                  console.warn('must have return value');
+                }
               }
+            } catch (e) {
+              reject(e);
             }
-          } catch (e) {
-            fail(e);
-          }
-        }
+          })
       };
     }
   }


### PR DESCRIPTION
点击[官方示例](https://baidu.github.io/amis/zh-CN/components/form/input-rich-text)进行上传图片出现报错, 如下图：

<img width="1474" alt="image" src="https://user-images.githubusercontent.com/39587710/190674669-5aeaf422-77b1-461a-ac63-3ff92eca784f.png">


升级到tinymce 6 后images_upload_handler 有变化。

The [version 6.X ](https://www.tiny.cloud/docs/tinymce/6/upload-images/#example-using-images_upload_handler)return a Promise and the [version 5.X](https://www.tiny.cloud/docs/configure/file-image-upload/#images_upload_handler) use callback function.

![image](https://user-images.githubusercontent.com/39587710/190675049-e29de79a-3066-4657-92db-18a0a60efe74.png)
