### PR TITLE
docs: 補充namespace缺少的cookie

### DIFF
--- a/docs/zh-CN/concepts/data-mapping.md
+++ b/docs/zh-CN/concepts/data-mapping.md
@@ -368,6 +368,7 @@ order: 12
 - `window` 即全局变量
 - `ls` 即 localStorage， 如果值是 json 对象，可以直接当对象用比如：`${ls:xxxxxlocalStrorageKey.xxxx}`
 - `ss` 即 sessionStorage，同上。
+- `cookie` 即 cookies，同上。
 
 ```schema
 {


### PR DESCRIPTION
以前 https://github.com/baidu/amis/pull/1996 就有的cookie數據映射
文檔沒寫到 順手添加