### PR TITLE
feat: 添加自定义解析页面URL方法

### DIFF
--- a/packages/amis-core/src/RootRenderer.tsx
+++ b/packages/amis-core/src/RootRenderer.tsx
@@ -34,7 +34,7 @@ export class RootRenderer extends React.Component<RootRendererProps> {
     }) as IRootStore;
 
     this.store.initData(props.data);
-    this.store.updateLocation(props.location);
+    this.store.updateLocation(props.location, this.props.env?.parseLocation);
 
     bulkBindFunctions<RootRenderer /*为毛 this 的类型自动识别不出来？*/>(this, [
       'handleAction',

--- a/packages/amis-core/src/env.tsx
+++ b/packages/amis-core/src/env.tsx
@@ -106,6 +106,10 @@ export interface RendererEnv {
    * 文本替换的黑名单，因为属性太多了所以改成黑名单的 fangs
    */
   replaceTextIgnoreKeys?: String[];
+  /**
+   * 解析url参数
+   */
+  parseLocation?: (location: any) => Object;
 }
 
 export const EnvContext = React.createContext<RendererEnv | void>(undefined);

--- a/packages/amis-core/src/store/root.ts
+++ b/packages/amis-core/src/store/root.ts
@@ -32,8 +32,8 @@ export const RootStore = ServiceStore.named('RootStore')
       self.runtimeError = error;
       self.runtimeErrorStack = errorStack;
     },
-    updateLocation(location?: any) {
-      self.query = parseQuery(location);
+    updateLocation(location?: any, parseFn?: Function) {
+      self.query = parseFn ? parseFn(location) : parseQuery(location);
     },
     setVisible(id: string, value: boolean) {
       const state = {


### PR DESCRIPTION
### 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化语料改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 其他改动（是关于什么的改动？）


### 需求背景和解决方案
SaaS中需要对页面入参进行结构化定义，意味着需要将url中的页面参数转化成对象、布尔等结构的值，因此添加自定义解析URL的方法来解析URL参数

### 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 英文 |          |
| 中文 |    添加自定义解析页面URL方法      |

### 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供