### PR TITLE
feat(API): 支持接口配置默认返回值，防止空值报错

### DIFF
--- a/docs/zh-CN/types/api.md
+++ b/docs/zh-CN/types/api.md
@@ -576,6 +576,72 @@ API 还支持配置对象类型
 
 需要注意上面例子中 `items` 是因为数据直接放在了 `data` 中，如果是放在其他字段中就换成对应的字段名。
 
+### 配置返回默认值
+
+amis 默认认为接口返回空数据是不合理的，假如接口实际返回为 `null` 或者 `""` 等空值，会提示错误`Response is empty`，一般情况下不需要使用该配置。
+
+当有时候业务接口确实是会合理返回空的情况，比如提交表单后，接口返回空表示正常提交成功，此时可以配置返回默认值来自定义返回数据。
+
+方法是配置 responseDefault 字段，在返回响应体为空的时候生效：
+
+```json
+{
+  "type": "page",
+  "body": {
+    "type": "form",
+    "api": {
+      "method": "post",
+      "url": "/api/mock2/form/saveForm", // 这是个例子，请使用真实返回空数据的接口代替
+      "responseDefault": {
+        "status": 0,
+        "msg": "保存成功"
+      }
+    },
+    "body": [
+      {
+        "type": "input-text",
+        "name": "name",
+        "label": "姓名："
+      },
+      {
+        "name": "email",
+        "type": "input-email",
+        "label": "邮箱："
+      }
+    ]
+  }
+}
+```
+
+```json
+{
+  "type": "page",
+  "body": {
+    "type": "form",
+    "api": {
+      "method": "post",
+      "url": "/api/mock2/form/saveForm", // 这是个例子，请使用真实返回空数据的接口代替
+      "responseDefault": {
+        "status": 1,
+        "msg": "保存失败"
+      }
+    },
+    "body": [
+      {
+        "type": "input-text",
+        "name": "name",
+        "label": "姓名："
+      },
+      {
+        "name": "email",
+        "type": "input-email",
+        "label": "邮箱："
+      }
+    ]
+  }
+}
+```
+
 ### 配置请求适配器
 
 amis 的 API 配置，如果无法配置出你想要的请求结构，那么可以配置`requestAdaptor`发送适配器

--- a/packages/amis-core/src/types.ts
+++ b/packages/amis-core/src/types.ts
@@ -116,6 +116,11 @@ export interface BaseApiObject {
   };
 
   /**
+   * 用来做接口返回为空情况下的默认值。
+   */
+  responseDefault?: fetcherResult['data'];
+
+  /**
    * 如果 method 为 get 的接口，设置了 data 信息。
    * 默认 data 会自动附带在 query 里面发送给后端。
    *

--- a/packages/amis-core/src/utils/api.ts
+++ b/packages/amis-core/src/utils/api.ts
@@ -277,7 +277,12 @@ export function responseAdaptor(ret: fetcherResult, api: ApiObject) {
   let hasStatusField = true;
 
   if (!data) {
-    throw new Error('Response is empty');
+    // 是否配置了返回默认值
+    if (api.responseDefault) {
+      data = api.responseDefault;
+    } else {
+      throw new Error('Response is empty');
+    }
   }
 
   // 返回内容是 string，说明 content-type 不是 json，这时可能是返回了纯文本或 html


### PR DESCRIPTION
#### 问题：
在form表单在配置提交接口，接口提交成功后，返回空或者没返回数据，amis会提示错误。
![image](https://user-images.githubusercontent.com/30541930/205045373-9ddac2a8-efa7-4e79-bd4b-1c152637c154.png)

#### 解决：
希望支持用户自定义默认值，当返回没有数据的时候允许使用默认值，否则才默认报错。