### PR TITLE
fix: moment默认中文vite显示英文问题

### DIFF
--- a/packages/amis-ui/src/components/DatePicker.tsx
+++ b/packages/amis-ui/src/components/DatePicker.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import moment from 'moment';
-import 'moment/locale/zh-cn';
+import 'moment/dist/locale/zh-cn';
 import {Icon} from './icons';
 import {PopOver} from 'amis-core';
 import PopUp from './PopUp';

--- a/packages/amis/src/renderers/Form/InputDate.tsx
+++ b/packages/amis/src/renderers/Form/InputDate.tsx
@@ -8,7 +8,7 @@ import {
 import cx from 'classnames';
 import {filterDate, isPureVariable, resolveVariableAndFilter} from 'amis-core';
 import moment from 'moment';
-import 'moment/locale/zh-cn';
+import 'moment/dist/locale/zh-cn';
 import {DatePicker} from 'amis-ui';
 import {FormBaseControlSchema, SchemaObject} from '../../Schema';
 import {createObject, anyChanged, isMobile, autobind} from 'amis-core';

--- a/packages/amis/src/renderers/Form/InputDateRange.tsx
+++ b/packages/amis/src/renderers/Form/InputDateRange.tsx
@@ -7,7 +7,7 @@ import {
 } from 'amis-core';
 import cx from 'classnames';
 import {filterDate, parseDuration} from 'amis-core';
-import 'moment/locale/zh-cn';
+import 'moment/dist/locale/zh-cn';
 import {DateRangePicker} from 'amis-ui';
 import {isMobile, createObject, autobind} from 'amis-core';
 import {ActionObject} from 'amis-core';


### PR DESCRIPTION
https://github.com/vitejs/vite/issues/3755#issuecomment-860548526

这个我修改本地构建会报错， 可能是我用的m1的mac   https://github.com/abbr/deasync/issues/142

![image](https://user-images.githubusercontent.com/11799110/226264096-a12f9d05-90ea-4f24-90d3-d817decc7df6.png)
