### PR TITLE
fix: 解决monaco环境变量和monaco插件的冲突

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,31 +78,6 @@
     <script type="module">
       import {bootstrap} from './examples/index.jsx';
 
-      import * as monaco from 'monaco-editor';
-      import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
-      import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
-      import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker';
-      import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker';
-      import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
-
-      self.MonacoEnvironment = {
-        getWorker(_, label) {
-          if (label === 'json') {
-            return new jsonWorker();
-          }
-          if (label === 'css' || label === 'scss' || label === 'less') {
-            return new cssWorker();
-          }
-          if (label === 'html' || label === 'handlebars' || label === 'razor') {
-            return new htmlWorker();
-          }
-          if (label === 'typescript' || label === 'javascript') {
-            return new tsWorker();
-          }
-          return new editorWorker();
-        }
-      };
-
       window.enableAMISDebug = true;
 
       const initialState = {};

--- a/packages/amis-ui/src/components/Editor.tsx
+++ b/packages/amis-ui/src/components/Editor.tsx
@@ -16,34 +16,34 @@ import {LocaleProps, localeable} from 'amis-core';
 function filterUrl(url: string) {
   return url;
 }
+if (!(window as any).MonacoEnvironment) {
+  (window as any).MonacoEnvironment = {
+    getWorkerUrl: function (moduleId: string, label: string) {
+      let url = '/pkg/editor.worker.js';
 
-(window as any).MonacoEnvironment = {
-  getWorkerUrl: function (moduleId: string, label: string) {
-    let url = '/pkg/editor.worker.js';
+      if (label === 'json') {
+        url = '/pkg/json.worker.js';
+      } else if (label === 'css') {
+        url = '/pkg/css.worker.js';
+      } else if (label === 'html') {
+        url = '/pkg/html.worker.js';
+      } else if (label === 'typescript' || label === 'javascript') {
+        url = '/pkg/ts.worker.js';
+      }
 
-    if (label === 'json') {
-      url = '/pkg/json.worker.js';
-    } else if (label === 'css') {
-      url = '/pkg/css.worker.js';
-    } else if (label === 'html') {
-      url = '/pkg/html.worker.js';
-    } else if (label === 'typescript' || label === 'javascript') {
-      url = '/pkg/ts.worker.js';
-    }
+      url = filterUrl(url);
 
-    url = filterUrl(url);
-
-    // url 有可能会插件替换成 cdn 地址，比如：fis3-prepackager-stand-alone-pack
-    if (/^https?/.test(url)) {
-      return `data:text/javascript;charset=utf-8,${encodeURIComponent(`
+      // url 有可能会插件替换成 cdn 地址，比如：fis3-prepackager-stand-alone-pack
+      if (/^https?/.test(url)) {
+        return `data:text/javascript;charset=utf-8,${encodeURIComponent(`
         importScripts('${url}');`)}
       `;
+      }
+
+      return url;
     }
-
-    return url;
-  }
-};
-
+  };
+}
 export function monacoFactory(
   containerElement: HTMLElement,
   monaco: any,


### PR DESCRIPTION
使用了vite-plugin-monaco-editor 会自动注入 MonacoEnvironment 这个全局变量，不用ui库改写了， 要不然代码还需要复写，现在我是这样处理的 😂

![image](https://user-images.githubusercontent.com/11799110/221836208-9e7c3dfa-c4d0-4708-b8b4-cbb68de22c85.png)
