### PR TITLE
fix: 修复number组件ts报错

### DIFF
--- a/packages/amis-ui/src/components/NumberInput.tsx
+++ b/packages/amis-ui/src/components/NumberInput.tsx
@@ -76,7 +76,11 @@ export interface NumberProps extends ThemeProps {
   inputControlClassName?: string;
 }
 
-export class NumberInput extends React.Component<NumberProps, any> {
+export interface NumberState {
+  focused: boolean;
+}
+
+export class NumberInput extends React.Component<NumberProps, NumberState> {
   static defaultProps: Pick<
     NumberProps,
     'step' | 'readOnly' | 'borderMode' | 'resetValue'

--- a/packages/amis-ui/src/components/NumberInput.tsx
+++ b/packages/amis-ui/src/components/NumberInput.tsx
@@ -76,7 +76,7 @@ export interface NumberProps extends ThemeProps {
   inputControlClassName?: string;
 }
 
-export class NumberInput extends React.Component<any, any> {
+export class NumberInput extends React.Component<NumberProps, any> {
   static defaultProps: Pick<
     NumberProps,
     'step' | 'readOnly' | 'borderMode' | 'resetValue'

--- a/packages/amis-ui/src/components/NumberInput.tsx
+++ b/packages/amis-ui/src/components/NumberInput.tsx
@@ -76,15 +76,15 @@ export interface NumberProps extends ThemeProps {
   inputControlClassName?: string;
 }
 
-export class NumberInput extends React.Component<NumberProps, any> {
-  static defaultProps:
-    | Pick<NumberProps, 'step' | 'readOnly' | 'borderMode' | 'resetValue'>
-    | {focused: boolean} = {
+export class NumberInput extends React.Component<any, any> {
+  static defaultProps: Pick<
+    NumberProps,
+    'step' | 'readOnly' | 'borderMode' | 'resetValue'
+  > = {
     step: 1,
     readOnly: false,
     borderMode: 'full',
-    resetValue: '',
-    focused: false
+    resetValue: ''
   };
 
   /**


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b06f72</samp>

Removed unused `focused` prop from `NumberInput` component. This makes the component cleaner and easier to use.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7b06f72</samp>

> _`focused` prop gone_
> _`NumberInput` simpler_
> _like autumn leaves fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7b06f72</samp>

* Remove unused `focused` prop from `NumberInput` component ([link](https://github.com/baidu/amis/pull/6564/files?diff=unified&w=0#diff-546e57e204289f8983a75b6d74448711dc7fd5461cbc03acb7fdaa1548252954L79-R87))
