### PR TITLE
fix: 修复number render对于suffix的兼容

### DIFF
--- a/examples/components/Form/SwitchDisplay.jsx
+++ b/examples/components/Form/SwitchDisplay.jsx
@@ -304,9 +304,12 @@ export default {
           label: '数字',
           placeholder: '',
           inline: true,
-          value: 5,
+          value: 99999,
           min: 1,
-          max: 10
+          max: 1000000,
+          kilobitSeparator: true,
+          prefix: '前缀',
+          suffix: '后缀'
         },
         {
           type: 'divider'

--- a/packages/amis/src/renderers/Form/InputNumber.tsx
+++ b/packages/amis/src/renderers/Form/InputNumber.tsx
@@ -357,27 +357,6 @@ export default class NumberControl extends React.Component<
     this.input.focus();
   }
 
-  renderStatic(displayValue = '-') {
-    let {value, kilobitSeparator, prefix, suffix} = this.props;
-    if (value == null) {
-      return displayValue;
-    }
-    const unit = this.state?.unit || '';
-    // 处理单位
-    let finalValue =
-      unit && value && typeof value === 'string'
-        ? value.replace(unit, '')
-        : value;
-
-    // 增加千分分隔
-    if (kilobitSeparator && finalValue) {
-      finalValue = numberFormatter.format(finalValue);
-    }
-    // 增加前后缀
-    finalValue = (prefix ? prefix : '') + finalValue + (suffix ? suffix : '');
-    return <>{finalValue + unit}</>;
-  }
-
   @supportStatic()
   render() {
     const {

--- a/packages/amis/src/renderers/Number.tsx
+++ b/packages/amis/src/renderers/Number.tsx
@@ -61,6 +61,7 @@ export class NumberField extends React.Component<NumberProps> {
       precision,
       prefix,
       affix,
+      suffix,
       percent,
       className,
       style,
@@ -113,7 +114,7 @@ export class NumberField extends React.Component<NumberProps> {
       <>
         {prefix}
         {viewValue}
-        {affix}
+        {affix ?? suffix}
       </>
     );
 


### PR DESCRIPTION
1. `InputNumber.tsx`中的后缀属性是 suffix，`Number.tsx`的后缀属性是 affix，静态展示时，需要兼容一下
2. `InputNumber.tsx` renderStatic 函数的优先级高于 `StaticHoc.tsx`中的逻辑，但是这里已经多余了，可以去掉