### PR TITLE
chore(amis-editor): 优化 input-number 的 mock 逻辑

### DIFF
--- a/packages/amis-editor-core/src/mocker.ts
+++ b/packages/amis-editor-core/src/mocker.ts
@@ -18,7 +18,10 @@ export function mockValue(schema: any) {
   ) {
     return moment().format('X');
   } else if (schema.type === 'number' || schema.type === 'input-number') {
-    return (Math.random() * 10000).toFixed(2);
+    const precision = schema.precision || 0;
+    return precision
+      ? (Math.random() * 10000).toFixed(precision)
+      : Math.random() * 10000;
   } else if (schema.type === 'image' || schema.type === 'static-image') {
     return placeholderImage;
   } else if (schema.type === 'images' || schema.type === 'static-images') {

--- a/packages/amis-editor-core/src/mocker.ts
+++ b/packages/amis-editor-core/src/mocker.ts
@@ -17,6 +17,8 @@ export function mockValue(schema: any) {
     schema.type === 'input-month'
   ) {
     return moment().format('X');
+  } else if (schema.type === 'number' || schema.type === 'input-number') {
+    return (Math.random() * 10000).toFixed(2);
   } else if (schema.type === 'image' || schema.type === 'static-image') {
     return placeholderImage;
   } else if (schema.type === 'images' || schema.type === 'static-images') {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f9f04d5</samp>

Improve mock data generation for number types in `amis-editor-core`. Add a case to `mockValue` function to generate random numbers with two decimal places for `number` or `input-number` schema types.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f9f04d5</samp>

> _`mockValue` grows_
> _random numbers with decimals_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f9f04d5</samp>

* Add a case to generate random numbers for number schema types ([link](https://github.com/baidu/amis/pull/6583/files?diff=unified&w=0#diff-598550b3491ef0a16165552ed67edef56920744a0638a1321d3f9bb609cc18d1R20-R21))
