### PR TITLE
fix: 修复 drawer reload 目标可能找不到的问题

### DIFF
--- a/packages/amis-core/src/RootRenderer.tsx
+++ b/packages/amis-core/src/RootRenderer.tsx
@@ -152,10 +152,10 @@ export class RootRenderer extends React.Component<RootRendererProps> {
       window.open(mailto);
     } else if (action.actionType === 'dialog') {
       store.setCurrentAction(action);
-      store.openDialog(ctx);
+      store.openDialog(ctx, undefined, undefined, delegate);
     } else if (action.actionType === 'drawer') {
       store.setCurrentAction(action);
-      store.openDrawer(ctx);
+      store.openDrawer(ctx, undefined, undefined, delegate);
     } else if (action.actionType === 'toast') {
       action.toast?.items?.forEach((item: any) => {
         env.notify(
@@ -252,7 +252,15 @@ export class RootRenderer extends React.Component<RootRendererProps> {
       return;
     }
 
+    const dialogAction = store.action as ActionObject;
+    const reload = action.reload ?? dialogAction.reload;
+    const scoped = store.getDialogScoped() || this.context;
+
     store.closeDialog(true);
+
+    if (reload) {
+      scoped.reload(reload, store.data);
+    }
   }
 
   handleDialogClose(confirmed = false) {
@@ -280,7 +288,18 @@ export class RootRenderer extends React.Component<RootRendererProps> {
       return;
     }
 
+    const drawerAction = store.action as ActionObject;
+    const reload = action.reload ?? drawerAction.reload;
+    const scoped = store.getDrawerScoped() || (this.context as IScopedContext);
+
     store.closeDrawer();
+
+    // 稍等会，等动画结束。
+    setTimeout(() => {
+      if (reload) {
+        scoped.reload(reload, store.data);
+      }
+    }, 300);
   }
 
   handleDrawerClose() {

--- a/packages/amis-core/src/store/iRenderer.ts
+++ b/packages/amis-core/src/store/iRenderer.ts
@@ -10,6 +10,7 @@ import {
 import {dataMapping} from '../utils/tpl-builtin';
 import {SimpleMap} from '../utils/SimpleMap';
 import {StoreNode} from './node';
+import {IScopedContext} from '../Scoped';
 
 export const iRendererStore = StoreNode.named('iRendererStore')
   .props({
@@ -35,6 +36,8 @@ export const iRendererStore = StoreNode.named('iRendererStore')
   }))
   .actions(self => {
     const dialogCallbacks = new SimpleMap<(result?: any) => void>();
+    let dialogScoped: IScopedContext | null = null;
+    let drawerScoped: IScopedContext | null = null;
 
     return {
       initData(data: object = {}, skipSetPristine = false) {
@@ -140,7 +143,12 @@ export const iRendererStore = StoreNode.named('iRendererStore')
         self.action = action;
       },
 
-      openDialog(ctx: any, additonal?: object, callback?: (ret: any) => void) {
+      openDialog(
+        ctx: any,
+        additonal?: object,
+        callback?: (ret: any) => void,
+        scoped?: IScopedContext
+      ) {
         let proto = ctx.__super ? ctx.__super : self.data;
 
         if (additonal) {
@@ -167,12 +175,14 @@ export const iRendererStore = StoreNode.named('iRendererStore')
         }
         self.dialogOpen = true;
         callback && dialogCallbacks.set(self.dialogData, callback);
+        dialogScoped = scoped || null;
       },
 
       closeDialog(result?: any) {
         const callback = dialogCallbacks.get(self.dialogData);
 
         self.dialogOpen = false;
+        dialogScoped = null;
 
         if (callback) {
           dialogCallbacks.delete(self.dialogData);
@@ -180,7 +190,12 @@ export const iRendererStore = StoreNode.named('iRendererStore')
         }
       },
 
-      openDrawer(ctx: any, additonal?: object, callback?: (ret: any) => void) {
+      openDrawer(
+        ctx: any,
+        additonal?: object,
+        callback?: (ret: any) => void,
+        scoped?: IScopedContext
+      ) {
         let proto = ctx.__super ? ctx.__super : self.data;
 
         if (additonal) {
@@ -210,16 +225,27 @@ export const iRendererStore = StoreNode.named('iRendererStore')
         if (callback) {
           dialogCallbacks.set(self.drawerData, callback);
         }
+
+        drawerScoped = scoped || null;
       },
 
       closeDrawer(result?: any) {
         const callback = dialogCallbacks.get(self.drawerData);
         self.drawerOpen = false;
+        drawerScoped = null;
 
         if (callback) {
           dialogCallbacks.delete(self.drawerData);
           setTimeout(() => callback(result), 200);
         }
+      },
+
+      getDialogScoped() {
+        return dialogScoped;
+      },
+
+      getDrawerScoped() {
+        return drawerScoped;
       }
     };
   });

--- a/packages/amis/src/renderers/Page.tsx
+++ b/packages/amis/src/renderers/Page.tsx
@@ -480,10 +480,10 @@ export default class Page extends React.Component<PageProps> {
 
     if (action.actionType === 'dialog') {
       store.setCurrentAction(action);
-      store.openDialog(ctx);
+      store.openDialog(ctx, undefined, undefined, delegate);
     } else if (action.actionType === 'drawer') {
       store.setCurrentAction(action);
-      store.openDrawer(ctx);
+      store.openDrawer(ctx, undefined, undefined, delegate);
     } else if (action.actionType === 'ajax') {
       store.setCurrentAction(action);
 
@@ -1014,11 +1014,12 @@ export class PageRenderer extends Page {
     action: ActionObject,
     ...rest: Array<any>
   ) {
-    super.handleDialogConfirm(values, action, ...rest);
-    const scoped = this.context;
     const store = this.props.store;
     const dialogAction = store.action as ActionObject;
     const reload = action.reload ?? dialogAction.reload;
+    const scoped = store.getDialogScoped() || this.context;
+
+    super.handleDialogConfirm(values, action, ...rest);
 
     if (reload) {
       scoped.reload(reload, store.data);
@@ -1036,11 +1037,12 @@ export class PageRenderer extends Page {
     action: ActionObject,
     ...rest: Array<any>
   ) {
-    super.handleDrawerConfirm(values, action);
-    const scoped = this.context as IScopedContext;
     const store = this.props.store;
     const drawerAction = store.action as ActionObject;
     const reload = action.reload ?? drawerAction.reload;
+    const scoped = store.getDrawerScoped() || (this.context as IScopedContext);
+
+    super.handleDrawerConfirm(values, action);
 
     // 稍等会，等动画结束。
     setTimeout(() => {


### PR DESCRIPTION
因为 drawer 会委托上层来处理，reload 的时候查找目标也变成上层了，所以会存在某些组件找不到的问题