### PR TITLE
fix: 解决公式编辑器 搜索变量失效bug

### DIFF
--- a/packages/amis-ui/src/components/formula/VariableList.tsx
+++ b/packages/amis-ui/src/components/formula/VariableList.tsx
@@ -76,7 +76,7 @@ function VariableList(props: VariableListProps) {
 
   function onSearch(term: string) {
     const tree = findTree(list, i => ~i.label.indexOf(term));
-    setFilterVars(!term ? list : tree ? [tree] : list);
+    setFilterVars(!term ? list : tree ? [tree] : []);
   }
 
   function renderSearchBox() {


### PR DESCRIPTION
搜索变量，如果没有找到，则返回个空数组