### PR TITLE
fix: inputTable编辑按钮Bug

### DIFF
--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -660,7 +660,8 @@ export default class FormTable extends React.Component<TableProps, TableState> {
       {
         editIndex: -1,
         items: items,
-        raw: undefined
+        raw: undefined,
+        columns: this.buildColumns(this.props)
       },
       this.emitValue
     );
@@ -679,7 +680,8 @@ export default class FormTable extends React.Component<TableProps, TableState> {
       {
         editIndex: -1,
         raw: undefined,
-        items: items
+        items: items,
+        columns: this.buildColumns(this.props)
       },
       this.emitValue
     );


### PR DESCRIPTION
问题：inputTable组件，存在多行内容，当某行被编辑后，无论确认还是取消，操作列按钮显示Bug
[官方文档位置](https://aisuda.bce.baidu.com/amis/zh-CN/components/form/input-table#%E9%85%8D%E7%BD%AE%E6%8C%89%E9%92%AE%E4%B8%BA%E6%96%87%E5%AD%97)
解决：操作后，重新渲染列

问题截图：
<img width="814" alt="WechatIMG109" src="https://user-images.githubusercontent.com/20664932/205650291-53b75604-29fb-4f92-be7f-a3da74303744.png">
_编辑后：_
<img width="799" alt="WechatIMG110" src="https://user-images.githubusercontent.com/20664932/205650311-a040f6e0-cf77-4f37-b147-60f093f5e582.png">
第2行编辑后，1/3行的操作列没有被渲染
