### PR TITLE
feat: Action组件支持isolateScope

### DIFF
--- a/packages/amis/src/renderers/Action.tsx
+++ b/packages/amis/src/renderers/Action.tsx
@@ -182,6 +182,11 @@ export interface AjaxActionSchema extends ButtonSchema {
   reload?: SchemaReload;
   redirect?: string;
   ignoreConfirm?: boolean;
+
+  /**
+   * 是否开启请求隔离, 主要用于隔离联动CRUD, Service的请求
+   */
+  isolateScope?: boolean;
 }
 
 export interface DownloadActionSchema
@@ -416,7 +421,8 @@ const ActionProps = [
   'payload',
   'requireSelected',
   'countDown',
-  'fileName'
+  'fileName',
+  'isolateScope'
 ];
 import {filterContents} from './Remark';
 import {ClassNamesFn, themeable, ThemeProps} from 'amis-core';

--- a/packages/amis/src/renderers/Dialog.tsx
+++ b/packages/amis/src/renderers/Dialog.tsx
@@ -696,7 +696,6 @@ export class DialogRenderer extends Dialog {
     rawAction?: ActionObject
   ) {
     const scoped = this.context as IScopedContext;
-
     const targets: Array<any> = [];
     const {onConfirm, store} = this.props;
 
@@ -709,7 +708,8 @@ export class DialogRenderer extends Dialog {
       );
     }
 
-    if (!targets.length) {
+    /** 如果为隔离动作, 则不做联动处理, 继续交给handleAction */
+    if (action?.isolateScope !== true && !targets.length) {
       let components = scoped
         .getComponents()
         .filter(item => !~['drawer', 'dialog'].indexOf(item.props.type));

--- a/packages/amis/src/renderers/Drawer.tsx
+++ b/packages/amis/src/renderers/Drawer.tsx
@@ -711,7 +711,8 @@ export class DrawerRenderer extends Drawer {
       );
     }
 
-    if (!targets.length) {
+    /** 如果为隔离动作, 则不做联动处理, 继续交给handleAction */
+    if (action?.isolateScope !== true && !targets.length) {
       let components = scoped
         .getComponents()
         .filter(item => !~['drawer', 'dialog'].indexOf(item.props.type));


### PR DESCRIPTION
当dialog/drawer的body中同时存在`"actionType": "ajax"` 类型的按钮和CRUD/Service等组件时(平级关系), 触发Action的请求, 会联动触发CURD/Service组件的api请求, 此时设置`isolateScope`可以避免联动触发, 让Action单纯发出一个请求.