### PR TITLE
fix: nav组件中子菜单标题渲染时className与css中不一致问题

### DIFF
--- a/packages/amis-ui/scss/components/_nav.scss
+++ b/packages/amis-ui/scss/components/_nav.scss
@@ -1,7 +1,7 @@
 .#{$ns}Nav {
   position: relative;
 
-  .#{$ns}Nav-itemIcon {
+  .#{$ns}Menu-item-icon {
     margin-right: var(--gap-sm);
   }
 
@@ -12,7 +12,7 @@
     padding: 0;
     position: relative;
 
-    img.#{$ns}Nav-itemIcon {
+    img.#{$ns}Menu-item-icon {
       height: var(--Tabs-linkFontSize);
       vertical-align: middle;
     }


### PR DESCRIPTION
SubMenu.tsx中138~151行使用的className与原css中定义的className不一致，同步调整scss中的定义