### PR TITLE
docs: 修复ConditionBuilder文档中tree模式格式代码示例错误导致的下拉框无法被选中问题

### DIFF
--- a/docs/zh-CN/components/form/condition-builder.md
+++ b/docs/zh-CN/components/form/condition-builder.md
@@ -599,23 +599,34 @@ selectMode 为`tree`时
               children: [
                 {
                   "label": "Folder A",
+                  "type": "tree",
+                  "name": "Folder_A",
+                  "type": "number",
                   "value": 1,
                   "children": [
                     {
                       "label": "file A",
-                      "value": 2
+                      "value": 2,
+                      "name": "file_A",
+                      "type": "number",
                     },
                     {
                       "label": "Folder B",
                       "value": 3,
+                      "name": "Folder_B",
+                      "type": "number",
                       "children": [
                         {
                           "label": "file b1",
-                          "value": 3.1
+                          "value": 3.1,
+                          "name": "file_b1",
+                          "type": "number"
                         },
                         {
                           "label": "file b2",
-                          "value": 3.2
+                          "value": 3.2,
+                          "name": "file_b2",
+                          "type": "number"
                         }
                       ]
                     }


### PR DESCRIPTION
问题描述： 修复ConditionBuilder文档中tree模式格式代码示例错误导致的下拉框无法被选中问题，如下，点击file A后，仍然未

**选中前：**
<img width="1078" alt="image" src="https://user-images.githubusercontent.com/39587710/213104612-195e7f24-0ae7-4703-9fc3-d52e2be3b074.png">

**选中后：**
<img width="1106" alt="image" src="https://user-images.githubusercontent.com/39587710/213104821-f823d77a-bcab-42ae-8183-dbbf260748a6.png">


复现步骤：
官方网站示例即可复现
示例地址：https://baidu.github.io/amis/zh-CN/components/form/condition-builder#%E5%AD%97%E6%AE%B5%E9%80%89%E9%A1%B9%E7%B1%BB%E5%9E%8B


修复效果如下：
<img width="961" alt="image" src="https://user-images.githubusercontent.com/39587710/213104081-5041b294-95d1-4750-aef5-6bcd14c27c1f.png">
