### PR TITLE
fix: 修复tabs 内的表单项无法设置 static 属性的问题

### DIFF
--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -1533,7 +1533,7 @@ export default class Form extends React.Component<FormProps, object> {
       dispatchEvent,
       labelAlign,
       labelWidth,
-      static: isStatic = false
+      static: isStatic
     } = props;
 
     const subProps = {
@@ -1563,7 +1563,8 @@ export default class Form extends React.Component<FormProps, object> {
        * 2. 表单子项 static: false 或 不配置，跟随父表单
        * 3. 动作控制 表单子项 时，无视配置，优先级最高
        */
-      static: (control as Schema).static || isStatic,
+      ...(control as Schema).static || isStatic
+        ? {static: true} : {},
       btnDisabled: disabled || form.loading || form.validating,
       onAction: this.handleAction,
       onQuery: this.handleQuery,


### PR DESCRIPTION
复现schema
```
{
  "type": "form",
  "body": [
    {
      "type": "tabs",
      "tabs": [
        {
          "title": "基本信息",
          "body": [
            {
              "type": "input-text",
              "name": "status",
              "label": "状态",
              "static": true
            }
          ]
        }
      ]
    }
  ]
}
```

bug原因：
Form中包含容器类组件时，
这些组件会将此处的disbaled、static 等属性继续下发至子组件，
导致SchemaRenderer中 `props.static` 覆盖 `schema.static`


以上schema 渲染tabs时，`static: (control as Schema).static || props.static` 的结果为 `false`, 
下发后覆盖了表单项的 static ，从而导致了bug

