### PR TITLE
fix: Transfer tree mode 支持 onlyChildren;两个值为undefined的Option不相等 (#6342)

### DIFF
--- a/packages/amis-core/src/utils/optionValueCompare.ts
+++ b/packages/amis-core/src/utils/optionValueCompare.ts
@@ -12,9 +12,13 @@ export function matchOptionValue(
     isObject(a) && a && (a as Option).hasOwnProperty(valueField)
       ? (a as Option)[valueField]
       : a;
+  const bValue = b[valueField || 'value'];
   return isObject(aValue)
-    ? isEqual(aValue, b[valueField || 'value'])
-    : String(b[valueField || 'value']) === String(aValue);
+    ? isEqual(aValue, bValue)
+    : // 当值均为 undefined 时，不应该判定相等
+      aValue !== undefined &&
+        bValue !== undefined &&
+        String(bValue) === String(aValue);
 }
 
 export function optionValueCompare(

--- a/packages/amis-ui/src/components/Transfer.tsx
+++ b/packages/amis-ui/src/components/Transfer.tsx
@@ -9,7 +9,7 @@ import {
   unionWith
 } from 'lodash';
 
-import {ThemeProps, themeable} from 'amis-core';
+import {ThemeProps, themeable, findTree} from 'amis-core';
 import {BaseSelectionProps, BaseSelection, ItemRenderStates} from './Selection';
 import {Options, Option} from './Select';
 import {uncontrollable} from 'amis-core';
@@ -111,6 +111,8 @@ export interface TransferProps
   virtualThreshold?: number; // 数据量多大的时候开启虚拟渲染`
   virtualListHeight?: number; // 虚拟渲染时，列表高度
   showInvalidMatch?: boolean;
+  /** 树形模式下，给 tree 的属性 */
+  onlyChildren?: boolean;
 }
 
 export interface TransferState {
@@ -157,13 +159,12 @@ export class Transfer<
 
   static getDerivedStateFromProps(props: TransferProps) {
     // 计算是否是懒加载模式
-    let isTreeDeferLoad: boolean = false;
-    props.selectMode === 'tree' &&
-      props.options.forEach(item => {
-        if (item.defer) {
-          isTreeDeferLoad = true;
-        }
-      });
+    const isTreeDeferLoad =
+      props.selectMode === 'tree' &&
+      !!findTree(
+        props.options,
+        (option: Option) => option.deferApi || option.defer
+      );
 
     // 计算结果的selectMode
     let resultSelectMode = 'list';
@@ -473,7 +474,8 @@ export class Transfer<
       labelField,
       virtualThreshold,
       itemHeight,
-      virtualListHeight
+      virtualListHeight,
+      onlyChildren
     } = props;
     const {isTreeDeferLoad, searchResult} = this.state;
     const options = searchResult ?? [];
@@ -512,7 +514,7 @@ export class Transfer<
         showIcon={false}
         multiple={multiple}
         cascade={true}
-        onlyChildren={!isTreeDeferLoad}
+        onlyChildren={onlyChildren ?? !isTreeDeferLoad}
         itemRender={optionItemRender}
         labelField={labelField}
         virtualThreshold={virtualThreshold}
@@ -576,7 +578,8 @@ export class Transfer<
       virtualThreshold,
       itemHeight,
       virtualListHeight,
-      loadingConfig
+      loadingConfig,
+      onlyChildren
     } = props;
 
     return selectMode === 'table' ? (
@@ -603,7 +606,7 @@ export class Transfer<
         options={options}
         value={value}
         onChange={onChange!}
-        onlyChildren={!this.state.isTreeDeferLoad}
+        onlyChildren={onlyChildren ?? !this.state.isTreeDeferLoad}
         itemRender={optionItemRender}
         onDeferLoad={onDeferLoad}
         joinValues={false}

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -152,6 +152,11 @@ export interface TransferControlSchema
    * 当在value值未匹配到当前options中的选项时，是否value值对应文本飘红显示
    */
   showInvalidMatch?: boolean;
+
+  /**
+   * 树形模式下，仅选中子节点
+   */
+  onlyChildren?: boolean;
 }
 
 export interface BaseTransferProps
@@ -486,7 +491,8 @@ export class BaseTransferRenderer<
       virtualThreshold,
       itemHeight,
       loadingConfig,
-      showInvalidMatch
+      showInvalidMatch,
+      onlyChildren
     } = this.props;
 
     // 目前 LeftOptions 没有接口可以动态加载
@@ -509,6 +515,7 @@ export class BaseTransferRenderer<
     return (
       <div className={cx('TransferControl', className)}>
         <Transfer
+          onlyChildren={onlyChildren}
           value={selectedOptions}
           options={options}
           disabled={disabled}


### PR DESCRIPTION
* fix:transfer tree 支持 onlyChildren;两个值为undefined的Option不相等

* 修改

* 修改