### PR TITLE
fix(Table): #2978 嵌套表格如何设置默认全部展开

### DIFF
--- a/examples/components/CRUD/Nested.jsx
+++ b/examples/components/CRUD/Nested.jsx
@@ -5,7 +5,7 @@ export default {
     api: '/api/mock2/crud/table2',
     saveOrderApi: '/api/mock2/form/saveData',
     expandConfig: {
-      expand: 'first'
+      expand: 'all'
     },
     draggable: true,
     columns: [

--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -1115,19 +1115,19 @@ export const TableStore = iRendererStore
           self.expandConfig.expand === 'all' &&
           !self.expandConfig.accordion)
       ) {
-        self.expandedRows.replace(getExpandAllTreeIds(self.rows));
+        self.expandedRows.replace(getExpandAllRows(self.rows));
       }
 
       self.dragging = false;
     }
 
     // 获取所有层级的子节点id
-    function getExpandAllTreeIds(arr: Array<SRow>): string[] {
+    function getExpandAllRows(arr: Array<SRow>): string[] {
       return arr.reduce((result: string[], current) => {
         result.push(current.id);
 
         if (current.children && current.children.length) {
-          result = result.concat(getExpandAllTreeIds(current.children));
+          result = result.concat(getExpandAllRows(current.children));
         }
 
         return result;

--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -1115,10 +1115,23 @@ export const TableStore = iRendererStore
           self.expandConfig.expand === 'all' &&
           !self.expandConfig.accordion)
       ) {
-        self.expandedRows.replace(self.rows.map(item => item.id));
+        self.expandedRows.replace(getExpandAllTreeIds(self.rows));
       }
 
       self.dragging = false;
+    }
+
+    // 获取所有层级的子节点id
+    function getExpandAllTreeIds(arr: Array<SRow>): string[] {
+      return arr.reduce((result: string[], current) => {
+        result.push(current.id);
+
+        if (current.children && current.children.length) {
+          result = result.concat(getExpandAllTreeIds(current.children));
+        }
+
+        return result;
+      }, []);
     }
 
     // 尽可能的复用 row


### PR DESCRIPTION
```
{
  expandConfig: {
      expand: 'all'
    },
}
```

不能展开所有子节点，如果考虑性能展开第一个层级是否应该增加配置，保留原来模式

但 `expand: 'all'` 意在展开所有子节点更容易被用户记住和接受