### PR TITLE
fix:事件动作支持获取crud批量操作ids

### DIFF
--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -1672,6 +1672,8 @@ export default class CRUD extends React.Component<CRUDProps, any> {
 
     const ctx = createObject(store.mergedData, {
       currentPageData: store.mergedData.items.concat(),
+      rows: selectedItems.concat(),
+      items: selectedItems.concat(),
       selectedItems: selectedItems.concat(),
       unSelectedItems: unSelectedItems.concat(),
       ids: selectedItems

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -1651,7 +1651,14 @@ export default class CRUD extends React.Component<CRUDProps, any> {
   }
 
   renderBulkActions(childProps: any) {
-    let {bulkActions, itemActions, store, render, classnames: cx} = this.props;
+    let {
+      bulkActions,
+      itemActions,
+      store,
+      render,
+      classnames: cx,
+      primaryField
+    } = this.props;
 
     if (!bulkActions || !bulkActions.length) {
       return null;
@@ -1666,7 +1673,15 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     const ctx = createObject(store.mergedData, {
       currentPageData: store.mergedData.items.concat(),
       selectedItems: selectedItems.concat(),
-      unSelectedItems: unSelectedItems.concat()
+      unSelectedItems: unSelectedItems.concat(),
+      ids: selectedItems
+        .map(item =>
+          item.hasOwnProperty(primaryField)
+            ? item[primaryField as string]
+            : null
+        )
+        .filter(item => item)
+        .join(',')
     });
 
     // const ctx = createObject(store.data, {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f720fc5</samp>

Added bulk actions with ids to CRUD renderer. This allows performing actions on multiple items at once using their primary keys, specified by the `primaryField` prop. Modified `packages/amis/src/renderers/CRUD.tsx` and its child components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f720fc5</samp>

> _`CRUD` renderer_
> _bulk actions with `ids` prop_
> _autumn harvest time_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f720fc5</samp>

*  Add `primaryField` prop to `renderBulkActions` method to identify the primary key of each item in the CRUD list ([link](https://github.com/baidu/amis/pull/6551/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1654-R1661))
*  Pass `ids` property to the `render` function as part of the `childProps` object, containing a comma-separated string of the selected items' primary keys, to support bulk actions that require ids as parameters ([link](https://github.com/baidu/amis/pull/6551/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1669-R1684))
