### PR TITLE
chore: table 不应该透传 autoGenerateFilter

### DIFF
--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -459,7 +459,8 @@ export default class Table extends React.Component<TableProps, object> {
     'autoFillHeight',
     'onSelect',
     'keepItemSelectionOnPageChange',
-    'maxKeepItemSelectionLength'
+    'maxKeepItemSelectionLength',
+    'autoGenerateFilter'
   ];
   static defaultProps: Partial<TableProps> = {
     className: '',


### PR DESCRIPTION
否则 table 内嵌 table，会导致里面的 autoGenerateFilter 配置无效