### PR TITLE
fix: 修复condition-builder组件select类型placeholder属性不生效的bug

### DIFF
--- a/docs/zh-CN/components/form/condition-builder.md
+++ b/docs/zh-CN/components/form/condition-builder.md
@@ -348,6 +348,7 @@ type Value = ValueGroup;
             {
               "label": "A",
               "type": "select",
+              "placeholder": "这个是下拉框",
               "name": "a",
               "source": "/api/mock2/form/getOptions?waitSeconds=1",
               "searchable": true

--- a/packages/amis-ui/src/components/condition-builder/Value.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Value.tsx
@@ -117,6 +117,7 @@ export class Value extends React.Component<ValueProps> {
         <Select
           simpleValue
           options={field.options!}
+          placeholder={__(field.placeholder) || 'Select.placeholder'}
           source={field.source}
           autoComplete={autoComplete}
           searchable={field.searchable}


### PR DESCRIPTION
复现步骤，官方网站示例即可复现：

https://baidu.github.io/amis/zh-CN/components/form/condition-builder#%E4%B8%8B%E6%8B%89%E9%80%89%E6%8B%A9

修复完成的效果图
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/39587710/203752794-3f081fe9-623f-4105-9ef6-6ae93fb9c3ec.png">
