### PR TITLE
fix: 修复options选项hidden为true时无效的问题

### DIFF
--- a/packages/amis-core/src/store/formItem.ts
+++ b/packages/amis-core/src/store/formItem.ts
@@ -1088,7 +1088,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
             ? evalExpression(item.visibleOn, data) !== false
             : item.hiddenOn
             ? evalExpression(item.hiddenOn, data) !== true
-            : item.visible !== false || item.hidden !== true;
+            : item.visible !== false && item.hidden !== true;
         })
         .map((item: any, index) => {
           const disabled = evalExpression(item.disabledOn, data);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 45eb3f2</samp>

Fix hidden options bug in select component. Update `formItem.ts` to exclude hidden or not visible options from the form item store.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 45eb3f2</samp>

> _`select` component_
> _filters out hidden options_
> _a bug fix for fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 45eb3f2</samp>

*  Filter out hidden or not visible options from form item store ([link](https://github.com/baidu/amis/pull/6556/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9R1080-R1083))
