### PR TITLE
fix: json组件支持boolean基础类型

### DIFF
--- a/packages/amis/src/renderers/Json.tsx
+++ b/packages/amis/src/renderers/Json.tsx
@@ -146,7 +146,7 @@ export class JSONField extends React.Component<JSONProps, object> {
     }
 
     // JsonView 只支持对象，所以不是对象格式需要转成对象格式。
-    if (data && ~['string', 'number'].indexOf(typeof data)) {
+    if (~['string', 'number', 'boolean'].indexOf(typeof data)) {
       data = {
         [typeof data]: data
       };


### PR DESCRIPTION
### 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化语料改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 其他改动（是关于什么的改动？）


### 需求背景和解决方案
当使用JSON组件时，不能支持boolean类型的值展示，因此对boolean类型进行兼容
同时对于空对象和值为0时，不能够进行适配，因此去除data的判断

| 语言    | 更新描述 |
| ------- | -------- |
| 英文 |          |
| 中文 |      json组件支持boolean基础类型     |

### 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供