### PR TITLE
fix: 修复inputDate组件有默认值时首次触发blur值会被清空的问题

### DIFF
--- a/packages/amis-ui/src/components/DatePicker.tsx
+++ b/packages/amis-ui/src/components/DatePicker.tsx
@@ -368,6 +368,11 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
 
   componentDidMount() {
     this.props?.onRef?.(this);
+    const {value, format, inputFormat} = this.props;
+    if (value) {
+      let valueCache = normalizeValue(value, format);
+      this.inputValueCache = valueCache?.format(inputFormat) || '';
+    }
   }
 
   componentDidUpdate(prevProps: DateProps) {


### PR DESCRIPTION
bug原因： onInputBlur 时候会把inputValue 设置为 缓存值，当有默认值，componentDidMount 中未对 inputValueCache 进行初始化
```
  onInputBlur() {
    this.setState({
      inputValue: this.inputValueCache
    });
  }
```