### PR TITLE
fix:amis-ui/scss/_thirds.scss import path error

### DIFF
--- a/packages/amis-ui/scss/_thirds.scss
+++ b/packages/amis-ui/scss/_thirds.scss
@@ -1,8 +1,8 @@
-@import '../../../node_modules/codemirror/lib/codemirror';
-@import '../../../node_modules/froala-editor/css/froala_style.min';
-@import '../../../node_modules/froala-editor/css/froala_editor.pkgd.min';
-@import '../../../node_modules/tinymce/skins/ui/oxide/skin';
-@import '../../../node_modules/video-react/dist/video-react';
-@import '../../../node_modules/cropperjs/dist/cropper';
+@import '../node_modules/codemirror/lib/codemirror';
+@import '../node_modules/froala-editor/css/froala_style.min';
+@import '../node_modules/froala-editor/css/froala_editor.pkgd.min';
+@import '../node_modules/tinymce/skins/ui/oxide/skin';
+@import '../amis/node_modules/video-react/dist/video-react';
+@import '../amis/node_modules/cropperjs/dist/cropper';
 
 @import './components/react-datetime';


### PR DESCRIPTION
npm vite 启动项目后报错

[plugin:vite:css] [sass] Can't find stylesheet to import.
  ╷
1 │ @import '../../../node_modules/codemirror/lib/codemirror';
  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
  packages\amis-ui\scss\_thirds.scss 1:9         @import
  packages\amis-ui\scss\themes\_common.scss 1:9  @import
  packages\amis-ui\scss\themes\cxd.scss 4:9      root stylesheet