### PR TITLE
fix: webpack5 import css error

### DIFF
--- a/packages/amis-editor-core/package.json
+++ b/packages/amis-editor-core/package.json
@@ -10,11 +10,17 @@
       "require": "./lib/index.js",
       "import": "./esm/index.js"
     },
+    "./lib/style.css": {
+      "style": "./lib/style.css",
+      "require": "./lib/style.css",
+      "import": "./lib/style.css"
+    },
     "./lib/*": {
       "require": "./lib/*",
       "import": "./esm/*"
     },
     "./scss/*": {
+      "style": "./scss/*",
       "require": "./scss/*",
       "import": "./scss/*"
     },

--- a/packages/amis/package.json
+++ b/packages/amis/package.json
@@ -162,10 +162,12 @@
       "import": "./esm/index.js"
     },
     "./lib/helper.css": {
+      "style": "./lib/helper.css",
       "require": "./lib/helper.css",
       "import": "./lib/helper.css"
     },
     "./lib/themes/*": {
+      "style": "./lib/themes/*",
       "require": "./lib/themes/*",
       "import": "./lib/themes/*"
     },
@@ -174,6 +176,9 @@
       "import": "./esm/*.js"
     },
     "./sdk/*": {
+      "style": [
+        "./sdk/*"
+      ],
       "require": [
         "./sdk/*"
       ],


### PR DESCRIPTION
https://webpack.js.org/guides/package-exports/#reference-syntax

webpack5 引入css的时候会报错