### PR TITLE
docs: 修正 crud 文档错别字

### DIFF
--- a/docs/zh-CN/components/crud.md
+++ b/docs/zh-CN/components/crud.md
@@ -2901,7 +2901,7 @@ itemAction 里的 onClick 还能通过 `data` 参数拿到当前行的数据，�
 | multiple      | `boolean`                     | `false` | 是否支持多选                                             |         |
 | source        | [`Api`](../../docs/types/api) | -       | 选项 API 接口                                            |         |
 | refreshOnOpen | `boolean`                     | `false` | 配置 source 前提下，每次展开筛选浮层是否重新加载选项数据 | `2.9.0` |
-| strictMode    | `boolean`                     | `false` | 严格模式，开启严格模式后，会采用 JavaScript 严格想等比较 | `2.3.0` |
+| strictMode    | `boolean`                     | `false` | 严格模式，开启严格模式后，会采用 JavaScript 严格相等比较 | `2.3.0` |
 
 #### QuickEditConfig
 


### PR DESCRIPTION
错别字

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a9ce5c</samp>

This pull request fixes a typo in the `crud.md` file of the Chinese documentation. The change corrects the spelling of a word that describes a filter option for the CRUD component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0a9ce5c</samp>

> _`QuickFilterConfig`_
> _想 becomes 相, equal_
> _A clear autumn sky_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0a9ce5c</samp>

* Fix typo in `QuickFilterConfig` documentation ([link](https://github.com/baidu/amis/pull/6571/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653L2904-R2904))
