### PR TITLE
style: quickEdit 列去掉 min-width 设置,因为如果是个开关用不了那么宽

### DIFF
--- a/packages/amis-ui/scss/components/form/_form.scss
+++ b/packages/amis-ui/scss/components/form/_form.scss
@@ -406,9 +406,9 @@
   position: relative;
 }
 
-.#{$ns}Form--quickEdit {
-  min-width: var(--Form-control-widthSm);
-}
+// .#{$ns}Form--quickEdit {
+//   min-width: var(--Form-control-widthSm);
+// }
 
 .#{$ns}Form--column {
   display: flex;


### PR DESCRIPTION
<img width="828" alt="image" src="https://user-images.githubusercontent.com/2698393/199002078-588a9a72-1027-40f6-8a56-bc8152c5b0d6.png">
