### PR TITLE
fix: 数字输入框-属性配置-placeholder置灰+边框与form-input统一

### DIFF
--- a/packages/amis-ui/scss/components/form/_number.scss
+++ b/packages/amis-ui/scss/components/form/_number.scss
@@ -7,7 +7,7 @@
   display: inline-block;
   vertical-align: middle;
   background: var(--Number-bg);
-  border: var(--Number-borderWidth) solid var(--Number-borderColor);
+  border: var(--Number-borderWidth) solid var(--Form-input-borderColor);
   border-radius: var(--Number-borderRadius);
   overflow: hidden;
 
@@ -69,6 +69,11 @@
     border-radius: var(--Form-input-borderRadius);
     color: var(--Form-input-color);
     padding: 0 var(--Form-inputNumber-paddingX);
+
+    &::placeholder {
+      color: var(--Form-input-placeholderColor);
+      user-select: none;
+    }
   }
 
   &-handler {


### PR DESCRIPTION
<!-- 感谢你的贡献！组件优化请提交至 master 分支,维护者审核通过后会合并。请确保填写以下 pull request 的信息，谢谢！~ -->

### 这个变动的性质是？

- [ ] 新特性提交
- [✓] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化语料改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 其他改动（是关于什么的改动？）


### 需求背景和解决方案

<!-- 附上设计文档和自测CASE文档的链接 -->
1. 改变`amis_ui `中的`_number.scss` 文件 input border颜色 为`--Form-input-borderColor`
2. 向`amis_ui` 中的`_number.scss `文件 中的相应input类加入placeholder伪元素 控制颜色
自测case文档：https://ku.baidu-int.com/knowledge/HFVrC7hq1Q/pKzJfZczuc/CHrzXx4sGW/pRAcc5vDQDbrtP

### 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->
总共两项变化：
1. input-number组件边框与其余form-input组件（例如input-text）边框颜色统一
2. input-number组件 placeholder颜色置灰 与input-text组件颜色统一

| 语言    | 更新描述 |
| ------- | -------- |
| 英文 |          |
| 中文 |          |

### 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [✓] 文档已补充或无须补充
- [✓] 代码演示已提供或无须提供
- [✓] TypeScript 定义已补充或无须补充
- [✓] Changelog 已提供或无须提供