### PR TITLE
fix: 自定义列样式修复

### DIFF
--- a/packages/amis/src/renderers/Table2/ColumnToggler.tsx
+++ b/packages/amis/src/renderers/Table2/ColumnToggler.tsx
@@ -39,6 +39,7 @@ export class ColumnTogglerRenderer extends React.Component<ColumnTogglerRenderer
       toggleAllColumns,
       toggleToggle,
       data,
+      size,
       ...rest
     } = this.props;
     const __ = rest.translate;
@@ -73,6 +74,7 @@ export class ColumnTogglerRenderer extends React.Component<ColumnTogglerRenderer
         columns={cols}
         activeToggaleColumns={activeToggaleColumns}
         data={data}
+        size={size || 'sm'}
       >
         {toggableColumns?.length ? (
           <li


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c464dc8</samp>

Added a `size` prop to `ColumnTogglerRenderer` to allow adjusting the column toggler button size in table renderer. Modified `packages/amis/src/renderers/Table2/ColumnToggler.tsx` to implement this feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c464dc8</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A cunning feature for the table renderer's pride,_
> _To let the users choose the size of the toggler's face_
> _That shows or hides the columns with a button's grace._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c464dc8</samp>

*  Add a `size` prop to customize the column toggler button size ([link](https://github.com/baidu/amis/pull/6535/files?diff=unified&w=0#diff-37861c0d8da4a32144d6e3c49c447f9f077dc59a1e32c832db2a62c81d8c522dR42))
*  Pass the `size` prop to the `Button` component and set a default value of `'sm'` ([link](https://github.com/baidu/amis/pull/6535/files?diff=unified&w=0#diff-37861c0d8da4a32144d6e3c49c447f9f077dc59a1e32c832db2a62c81d8c522dR77))
