### PR TITLE
fix: 修复旧版static-xxx组件inputClassName重复的问题

### DIFF
--- a/packages/amis-core/src/renderers/Item.tsx
+++ b/packages/amis-core/src/renderers/Item.tsx
@@ -860,6 +860,8 @@ export class FormItemWrap extends React.Component<FormItemProps> {
 
   renderControl(): JSX.Element | null {
     const {
+      // 这里解构，不可轻易删除，避免被rest传到子组件
+      inputClassName,
       formItem: model,
       classnames: cx,
       children,
@@ -1641,6 +1643,8 @@ export function asFormItem(config: Omit<FormItemConfig, 'component'>) {
 
           renderControl() {
             const {
+              // 这里解构，不可轻易删除，避免被rest传到子组件
+              inputClassName,
               formItem: model,
               classnames: cx,
               children,


### PR DESCRIPTION
修复static-xxx组件配置inputClassName时，会重复设置的问题，如图
<img width="461" alt="image" src="https://user-images.githubusercontent.com/16409259/206133645-03708dd6-5152-441c-8f88-d30ee4f8f76b.png">

bug原因：
在开发表单静态展示的时候，删除了两行代码导致

解决：
还原代码，在解构赋值时，加入inputClassName，让 rest 不包含inputClassName
