### PR TITLE
fix: CRUD2 不透传columnsTogglable;getData问题修改

### DIFF
--- a/packages/amis/src/renderers/CRUD2.tsx
+++ b/packages/amis/src/renderers/CRUD2.tsx
@@ -1145,7 +1145,7 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
       showSelection,
       headerToolbar,
       footerToolbar,
-      // columnsTogglable 在本渲染器中渲染，不需要 table 渲染
+      // columnsTogglable 在本渲染器中渲染，不需要 table 渲染，避免重复
       columnsTogglable,
       ...rest
     } = this.props;

--- a/packages/amis/src/renderers/CRUD2.tsx
+++ b/packages/amis/src/renderers/CRUD2.tsx
@@ -546,7 +546,7 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
             silent,
             pageField,
             perPageField,
-            loadDataMode,
+            loadDataMode: false,
             syncResponse2Query,
             columns: store.columns ?? columns,
             isTable2: true
@@ -662,7 +662,7 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
         })
         .then(() => {
           reload && this.reloadTarget(filter(reload, data), data);
-          this.getData(undefined, undefined, true, true);
+          this.getData(undefined, undefined, true);
         })
         .catch(() => {});
     } else {
@@ -682,7 +682,8 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
         .saveRemote(quickSaveItemApi, sendData)
         .then(() => {
           reload && this.reloadTarget(filter(reload, data), data);
-          this.getData(undefined, undefined, true, true);
+
+          this.getData(undefined, undefined, true);
         })
         .catch(() => {
           options?.resetOnFailed && this.control.reset();
@@ -788,7 +789,7 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
         .saveRemote(saveOrderApi, model)
         .then(() => {
           reload && this.reloadTarget(filter(reload, model), model);
-          this.getData(undefined, undefined, true, true);
+          this.getData(undefined, undefined, true);
         })
         .catch(() => {});
   }
@@ -916,14 +917,14 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
       pageField,
       perPageField
     );
-    this.getData(undefined, undefined, undefined, forceReload);
+    this.getData(undefined, undefined, forceReload);
   }
 
   reload(subpath?: string, query?: any) {
     if (query) {
       return this.receive(query);
     } else {
-      this.getData(undefined, undefined, true, true);
+      this.getData(undefined, undefined, true);
     }
   }
 
@@ -1144,6 +1145,8 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
       showSelection,
       headerToolbar,
       footerToolbar,
+      // columnsTogglable 在本渲染器中渲染，不需要 table 渲染
+      columnsTogglable,
       ...rest
     } = this.props;
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7129b8c</samp>

This pull request improves the CRUD2 renderer by enabling custom data loading, optimizing data syncing, and supporting column toggling. It changes the `loadDataMode`, `this.getData`, and `columnsTogglable` props in `./packages/amis/src/renderers/CRUD2.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7129b8c</samp>

> _Oh we are the CRUD2 renderers, we load the data as we please_
> _We don't need no data syncing, we just use `loadDataMode`_
> _And when we want to see the columns, we toggle them with ease_
> _We are the CRUD2 renderers, we sail the AMIS seas_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7129b8c</samp>

*  Disable default data loading from API when query changes and add `loadDataMode` prop to CRUD2 renderer ([link](https://github.com/baidu/amis/pull/6569/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL549-R549))
*  Remove redundant flag for syncing response data to query in `this.getData` calls and avoid unnecessary re-rendering ([link](https://github.com/baidu/amis/pull/6569/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL665-R665), [link](https://github.com/baidu/amis/pull/6569/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL685-R686), [link](https://github.com/baidu/amis/pull/6569/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL791-R792), [link](https://github.com/baidu/amis/pull/6569/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL919-R920), [link](https://github.com/baidu/amis/pull/6569/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL926-R927))
*  Add `columnsTogglable` prop to `renderTable` method and handle column toggling logic in CRUD2 renderer instead of Table renderer ([link](https://github.com/baidu/amis/pull/6569/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaR1148-R1149))
