### PR TITLE
feat: 修复ts-json-schema-generator生成的schema.json组件链接不正确的问题

### DIFF
--- a/packages/amis-core/src/factory.tsx
+++ b/packages/amis-core/src/factory.tsx
@@ -269,13 +269,13 @@ export const defaultOptions: RenderOptions = {
   },
   isCancel() {
     console.error(
-      'Please implement isCancel. see https://baidu.gitee.io/amis/docs/start/getting-started#%E4%BD%BF%E7%94%A8%E6%8C%87%E5%8D%97'
+      'Please implement isCancel. see https://aisuda.bce.baidu.com/amis/zh-CN/start/getting-started#%E4%BD%BF%E7%94%A8%E6%8C%87%E5%8D%97'
     );
     return false;
   },
   updateLocation() {
     console.error(
-      'Please implement updateLocation. see https://baidu.gitee.io/amis/docs/start/getting-started#%E4%BD%BF%E7%94%A8%E6%8C%87%E5%8D%97'
+      'Please implement updateLocation. see https://aisuda.bce.baidu.com/amis/zh-CN/start/getting-started#%E4%BD%BF%E7%94%A8%E6%8C%87%E5%8D%97'
     );
   },
 

--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -186,7 +186,7 @@ export interface FormSchemaBase {
   /**
    * Form 用来保存数据的 api。
    *
-   * 详情：https://baidu.gitee.io/amis/docs/components/form/index#%E8%A1%A8%E5%8D%95%E6%8F%90%E4%BA%A4
+   * 详情：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/index#%E8%A1%A8%E5%8D%95%E6%8F%90%E4%BA%A4
    */
   api?: string | BaseApiObject;
 

--- a/packages/amis-ui/src/components/Badge.tsx
+++ b/packages/amis-ui/src/components/Badge.tsx
@@ -11,7 +11,7 @@ import {ClassNamesFn} from 'amis-core';
 
 /**
  * Badge 角标。
- * 文档：https://baidu.gitee.io/amis/docs/components/badge
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/badge
  */
 export interface BadgeObject {
   className?: string;

--- a/packages/amis/src/Schema.ts
+++ b/packages/amis/src/Schema.ts
@@ -640,7 +640,7 @@ export type SchemaRedirect = string;
  * 2. `<%= data.xxx %>`
  *
  *
- * 更多文档：https://aisuda.bce.baidu.com/amis/zh-CN/concepts/template
+ * 更多文档：https://aisuda.bce.baidu.com/amis/zh-CN/docs/concepts/template
  */
 export type SchemaTpl = string;
 

--- a/packages/amis/src/Schema.ts
+++ b/packages/amis/src/Schema.ts
@@ -640,7 +640,7 @@ export type SchemaRedirect = string;
  * 2. `<%= data.xxx %>`
  *
  *
- * 更多文档：https://baidu.gitee.io/amis/docs/concepts/template
+ * 更多文档：https://aisuda.bce.baidu.com/amis/zh-CN/concepts/template
  */
 export type SchemaTpl = string;
 
@@ -851,7 +851,7 @@ export interface ToastSchemaBase extends BaseSchema {
 /**
  * Form 表单渲染器。
  *
- * 说明：https://baidu.gitee.io/amis/docs/components/form/index
+ * 说明：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/index
  */
 export interface FormSchema extends FormSchemaBase, BaseSchema {
   /**

--- a/packages/amis/src/renderers/Action.tsx
+++ b/packages/amis/src/renderers/Action.tsx
@@ -232,7 +232,7 @@ export interface DialogActionSchema extends ButtonSchema {
 
   /**
    * 弹框详情
-   * 文档：https://baidu.gitee.io/amis/docs/components/dialog
+   * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/dialog
    */
   dialog: DialogSchemaBase;
 
@@ -252,7 +252,7 @@ export interface DrawerActionSchema extends ButtonSchema {
 
   /**
    * 抽出式弹框详情
-   * 文档：https://baidu.gitee.io/amis/docs/components/drawer
+   * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/drawer
    */
   drawer: DrawerSchemaBase;
 
@@ -272,7 +272,7 @@ export interface ToastActionSchema extends ButtonSchema {
 
   /**
    * 轻提示详情
-   * 文档：https://baidu.gitee.io/amis/docs/components/toast
+   * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/toast
    */
   toast: ToastSchemaBase;
 }
@@ -365,7 +365,7 @@ export interface VanillaAction extends ButtonSchema {
 
 /**
  * 按钮动作渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/action
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/action
  */
 export type ActionSchema =
   | AjaxActionSchema

--- a/packages/amis/src/renderers/Alert.tsx
+++ b/packages/amis/src/renderers/Alert.tsx
@@ -12,7 +12,7 @@ import type {AlertProps} from 'amis-ui/lib/components/Alert2';
 
 /**
  * Alert 提示渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/alert
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/alert
  */
 export interface AlertSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/AnchorNav.tsx
+++ b/packages/amis/src/renderers/AnchorNav.tsx
@@ -8,7 +8,7 @@ import {BaseSchema, SchemaClassName, SchemaCollection} from '../Schema';
 
 /**
  * AnchorNavSection 锚点区域渲染器
- * 文档：https://baidu.gitee.io/amis/docs/components/anchor-nav
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/anchor-nav
  */
 
 export type AnchorNavSectionSchema = {
@@ -30,7 +30,7 @@ export type AnchorNavSectionSchema = {
 
 /**
  * AnchorNav 锚点导航渲染器
- * 文档：https://baidu.gitee.io/amis/docs/components/anchor-nav
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/anchor-nav
  */
 export interface AnchorNavSchema extends BaseSchema {
   /**
@@ -162,22 +162,24 @@ export default class AnchorNav extends React.Component<
     links = Array.isArray(links) ? links : [links];
     let children: Array<JSX.Element | null> = [];
 
-    children = links.map((section, index) =>
-      isVisible(section, data) ? (
-        <AnchorNavSection
-          {...(section as any)}
-          title={filter(section.title, data)}
-          key={index}
-          name={section.href || index}
-        >
-          {this.renderSection
-            ? this.renderSection(section, this.props, index)
-            : sectionRender
-            ? sectionRender(section, this.props, index)
-            : render(`section/${index}`, section.body || '')}
-        </AnchorNavSection>
-      ) : null
-    ).filter(item => !!item);
+    children = links
+      .map((section, index) =>
+        isVisible(section, data) ? (
+          <AnchorNavSection
+            {...(section as any)}
+            title={filter(section.title, data)}
+            key={index}
+            name={section.href || index}
+          >
+            {this.renderSection
+              ? this.renderSection(section, this.props, index)
+              : sectionRender
+              ? sectionRender(section, this.props, index)
+              : render(`section/${index}`, section.body || '')}
+          </AnchorNavSection>
+        ) : null
+      )
+      .filter(item => !!item);
 
     return (
       <CAnchorNav

--- a/packages/amis/src/renderers/App.tsx
+++ b/packages/amis/src/renderers/App.tsx
@@ -81,7 +81,7 @@ export interface AppPage extends SpinnerExtraProps {
 
 /**
  * App 渲染器，适合 JSSDK 用来做多页渲染。
- * 文档：https://baidu.gitee.io/amis/docs/components/app
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/app
  */
 export interface AppSchema extends BaseSchema, SpinnerExtraProps {
   /**

--- a/packages/amis/src/renderers/Audio.tsx
+++ b/packages/amis/src/renderers/Audio.tsx
@@ -9,7 +9,7 @@ import {BaseSchema, SchemaUrlPath} from '../Schema';
 
 /**
  * Audio 音频渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/audio
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/audio
  */
 export interface AudioSchema extends BaseSchema {
   /**
@@ -300,7 +300,9 @@ export class Audio extends React.Component<AudioProps, AudioState> {
     const date = new Date(seconds * 1000);
     const hh = date.getUTCHours();
     const mm = isNaN(date.getUTCMinutes()) ? 0 : date.getUTCMinutes();
-    const ss = isNaN(date.getUTCSeconds()) ? '00': this.pad(date.getUTCSeconds());
+    const ss = isNaN(date.getUTCSeconds())
+      ? '00'
+      : this.pad(date.getUTCSeconds());
     if (hh) {
       return `${hh}:${this.pad(mm)}:${ss}`;
     }
@@ -460,7 +462,10 @@ export class Audio extends React.Component<AudioProps, AudioState> {
     const {muted, src} = this.state;
 
     return (
-      <div className={cx('Audio', className, inline ? 'Audio--inline' : '')} style={style}>
+      <div
+        className={cx('Audio', className, inline ? 'Audio--inline' : '')}
+        style={style}
+      >
         <audio
           className={cx('Audio-original')}
           ref={this.audioRef}

--- a/packages/amis/src/renderers/BarCode.tsx
+++ b/packages/amis/src/renderers/BarCode.tsx
@@ -9,7 +9,7 @@ const BarCode = React.lazy(() => import('amis-ui/lib/components/BarCode'));
 
 /**
  * BarCode 显示渲染器，格式说明。
- * 文档：https://baidu.gitee.io/amis/docs/components/barcode
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/barcode
  */
 export interface BarCodeSchema extends BaseSchema {
   /**
@@ -39,12 +39,23 @@ export interface BarCodeProps
 
 export class BarCodeField extends React.Component<BarCodeProps, object> {
   render() {
-    const {className, style, width, height, classnames: cx, options} = this.props;
+    const {
+      className,
+      style,
+      width,
+      height,
+      classnames: cx,
+      options
+    } = this.props;
     const value = getPropValue(this.props);
 
     return (
       <Suspense fallback={<div>...</div>}>
-        <div data-testid="barcode" className={cx('BarCode', className)} style={style}>
+        <div
+          data-testid="barcode"
+          className={cx('BarCode', className)}
+          style={style}
+        >
           <BarCode value={value} options={options}></BarCode>
         </div>
       </Suspense>

--- a/packages/amis/src/renderers/Breadcrumb.tsx
+++ b/packages/amis/src/renderers/Breadcrumb.tsx
@@ -53,7 +53,7 @@ export type ItemPlace = 'start' | 'middle' | 'end';
 
 /**
  * Breadcrumb 显示渲染器
- * 文档：https://baidu.gitee.io/amis/docs/components/breadcrumb
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/breadcrumb
  */
 
 export interface BreadcrumbSchema extends BaseSchema {

--- a/packages/amis/src/renderers/ButtonGroup.tsx
+++ b/packages/amis/src/renderers/ButtonGroup.tsx
@@ -6,7 +6,7 @@ import {ActionSchema} from './Action';
 
 /**
  * Button Group 渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/button-group
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/button-group
  */
 export interface ButtonGroupSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -320,7 +320,7 @@ export type CRUDTableSchema = CRUDCommonSchema & {
 
 /**
  * CRUD 增删改查渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/crud
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/crud
  */
 export type CRUDSchema = CRUDCardsSchema | CRUDListSchema | CRUDTableSchema;
 

--- a/packages/amis/src/renderers/Card.tsx
+++ b/packages/amis/src/renderers/Card.tsx
@@ -59,7 +59,7 @@ export type CardBodyField = SchemaObject & {
 
 /**
  * Card 卡片渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/card
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/card
  */
 export interface CardSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Card2.tsx
+++ b/packages/amis/src/renderers/Card2.tsx
@@ -7,7 +7,7 @@ import {buildStyle} from 'amis-core';
 
 /**
  * Card2 新卡片渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/card2
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/card2
  */
 export interface Card2Schema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Cards.tsx
+++ b/packages/amis/src/renderers/Cards.tsx
@@ -32,7 +32,7 @@ import type {IItem} from 'amis-core/lib/store/list';
 
 /**
  * Cards 卡片集合渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/card
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/card
  */
 export interface CardsSchema extends BaseSchema, SpinnerExtraProps {
   /**

--- a/packages/amis/src/renderers/Carousel.tsx
+++ b/packages/amis/src/renderers/Carousel.tsx
@@ -23,7 +23,7 @@ import {ScopedContext, IScopedContext} from 'amis-core';
 
 /**
  * Carousel 轮播图渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/carousel
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/carousel
  */
 export interface CarouselSchema extends BaseSchema {
   /**
@@ -99,7 +99,7 @@ export interface CarouselSchema extends BaseSchema {
    * 多图模式配置项
    */
   multiple?: {
-    count: number
+    count: number;
   };
 
   /**
@@ -431,7 +431,7 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
       newOptions = new Array(options.length);
       for (let i = 0; i < options.length; i++) {
         newOptions[i] = new Array(count);
-        for(let j = 0; j < count; j++) {
+        for (let j = 0; j < count; j++) {
           newOptions[i][j] = options[(i + j) % options.length];
         }
       }
@@ -472,16 +472,26 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
       controls!.indexOf('arrows') > -1
     ];
     const animationName = nextAnimation || animation;
-    
+
     if (Array.isArray(options) && options.length) {
       let multipleCount = 1;
-      if (multiple && typeof multiple.count === 'number' && multiple.count >= 2) {
-        multipleCount = Math.floor(multiple.count) < options.length ? Math.floor(multiple.count) : options.length;
+      if (
+        multiple &&
+        typeof multiple.count === 'number' &&
+        multiple.count >= 2
+      ) {
+        multipleCount =
+          Math.floor(multiple.count) < options.length
+            ? Math.floor(multiple.count)
+            : options.length;
       }
       const newOptions = this.getNewOptions(options, multipleCount);
-      const transitionDuration = multipleCount > 1 && typeof duration === 'number'
-        ? `${duration}ms`: (duration || '500ms');
-      const timeout = multipleCount > 1 && typeof duration === 'number' ? duration : 500;
+      const transitionDuration =
+        multipleCount > 1 && typeof duration === 'number'
+          ? `${duration}ms`
+          : duration || '500ms';
+      const timeout =
+        multipleCount > 1 && typeof duration === 'number' ? duration : 500;
 
       body = (
         <div
@@ -506,9 +516,15 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
                     );
                 }
                 if (multipleCount > 1) {
-                  if ((status === ENTERING || status === EXITING) && !this.loading) {
+                  if (
+                    (status === ENTERING || status === EXITING) &&
+                    !this.loading
+                  ) {
                     this.loading = true;
-                  } else if ((status === ENTERED || status === EXITED) && this.loading) {
+                  } else if (
+                    (status === ENTERED || status === EXITED) &&
+                    this.loading
+                  ) {
                     this.loading = false;
                   }
                 }
@@ -518,27 +534,41 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
                 } = {
                   [ENTERING]: 0,
                   [ENTERED]: 0,
-                  [EXITING]: animationName === 'slideRight' ? 100 / multipleCount : -100 / multipleCount,
-                  [EXITED]: animationName === 'slideRight' ? -100 / multipleCount : 100 / multipleCount
+                  [EXITING]:
+                    animationName === 'slideRight'
+                      ? 100 / multipleCount
+                      : -100 / multipleCount,
+                  [EXITED]:
+                    animationName === 'slideRight'
+                      ? -100 / multipleCount
+                      : 100 / multipleCount
                 };
-                const itemStyle = multipleCount > 1 ? {
-                  transitionTimingFunction: 'linear',
-                  transitionDuration: transitionDuration,
-                  ...(animation === 'slide' ? {transform: `translateX(${transformStyles[status]}%)`} : {})
-                } : {};
-                const itemRender = (option: any) => render(
-                  `${current}/body`,
-                  itemSchema ? itemSchema : (defaultSchema as any),
-                  {
-                    thumbMode: this.props.thumbMode,
-                    data: createObject(
-                      data,
-                      isObject(option)
-                        ? option
-                        : {item: option, [name!]: option}
-                    )
-                  }
-                );
+                const itemStyle =
+                  multipleCount > 1
+                    ? {
+                        transitionTimingFunction: 'linear',
+                        transitionDuration: transitionDuration,
+                        ...(animation === 'slide'
+                          ? {
+                              transform: `translateX(${transformStyles[status]}%)`
+                            }
+                          : {})
+                      }
+                    : {};
+                const itemRender = (option: any) =>
+                  render(
+                    `${current}/body`,
+                    itemSchema ? itemSchema : (defaultSchema as any),
+                    {
+                      thumbMode: this.props.thumbMode,
+                      data: createObject(
+                        data,
+                        isObject(option)
+                          ? option
+                          : {item: option, [name!]: option}
+                      )
+                    }
+                  );
 
                 return (
                   <div
@@ -550,16 +580,20 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
                     style={itemStyle}
                   >
                     {multipleCount === 1 ? itemRender(option) : null}
-                    {multipleCount > 1 ? 
-                      newOptions[key].map((option: any, index: number) => (
-                        <div key={index} style={{
-                          width: 100 / multipleCount + '%',
-                          height: '100%',
-                          float: 'left'
-                        }}>
-                          {itemRender(option)}
-                        </div>
-                      )) : null}
+                    {multipleCount > 1
+                      ? newOptions[key].map((option: any, index: number) => (
+                          <div
+                            key={index}
+                            style={{
+                              width: 100 / multipleCount + '%',
+                              height: '100%',
+                              float: 'left'
+                            }}
+                          >
+                            {itemRender(option)}
+                          </div>
+                        ))
+                      : null}
                   </div>
                 );
               }}
@@ -571,7 +605,11 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
 
     return (
       <div
-        className={cx(`Carousel Carousel--${controlsTheme}`, {['Carousel-arrow--always']: !!alwaysShowArrow}, className)}
+        className={cx(
+          `Carousel Carousel--${controlsTheme}`,
+          {['Carousel-arrow--always']: !!alwaysShowArrow},
+          className
+        )}
         style={carouselStyles}
       >
         {body ? body : placeholder}
@@ -579,16 +617,28 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
         {dots ? this.renderDots() : null}
         {arrows ? (
           <div className={cx('Carousel-leftArrow')} onClick={this.prev}>
-            {icons && icons.prev
-              ? React.isValidElement(icons.prev) ? icons.prev : render('arrow-prev', icons.prev)
-              : (<Icon icon="left-arrow" className="icon" />)}
+            {icons && icons.prev ? (
+              React.isValidElement(icons.prev) ? (
+                icons.prev
+              ) : (
+                render('arrow-prev', icons.prev)
+              )
+            ) : (
+              <Icon icon="left-arrow" className="icon" />
+            )}
           </div>
         ) : null}
         {arrows ? (
           <div className={cx('Carousel-rightArrow')} onClick={this.next}>
-            {icons && icons.next
-              ? React.isValidElement(icons.next) ? icons.next : render('arrow-next', icons.next)
-              : (<Icon icon="right-arrow" className="icon" />)}
+            {icons && icons.next ? (
+              React.isValidElement(icons.next) ? (
+                icons.next
+              ) : (
+                render('arrow-next', icons.next)
+              )
+            ) : (
+              <Icon icon="right-arrow" className="icon" />
+            )}
           </div>
         ) : null}
       </div>

--- a/packages/amis/src/renderers/Chart.tsx
+++ b/packages/amis/src/renderers/Chart.tsx
@@ -50,7 +50,7 @@ const DEFAULT_EVENT_PARAMS = [
 
 /**
  * Chart 图表渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/carousel
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/carousel
  */
 export interface ChartSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Code.tsx
+++ b/packages/amis/src/renderers/Code.tsx
@@ -71,7 +71,7 @@ export interface CustomLang {
 
 /**
  * 代码高亮组件
- * 文档：https://baidu.gitee.io/amis/docs/components/code
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/code
  */
 export interface CodeSchema extends BaseSchema {
   type: 'code';

--- a/packages/amis/src/renderers/Collapse.tsx
+++ b/packages/amis/src/renderers/Collapse.tsx
@@ -10,7 +10,7 @@ import {BaseSchema, SchemaCollection, SchemaTpl, SchemaObject} from '../Schema';
 
 /**
  * Collapse 折叠渲染器，格式说明。
- * 文档：https://baidu.gitee.io/amis/docs/components/collapse
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/collapse
  */
 export interface CollapseSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/CollapseGroup.tsx
+++ b/packages/amis/src/renderers/CollapseGroup.tsx
@@ -5,7 +5,7 @@ import {CollapseGroup} from 'amis-ui';
 
 /**
  * CollapseGroup 折叠渲染器，格式说明。
- * 文档：https://baidu.gitee.io/amis/docs/components/collapse
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/collapse
  */
 export interface CollapseGroupSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Color.tsx
+++ b/packages/amis/src/renderers/Color.tsx
@@ -8,7 +8,7 @@ import {getPropValue} from 'amis-core';
 
 /**
  * Color 显示渲染器，格式说明。
- * 文档：https://baidu.gitee.io/amis/docs/components/color
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/color
  */
 export interface ColorSchema extends BaseSchema {
   /**
@@ -39,7 +39,13 @@ export class ColorField extends React.Component<ColorProps, object> {
   };
 
   render() {
-    const {className, style, classnames: cx, defaultColor, showValue} = this.props;
+    const {
+      className,
+      style,
+      classnames: cx,
+      defaultColor,
+      showValue
+    } = this.props;
     const color = getPropValue(this.props);
 
     return (
@@ -49,7 +55,9 @@ export class ColorField extends React.Component<ColorProps, object> {
           style={{backgroundColor: color || defaultColor}}
         />
         {showValue ? (
-          <span className={cx('ColorField-value')}>{color || defaultColor}</span>
+          <span className={cx('ColorField-value')}>
+            {color || defaultColor}
+          </span>
         ) : null}
       </div>
     );

--- a/packages/amis/src/renderers/Container.tsx
+++ b/packages/amis/src/renderers/Container.tsx
@@ -62,7 +62,7 @@ export interface ContainerDraggableConfig {
 
 /**
  * Container 容器渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/container
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/container
  */
 export interface ContainerSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Date.tsx
+++ b/packages/amis/src/renderers/Date.tsx
@@ -6,7 +6,7 @@ import {getPropValue} from 'amis-core';
 
 /**
  * Date 展示渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/date
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/date
  */
 export interface DateSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Dialog.tsx
+++ b/packages/amis/src/renderers/Dialog.tsx
@@ -29,7 +29,7 @@ import {isAlive} from 'mobx-state-tree';
 
 /**
  * Dialog 弹框渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/dialog
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/dialog
  */
 export interface DialogSchema extends BaseSchema {
   type: 'dialog';

--- a/packages/amis/src/renderers/Divider.tsx
+++ b/packages/amis/src/renderers/Divider.tsx
@@ -4,7 +4,7 @@ import {BaseSchema} from '../Schema';
 
 /**
  * Divider 分割线渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/divider
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/divider
  */
 export interface DividerSchema extends BaseSchema {
   type: 'divider';

--- a/packages/amis/src/renderers/Drawer.tsx
+++ b/packages/amis/src/renderers/Drawer.tsx
@@ -27,7 +27,7 @@ import {isAlive} from 'mobx-state-tree';
 
 /**
  * Drawer 抽出式弹框。
- * 文档：https://baidu.gitee.io/amis/docs/components/drawer
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/drawer
  */
 export interface DrawerSchema extends BaseSchema {
   type: 'drawer';

--- a/packages/amis/src/renderers/DropDownButton.tsx
+++ b/packages/amis/src/renderers/DropDownButton.tsx
@@ -23,7 +23,7 @@ export type DropdownButton =
 
 /**
  * 下拉按钮渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/dropdown-button
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/dropdown-button
  */
 export interface DropdownButtonSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Each.tsx
+++ b/packages/amis/src/renderers/Each.tsx
@@ -7,7 +7,7 @@ import {BaseSchema, SchemaCollection} from '../Schema';
 
 /**
  * Each 循环功能渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/each
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/each
  */
 export interface EachSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Flex.tsx
+++ b/packages/amis/src/renderers/Flex.tsx
@@ -9,7 +9,7 @@ import {BaseSchema, SchemaCollection, SchemaObject} from '../Schema';
 
 /**
  * Flex 布局
- * 文档：https://baidu.gitee.io/amis/docs/components/flex
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/flex
  */
 export interface FlexSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Form/ButtonGroupSelect.tsx
+++ b/packages/amis/src/renderers/Form/ButtonGroupSelect.tsx
@@ -12,7 +12,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * 按钮组控件。
- * 文档：https://baidu.gitee.io/amis/docs/components/form/button-group
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/button-group
  */
 export interface ButtonGroupControlSchema
   extends Omit<ButtonGroupSchema, 'type'>,

--- a/packages/amis/src/renderers/Form/ButtonToolbar.tsx
+++ b/packages/amis/src/renderers/Form/ButtonToolbar.tsx
@@ -5,7 +5,7 @@ import {FormControlProps, FormItem} from 'amis-core';
 
 /**
  * Button Toolar 渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/button-toolbar
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/button-toolbar
  */
 export interface ButtonToolbarSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Form/ChainedSelect.tsx
+++ b/packages/amis/src/renderers/Form/ChainedSelect.tsx
@@ -19,7 +19,7 @@ import {isEmpty} from 'lodash';
 
 /**
  * 链式下拉框
- * 文档：https://baidu.gitee.io/amis/docs/components/form/chained-select
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/chained-select
  */
 export interface ChainedSelectControlSchema extends FormOptionsSchema {
   type: 'chained-select';

--- a/packages/amis/src/renderers/Form/ChartRadios.tsx
+++ b/packages/amis/src/renderers/Form/ChartRadios.tsx
@@ -10,7 +10,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * 图表 Radio 单选框。
- * 文档：https://baidu.gitee.io/amis/docs/components/form/chart-radios
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/chart-radios
  */
 export interface ChartRadiosControlSchema extends FormOptionsSchema {
   type: 'chart-radios';
@@ -111,10 +111,13 @@ export default class ChartRadiosControl extends React.Component<
     } = this.props;
     if (options.length && selectedOptions.length) {
       const count = options.reduce((all, cur) => {
-        return all + cur[chartValueField || valueField]
+        return all + cur[chartValueField || valueField];
       }, 0);
       if (count > 0) {
-        const percent = (+selectedOptions[0][chartValueField || valueField] / count * 100).toFixed(2);
+        const percent = (
+          (+selectedOptions[0][chartValueField || valueField] / count) *
+          100
+        ).toFixed(2);
         displayValue = `${selectedOptions[0][labelField]}：${percent}%`;
       }
     }

--- a/packages/amis/src/renderers/Form/Checkbox.tsx
+++ b/packages/amis/src/renderers/Form/Checkbox.tsx
@@ -19,7 +19,7 @@ export interface SchemaMap {
 
 /**
  * Checkbox 勾选框。
- * 文档：https://baidu.gitee.io/amis/docs/components/form/checkbox
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/checkbox
  */
 export interface CheckboxControlSchema extends FormBaseControlSchema {
   /**

--- a/packages/amis/src/renderers/Form/Checkboxes.tsx
+++ b/packages/amis/src/renderers/Form/Checkboxes.tsx
@@ -15,7 +15,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * 复选框
- * 文档：https://baidu.gitee.io/amis/docs/components/form/checkboxes
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/checkboxes
  */
 export interface CheckboxesControlSchema extends FormOptionsSchema {
   type: 'checkboxes';

--- a/packages/amis/src/renderers/Form/Combo.tsx
+++ b/packages/amis/src/renderers/Form/Combo.tsx
@@ -68,7 +68,7 @@ export type ComboSubControl = SchemaObject & {
 
 /**
  * Combo 组合输入框类型
- * 文档：https://baidu.gitee.io/amis/docs/components/form/combo
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/combo
  */
 export interface ComboControlSchema extends FormBaseControlSchema {
   /**

--- a/packages/amis/src/renderers/Form/ConditionBuilder.tsx
+++ b/packages/amis/src/renderers/Form/ConditionBuilder.tsx
@@ -27,7 +27,7 @@ import {IconSchema} from '../Icon';
 
 /**
  * 条件组合控件
- * 文档：https://baidu.gitee.io/amis/docs/components/form/condition-builder
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/condition-builder
  */
 export interface ConditionBuilderControlSchema extends FormBaseControlSchema {
   /**

--- a/packages/amis/src/renderers/Form/Control.tsx
+++ b/packages/amis/src/renderers/Form/Control.tsx
@@ -7,7 +7,7 @@ import {FormBaseControl, FormItemWrap} from 'amis-core';
 
 /**
  * Group 表单集合渲染器，能让多个表单在一行显示
- * 文档：https://baidu.gitee.io/amis/docs/components/form/group
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/group
  */
 export interface FormControlSchema extends FormBaseControlSchema {
   type: 'control';

--- a/packages/amis/src/renderers/Form/DiffEditor.tsx
+++ b/packages/amis/src/renderers/Form/DiffEditor.tsx
@@ -15,7 +15,7 @@ import type {ListenerAction} from 'amis-core';
 
 /**
  * Diff 编辑器
- * 文档：https://baidu.gitee.io/amis/docs/components/form/diff
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/diff
  */
 export interface DiffControlSchema extends FormBaseControlSchema {
   /**

--- a/packages/amis/src/renderers/Form/Editor.tsx
+++ b/packages/amis/src/renderers/Form/Editor.tsx
@@ -15,7 +15,7 @@ import type {ListenerAction} from 'amis-core';
 
 /**
  * Editor 代码编辑器
- * 文档：https://baidu.gitee.io/amis/docs/components/form/editor
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/editor
  */
 export interface EditorControlSchema extends Omit<FormBaseControl, 'size'> {
   type:

--- a/packages/amis/src/renderers/Form/FieldSet.tsx
+++ b/packages/amis/src/renderers/Form/FieldSet.tsx
@@ -7,7 +7,7 @@ import type {FormHorizontal} from 'amis-core';
 
 /**
  * FieldSet 表单项集合
- * 文档：https://baidu.gitee.io/amis/docs/components/form/fieldset
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/fieldset
  */
 export interface FieldSetControlSchema
   extends Omit<FormBaseControl, 'size'>,

--- a/packages/amis/src/renderers/Form/Formula.tsx
+++ b/packages/amis/src/renderers/Form/Formula.tsx
@@ -6,7 +6,7 @@ import {FormBaseControlSchema} from '../../Schema';
 
 /**
  * 公式功能控件。
- * 文档：https://baidu.gitee.io/amis/docs/components/form/formula
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/formula
  */
 export interface FormulaControlSchema extends FormBaseControlSchema {
   /**

--- a/packages/amis/src/renderers/Form/Group.tsx
+++ b/packages/amis/src/renderers/Form/Group.tsx
@@ -24,7 +24,7 @@ export type GroupSubControl = SchemaObject & {
 
 /**
  * Group 表单集合渲染器，能让多个表单在一行显示
- * 文档：https://baidu.gitee.io/amis/docs/components/form/group
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/group
  */
 export interface GroupControlSchema extends FormBaseControlSchema {
   type: 'group';

--- a/packages/amis/src/renderers/Form/Hidden.tsx
+++ b/packages/amis/src/renderers/Form/Hidden.tsx
@@ -4,7 +4,7 @@ import {FormBaseControlSchema} from '../../Schema';
 
 /**
  * Hidden 隐藏域。功能性组件
- * 文档：https://baidu.gitee.io/amis/docs/components/form/hidden
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/hidden
  */
 export interface HiddenControlSchema extends FormBaseControlSchema {
   type: 'hidden';

--- a/packages/amis/src/renderers/Form/IconPicker.tsx
+++ b/packages/amis/src/renderers/Form/IconPicker.tsx
@@ -12,7 +12,7 @@ import {FormBaseControlSchema} from '../../Schema';
 
 /**
  * 图标选择器
- * 文档：https://baidu.gitee.io/amis/docs/components/form/icon-picker
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/icon-picker
  */
 export interface IconPickerControlSchema extends FormBaseControlSchema {
   type: 'icon-picker';
@@ -281,9 +281,7 @@ export default class IconPickerControl extends React.PureComponent<
                 {!value || (inputValue && isOpen) ? null : (
                   <div className={cx('IconPickerControl-value')}>
                     <i className={cx(value)} />
-                    {
-                      typeof value === 'string' ? value : ''
-                    }
+                    {typeof value === 'string' ? value : ''}
                   </div>
                 )}
 

--- a/packages/amis/src/renderers/Form/InputArray.tsx
+++ b/packages/amis/src/renderers/Form/InputArray.tsx
@@ -6,7 +6,7 @@ import {SchemaCollection} from '../../Schema';
 
 /**
  * InputArray 数组输入框。 combo 的别名。
- * 文档：https://baidu.gitee.io/amis/docs/components/form/array
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/array
  */
 export interface ArrayControlSchema
   extends Omit<

--- a/packages/amis/src/renderers/Form/InputCity.tsx
+++ b/packages/amis/src/renderers/Form/InputCity.tsx
@@ -18,7 +18,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * City 城市选择框。
- * 文档：https://baidu.gitee.io/amis/docs/components/form/city
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/city
  */
 export interface InputCityControlSchema
   extends FormBaseControlSchema,

--- a/packages/amis/src/renderers/Form/InputColor.tsx
+++ b/packages/amis/src/renderers/Form/InputColor.tsx
@@ -14,7 +14,7 @@ export const ColorPicker = React.lazy(
 
 /**
  * Color 颜色选择框
- * 文档：https://baidu.gitee.io/amis/docs/components/form/color
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/color
  */
 export interface InputColorControlSchema extends FormBaseControlSchema {
   /**

--- a/packages/amis/src/renderers/Form/InputDate.tsx
+++ b/packages/amis/src/renderers/Form/InputDate.tsx
@@ -60,7 +60,7 @@ export interface InputDateBaseControlSchema extends FormBaseControlSchema {
 
 /**
  * Date日期选择控件
- * 文档：https://baidu.gitee.io/amis/docs/components/form/date
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/date
  */
 export interface DateControlSchema extends InputDateBaseControlSchema {
   /**
@@ -98,7 +98,7 @@ export interface DateControlSchema extends InputDateBaseControlSchema {
 
 /**
  * Datetime日期时间选择控件
- * 文档：https://baidu.gitee.io/amis/docs/components/form/datetime
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/datetime
  */
 export interface DateTimeControlSchema extends InputDateBaseControlSchema {
   /**
@@ -143,7 +143,7 @@ export interface DateTimeControlSchema extends InputDateBaseControlSchema {
 
 /**
  * Time 时间选择控件
- * 文档：https://baidu.gitee.io/amis/docs/components/form/time
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/time
  */
 export interface TimeControlSchema extends InputDateBaseControlSchema {
   /**
@@ -178,7 +178,7 @@ export interface TimeControlSchema extends InputDateBaseControlSchema {
 
 /**
  * Month 月份选择控件
- * 文档：https://baidu.gitee.io/amis/docs/components/form/Month
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/Month
  */
 export interface MonthControlSchema extends InputDateBaseControlSchema {
   /**

--- a/packages/amis/src/renderers/Form/InputDateRange.tsx
+++ b/packages/amis/src/renderers/Form/InputDateRange.tsx
@@ -17,7 +17,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * DateRange 日期范围控件
- * 文档：https://baidu.gitee.io/amis/docs/components/form/date-range
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/date-range
  */
 export interface DateRangeControlSchema extends FormBaseControlSchema {
   /**

--- a/packages/amis/src/renderers/Form/InputExcel.tsx
+++ b/packages/amis/src/renderers/Form/InputExcel.tsx
@@ -7,7 +7,7 @@ import type {CellValue, CellRichTextValue} from 'exceljs';
 
 /**
  * Excel 解析
- * 文档：https://baidu.gitee.io/amis/docs/components/form/input-excel
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/input-excel
  */
 export interface InputExcelControlSchema extends FormBaseControlSchema {
   /**

--- a/packages/amis/src/renderers/Form/InputFile.tsx
+++ b/packages/amis/src/renderers/Form/InputFile.tsx
@@ -32,7 +32,7 @@ import omit from 'lodash/omit';
 
 /**
  * File 文件上传控件
- * 文档：https://baidu.gitee.io/amis/docs/components/form/file
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/file
  */
 export interface FileControlSchema extends FormBaseControlSchema {
   /**

--- a/packages/amis/src/renderers/Form/InputGroup.tsx
+++ b/packages/amis/src/renderers/Form/InputGroup.tsx
@@ -12,7 +12,7 @@ import {FormBaseControlSchema, SchemaCollection} from '../../Schema';
 
 /**
  * InputGroup
- * 文档：https://baidu.gitee.io/amis/docs/components/form/input-group
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/input-group
  */
 export interface InputGroupControlSchema extends FormBaseControlSchema {
   type: 'input-group';

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -36,7 +36,7 @@ import omit from 'lodash/omit';
 
 /**
  * Image 图片上传控件
- * 文档：https://baidu.gitee.io/amis/docs/components/form/image
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/image
  */
 export interface ImageControlSchema extends FormBaseControlSchema {
   /**

--- a/packages/amis/src/renderers/Form/InputMonthRange.tsx
+++ b/packages/amis/src/renderers/Form/InputMonthRange.tsx
@@ -8,7 +8,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * MonthRange 月范围控件
- * 文档：https://baidu.gitee.io/amis/docs/components/form/month-range
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/month-range
  */
 
 export interface MonthRangeControlSchema

--- a/packages/amis/src/renderers/Form/InputNumber.tsx
+++ b/packages/amis/src/renderers/Form/InputNumber.tsx
@@ -22,7 +22,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * 数字输入框
- * 文档：https://baidu.gitee.io/amis/docs/components/form/number
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/number
  */
 export interface NumberControlSchema extends FormBaseControlSchema {
   type: 'input-number';

--- a/packages/amis/src/renderers/Form/InputQuarterRange.tsx
+++ b/packages/amis/src/renderers/Form/InputQuarterRange.tsx
@@ -7,7 +7,7 @@ import {DateRangePicker} from 'amis-ui';
 import {supportStatic} from './StaticHoc';
 /**
  * QuarterRange 季度范围控件
- * 文档：https://baidu.gitee.io/amis/docs/components/form/input-quarter-range
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/input-quarter-range
  */
 export interface QuarterRangeControlSchema
   extends Omit<DateRangeControlSchema, 'type'> {

--- a/packages/amis/src/renderers/Form/InputRange.tsx
+++ b/packages/amis/src/renderers/Form/InputRange.tsx
@@ -19,7 +19,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * Range
- * 文档：https://baidu.gitee.io/amis/docs/components/form/range
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/range
  */
 
 export type Value = string | MultipleValue | number | [number, number];

--- a/packages/amis/src/renderers/Form/InputRating.tsx
+++ b/packages/amis/src/renderers/Form/InputRating.tsx
@@ -14,7 +14,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * Rating
- * 文档：https://baidu.gitee.io/amis/docs/components/form/rating
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/rating
  */
 export interface RatingControlSchema extends FormBaseControlSchema {
   type: 'input-rating';

--- a/packages/amis/src/renderers/Form/InputRepeat.tsx
+++ b/packages/amis/src/renderers/Form/InputRepeat.tsx
@@ -11,7 +11,7 @@ import {FormItem, FormControlProps, FormBaseControl} from 'amis-core';
 
 /**
  * Repeat
- * 文档：https://baidu.gitee.io/amis/docs/components/form/repeat
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/repeat
  */
 export interface RepeatControlSchema extends FormBaseControlSchema {
   type: 'input-repeat';

--- a/packages/amis/src/renderers/Form/InputRichText.tsx
+++ b/packages/amis/src/renderers/Form/InputRichText.tsx
@@ -15,7 +15,7 @@ import type {FormBaseControlSchema, SchemaApi} from '../../Schema';
 
 /**
  * RichText
- * 文档：https://baidu.gitee.io/amis/docs/components/form/input-rich-text
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/input-rich-text
  */
 export interface RichTextControlSchema extends FormBaseControlSchema {
   type: 'input-rich-text';

--- a/packages/amis/src/renderers/Form/InputSubForm.tsx
+++ b/packages/amis/src/renderers/Form/InputSubForm.tsx
@@ -11,7 +11,7 @@ import {findDOMNode} from 'react-dom';
 
 /**
  * SubForm 子表单
- * 文档：https://baidu.gitee.io/amis/docs/components/form/subform
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/subform
  */
 export interface SubFormControlSchema extends FormBaseControlSchema {
   /**

--- a/packages/amis/src/renderers/Form/InputTag.tsx
+++ b/packages/amis/src/renderers/Form/InputTag.tsx
@@ -23,7 +23,7 @@ import {TooltipWrapperSchema} from '../TooltipWrapper';
 
 /**
  * Tag 输入框
- * 文档：https://baidu.gitee.io/amis/docs/components/form/tag
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/tag
  */
 export interface TagControlSchema extends FormOptionsSchema {
   type: 'input-tag';

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -30,7 +30,7 @@ import type {ListenerAction} from 'amis-core';
 
 /**
  * Text 文本输入框。
- * 文档：https://baidu.gitee.io/amis/docs/components/form/text
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/text
  */
 export interface TextControlSchema extends FormOptionsSchema {
   type:

--- a/packages/amis/src/renderers/Form/InputTree.tsx
+++ b/packages/amis/src/renderers/Form/InputTree.tsx
@@ -23,7 +23,7 @@ import type {ItemRenderStates} from 'amis-ui/lib/components/Selection';
 
 /**
  * Tree 下拉选择框。
- * 文档：https://baidu.gitee.io/amis/docs/components/form/tree
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/tree
  */
 export interface TreeControlSchema extends FormOptionsSchema {
   type: 'input-tree';

--- a/packages/amis/src/renderers/Form/InputYearRange.tsx
+++ b/packages/amis/src/renderers/Form/InputYearRange.tsx
@@ -8,7 +8,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * YearRange 年份范围控件
- * 文档：https://baidu.gitee.io/amis/docs/components/form/input-year-range
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/input-year-range
  */
 export interface YearRangeControlSchema
   extends Omit<DateRangeControlSchema, 'type'> {

--- a/packages/amis/src/renderers/Form/JSONSchema.tsx
+++ b/packages/amis/src/renderers/Form/JSONSchema.tsx
@@ -6,7 +6,7 @@ import {FormBaseControlSchema} from '../../Schema';
 
 /**
  * JSON Schema
- * 文档：https://baidu.gitee.io/amis/docs/components/form/json-schema
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/json-schema
  */
 export interface JSONSchemaControlSchema extends FormBaseControlSchema {
   /**

--- a/packages/amis/src/renderers/Form/JSONSchemaEditor.tsx
+++ b/packages/amis/src/renderers/Form/JSONSchemaEditor.tsx
@@ -10,9 +10,10 @@ import type {SchemaEditorItemPlaceholder} from 'amis-ui/lib/components/schema-ed
 
 /**
  * JSON Schema Editor
- * 文档：https://baidu.gitee.io/amis/docs/components/form/json-schema-editor
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/json-schema-editor
  */
-export interface JSONSchemaEditorControlSchema extends Omit<FormBaseControlSchema, 'placeholder'> {
+export interface JSONSchemaEditorControlSchema
+  extends Omit<FormBaseControlSchema, 'placeholder'> {
   /**
    * 指定为 JSON Schema Editor
    */

--- a/packages/amis/src/renderers/Form/ListSelect.tsx
+++ b/packages/amis/src/renderers/Form/ListSelect.tsx
@@ -16,7 +16,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * List 复选框
- * 文档：https://baidu.gitee.io/amis/docs/components/form/list
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/list
  */
 export interface ListControlSchema extends FormOptionsSchema {
   type: 'list-select';
@@ -119,51 +119,41 @@ export default class ListControl extends React.Component<ListProps, any> {
         return (
           <div
             key={key}
-            className={cx(
-              'ListControl-static-item',
-              itemClassName
-            )}
+            className={cx('ListControl-static-item', itemClassName)}
           >
             {itemSchema
               ? render(`${key}/body`, itemSchema, {
-                data: createObject(data, option)
-              })
+                  data: createObject(data, option)
+                })
               : option.body
-                ? render(`${key}/body`, option.body)
-                : [(option.image
-                      ? <div key="image"
-                          className={cx('ListControl-itemImage', imageClassName)}
-                        >
-                          <img src={option.image} alt={label} />
-                        </div>
-                      : null
-                    ),
-                    (
-                      <div key="label"
-                        className={cx('ListControl-itemLabel')}
-                      >
-                        {label}
-                      </div>
-                    )
-                  ]
-            }
+              ? render(`${key}/body`, option.body)
+              : [
+                  option.image ? (
+                    <div
+                      key="image"
+                      className={cx('ListControl-itemImage', imageClassName)}
+                    >
+                      <img src={option.image} alt={label} />
+                    </div>
+                  ) : null,
+                  <div key="label" className={cx('ListControl-itemLabel')}>
+                    {label}
+                  </div>
+                ]}
           </div>
         );
       }
 
       return (
-        <div
-          key={key}
-          className={cx(`ListControl-static-item`)}
-        >
+        <div key={key} className={cx(`ListControl-static-item`)}>
           {label}
         </div>
       );
-    }
+    };
 
-    return <div className={cx('StaticList')}>
-      {selectedOptions.map(itemRender)}
-    </div>
+    return (
+      <div className={cx('StaticList')}>{selectedOptions.map(itemRender)}</div>
+    );
   }
 
   @supportStatic()

--- a/packages/amis/src/renderers/Form/LocationPicker.tsx
+++ b/packages/amis/src/renderers/Form/LocationPicker.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import {themeable, ClassNamesFn, ThemeProps, Overlay, PopOver, autobind} from 'amis-core';
+import {
+  themeable,
+  ClassNamesFn,
+  ThemeProps,
+  Overlay,
+  PopOver,
+  autobind
+} from 'amis-core';
 import {FormItem, FormBaseControl, FormControlProps} from 'amis-core';
 import {LocationPicker, Alert2, BaiduMapPicker, Icon} from 'amis-ui';
 import {filter} from 'amis-core';
@@ -7,7 +14,7 @@ import {FormBaseControlSchema} from '../../Schema';
 import {supportStatic} from './StaticHoc';
 /**
  * Location 选点组件
- * 文档：https://baidu.gitee.io/amis/docs/components/form/location
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/location
  */
 export interface LocationControlSchema extends FormBaseControlSchema {
   type: 'location-picker';
@@ -83,7 +90,7 @@ export class LocationControl extends React.Component<LocationControlProps> {
       vendor,
       ak,
       coordinatesType,
-      popOverContainer,
+      popOverContainer
     } = this.props;
     const __ = this.props.translate;
 
@@ -92,9 +99,15 @@ export class LocationControl extends React.Component<LocationControlProps> {
     }
 
     return (
-      <div className={this.props.classnames('LocationControl')} ref={this.domRef}>
+      <div
+        className={this.props.classnames('LocationControl')}
+        ref={this.domRef}
+      >
         <span>{value.address}</span>
-        <a className={cx('LocationPicker-toggler', 'ml-1')} onClick={this.handleClick}>
+        <a
+          className={cx('LocationPicker-toggler', 'ml-1')}
+          onClick={this.handleClick}
+        >
           <Icon icon="location" className="icon" />
         </a>
         <Overlay

--- a/packages/amis/src/renderers/Form/MatrixCheckboxes.tsx
+++ b/packages/amis/src/renderers/Form/MatrixCheckboxes.tsx
@@ -19,7 +19,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * Matrix 选择控件。适合做权限勾选。
- * 文档：https://baidu.gitee.io/amis/docs/components/form/matrix
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/matrix
  */
 export interface MatrixControlSchema extends FormBaseControlSchema {
   type: 'matrix-checkboxes';

--- a/packages/amis/src/renderers/Form/NestedSelect.tsx
+++ b/packages/amis/src/renderers/Form/NestedSelect.tsx
@@ -1,8 +1,19 @@
 import React from 'react';
-import {ResultBox, Spinner,Icon, PopUp, Checkbox, Cascader, SpinnerExtraProps} from 'amis-ui';
 import {
-  Overlay, resolveEventData,
-  PopOver, Option, Options,
+  ResultBox,
+  Spinner,
+  Icon,
+  PopUp,
+  Checkbox,
+  Cascader,
+  SpinnerExtraProps
+} from 'amis-ui';
+import {
+  Overlay,
+  resolveEventData,
+  PopOver,
+  Option,
+  Options,
   autobind,
   flattenTree,
   filterTree,
@@ -25,7 +36,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * Nested Select
- * 文档：https://baidu.gitee.io/amis/docs/components/form/nested-select
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/nested-select
  */
 export interface NestedSelectControlSchema extends FormOptionsSchema {
   type: 'nested-select';

--- a/packages/amis/src/renderers/Form/Picker.tsx
+++ b/packages/amis/src/renderers/Form/Picker.tsx
@@ -28,7 +28,7 @@ import intersectionWith from 'lodash/intersectionWith';
 
 /**
  * Picker
- * 文档：https://baidu.gitee.io/amis/docs/components/form/picker
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/picker
  */
 export interface PickerControlSchema extends FormOptionsSchema {
   type: 'picker';

--- a/packages/amis/src/renderers/Form/Radios.tsx
+++ b/packages/amis/src/renderers/Form/Radios.tsx
@@ -15,7 +15,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * Radio 单选框。
- * 文档：https://baidu.gitee.io/amis/docs/components/form/radios
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/radios
  */
 export interface RadiosControlSchema extends FormOptionsSchema {
   type: 'radios';

--- a/packages/amis/src/renderers/Form/Select.tsx
+++ b/packages/amis/src/renderers/Form/Select.tsx
@@ -26,7 +26,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * Select 下拉选择框。
- * 文档：https://baidu.gitee.io/amis/docs/components/form/select
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/select
  */
 export interface SelectControlSchema
   extends FormOptionsSchema,

--- a/packages/amis/src/renderers/Form/Static.tsx
+++ b/packages/amis/src/renderers/Form/Static.tsx
@@ -16,7 +16,7 @@ import {
 
 /**
  * Static
- * 文档：https://baidu.gitee.io/amis/docs/components/form/static
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/static
  */
 export interface StaticExactControlSchema extends FormBaseControlSchema {
   type: 'static';

--- a/packages/amis/src/renderers/Form/Switch.tsx
+++ b/packages/amis/src/renderers/Form/Switch.tsx
@@ -14,7 +14,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * Switch
- * 文档：https://baidu.gitee.io/amis/docs/components/form/switch
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/switch
  */
 
 export interface SwitchControlSchema extends FormBaseControlSchema {
@@ -83,11 +83,7 @@ export default class SwitchControl extends React.Component<SwitchProps, any> {
   }
 
   getResult() {
-    const {
-      classnames: cx,
-      onText,
-      offText,
-    } = this.props;
+    const {classnames: cx, onText, offText} = this.props;
     const on = isObject(onText)
       ? generateIcon(cx, onText.icon, 'Switch-icon')
       : onText;
@@ -98,11 +94,7 @@ export default class SwitchControl extends React.Component<SwitchProps, any> {
   }
 
   renderBody(children: any) {
-    const {
-      classnames: cx,
-      option,
-      optionAtLeft
-    } = this.props;
+    const {classnames: cx, option, optionAtLeft} = this.props;
 
     const Option = <span className={cx('Switch-option')}>{option}</span>;
     return (
@@ -115,11 +107,8 @@ export default class SwitchControl extends React.Component<SwitchProps, any> {
   }
 
   renderStatic() {
-    const {
-      value,
-      trueValue,
-    } = this.props;
-    
+    const {value, trueValue} = this.props;
+
     const {on = '开', off = '关'} = this.getResult();
     const body = <span>{value === trueValue ? on : off}</span>;
     return this.renderBody(body);
@@ -137,7 +126,7 @@ export default class SwitchControl extends React.Component<SwitchProps, any> {
       trueValue,
       falseValue,
       onChange,
-      disabled,
+      disabled
     } = this.props;
 
     const {on, off} = this.getResult();

--- a/packages/amis/src/renderers/Form/TabsTransfer.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransfer.tsx
@@ -21,7 +21,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * TabsTransfer
- * 文档：https://baidu.gitee.io/amis/docs/components/form/tabs-transfer
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/tabs-transfer
  */
 export interface TabsTransferControlSchema
   extends Omit<TransferControlSchema, 'type'>,

--- a/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
@@ -12,7 +12,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * TabsTransferPicker 穿梭器的弹框形态
- * 文档：https://baidu.gitee.io/amis/docs/components/form/tabs-transfer-picker
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/tabs-transfer-picker
  */
 export interface TabsTransferPickerControlSchema
   extends Omit<TabsTransferControlSchema, 'type'>,

--- a/packages/amis/src/renderers/Form/Textarea.tsx
+++ b/packages/amis/src/renderers/Form/Textarea.tsx
@@ -12,7 +12,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * TextArea 多行文本输入框。
- * 文档：https://baidu.gitee.io/amis/docs/components/form/textarea
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/textarea
  */
 export interface TextareaControlSchema extends FormBaseControlSchema {
   /**

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -31,7 +31,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * Transfer
- * 文档：https://baidu.gitee.io/amis/docs/components/form/transfer
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/transfer
  */
 export interface TransferControlSchema
   extends FormOptionsSchema,

--- a/packages/amis/src/renderers/Form/TransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TransferPicker.tsx
@@ -9,7 +9,7 @@ import {supportStatic} from './StaticHoc';
 
 /**
  * TransferPicker 穿梭器的弹框形态
- * 文档：https://baidu.gitee.io/amis/docs/components/form/transfer-picker
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/transfer-picker
  */
 export interface TransferPickerControlSchema
   extends Omit<TransferControlSchema, 'type'>,

--- a/packages/amis/src/renderers/Form/TreeSelect.tsx
+++ b/packages/amis/src/renderers/Form/TreeSelect.tsx
@@ -30,7 +30,7 @@ import type {ItemRenderStates} from 'amis-ui/lib/components/Selection';
 
 /**
  * Tree 下拉选择框。
- * 文档：https://baidu.gitee.io/amis/docs/components/form/tree
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/tree
  */
 export interface TreeSelectControlSchema extends FormOptionsSchema {
   type: 'tree-select';

--- a/packages/amis/src/renderers/Form/UUID.tsx
+++ b/packages/amis/src/renderers/Form/UUID.tsx
@@ -5,7 +5,7 @@ import {FormBaseControlSchema} from '../../Schema';
 
 /**
  * UUID 功能性组件
- * 文档：https://baidu.gitee.io/amis/docs/components/form/uuid
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/uuid
  */
 export interface UUIDControlSchema extends FormBaseControlSchema {
   type: 'uuid';

--- a/packages/amis/src/renderers/Grid.tsx
+++ b/packages/amis/src/renderers/Grid.tsx
@@ -58,7 +58,7 @@ export interface ColumnArray extends Array<ColumnNode> {}
 
 /**
  * Grid 格子布局渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/grid
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/grid
  */
 export interface GridSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Grid2D.tsx
+++ b/packages/amis/src/renderers/Grid2D.tsx
@@ -55,7 +55,7 @@ export type Grid = GridObject & SchemaObject;
 
 /**
  * 二维布局渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/grid-2d
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/grid-2d
  */
 export interface Grid2DSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/GridNav.tsx
+++ b/packages/amis/src/renderers/GridNav.tsx
@@ -53,7 +53,7 @@ export interface ListItemSchema extends Omit<BaseSchema, 'type'> {
 
 /**
  * List 列表展示控件。
- * 文档：https://baidu.gitee.io/amis/docs/components/card
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/card
  */
 export interface ListSchema extends BaseSchema {
   /**
@@ -154,7 +154,8 @@ export default class List extends React.Component<ListProps, object> {
   }
 
   render() {
-    const {itemClassName, style, source, data, options, classnames} = this.props;
+    const {itemClassName, style, source, data, options, classnames} =
+      this.props;
 
     let value = getPropValue(this.props);
     let list: any = [];

--- a/packages/amis/src/renderers/HBox.tsx
+++ b/packages/amis/src/renderers/HBox.tsx
@@ -69,7 +69,7 @@ export type HBoxColumn = HBoxColumnObject;
 
 /**
  * Hbox 水平布局渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/hbox
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/hbox
  */
 export interface HBoxSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/IFrame.tsx
+++ b/packages/amis/src/renderers/IFrame.tsx
@@ -16,7 +16,7 @@ import {dataMapping, resolveVariableAndFilter} from 'amis-core';
 
 /**
  * IFrame 渲染器
- * 文档：https://baidu.gitee.io/amis/docs/components/iframe
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/iframe
  */
 export interface IFrameSchema extends BaseSchema {
   type: 'iframe';

--- a/packages/amis/src/renderers/Icon.tsx
+++ b/packages/amis/src/renderers/Icon.tsx
@@ -15,7 +15,7 @@ import {isObject} from 'lodash';
 
 /**
  * Icon 图表渲染器
- * 文档：https://baidu.gitee.io/amis/docs/components/icon
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/icon
  */
 export interface IconSchema extends BaseSchema {
   type: 'icon';

--- a/packages/amis/src/renderers/Image.tsx
+++ b/packages/amis/src/renderers/Image.tsx
@@ -22,7 +22,7 @@ export interface ImageToolbarAction {
 
 /**
  * 图片展示控件。
- * 文档：https://baidu.gitee.io/amis/docs/components/image
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/image
  */
 export interface ImageSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Images.tsx
+++ b/packages/amis/src/renderers/Images.tsx
@@ -13,7 +13,7 @@ import type {ImageToolbarAction} from './Image';
 
 /**
  * 图片集展示控件。
- * 文档：https://baidu.gitee.io/amis/docs/components/images
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/images
  */
 export interface ImagesSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Json.tsx
+++ b/packages/amis/src/renderers/Json.tsx
@@ -7,7 +7,7 @@ import {BaseSchema} from '../Schema';
 import {resolveVariableAndFilter, isPureVariable} from 'amis-core';
 /**
  * JSON 数据展示控件。
- * 文档：https://baidu.gitee.io/amis/docs/components/json
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/json
  */
 export interface JsonSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Link.tsx
+++ b/packages/amis/src/renderers/Link.tsx
@@ -8,7 +8,7 @@ import {Link} from 'amis-ui';
 
 /**
  * Link 链接展示控件。
- * 文档：https://baidu.gitee.io/amis/docs/components/link
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/link
  */
 export interface LinkSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/List.tsx
+++ b/packages/amis/src/renderers/List.tsx
@@ -128,7 +128,7 @@ export interface ListItemSchema extends Omit<BaseSchema, 'type'> {
 
 /**
  * List 列表展示控件。
- * 文档：https://baidu.gitee.io/amis/docs/components/card
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/card
  */
 export interface ListSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Log.tsx
+++ b/packages/amis/src/renderers/Log.tsx
@@ -15,7 +15,7 @@ export type LogOperation =
 
 /**
  * 日志展示组件
- * 文档：https://baidu.gitee.io/amis/docs/components/log
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/log
  */
 export interface LogSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Mapping.tsx
+++ b/packages/amis/src/renderers/Mapping.tsx
@@ -21,7 +21,7 @@ import {
 } from 'amis-core';
 /**
  * Mapping 映射展示控件。
- * 文档：https://baidu.gitee.io/amis/docs/components/mapping
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/mapping
  */
 export interface MappingSchema extends BaseSchema {
   /**
@@ -264,10 +264,10 @@ export const MappingField = withStore(props =>
         }
         let realValue = value;
         if (
-          isObject(label)
-          && label.type === 'tag'
-          && !isObject(label.label)
-          && label.label != null
+          isObject(label) &&
+          label.type === 'tag' &&
+          !isObject(label.label) &&
+          label.label != null
         ) {
           realValue = label.label;
         }

--- a/packages/amis/src/renderers/Markdown.tsx
+++ b/packages/amis/src/renderers/Markdown.tsx
@@ -11,7 +11,7 @@ import {isApiOutdated, isEffectiveApi} from 'amis-core';
 
 /**
  * Markdown 渲染
- * 文档：https://baidu.gitee.io/amis/docs/components/markdown
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/markdown
  */
 export interface MarkdownSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Nav.tsx
+++ b/packages/amis/src/renderers/Nav.tsx
@@ -152,7 +152,7 @@ export interface NavOverflow {
 
 /**
  * Nav 导航渲染器
- * 文档：https://baidu.gitee.io/amis/docs/components/nav
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/nav
  */
 export interface NavSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Number.tsx
+++ b/packages/amis/src/renderers/Number.tsx
@@ -6,7 +6,7 @@ import {getPropValue} from 'amis-core';
 
 /**
  * Number 展示渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/number
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/number
  */
 export interface NumberSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Operation.tsx
+++ b/packages/amis/src/renderers/Operation.tsx
@@ -10,7 +10,7 @@ import {ActionSchema} from './Action';
 
 /**
  * 操作栏渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/operation
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/operation
  */
 export interface OperationSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Page.tsx
+++ b/packages/amis/src/renderers/Page.tsx
@@ -51,7 +51,7 @@ interface CSSRule {
 }
 
 /**
- * amis Page 渲染器。详情请见：https://baidu.gitee.io/amis/docs/components/page
+ * amis Page 渲染器。详情请见：https://aisuda.bce.baidu.com/amis/zh-CN/components/page
  */
 export interface PageSchema extends BaseSchema, SpinnerExtraProps {
   /**

--- a/packages/amis/src/renderers/PaginationWrapper.tsx
+++ b/packages/amis/src/renderers/PaginationWrapper.tsx
@@ -4,7 +4,7 @@ import {BaseSchema, SchemaCollection} from '../Schema';
 import {IPaginationStore, PaginationStore} from 'amis-core';
 
 /**
- * 分页容器功能性渲染器。详情请见：https://baidu.gitee.io/amis/docs/components/pagination-wrapper
+ * 分页容器功能性渲染器。详情请见：https://aisuda.bce.baidu.com/amis/zh-CN/components/pagination-wrapper
  */
 export interface PaginationWrapperSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Panel.tsx
+++ b/packages/amis/src/renderers/Panel.tsx
@@ -15,7 +15,7 @@ import {FormHorizontal} from 'amis-core';
 
 /**
  * Panel渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/panel
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/panel
  */
 export interface PanelSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Plain.tsx
+++ b/packages/amis/src/renderers/Plain.tsx
@@ -7,13 +7,13 @@ import {getPropValue} from 'amis-core';
 
 /**
  * Plain 纯文本渲染器
- * 文档：https://baidu.gitee.io/amis/docs/components/plain
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/plain
  */
 export interface PlainSchema extends BaseSchema {
   /**
    * 指定为模板渲染器。
    *
-   * 文档：https://baidu.gitee.io/amis/docs/concepts/template
+   * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/concepts/template
    */
   type: 'plain' | 'text';
 

--- a/packages/amis/src/renderers/Plain.tsx
+++ b/packages/amis/src/renderers/Plain.tsx
@@ -13,7 +13,7 @@ export interface PlainSchema extends BaseSchema {
   /**
    * 指定为模板渲染器。
    *
-   * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/concepts/template
+   * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/docs/concepts/template
    */
   type: 'plain' | 'text';
 

--- a/packages/amis/src/renderers/Portlet.tsx
+++ b/packages/amis/src/renderers/Portlet.tsx
@@ -26,7 +26,7 @@ import {ActionSchema} from './Action';
 
 /**
  * 栏目容器渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/portlet
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/portlet
  */
 export interface PortletTabSchema extends Omit<BaseSchema, 'type'> {
   /**

--- a/packages/amis/src/renderers/Progress.tsx
+++ b/packages/amis/src/renderers/Progress.tsx
@@ -9,7 +9,7 @@ import type {ColorMapType} from 'amis-ui/lib/components/Progress';
 
 /**
  * 进度展示控件。
- * 文档：https://baidu.gitee.io/amis/docs/components/progress
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/progress
  */
 export interface ProgressSchema extends BaseSchema {
   type: 'progress';

--- a/packages/amis/src/renderers/Property.tsx
+++ b/packages/amis/src/renderers/Property.tsx
@@ -40,7 +40,7 @@ export type PropertyItem = PropertyItemProps & SchemaObject;
 
 /**
  * Property 属性列表
- * 文档：https://baidu.gitee.io/amis/docs/components/property
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/property
  */
 export interface PropertySchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/QRCode.tsx
+++ b/packages/amis/src/renderers/QRCode.tsx
@@ -26,7 +26,7 @@ export interface QRCodeImageSettings {
 
 /**
  * 二维码展示控件。
- * 文档：https://baidu.gitee.io/amis/docs/components/qrcode
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/qrcode
  */
 export interface QRCodeSchema extends BaseSchema {
   type: 'qrcode' | 'qr-code';

--- a/packages/amis/src/renderers/SearchBox.tsx
+++ b/packages/amis/src/renderers/SearchBox.tsx
@@ -20,7 +20,7 @@ export interface SearchBoxSchema extends BaseSchema {
   /**
    * 指定为搜索框。
    *
-   * 文档：https://baidu.gitee.io/amis/docs/components/search-box
+   * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/search-box
    */
   type: 'search-box';
 

--- a/packages/amis/src/renderers/Service.tsx
+++ b/packages/amis/src/renderers/Service.tsx
@@ -59,7 +59,7 @@ export type ComposedDataProvider = DataProvider | DataProviderCollection;
 
 /**
  * Service 服务类控件。
- * 文档：https://baidu.gitee.io/amis/docs/components/service
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/service
  */
 export interface ServiceSchema extends BaseSchema, SpinnerExtraProps {
   /**

--- a/packages/amis/src/renderers/Status.tsx
+++ b/packages/amis/src/renderers/Status.tsx
@@ -24,7 +24,7 @@ export interface StatusSource {
 
 /**
  * 状态展示控件。
- * 文档：https://baidu.gitee.io/amis/docs/components/status
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/status
  */
 export interface StatusSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -187,7 +187,7 @@ export type TableColumn = TableColumnWithType | TableColumnObject;
 type AutoFillHeightObject = Record<'height' | 'maxHeight', number>;
 /**
  * Table 表格渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/table
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/table
  */
 export interface TableSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -48,7 +48,7 @@ import {Action} from '../../types';
 
 /**
  * Table 表格2渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/table2
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/table2
  */
 
 export interface CellSpan {

--- a/packages/amis/src/renderers/TableView.tsx
+++ b/packages/amis/src/renderers/TableView.tsx
@@ -96,7 +96,7 @@ export type ColObject = {
 
 /**
  * 表格展现渲染器
- * 文档：https://baidu.gitee.io/amis/docs/components/table-view
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/table-view
  */
 export interface TableViewSchema extends BaseSchema {
   /**

--- a/packages/amis/src/renderers/Tabs.tsx
+++ b/packages/amis/src/renderers/Tabs.tsx
@@ -98,7 +98,7 @@ export interface TabSchema extends Omit<BaseSchema, 'type'> {
 
 /**
  * 选项卡控件。
- * 文档：https://baidu.gitee.io/amis/docs/components/tabs
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/tabs
  */
 export interface TabsSchema extends BaseSchema {
   type: 'tabs';

--- a/packages/amis/src/renderers/Tasks.tsx
+++ b/packages/amis/src/renderers/Tasks.tsx
@@ -13,7 +13,7 @@ import {createObject} from 'amis-core';
 
 /**
  * Tasks 渲染器，格式说明
- * 文档：https://baidu.gitee.io/amis/docs/components/tasks
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/tasks
  */
 export interface TasksSchema extends BaseSchema, SpinnerExtraProps {
   /** 指定为任务类型 */

--- a/packages/amis/src/renderers/Tpl.tsx
+++ b/packages/amis/src/renderers/Tpl.tsx
@@ -15,7 +15,7 @@ export interface TplSchema extends BaseSchema {
   /**
    * 指定为模板渲染器。
    *
-   * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/concepts/template
+   * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/docs/concepts/template
    */
   type: 'tpl' | 'html';
 

--- a/packages/amis/src/renderers/Tpl.tsx
+++ b/packages/amis/src/renderers/Tpl.tsx
@@ -15,7 +15,7 @@ export interface TplSchema extends BaseSchema {
   /**
    * 指定为模板渲染器。
    *
-   * 文档：https://baidu.gitee.io/amis/docs/concepts/template
+   * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/concepts/template
    */
   type: 'tpl' | 'html';
 

--- a/packages/amis/src/renderers/VBox.tsx
+++ b/packages/amis/src/renderers/VBox.tsx
@@ -11,7 +11,7 @@ export type HboxRow = SchemaObject & {
 
 /**
  * 垂直布局控件
- * 文档：https://baidu.gitee.io/amis/docs/components/vbox
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/vbox
  */
 export interface VBoxSchema extends BaseSchema {
   type: 'vbox';

--- a/packages/amis/src/renderers/Video.tsx
+++ b/packages/amis/src/renderers/Video.tsx
@@ -22,7 +22,7 @@ import {BaseSchema, SchemaClassName, SchemaUrlPath} from '../Schema';
 
 /**
  * 视频播放器
- * 文档：https://baidu.gitee.io/amis/docs/components/video
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/video
  */
 export interface VideoSchema extends BaseSchema {
   /**
@@ -270,7 +270,7 @@ export class FlvSource extends React.Component<FlvSourceProps, any> {
 
   render() {
     return (
-      <source src={this.props.src} type={this.props.type || 'video/x-flv'}/>
+      <source src={this.props.src} type={this.props.type || 'video/x-flv'} />
     );
   }
 }
@@ -766,10 +766,20 @@ export default class Video extends React.Component<VideoProps, VideoState> {
   }
 
   render() {
-    let {splitPoster, className, style, classPrefix: ns, classnames: cx} = this.props;
+    let {
+      splitPoster,
+      className,
+      style,
+      classPrefix: ns,
+      classnames: cx
+    } = this.props;
 
     return (
-      <div className={cx(`Video`, className)} onClick={this.onClick as any} style={style}>
+      <div
+        className={cx(`Video`, className)}
+        onClick={this.onClick as any}
+        style={style}
+      >
         {this.renderFrames()}
         {splitPoster ? this.renderPosterAndPlayer() : this.renderPlayer()}
       </div>

--- a/packages/amis/src/renderers/WebComponent.tsx
+++ b/packages/amis/src/renderers/WebComponent.tsx
@@ -6,7 +6,7 @@ import mapValues from 'lodash/mapValues';
 
 /**
  * WebComponent 容器渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/web-component
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/web-component
  */
 export interface WebComponentSchema extends BaseSchema {
   /**
@@ -49,7 +49,11 @@ export default class WebComponent extends React.Component<RendererProps> {
       }
     });
     const Component = (tag as keyof JSX.IntrinsicElements) || 'div';
-    return <Component {...propsValues} style={style}>{this.renderBody()}</Component>;
+    return (
+      <Component {...propsValues} style={style}>
+        {this.renderBody()}
+      </Component>
+    );
   }
 }
 

--- a/packages/amis/src/renderers/Wizard.tsx
+++ b/packages/amis/src/renderers/Wizard.tsx
@@ -82,7 +82,7 @@ export type WizardStepSchema = Omit<FormSchema, 'type'> & {
 
 /**
  * 表单向导
- * 文档：https://baidu.gitee.io/amis/docs/components/wizard
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/wizard
  */
 export interface WizardSchema extends BaseSchema, SpinnerExtraProps {
   /**

--- a/packages/amis/src/renderers/Wrapper.tsx
+++ b/packages/amis/src/renderers/Wrapper.tsx
@@ -8,7 +8,7 @@ import {buildStyle} from 'amis-core';
 
 /**
  * Wrapper 容器渲染器。
- * 文档：https://baidu.gitee.io/amis/docs/components/wrapper
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/wrapper
  */
 export interface WrapperSchema extends BaseSchema {
   /**


### PR DESCRIPTION
修复ts-json-schema-generator组件生成的`schema.json`中的链接、代码注释中链接点不开的问题。
如修改gitee page 链接
https://baidu.gitee.io/amis/docs/components/page
修改为https://aisuda.bce.baidu.com/amis/zh-CN/components/page, 


解决采用`schema.json` JSON提示链接不正确的情况，出现链接不正确的情况，如下

<img width="678" alt="image" src="https://user-images.githubusercontent.com/39587710/228713718-29abdeb6-2652-474a-b2a8-ba6e36f4c1b3.png">
<img width="609" alt="image" src="https://user-images.githubusercontent.com/39587710/228714320-ac0fabf5-e073-451d-97a1-89ffb9c686f3.png">

