### PR TITLE
fix: CRUD组件列类型为mapping时导出excel展示错误

### DIFF
--- a/docs/zh-CN/components/crud.md
+++ b/docs/zh-CN/components/crud.md
@@ -1845,7 +1845,11 @@ crud 组件支持通过配置`headerToolbar`和`footerToolbar`属性，实现在
         },
         {
             "name": "grade",
-            "label": "CSS grade"
+            "label": "CSS grade",
+            "type": "mapping",
+            "map": {
+                "*": "<span class=\"label label-info\">${grade}</span>"
+            }
         }
     ]
 }
@@ -1862,11 +1866,13 @@ crud 组件支持通过配置`headerToolbar`和`footerToolbar`属性，实现在
     "type": "crud",
     "syncLocation": false,
     "api": "/api/mock2/sample",
-    "headerToolbar": [{
-        "type": "export-csv",
-        "label": "全量导出 CSV",
-        "api": "/api/mock2/sample"
-    }],
+    "headerToolbar": [
+        {
+            "type": "export-csv",
+            "label": "全量导出 CSV",
+            "api": "/api/mock2/sample"
+        }
+    ],
     "columns": [
         {
             "name": "id",
@@ -1890,7 +1896,11 @@ crud 组件支持通过配置`headerToolbar`和`footerToolbar`属性，实现在
         },
         {
             "name": "grade",
-            "label": "CSS grade"
+            "label": "CSS grade",
+            "type": "mapping",
+            "map": {
+                "*": "<span class=\"label label-info\">${grade}</span>"
+            }
         }
     ]
 }
@@ -1933,7 +1943,11 @@ crud 组件支持通过配置`headerToolbar`和`footerToolbar`属性，实现在
         },
         {
             "name": "grade",
-            "label": "CSS grade"
+            "label": "CSS grade",
+            "type": "mapping",
+            "map": {
+                "*": "<span class=\"label label-info\">${grade}</span>"
+            }
         }
     ]
 }

--- a/packages/amis/src/renderers/Table/exportExcel.ts
+++ b/packages/amis/src/renderers/Table/exportExcel.ts
@@ -275,7 +275,16 @@ export async function exportExcel(
               : value === false && map['0']
               ? map['0']
               : map['*']); // 兼容平台旧用法：即 value 为 true 时映射 1 ，为 false 时映射 0
-          sheetRow.getCell(columIndex).value = removeHTMLTag(viewValue);
+          let text = removeHTMLTag(viewValue);
+
+          /** map可能会使用比较复杂的html结构，富文本也无法完全支持，直接把里面的变量解析出来即可 */
+          if (isPureVariable(text)) {
+            text = resolveVariableAndFilter(text, rowData, '| raw');
+          } else {
+            text = filter(text, rowData);
+          }
+
+          sheetRow.getCell(columIndex).value = text;
         } else {
           sheetRow.getCell(columIndex).value = removeHTMLTag(value);
         }

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -2622,7 +2622,6 @@ export default class Table extends React.Component<TableProps, object> {
       data,
       render
     } = this.props;
-
     let columns = store.filteredColumns || [];
 
     if (!columns) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a8986e</samp>

This pull request improves the `crud` component's documentation and export functionality. It adds support for customizing the exported CSV and Excel data using the `type` and `map` properties of the columns. It also fixes a bug that caused the exported Excel data to show raw variables or filter expressions instead of resolved values.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0a8986e</samp>

> _We are the masters of the spreadsheet_
> _We export the data with no regret_
> _We parse the variables and the filters_
> _We resolve the values with our skills_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0a8986e</samp>

*  Fix a bug that caused the exported Excel data to show the raw variable or filter expression instead of the resolved value ([link](https://github.com/baidu/amis/pull/6592/files?diff=unified&w=0#diff-8814befa6c6247c465ab39fa28f3db15c2280e238d8254286fa1f29d29500c51L278-R287))
*  Add `type` and `map` properties to the `grade` column in the `docs/zh-CN/components/crud.md` file to demonstrate how to customize the appearance of the exported CSV and Excel data using the mapping feature ([link](https://github.com/baidu/amis/pull/6592/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653L1848-R1852), [link](https://github.com/baidu/amis/pull/6592/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653L1893-R1903), [link](https://github.com/baidu/amis/pull/6592/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653L1936-R1950))
*  Format the `headerToolbar` property as an array of objects in the `docs/zh-CN/components/crud.md` file to make the code more consistent with the rest of the documentation and the actual usage of the property ([link](https://github.com/baidu/amis/pull/6592/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653L1865-R1875))
*  Remove an empty line of code from the `packages/amis/src/renderers/Table/index.tsx` file ([link](https://github.com/baidu/amis/pull/6592/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2625))
