### PR TITLE
feat: button-group-select支持角标

### DIFF
--- a/docs/zh-CN/components/form/button-group-select.md
+++ b/docs/zh-CN/components/form/button-group-select.md
@@ -143,18 +143,60 @@ order: 6
 }
 ```
 
+## 支持角标
+
+按钮可支持角标，在 options 中配置
+
+```schema: scope="body"
+{
+  "type": "form",
+  "api": "/api/mock2/form/saveForm",
+  "debug": true,
+  "body": [
+    {
+      "type": "button-group-select",
+      "label": "选项",
+      "name": "type",
+      "options": [
+        {
+          "label": "Option A",
+          "value": "a"
+        },
+        {
+          "label": "Option B",
+          "value": "b",
+          "badge": {
+            "mode": "text",
+            "text": 15
+          }
+        },
+        {
+          "label": "Option C",
+          "value": "c",
+          "badge": {
+            "mode": "ribbon",
+            "text": "HOT"
+      }
+        }
+      ]
+    }
+  ]
+}
+```
+
 ## 属性表
 
 当做选择器表单项使用时，除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置
 
-| 属性名         | 类型                                                                                                                | 默认值                  | 说明                                                                                        |
-| -------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------- |
+| 属性名         | 类型                                                                                                                | 默认值                  | 说明                                                                                        | 版本    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------- | ------- |
 | type           | `string`                                                                                                            | `"button-group-select"` | 指定为 button-group-select 渲染器                                                           |
 | vertical       | `boolean`                                                                                                           | `false`                 | 是否使用垂直模式                                                                            |
 | tiled          | `boolean`                                                                                                           | `false`                 | 是否使用平铺模式                                                                            |
 | btnLevel       | `'link' \| 'primary' \| 'secondary' \| 'info'\|'success' \| 'warning' \| 'danger' \| 'light'\| 'dark' \| 'default'` | `"default"`             | 按钮样式                                                                                    |
 | btnActiveLevel | `'link' \| 'primary' \| 'secondary' \| 'info'\|'success' \| 'warning' \| 'danger' \| 'light'\| 'dark' \| 'default'` | `"default"`             | 选中按钮样式                                                                                |
 | options        | `Array<object>`或`Array<string>`                                                                                    |                         | [选项组](./options#%E9%9D%99%E6%80%81%E9%80%89%E9%A1%B9%E7%BB%84-options)                   |
+| option.badge   | `object`                                                                                                            |                         | [角标](../badge#属性表)                                                                     | `2.8.1` |
 | source         | `string`或 [API](../../../docs/types/api)                                                                           |                         | [动态选项组](./options#%E5%8A%A8%E6%80%81%E9%80%89%E9%A1%B9%E7%BB%84-source)                |
 | multiple       | `boolean`                                                                                                           | `false`                 | [多选](./options#%E5%A4%9A%E9%80%89-multiple)                                               |
 | labelField     | `boolean`                                                                                                           | `"label"`               | [选项标签字段](./options#%E9%80%89%E9%A1%B9%E6%A0%87%E7%AD%BE%E5%AD%97%E6%AE%B5-labelfield) |

--- a/packages/amis-ui/scss/components/_button-group.scss
+++ b/packages/amis-ui/scss/components/_button-group.scss
@@ -25,6 +25,15 @@
     }
   }
 
+  .#{$ns}Badge {
+    .#{$ns}Badge-text,
+    .#{$ns}Badge-dot,
+    .#{$ns}Badge-ribbon,
+    .#{$ns}Badge-dot {
+      z-index: 2;
+    }
+  }
+
   .#{$ns}Button + .#{$ns}Button,
   .#{$ns}Button + .#{$ns}ButtonGroup,
   .#{$ns}ButtonGroup + .#{$ns}Button,

--- a/packages/amis/src/renderers/Form/ButtonGroupSelect.tsx
+++ b/packages/amis/src/renderers/Form/ButtonGroupSelect.tsx
@@ -109,6 +109,7 @@ export default class ButtonGroupControl extends React.Component<
             label: option[labelField || 'label'],
             icon: option.icon,
             size: option.size || size,
+            badge: option.badge,
             type: 'button',
             block: block
           },


### PR DESCRIPTION
- bucket-group-select支持给option设置角标
- 修改角标z-index，避免被button激活样式覆盖