### PR TITLE
fix:编辑态弹窗问题

### DIFF
--- a/packages/amis-core/src/actions/DialogAction.ts
+++ b/packages/amis-core/src/actions/DialogAction.ts
@@ -45,6 +45,11 @@ export class DialogAction implements RendererAction {
     renderer: ListenerContext,
     event: RendererEvent<any>
   ) {
+    // 防止editor preview模式下执行
+    if ((action as any).$$id !== undefined) {
+      return;
+    }
+
     renderer.props.onAction?.(
       event,
       {
@@ -113,7 +118,10 @@ export class ConfirmAction implements RendererAction {
     renderer: ListenerContext,
     event: RendererEvent<any>
   ) {
-    const confirmed = await event.context.env.confirm?.(action.args?.msg, action.args?.title);
+    const confirmed = await event.context.env.confirm?.(
+      action.args?.msg,
+      action.args?.title
+    );
     return confirmed;
   }
 }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 27f81d6</samp>

Fix dialog action bug and improve code style in `DialogAction.ts`. Prevent the dialog action from popping up in the editor preview mode by checking the `$$id` property, and make the confirm action code more readable by breaking a long line.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 27f81d6</samp>

> _We're fixing bugs and styling code, me hearties, yo ho ho_
> _We check the `$$id` before we run the dialog, yo ho ho_
> _We break the line that was too long in `ConfirmAction`, yo ho ho_
> _And when we're done we'll test it well and push it to the repo_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 27f81d6</samp>

*  Prevent dialog action from executing in editor preview mode by checking the `$$id` property of the action ([link](https://github.com/baidu/amis/pull/6550/files?diff=unified&w=0#diff-22e8cf0392427a45b5b88b06382a0c4f243f20936ce4cdf806ee15fa47282d26R48-R52))
*  Reformat the code of the confirm action to break the long line into two lines for better readability ([link](https://github.com/baidu/amis/pull/6550/files?diff=unified&w=0#diff-22e8cf0392427a45b5b88b06382a0c4f243f20936ce4cdf806ee15fa47282d26L116-R124))
