### PR TITLE
增加动态注册渲染器机制后，自定义控件无法传入 autoVar 参数 #5886

### DIFF
--- a/packages/amis-core/src/renderers/register.ts
+++ b/packages/amis-core/src/renderers/register.ts
@@ -88,6 +88,7 @@ function registerAmisRendererByUsage(curUsage: string, curAmisRenderer: any) {
     registerMap[curUsage as keyof typeof registerMap]({
       type: curAmisRenderer.type,
       weight: curAmisRenderer.weight || 0,
+      autoVar: curAmisRenderer.autoVar || false,
     })(curAmisRendererComponent);
   }
 }


### PR DESCRIPTION
动态注册渲染器，自动解析消息中带入的 autoVar 参数。

使用实例：
```
          window.postMessage(
            {
              type: 'amis-renderer-register-event',
              eventMsg: `${consoleTag}注册一个自定义amis渲染器`,
              amisRenderer: {
                type: newComponentType,
                weight: curRendererOption.weight,
                usage: curRendererOption.usage,
                autoVar: true,
              },
            },
            '*',
          );
```