### PR TITLE
fix: 修复 inputText 对日期对象显示问题

### DIFF
--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -586,6 +586,8 @@ export default class TextControl extends React.PureComponent<
       ? ''
       : typeof value === 'string'
       ? value
+      : value instanceof Date
+      ? value.toISOString()
       : JSON.stringify(value);
   }
 


### PR DESCRIPTION
通过 JSON.stringify 后变成了带引号的格式比如 `"2022-09-26T14:55:17.301Z"` 实际上应该显示 `2022-09-26T14:55:17.301Z`