### PR TITLE
chore: ConditionBuilder右侧控件禁止替换amis内部保留字为name

### DIFF
--- a/packages/amis-ui/src/components/condition-builder/Value.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Value.tsx
@@ -21,6 +21,9 @@ export interface ValueProps extends ThemeProps, LocaleProps {
   renderEtrValue?: any;
 }
 
+/** amis内部保留字 */
+export const reservedWords = ['id'];
+
 export class Value extends React.Component<ValueProps> {
   render() {
     let {
@@ -141,7 +144,11 @@ export class Value extends React.Component<ValueProps> {
     } else if (field.type === 'custom') {
       input = renderEtrValue
         ? renderEtrValue(
-            {...field.value, name: field.name},
+            {
+              ...field.value,
+              // amis内部保留字不能替换，否则控件回显有问题
+              ...(reservedWords.includes(field.name) ? {} : {name: field.name})
+            },
             {
               data,
               onChange,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e5bc08b</samp>

This pull request fixes a bug in the condition builder that caused reserved words to be replaced with field names. It also introduces a constant array of `RESERVED_WORDS` in `Value.tsx` to avoid hard-coding them.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e5bc08b</samp>

> _No more deception, no more lies_
> _`amis` can't replace the words that we despise_
> _We stand against the tyranny of the condition builder_
> _We have the power, we have the `RESERVED_WORDS`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e5bc08b</samp>

*  Prevent reserved words from being replaced by field value names in value component ([link](https://github.com/baidu/amis/pull/6563/files?diff=unified&w=0#diff-3157122d98c25f17ff8d96042468d09f17a5b91ec601c8f5688b30e0c93c7dfdR24-R26), [link](https://github.com/baidu/amis/pull/6563/files?diff=unified&w=0#diff-3157122d98c25f17ff8d96042468d09f17a5b91ec601c8f5688b30e0c93c7dfdL144-R152))
  - Define a constant array of reserved words in `Value.tsx` ([link](https://github.com/baidu/amis/pull/6563/files?diff=unified&w=0#diff-3157122d98c25f17ff8d96042468d09f17a5b91ec601c8f5688b30e0c93c7dfdR24-R26))
  - Check if field name is a reserved word before passing it to renderEtrValue function ([link](https://github.com/baidu/amis/pull/6563/files?diff=unified&w=0#diff-3157122d98c25f17ff8d96042468d09f17a5b91ec601c8f5688b30e0c93c7dfdL144-R152))
