### PR TITLE
chore(amis-editor): 调整部分 ts 逻辑

### DIFF
--- a/packages/amis-editor-core/package.json
+++ b/packages/amis-editor-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amis-editor-core",
-  "version": "5.2.5-alpha.12",
+  "version": "5.2.5-alpha.16",
   "description": "amis 可视化编辑器",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/packages/amis-editor-core/src/builder/ApiBuilder.ts
+++ b/packages/amis-editor-core/src/builder/ApiBuilder.ts
@@ -2,7 +2,7 @@
  * API数据源处理器
  */
 
-import {Schema, toast} from 'amis';
+import {toast} from 'amis';
 import {
   DSBuilder,
   DSFeature,

--- a/packages/amis-editor-core/src/component/ClassNameControl.tsx
+++ b/packages/amis-editor-core/src/component/ClassNameControl.tsx
@@ -1,6 +1,6 @@
 import {FormItem, utils, Button, Overlay, PopOver, RendererProps} from 'amis';
 import React from 'react';
-import {Schema} from 'amis';
+import type {Schema} from 'amis';
 import {findDOMNode} from 'react-dom';
 
 interface ClassNameControlProps extends RendererProps {

--- a/packages/amis-editor-core/src/component/ContainerWrapper.tsx
+++ b/packages/amis-editor-core/src/component/ContainerWrapper.tsx
@@ -2,7 +2,7 @@ import {NodeWrapper, NodeWrapperProps} from './NodeWrapper';
 import React from 'react';
 import {observer} from 'mobx-react';
 import {autobind} from '../util';
-import {Schema} from 'amis';
+import type {Schema} from 'amis';
 import find from 'lodash/find';
 import {RegionWrapper} from './RegionWrapper';
 

--- a/packages/amis-editor-core/src/component/IFramePreview.tsx
+++ b/packages/amis-editor-core/src/component/IFramePreview.tsx
@@ -4,7 +4,7 @@ import {EditorStoreType} from '../store/editor';
 import {render, toast, resolveRenderer, resizeSensor} from 'amis';
 import {autobind} from '../util';
 import {RendererConfig, RenderOptions} from 'amis-core';
-import {Schema} from 'amis';
+import type {Schema} from 'amis';
 import {ErrorRenderer} from './base/ErrorRenderer';
 import cx from 'classnames';
 import {findDOMNode} from 'react-dom';

--- a/packages/amis-editor-core/src/component/Preview.tsx
+++ b/packages/amis-editor-core/src/component/Preview.tsx
@@ -3,7 +3,7 @@ import React, {Component} from 'react';
 import cx from 'classnames';
 import {autobind, guid, noop, reactionWithOldValue} from '../util';
 import {clearStoresCache, RenderOptions} from 'amis-core';
-import {Schema} from 'amis';
+import type {Schema} from 'amis';
 import {EditorStoreType} from '../store/editor';
 import {observer} from 'mobx-react';
 import {findDOMNode} from 'react-dom';

--- a/packages/amis-editor-core/src/component/RendererThumb.tsx
+++ b/packages/amis-editor-core/src/component/RendererThumb.tsx
@@ -1,4 +1,5 @@
-import {LazyComponent, Schema} from 'amis-core';
+import type {Schema} from 'amis-core';
+import {LazyComponent} from 'amis-core';
 import React from 'react';
 import {resizeSensor, render, Icon} from 'amis';
 

--- a/packages/amis-editor-core/src/component/factory.tsx
+++ b/packages/amis-editor-core/src/component/factory.tsx
@@ -16,7 +16,7 @@ import {render as reactRender, unmountComponentAtNode} from 'react-dom';
 import {autobind, diff} from '../util';
 import {createObject} from 'amis-core';
 import {CommonConfigWrapper} from './CommonConfigWrapper';
-import {Schema} from 'amis';
+import type {Schema} from 'amis';
 import type {DataScope} from 'amis-core';
 import type {RendererConfig} from 'amis-core/lib/factory';
 import {SchemaCollection} from 'amis/lib/Schema';

--- a/packages/amis-editor-core/src/store/editor.ts
+++ b/packages/amis-editor-core/src/store/editor.ts
@@ -42,7 +42,7 @@ import {
   JSONPipeOut,
   JSONUpdate
 } from '../util';
-import {Schema} from 'amis';
+import type {Schema} from 'amis';
 import {toast, resolveVariable} from 'amis';
 import find from 'lodash/find';
 import {InsertSubRendererPanel} from '../component/Panel/InsertSubRendererPanel';

--- a/packages/amis-editor/package.json
+++ b/packages/amis-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amis-editor",
-  "version": "5.2.5-alpha.12",
+  "version": "5.2.5-alpha.16",
   "description": "amis 可视化编辑器",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/packages/amis-editor/src/plugin/TableCell2.tsx
+++ b/packages/amis-editor/src/plugin/TableCell2.tsx
@@ -12,9 +12,9 @@ import {
   AfterBuildPanelBody,
   defaultValue,
   getSchemaTpl,
-  tipedLabel,
-  DSField
+  tipedLabel
 } from 'amis-editor-core';
+import type {DSField} from 'amis-editor-core';
 import {fromPairs} from 'lodash';
 import {TabsSchema} from 'amis/lib/renderers/Tabs';
 import {SchemaObject} from 'amis/lib/Schema';

--- a/packages/amis-editor/src/renderer/DataBindingControl.tsx
+++ b/packages/amis-editor/src/renderer/DataBindingControl.tsx
@@ -18,13 +18,8 @@ import {
 } from 'amis-core';
 import {debounce, remove} from 'lodash';
 import React from 'react';
-import {
-  EditorManager,
-  EditorNodeType,
-  autobind,
-  DSField,
-  DSFieldGroup
-} from 'amis-editor-core';
+import {EditorManager, EditorNodeType, autobind} from 'amis-editor-core';
+import type {DSField, DSFieldGroup} from 'amis-editor-core';
 import {matchSorter} from 'match-sorter';
 import {SchemaCollection} from 'amis/lib/Schema';
 import {default as cx} from 'classnames';

--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -4,9 +4,9 @@ import {
   defaultValue,
   isObject,
   tipedLabel,
-  DSField,
   EditorManager
 } from 'amis-editor-core';
+import type {DSField} from 'amis-editor-core';
 import {SchemaObject} from 'amis/lib/Schema';
 import flatten from 'lodash/flatten';
 import _ from 'lodash';


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a42bba3</samp>

This pull request updates the versions of the amis-editor-core and amis-editor packages and changes some imports from value imports to type imports. This improves the code quality, reduces unnecessary dependencies, and optimizes the bundling process. The affected files are mostly related to the amis-editor-core component and its usage in the amis-editor plugin.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a42bba3</samp>

> _`Schema` imports_
> _Changed to type, not value_
> _Winter pruning code_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a42bba3</samp>

*  Update the version of amis-editor-core and amis-editor packages to 5.2.5-alpha.16 ([link](https://github.com/baidu/amis/pull/6586/files?diff=unified&w=0#diff-a4748fb9fe2d46502c7750a6b7c1cf5b4421968cea8501b3a9aaccb825ca35ecL3-R3), [link](https://github.com/baidu/amis/pull/6586/files?diff=unified&w=0#diff-7ae8386aceb47f61a4a2b316c8113f28fa64c584162ac38e128559bda675b242L3-R3))
*  Change the Schema import from amis to a type import in several files, to improve code quality and performance ([link](https://github.com/baidu/amis/pull/6586/files?diff=unified&w=0#diff-9535aa7ed3a9f30ed832ccc42c80ff7c484ffedeae2d2454d8d4e6d88b58073cL5-R5), [link](https://github.com/baidu/amis/pull/6586/files?diff=unified&w=0#diff-45db8cde12aead9319ecae30f2bee228aa43f1562cf7076b371aee39b9429e97L3-R3), [link](https://github.com/baidu/amis/pull/6586/files?diff=unified&w=0#diff-9c09a4c4a0db1c39149f5c47a5ddbee7074e9f14f23eb626d2f230696765c235L5-R5), [link](https://github.com/baidu/amis/pull/6586/files?diff=unified&w=0#diff-acafbdd055d55bdea83368e433e85e8c5d1831c9af33a8e21501cd24ac33128cL7-R7), [link](https://github.com/baidu/amis/pull/6586/files?diff=unified&w=0#diff-d9b508133ad06e8946597f0255a1b4529b6fb9f0c2bf3c170e0fcef582fff0e9L6-R6), [link](https://github.com/baidu/amis/pull/6586/files?diff=unified&w=0#diff-5bcb2370bda7a8f3b1b692f3d568f62e4fd6aadd951424c0b7340c1ef5f40fe1L19-R19), [link](https://github.com/baidu/amis/pull/6586/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8L45-R45))
*  Change the Schema import from amis-core to a type import in `ClassNameControl.tsx` and `RendererThumb.tsx`, and move the LazyComponent import to a separate line in the latter file, for the same reasons as above ([link](https://github.com/baidu/amis/pull/6586/files?diff=unified&w=0#diff-45db8cde12aead9319ecae30f2bee228aa43f1562cf7076b371aee39b9429e97L3-R3), [link](https://github.com/baidu/amis/pull/6586/files?diff=unified&w=0#diff-662e7f652786f19331e4d731a5dc40f65ca86e303788b252e0f8a1e36ffb2541L1-R2))
*  Change the DSField, DSFieldGroup, and DSFieldArray imports from amis-editor-core to type imports in `TableCell2.tsx`, `DataBindingControl.tsx`, and `common.tsx`, and move them to separate lines where necessary, for the same reasons as above ([link](https://github.com/baidu/amis/pull/6586/files?diff=unified&w=0#diff-c7da298719acb9527ea1c1920686a38dbb5ccbebfe4a6a745d59df3271c28ed7L15-R17), [link](https://github.com/baidu/amis/pull/6586/files?diff=unified&w=0#diff-356912b33e7beb16160bcb11dd6545ab163826d831934adee56510cbd4ea490bL21-R22), [link](https://github.com/baidu/amis/pull/6586/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05L7-R9))
