### PR TITLE
chore: input-number 有对应 number 渲染器渲染静态值,无需 renderStatic

### DIFF
--- a/packages/amis/src/renderers/Form/InputNumber.tsx
+++ b/packages/amis/src/renderers/Form/InputNumber.tsx
@@ -357,26 +357,26 @@ export default class NumberControl extends React.Component<
     this.input.focus();
   }
 
-  renderStatic(displayValue = '-') {
-    let {value, kilobitSeparator, prefix, suffix} = this.props;
-    if (value == null) {
-      return displayValue;
-    }
-    const unit = this.state?.unit || '';
-    // 处理单位
-    let finalValue =
-      unit && value && typeof value === 'string'
-        ? value.replace(unit, '')
-        : value;
+  // renderStatic(displayValue = '-') {
+  //   let {value, kilobitSeparator, prefix, suffix} = this.props;
+  //   if (value == null) {
+  //     return displayValue;
+  //   }
+  //   const unit = this.state?.unit || '';
+  //   // 处理单位
+  //   let finalValue =
+  //     unit && value && typeof value === 'string'
+  //       ? value.replace(unit, '')
+  //       : value;
 
-    // 增加千分分隔
-    if (kilobitSeparator && finalValue) {
-      finalValue = numberFormatter.format(finalValue);
-    }
-    // 增加前后缀
-    finalValue = (prefix ? prefix : '') + finalValue + (suffix ? suffix : '');
-    return <>{finalValue + unit}</>;
-  }
+  //   // 增加千分分隔
+  //   if (kilobitSeparator && finalValue) {
+  //     finalValue = numberFormatter.format(finalValue);
+  //   }
+  //   // 增加前后缀
+  //   finalValue = (prefix ? prefix : '') + finalValue + (suffix ? suffix : '');
+  //   return <>{finalValue + unit}</>;
+  // }
 
   @supportStatic()
   render() {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2cafd41</samp>

Fixed a bug in the `InputNumber` component that caused incorrect display in `static` mode. Commented out the `renderStatic` method in `InputNumber.tsx` to use the default logic from the `BaseInput` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2cafd41</samp>

> _`renderStatic` gone_
> _Input number bug fixed now_
> _Base input shines through_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2cafd41</samp>

* Fix input number display bug in static mode by commenting out `renderStatic` method in `InputNumber` component ([link](https://github.com/baidu/amis/pull/6554/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685L360-R379))
