### PR TITLE
fix: 增加 cache 来存储 Tree 中的 key 和 level (#6042), 优化 defer 节点收起逻辑

### DIFF
--- a/examples/components/Form/Tree.jsx
+++ b/examples/components/Form/Tree.jsx
@@ -29,7 +29,8 @@ export default {
       // "type": "nested-select",
       name: 'output_fields',
       label: '输出字段',
-      description: '输出字段中的制表符会转换为"\\t",换行符会转换为"\
+      description:
+        '输出字段中的制表符会转换为"\\t",换行符会转换为"\
     "',
       mode: 'horizontal',
       multiple: true,
@@ -53,6 +54,24 @@ export default {
       multiple: true,
       menuTpl: '<div>${label} 值：${value}, 当前是否选中: ${checked}</div>',
       options: options
+    },
+    {
+      type: 'input-tree',
+      name: 'tree',
+      label: 'Tree',
+      deferApi: '/api/mock2/form/deferOptions?label=${label}&waitSeconds=2',
+      options: [
+        {
+          label: 'lazy1',
+          value: 4,
+          defer: true
+        },
+        {
+          label: 'lazy2',
+          value: 5,
+          defer: true
+        }
+      ]
     }
   ]
 };

--- a/packages/amis-core/src/renderers/Options.tsx
+++ b/packages/amis-core/src/renderers/Options.tsx
@@ -827,6 +827,11 @@ export function registerOptionsControl(config: OptionsConfig) {
         return;
       }
 
+      if (option.loaded) {
+        formItem?.updateOptions(option, createObject(data, option));
+        return;
+      }
+
       const json = await formItem?.deferLoadOptions(
         option,
         api,

--- a/packages/amis-core/src/store/formItem.ts
+++ b/packages/amis-core/src/store/formItem.ts
@@ -919,6 +919,40 @@ export const FormItemStore = StoreNode.named('FormItemStore')
       return json;
     });
 
+    const updateOptions = (option: any, data?: object) => {
+      const labelField = self.labelField || 'label';
+      const valueField = self.valueField || 'value';
+      const indexes = findTreeIndex(
+        self.options,
+        item =>
+          item === option ||
+          /** tree-select中会对option添加collapsed, visible属性，导致item === option不通过 */
+          isEqualWith(
+            item,
+            option,
+            (source, target) =>
+              source?.[valueField] != null &&
+              target?.[valueField] != null &&
+              source?.[labelField] === target?.[labelField] &&
+              source?.[valueField] === target?.[valueField]
+          )
+      );
+      if (!indexes) {
+        return false;
+      }
+
+      setOptions(
+        spliceTree(self.options, indexes, 1, {
+          ...option,
+          loading: !option.loaded
+        }),
+        undefined,
+        data
+      );
+
+      return true;
+    };
+
     /**
      * 根据当前节点路径展开树形组件父节点
      */
@@ -1253,7 +1287,8 @@ export const FormItemStore = StoreNode.named('FormItemStore')
       changeEmitedValue,
       addSubFormItem,
       removeSubFormItem,
-      loadAutoUpdateData
+      loadAutoUpdateData,
+      updateOptions
     };
   });
 

--- a/packages/amis-core/src/utils/normalizeOptions.ts
+++ b/packages/amis-core/src/utils/normalizeOptions.ts
@@ -14,10 +14,10 @@ export function normalizeOptions(
 ): Options {
   if (typeof options === 'string') {
     return options.split(',').map(item => {
-      const idx = share.values.indexOf(item);
-      if (~idx) {
-        return share.options[idx];
-      }
+      // const idx = share.values.indexOf(item);
+      // if (~idx) {
+      //   return share.options[idx];
+      // }
 
       const option = {
         label: item,
@@ -36,10 +36,10 @@ export function normalizeOptions(
     typeof (options as Array<string>)[0] === 'string'
   ) {
     return (options as Array<string>).map(item => {
-      const idx = share.values.indexOf(item);
-      if (~idx) {
-        return share.options[idx];
-      }
+      // const idx = share.values.indexOf(item);
+      // if (~idx) {
+      //   return share.options[idx];
+      // }
 
       const option = {
         label: item,
@@ -55,14 +55,14 @@ export function normalizeOptions(
     return (options as Options).map(item => {
       const value = item && item[valueField];
 
-      const idx =
-        value !== undefined && !item.children
-          ? share.values.indexOf(value)
-          : -1;
+      // const idx =
+      //   value !== undefined && !item.children
+      //     ? share.values.indexOf(value)
+      //     : -1;
 
-      if (~idx) {
-        return share.options[idx];
-      }
+      // if (~idx) {
+      //   return share.options[idx];
+      // }
 
       const option = {
         ...item,
@@ -80,10 +80,10 @@ export function normalizeOptions(
     });
   } else if (isPlainObject(options)) {
     return Object.keys(options).map(key => {
-      const idx = share.values.indexOf(key);
-      if (~idx) {
-        return share.options[idx];
-      }
+      // const idx = share.values.indexOf(key);
+      // if (~idx) {
+      //   return share.options[idx];
+      // }
 
       const option = {
         label: (options as {[propName: string]: string})[key] as string,

--- a/packages/amis-ui/src/components/Selection.tsx
+++ b/packages/amis-ui/src/components/Selection.tsx
@@ -44,7 +44,7 @@ export interface BaseSelectionProps extends ThemeProps, LocaleProps {
 }
 
 export interface ItemRenderStates {
-  index: number;
+  index: number | string;
   labelField?: string;
   multiple?: boolean;
   checked: boolean;


### PR DESCRIPTION
Tree组件中的逻辑调整
- 不再props.options 上增加key属性和level属性，改为通过 WeakMap 来保存
- 对于 defer 加载过的 option (loaded === true)，收起时直接更新 store 中的 options