### PR TITLE
fix: 「组件」「Bug」Dropdown组件hover触发时移开不消失 (#6568)

### DIFF
--- a/packages/amis/src/renderers/DropDownButton.tsx
+++ b/packages/amis/src/renderers/DropDownButton.tsx
@@ -271,7 +271,8 @@ export default class DropDownButton extends React.Component<
       closeOnClick,
       closeOnOutside,
       menuClassName,
-      overlayPlacement
+      overlayPlacement,
+      trigger
     } = this.props;
     let body = (
       <RootClose
@@ -311,7 +312,7 @@ export default class DropDownButton extends React.Component<
           show
         >
           <PopOver
-            overlay
+            overlay={trigger !== 'hover'}
             onHide={this.close}
             classPrefix={ns}
             className={cx('DropDown-popover', menuClassName)}


### PR DESCRIPTION
* fix: 「组件」「Bug」Dropdown组件hover触发时移开不消失

* fix: 「组件」「Bug」Dropdown组件hover触发时移开不消失

* fix: 「组件」「Bug」Dropdown组件hover触发时移开不消失

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9865855</samp>

Added a new feature to the `DropDownButton` component to support both click and hover triggers for the dropdown menu. Modified the `PopOver` component to align with the chosen trigger mode.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9865855</samp>

> _To open the menu with a click or a hover_
> _We added a `trigger` prop to the `DropDownButton` lover_
> _The `PopOver` component also got a tweak_
> _To match the `overlay` prop to the trigger technique_
> _And now we have more options to discover_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9865855</samp>

*  Add `trigger` prop to `DropDownButton` component to control how the dropdown menu is triggered ([link](https://github.com/baidu/amis/pull/6578/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L274-R275))
*  Adjust `overlay` prop of `PopOver` component to depend on `trigger` prop of `DropDownButton` component, making the dropdown behavior more consistent with the trigger mode ([link](https://github.com/baidu/amis/pull/6578/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L314-R315))
