### PR TITLE
fix: 修复开发态编辑器没有主题和翻译的问题

### DIFF
--- a/packages/amis-editor/examples/Editor.tsx
+++ b/packages/amis-editor/examples/Editor.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable */
 import * as React from 'react';
-import {Editor, ShortcutKey, BasePlugin} from '../src/index';
+import {Editor, ShortcutKey, BasePlugin, setThemeConfig} from '../src/index';
 import {Select, Renderer, uuid, Button} from 'amis';
 import {currentLocale} from 'i18n-runtime';
 import {Portal} from 'react-overlays';
 import {Icon} from './icons/index';
 import LayoutList from './layout/index';
+import themeConfig from 'amis-theme-editor-helper/lib/systemTheme/cxd';
 
 // 测试组织属性配置面板的国际化，可以放开如下注释
 // import '../renderer/InputTextI18n';
@@ -13,6 +14,7 @@ import LayoutList from './layout/index';
 // import '../utils/overwriteSchemaTpl';
 // const i18nEnabled = true;
 const i18nEnabled = false;
+setThemeConfig(themeConfig);
 
 const schema = {
   type: 'page',

--- a/packages/amis-editor/src/index.tsx
+++ b/packages/amis-editor/src/index.tsx
@@ -184,6 +184,8 @@ import './renderer/TransferTableControl';
 import './renderer/style-control/ThemeCssCode';
 import './renderer/ButtonGroupControl';
 import './renderer/FlexSettingControl';
+import 'amis-theme-editor/lib/locale/zh-CN';
+import 'amis-theme-editor/lib/locale/en-US';
 import 'amis-theme-editor/lib/renderers/Border';
 import 'amis-theme-editor/lib/renderers/ColorPicker';
 import 'amis-theme-editor/lib/renderers/Font';


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca122f6</samp>

This pull request enhances the amis-editor package by adding theme configuration and internationalization support. It uses the `amis-theme-editor-helper` and `amis-theme-editor` packages to set the default theme and import the locale files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ca122f6</samp>

> _We are the masters of the theme_
> _We set the colors and the scheme_
> _With `setThemeConfig` we unleash our power_
> _With `themeConfig` we make the editor ours_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca122f6</samp>

* Import and apply the default theme configuration for the editor ([link](https://github.com/baidu/amis/pull/6594/files?diff=unified&w=0#diff-ac37ef7e74b39117226be066461e8c65edafc2318cf9874536ac80f09b6f9f41L3-R3), [link](https://github.com/baidu/amis/pull/6594/files?diff=unified&w=0#diff-ac37ef7e74b39117226be066461e8c65edafc2318cf9874536ac80f09b6f9f41R9), [link](https://github.com/baidu/amis/pull/6594/files?diff=unified&w=0#diff-ac37ef7e74b39117226be066461e8c65edafc2318cf9874536ac80f09b6f9f41R17))
* Import the locale files for `zh-CN` and `en-US` to support internationalization for the editor ([link](https://github.com/baidu/amis/pull/6594/files?diff=unified&w=0#diff-fa77f562c6a58cf12dee0f269ae4d27bbbdd30fb852016af309b4bd6fe1b6cd5R187-R188))
