### PR TITLE
feat: Added support for German to momentjs calendars

### DIFF
--- a/packages/amis-ui/src/components/DatePicker.tsx
+++ b/packages/amis-ui/src/components/DatePicker.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import moment from 'moment';
 import 'moment/locale/zh-cn';
+import 'moment/locale/de';
 import {Icon} from './icons';
 import {PopOver} from 'amis-core';
 import PopUp from './PopUp';

--- a/packages/amis/src/renderers/Form/InputDate.tsx
+++ b/packages/amis/src/renderers/Form/InputDate.tsx
@@ -9,6 +9,7 @@ import cx from 'classnames';
 import {filterDate, isPureVariable, resolveVariableAndFilter} from 'amis-core';
 import moment from 'moment';
 import 'moment/locale/zh-cn';
+import 'moment/locale/de';
 import {DatePicker} from 'amis-ui';
 import {FormBaseControlSchema, SchemaObject} from '../../Schema';
 import {createObject, anyChanged, isMobile, autobind} from 'amis-core';

--- a/packages/amis/src/renderers/Form/InputDateRange.tsx
+++ b/packages/amis/src/renderers/Form/InputDateRange.tsx
@@ -8,6 +8,7 @@ import {
 import cx from 'classnames';
 import {filterDate, parseDuration} from 'amis-core';
 import 'moment/locale/zh-cn';
+import 'moment/locale/de';
 import {DateRangePicker} from 'amis-ui';
 import {isMobile, createObject, autobind} from 'amis-core';
 import {ActionObject} from 'amis-core';


### PR DESCRIPTION
### What

Added include for German moments language file to calendar files.

### Why

To use the locale "de-DE" wtih amis requires the German momentjs language file to be included in the SDK.
Otherwise the calendar will show year, month etc. in  Chinese.
