### PR TITLE
feat: wizard组件样式交互改造

### DIFF
--- a/docs/zh-CN/components/wizard.md
+++ b/docs/zh-CN/components/wizard.md
@@ -16,7 +16,6 @@ order: 73
 {
     "type": "wizard",
     "initApi": "/api/mock2/form/saveForm?waitSeconds=2",
-    "mode": "vertical",
     "steps": [
         {
             "title": "第一步",

--- a/examples/components/Example.jsx
+++ b/examples/components/Example.jsx
@@ -128,6 +128,7 @@ import Loading from './Loading';
 import CodeSchema from './Code';
 import OfficeViewer from './OfficeViewer';
 import InputTableEvent from './EventAction/cmpt-event-action/InputTableEvent';
+import WizardPage from './WizardPage';
 
 import {Switch} from 'react-router-dom';
 import {navigations2route} from './App';
@@ -908,6 +909,13 @@ export const examples = [
 
           return null;
         }
+      },
+
+      {
+        label: 'wizard页面',
+        icon: 'fa fa-desktop',
+        path: '/examples/wizard-page',
+        component: makeSchemaRenderer(WizardPage)
       }
 
       // {

--- a/examples/components/WizardPage.jsx
+++ b/examples/components/WizardPage.jsx
@@ -1,0 +1,117 @@
+export default {
+  "type": "page",
+  "title": "Simple Form Page",
+  "regions": [
+    "body"
+  ],
+  "body": [
+    {
+      "type": "wizard",
+      "steps": [
+        {
+          "title": "基本信息",
+          "hiddenOn": "${!validateCode}",
+          "body": [
+            {
+              "type": "input-text",
+              "label": "用户名",
+              "name": "username",
+              "value": "12121123123",
+              "mode": "horizontal"
+            },
+            {
+              "type": "input-password",
+              "label": "密码",
+              "name": "password",
+              "value": "qwerasdfzxcv",
+              "mode": "horizontal"
+            },
+            {
+              "type": "input-password",
+              "label": "确认密码",
+              "name": "confirmPassword",
+              "mode": "horizontal"
+            },
+            {
+              "type": "button-group-select",
+              "name": "hiddenTest",
+              "label": "测试下隐藏",
+              "inline": false,
+              "value": 1,
+              "options": [
+                {
+                  "label": "选项1",
+                  "value": 1
+                },
+                {
+                  "label": "选项2",
+                  "value": 2
+                }
+              ],
+              "id": "u:20069f4652a4",
+              "multiple": false,
+              "mode": "horizontal"
+            }
+          ],
+          "id": "u:4a7fd475044b",
+          "mode": "normal"
+        },
+        {
+          "title": "验证码",
+          "body": [
+            {
+              "type": "input-group",
+              "label": "验证码",
+              "body": [
+                {
+                  "type": "input-text",
+                  "label": "验证码",
+                  "name": "validateCode",
+                  "mode": "horizontal"
+                },
+                {
+                  "type": "button",
+                  "label": "发送验证码"
+                }
+              ]
+            }
+          ],
+          "mode": "normal"
+        },
+        {
+          "title": "确认信息",
+          "body": [
+            {
+              "type": "tpl",
+              "tpl": "用户名: ${username}"
+            },
+            {
+              "type": "input-text",
+              "name": "hahahha"
+            }
+          ],
+          "mode": "normal"
+        }
+      ],
+      "id": "u:4bd3ac2a9a78",
+      "mode": "horizontal",
+      "stepsClassName": "w-1/2 mx-auto",
+      "wrapWithPanel": false,
+      "footerClassName": "bg-white fixed -bottom-0 w-full",
+      "className": "bg-gray-50 overflow-hidden h-full -mx-3 -my-4",
+      "stepClassName": "overflow-hidden mb-14",
+      "bodyClassName": "bg-white wizard-body"
+    }
+  ],
+  "id": "u:ee4880c00289",
+  "pullRefresh": {
+    "disabled": true
+  },
+  "css": {
+    ".wizard-body": {
+      "margin": "16px",
+      "padding": "24px"
+    }
+  },
+  "className": "h-full"
+}

--- a/packages/amis-ui/scss/components/_steps.scss
+++ b/packages/amis-ui/scss/components/_steps.scss
@@ -385,6 +385,14 @@
       content: var(--steps-simple-icon);
     }
   }
+
+  .#{$ns}StepsItem.is-clickable {
+    .#{$ns}StepsItem-container {
+      &ProgressDot, &Icon, &Wrapper {
+        cursor: pointer;
+      }
+    }
+  }
 }
 
 .#{$ns}Steps-mobile.#{$ns}Steps--horizontal {

--- a/packages/amis-ui/scss/components/_wizard.scss
+++ b/packages/amis-ui/scss/components/_wizard.scss
@@ -222,6 +222,21 @@
     }
   }
 
+  &-footer {
+    padding: var(--sizes-size-5) var(--sizes-size-7);
+    .#{$ns}Button {
+      &+.#{$ns}Button {
+        margin-left: var(--Panel-footerButtonMarginLeft)
+      }
+    }
+  }
+
+  &-fixedButtom {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+  }
+
   &--vertical {
     > .#{$ns}Wizard-step {
       display: flex;

--- a/packages/amis-ui/src/components/Steps.tsx
+++ b/packages/amis-ui/src/components/Steps.tsx
@@ -90,6 +90,7 @@ export interface StepsProps extends ThemeProps {
   labelPlacement?: 'horizontal' | 'vertical';
   progressDot?: boolean;
   useMobileUI?: boolean;
+  onClickStep?: (i: number, step: StepObject) => void;
 }
 
 export function Steps(props: StepsProps) {
@@ -103,7 +104,8 @@ export function Steps(props: StepsProps) {
     mode = 'horizontal',
     labelPlacement = 'horizontal',
     progressDot = false,
-    useMobileUI
+    useMobileUI,
+    onClickStep
   } = props;
   const FINISH_ICON = 'check';
   const ERROR_ICON = 'close';
@@ -165,26 +167,28 @@ export function Steps(props: StepsProps) {
               'StepsItem',
               `is-${stepStatus}`,
               step.className,
-              `StepsItem-${progressDot ? 'ProgressDot' : ''}`
+              `${progressDot ? 'StepsItem-ProgressDot' : ''}`,
+              `${onClickStep && stepStatus === StepStatus.finish ? 'is-clickable' : ''}`
             )}
           >
             <div className={cx('StepsItem-container')}>
               <div className={cx('StepsItem-containerTail')}></div>
               {progressDot ? (
-                <div className={cx('StepsItem-containerProgressDot')}></div>
+                <div className={cx('StepsItem-containerProgressDot')} onClick={() => (onClickStep && onClickStep(i, step))}></div>
               ) : (
                 <div
                   className={cx(
                     'StepsItem-containerIcon',
                     i < current && 'is-success'
                   )}
+                  onClick={() => (onClickStep && onClickStep(i, step))}
                 >
                   <span className={cx('StepsItem-icon', step.iconClassName)}>
                     {icon ? <Icon icon={icon} className="icon" /> : i + 1}
                   </span>
                 </div>
               )}
-              <div className={cx('StepsItem-containerWrapper')}>
+              <div className={cx('StepsItem-containerWrapper')} onClick={() => (onClickStep && onClickStep(i, step))}>
                 <div className={cx('StepsItem-body')}>
                   <div
                     className={cx(

--- a/packages/amis-ui/src/locale/de-DE.ts
+++ b/packages/amis-ui/src/locale/de-DE.ts
@@ -241,7 +241,8 @@ register('de-DE', {
   'Table.valueField': 'valueField muss vorhanden sein',
   'Table.index': 'Index',
   'Table.add': 'Neu',
-  'Table.addButtonDisabledTip': 'Reichen Sie bei der Inhaltsbearbeitung zuerst ein und erstellen Sie dann eine neue Option',
+  'Table.addButtonDisabledTip':
+    'Reichen Sie bei der Inhaltsbearbeitung zuerst ein und erstellen Sie dann eine neue Option',
   'Table.toggleColumn': 'Spalten anzeigen',
   'Table.searchFields': 'Abfragefelder setzen',
   'Tag.placeholder': 'Noch kein Tag',
@@ -405,5 +406,6 @@ register('de-DE', {
   'JSONSchema.description': 'Description',
   'JSONSchema.key': 'Key',
   'JSONSchema.array_items': 'Items',
-  'TimeNow': 'Jetzt'
+  'TimeNow': 'Jetzt',
+  'Steps.step': 'Schritt {{index}}'
 });

--- a/packages/amis-ui/src/locale/en-US.ts
+++ b/packages/amis-ui/src/locale/en-US.ts
@@ -233,7 +233,8 @@ register('en-US', {
   'Table.valueField': 'Must have valueField',
   'Table.index': 'Index',
   'Table.add': 'Add',
-  'Table.addButtonDisabledTip': 'In content editing, please submit first and then create a new option',
+  'Table.addButtonDisabledTip':
+    'In content editing, please submit first and then create a new option',
   'Table.toggleColumn': 'Display columns',
   'Table.searchFields': 'Set query fields',
   'Tag.placeholder': 'No tag yet',
@@ -393,5 +394,6 @@ register('en-US', {
   'JSONSchema.array_items': 'Items',
   'TimeNow': 'Now',
   'IconSelect.all': 'All',
-  'IconSelect.choice': 'Icon selection'
+  'IconSelect.choice': 'Icon selection',
+  'Steps.step': 'Step {{index}}'
 });

--- a/packages/amis-ui/src/locale/zh-CN.ts
+++ b/packages/amis-ui/src/locale/zh-CN.ts
@@ -389,5 +389,6 @@ register('zh-CN', {
   'Required': '必填',
   'TimeNow': '此刻',
   'IconSelect.all': '全部',
-  'IconSelect.choice': '图标选择'
+  'IconSelect.choice': '图标选择',
+  'Steps.step': '第 {{index}} 步'
 });

--- a/packages/amis/__tests__/renderers/Wizard.test.tsx
+++ b/packages/amis/__tests__/renderers/Wizard.test.tsx
@@ -1338,6 +1338,7 @@ test('Renderer:Wizard steps not array', async () => {
       steps: ''
     })
   );
+
   await waitFor(() => {
     expect(getByText('配置错误')).toBeInTheDocument();
   });
@@ -1537,8 +1538,12 @@ test('Renderer:Wizard mode', async () => {
       makeEnv()
     )
   );
-  const steps = container.querySelectorAll('li');
 
-  expect(steps[0].className).toBe('is-complete');
-  expect(steps[1].className).toBe('is-active');
+  waitFor(() => {
+    const steps = container.querySelectorAll('li');
+
+    expect(steps[0].className).toBe('is-finish');
+    expect(steps[1].className).toBe('is-process');
+  });
+
 });

--- a/packages/amis/__tests__/renderers/__snapshots__/Steps.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Steps.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Renderer:steps 1`] = `
     class="cxd-Steps cxd-Steps--Placement- cxd-Steps-- cxd-Steps--horizontal"
   >
     <li
-      class="cxd-StepsItem is-process className cxd-StepsItem-"
+      class="cxd-StepsItem is-process className"
     >
       <div
         class="cxd-StepsItem-container"
@@ -61,7 +61,7 @@ exports[`Renderer:steps 1`] = `
       </div>
     </li>
     <li
-      class="cxd-StepsItem is-wait cxd-StepsItem-"
+      class="cxd-StepsItem is-wait"
     >
       <div
         class="cxd-StepsItem-container"
@@ -105,7 +105,7 @@ exports[`Renderer:steps 1`] = `
       </div>
     </li>
     <li
-      class="cxd-StepsItem is-wait cxd-StepsItem-"
+      class="cxd-StepsItem is-wait"
     >
       <div
         class="cxd-StepsItem-container"
@@ -158,7 +158,7 @@ exports[`Renderer:steps 2`] = `
     class="cxd-Steps cxd-Steps--Placement- cxd-Steps-- cxd-Steps--horizontal"
   >
     <li
-      class="cxd-StepsItem is-process className cxd-StepsItem-"
+      class="cxd-StepsItem is-process className"
     >
       <div
         class="cxd-StepsItem-container"
@@ -213,7 +213,7 @@ exports[`Renderer:steps 2`] = `
       </div>
     </li>
     <li
-      class="cxd-StepsItem is-wait cxd-StepsItem-"
+      class="cxd-StepsItem is-wait"
     >
       <div
         class="cxd-StepsItem-container"
@@ -257,7 +257,7 @@ exports[`Renderer:steps 2`] = `
       </div>
     </li>
     <li
-      class="cxd-StepsItem is-wait cxd-StepsItem-"
+      class="cxd-StepsItem is-wait"
     >
       <div
         class="cxd-StepsItem-container"
@@ -310,7 +310,7 @@ exports[`Renderer:steps labelPlacement 1`] = `
     class="cxd-Steps cxd-Steps--Placement-vertical cxd-Steps-- cxd-Steps--horizontal className"
   >
     <li
-      class="cxd-StepsItem is-process cxd-StepsItem-"
+      class="cxd-StepsItem is-process"
     >
       <div
         class="cxd-StepsItem-container"
@@ -354,7 +354,7 @@ exports[`Renderer:steps labelPlacement 1`] = `
       </div>
     </li>
     <li
-      class="cxd-StepsItem is-wait cxd-StepsItem-"
+      class="cxd-StepsItem is-wait"
     >
       <div
         class="cxd-StepsItem-container"
@@ -406,7 +406,7 @@ exports[`Renderer:steps labelPlacement 1`] = `
       </div>
     </li>
     <li
-      class="cxd-StepsItem is-wait cxd-StepsItem-"
+      class="cxd-StepsItem is-wait"
     >
       <div
         class="cxd-StepsItem-container"
@@ -590,7 +590,7 @@ exports[`Renderer:steps status 1`] = `
     class="cxd-Steps cxd-Steps--Placement- cxd-Steps-- cxd-Steps--horizontal className"
   >
     <li
-      class="cxd-StepsItem is-finish cxd-StepsItem-"
+      class="cxd-StepsItem is-finish"
     >
       <div
         class="cxd-StepsItem-container"
@@ -634,7 +634,7 @@ exports[`Renderer:steps status 1`] = `
       </div>
     </li>
     <li
-      class="cxd-StepsItem is-error cxd-StepsItem-"
+      class="cxd-StepsItem is-error"
     >
       <div
         class="cxd-StepsItem-container"
@@ -686,7 +686,7 @@ exports[`Renderer:steps status 1`] = `
       </div>
     </li>
     <li
-      class="cxd-StepsItem is-wait cxd-StepsItem-"
+      class="cxd-StepsItem is-wait"
     >
       <div
         class="cxd-StepsItem-container"

--- a/packages/amis/__tests__/renderers/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Wizard.test.tsx.snap
@@ -121,6 +121,13 @@ exports[`Renderer:Wizard actionPrevLabel actionNextLabel actionFinishLabel class
             style="display: none;"
             type="submit"
           />
+          <span
+            class="cxd-TplField"
+          >
+            <span>
+              这是最后一步了
+            </span>
+          </span>
         </form>
       </div>
       <div
@@ -725,6 +732,89 @@ exports[`Renderer:Wizard dialog 1`] = `
                     style="display: none;"
                     type="submit"
                   />
+                  <div
+                    class="cxd-Form-item cxd-Form-item--normal"
+                    data-role="form-item"
+                  >
+                    <label
+                      class="cxd-Form-label"
+                    >
+                      <span>
+                        <span
+                          class="cxd-TplField"
+                        >
+                          <span>
+                            网址
+                          </span>
+                        </span>
+                      </span>
+                    </label>
+                    <div
+                      class="cxd-Form-control cxd-TextControl"
+                    >
+                      <div
+                        class="cxd-TextControl-input"
+                      >
+                        <input
+                          autocomplete="off"
+                          class=""
+                          name="website"
+                          placeholder=""
+                          size="10"
+                          type="url"
+                          value="http://amis.baidu.com"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="cxd-Form-item cxd-Form-item--normal"
+                    data-role="form-item"
+                  >
+                    <label
+                      class="cxd-Form-label"
+                    >
+                      <span>
+                        <span
+                          class="cxd-TplField"
+                        >
+                          <span>
+                            名称
+                          </span>
+                        </span>
+                      </span>
+                    </label>
+                    <div
+                      class="cxd-Form-control cxd-TextControl"
+                    >
+                      <div
+                        class="cxd-TextControl-input"
+                      >
+                        <input
+                          autocomplete="off"
+                          class=""
+                          name="name"
+                          placeholder=""
+                          size="10"
+                          type="text"
+                          value="Amis"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="cxd-Form-item cxd-Form-item--normal"
+                    data-role="form-item"
+                  >
+                    <button
+                      class="cxd-Button cxd-Button--default cxd-Button--size-default"
+                      type="button"
+                    >
+                      <span>
+                        OpenDialog
+                      </span>
+                    </button>
+                  </div>
                 </form>
               </div>
               <div
@@ -1031,6 +1121,89 @@ exports[`Renderer:Wizard dialog 2`] = `
                     style="display: none;"
                     type="submit"
                   />
+                  <div
+                    class="cxd-Form-item cxd-Form-item--normal"
+                    data-role="form-item"
+                  >
+                    <label
+                      class="cxd-Form-label"
+                    >
+                      <span>
+                        <span
+                          class="cxd-TplField"
+                        >
+                          <span>
+                            网址
+                          </span>
+                        </span>
+                      </span>
+                    </label>
+                    <div
+                      class="cxd-Form-control cxd-TextControl"
+                    >
+                      <div
+                        class="cxd-TextControl-input"
+                      >
+                        <input
+                          autocomplete="off"
+                          class=""
+                          name="website"
+                          placeholder=""
+                          size="10"
+                          type="url"
+                          value="http://amis.baidu.com"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="cxd-Form-item cxd-Form-item--normal"
+                    data-role="form-item"
+                  >
+                    <label
+                      class="cxd-Form-label"
+                    >
+                      <span>
+                        <span
+                          class="cxd-TplField"
+                        >
+                          <span>
+                            名称
+                          </span>
+                        </span>
+                      </span>
+                    </label>
+                    <div
+                      class="cxd-Form-control cxd-TextControl"
+                    >
+                      <div
+                        class="cxd-TextControl-input"
+                      >
+                        <input
+                          autocomplete="off"
+                          class=""
+                          name="name"
+                          placeholder=""
+                          size="10"
+                          type="text"
+                          value="Amis"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="cxd-Form-item cxd-Form-item--normal"
+                    data-role="form-item"
+                  >
+                    <button
+                      class="cxd-Button cxd-Button--default cxd-Button--size-default"
+                      type="button"
+                    >
+                      <span>
+                        OpenDialog
+                      </span>
+                    </button>
+                  </div>
                 </form>
               </div>
               <div
@@ -1553,6 +1726,76 @@ exports[`Renderer:Wizard initApi reload 1`] = `
                     style="display: none;"
                     type="submit"
                   />
+                  <div
+                    class="cxd-Form-item cxd-Form-item--normal"
+                    data-role="form-item"
+                  >
+                    <label
+                      class="cxd-Form-label"
+                    >
+                      <span>
+                        <span
+                          class="cxd-TplField"
+                        >
+                          <span>
+                            网址
+                          </span>
+                        </span>
+                      </span>
+                    </label>
+                    <div
+                      class="cxd-Form-control cxd-TextControl"
+                    >
+                      <div
+                        class="cxd-TextControl-input"
+                      >
+                        <input
+                          autocomplete="off"
+                          class=""
+                          name="website"
+                          placeholder=""
+                          size="10"
+                          type="url"
+                          value="http://amis.baidu.com"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="cxd-Form-item cxd-Form-item--normal"
+                    data-role="form-item"
+                  >
+                    <label
+                      class="cxd-Form-label"
+                    >
+                      <span>
+                        <span
+                          class="cxd-TplField"
+                        >
+                          <span>
+                            名称
+                          </span>
+                        </span>
+                      </span>
+                    </label>
+                    <div
+                      class="cxd-Form-control cxd-TextControl"
+                    >
+                      <div
+                        class="cxd-TextControl-input"
+                      >
+                        <input
+                          autocomplete="off"
+                          class=""
+                          name="name"
+                          placeholder=""
+                          size="10"
+                          type="text"
+                          value="Amis"
+                        />
+                      </div>
+                    </div>
+                  </div>
                 </form>
               </div>
               <div
@@ -1758,6 +2001,13 @@ exports[`Renderer:Wizard initApi reload 2`] = `
                     style="display: none;"
                     type="submit"
                   />
+                  <span
+                    class="cxd-TplField"
+                  >
+                    <span>
+                      这是最后一步了
+                    </span>
+                  </span>
                 </form>
               </div>
               <div
@@ -1963,6 +2213,13 @@ exports[`Renderer:Wizard initApi reload 3`] = `
                     style="display: none;"
                     type="submit"
                   />
+                  <span
+                    class="cxd-TplField"
+                  >
+                    <span>
+                      这是最后一步了
+                    </span>
+                  </span>
                 </form>
               </div>
               <div
@@ -2270,6 +2527,86 @@ exports[`Renderer:Wizard initApi show loading 2`] = `
             style="display: none;"
             type="submit"
           />
+          <div
+            class="cxd-Form-item cxd-Form-item--normal is-required"
+            data-role="form-item"
+          >
+            <label
+              class="cxd-Form-label"
+            >
+              <span>
+                <span
+                  class="cxd-TplField"
+                >
+                  <span>
+                    网址
+                  </span>
+                </span>
+                <span
+                  class="cxd-Form-star"
+                >
+                  *
+                </span>
+              </span>
+            </label>
+            <div
+              class="cxd-Form-control cxd-TextControl"
+            >
+              <div
+                class="cxd-TextControl-input"
+              >
+                <input
+                  autocomplete="off"
+                  class=""
+                  name="website"
+                  placeholder=""
+                  size="10"
+                  type="url"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="cxd-Form-item cxd-Form-item--normal is-required"
+            data-role="form-item"
+          >
+            <label
+              class="cxd-Form-label"
+            >
+              <span>
+                <span
+                  class="cxd-TplField"
+                >
+                  <span>
+                    名称
+                  </span>
+                </span>
+                <span
+                  class="cxd-Form-star"
+                >
+                  *
+                </span>
+              </span>
+            </label>
+            <div
+              class="cxd-Form-control cxd-TextControl"
+            >
+              <div
+                class="cxd-TextControl-input"
+              >
+                <input
+                  autocomplete="off"
+                  class=""
+                  name="name"
+                  placeholder=""
+                  size="10"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
         </form>
       </div>
       <div
@@ -2600,6 +2937,13 @@ exports[`Renderer:Wizard send data 1`] = `
             style="display: none;"
             type="submit"
           />
+          <span
+            class="cxd-TplField"
+          >
+            <span>
+              这是最后一步了
+            </span>
+          </span>
         </form>
       </div>
       <div
@@ -3140,6 +3484,13 @@ exports[`Renderer:Wizard target 1`] = `
                     style="display: none;"
                     type="submit"
                   />
+                  <span
+                    class="cxd-TplField"
+                  >
+                    <span>
+                      这是最后一步了
+                    </span>
+                  </span>
                 </form>
               </div>
               <div

--- a/packages/amis/__tests__/renderers/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Wizard.test.tsx.snap
@@ -1287,7 +1287,144 @@ exports[`Renderer:Wizard initApi default 1`] = `
       <div
         class="cxd--Wizard-steps"
         id="form-wizard"
-      />
+      >
+        <ul
+          class="cxd-Steps cxd-Steps--Placement- cxd-Steps-- cxd-Steps--horizontal"
+        >
+          <li
+            class="cxd-StepsItem is-process"
+          >
+            <div
+              class="cxd-StepsItem-container"
+            >
+              <div
+                class="cxd-StepsItem-containerTail"
+              />
+              <div
+                class="cxd-StepsItem-containerIcon"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  1
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem-"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 1"
+                    >
+                      Step 1
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            class="cxd-StepsItem is-wait"
+          >
+            <div
+              class="cxd-StepsItem-container"
+            >
+              <div
+                class="cxd-StepsItem-containerTail"
+              />
+              <div
+                class="cxd-StepsItem-containerIcon"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  2
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem-"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 2"
+                    >
+                      Step 2
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            class="cxd-StepsItem is-wait"
+          >
+            <div
+              class="cxd-StepsItem-container"
+            >
+              <div
+                class="cxd-StepsItem-containerTail"
+              />
+              <div
+                class="cxd-StepsItem-containerIcon"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  3
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem-"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 3"
+                    >
+                      Step 3
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
       <div
         class="cxd-Wizard-stepContent clearfix"
         role="wizard-body"
@@ -1381,6 +1518,27 @@ exports[`Renderer:Wizard initApi default 1`] = `
             </div>
           </div>
         </form>
+      </div>
+      <div
+        class="cxd-Wizard-footer cxd-Panel-footer"
+        role="wizard-footer"
+      >
+        <div
+          class="cxd-Button cxd-Button--default cxd-Button--size-default is-disabled"
+          disabled=""
+        >
+          <span>
+            上一步
+          </span>
+        </div>
+        <button
+          class="cxd-Button cxd-Button--primary cxd-Button--size-default"
+          type="button"
+        >
+          <span>
+            下一步
+          </span>
+        </button>
       </div>
     </div>
     <div
@@ -2219,7 +2377,144 @@ exports[`Renderer:Wizard initApi show loading 2`] = `
       <div
         class="cxd--Wizard-steps"
         id="form-wizard"
-      />
+      >
+        <ul
+          class="cxd-Steps cxd-Steps--Placement- cxd-Steps-- cxd-Steps--horizontal"
+        >
+          <li
+            class="cxd-StepsItem is-process"
+          >
+            <div
+              class="cxd-StepsItem-container"
+            >
+              <div
+                class="cxd-StepsItem-containerTail"
+              />
+              <div
+                class="cxd-StepsItem-containerIcon"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  1
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem-"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 1"
+                    >
+                      Step 1
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            class="cxd-StepsItem is-wait"
+          >
+            <div
+              class="cxd-StepsItem-container"
+            >
+              <div
+                class="cxd-StepsItem-containerTail"
+              />
+              <div
+                class="cxd-StepsItem-containerIcon"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  2
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem-"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 2"
+                    >
+                      Step 2
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            class="cxd-StepsItem is-wait"
+          >
+            <div
+              class="cxd-StepsItem-container"
+            >
+              <div
+                class="cxd-StepsItem-containerTail"
+              />
+              <div
+                class="cxd-StepsItem-containerIcon"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  3
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem-"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 3"
+                    >
+                      Step 3
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
       <div
         class="cxd-Wizard-stepContent clearfix"
         role="wizard-body"
@@ -2313,6 +2608,27 @@ exports[`Renderer:Wizard initApi show loading 2`] = `
             </div>
           </div>
         </form>
+      </div>
+      <div
+        class="cxd-Wizard-footer cxd-Panel-footer"
+        role="wizard-footer"
+      >
+        <div
+          class="cxd-Button cxd-Button--default cxd-Button--size-default is-disabled"
+          disabled=""
+        >
+          <span>
+            上一步
+          </span>
+        </div>
+        <button
+          class="cxd-Button cxd-Button--primary cxd-Button--size-default"
+          type="button"
+        >
+          <span>
+            下一步
+          </span>
+        </button>
       </div>
     </div>
     <div

--- a/packages/amis/__tests__/renderers/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Wizard.test.tsx.snap
@@ -121,13 +121,6 @@ exports[`Renderer:Wizard actionPrevLabel actionNextLabel actionFinishLabel class
             style="display: none;"
             type="submit"
           />
-          <span
-            class="cxd-TplField"
-          >
-            <span>
-              这是最后一步了
-            </span>
-          </span>
         </form>
       </div>
       <div
@@ -732,89 +725,6 @@ exports[`Renderer:Wizard dialog 1`] = `
                     style="display: none;"
                     type="submit"
                   />
-                  <div
-                    class="cxd-Form-item cxd-Form-item--normal"
-                    data-role="form-item"
-                  >
-                    <label
-                      class="cxd-Form-label"
-                    >
-                      <span>
-                        <span
-                          class="cxd-TplField"
-                        >
-                          <span>
-                            网址
-                          </span>
-                        </span>
-                      </span>
-                    </label>
-                    <div
-                      class="cxd-Form-control cxd-TextControl"
-                    >
-                      <div
-                        class="cxd-TextControl-input"
-                      >
-                        <input
-                          autocomplete="off"
-                          class=""
-                          name="website"
-                          placeholder=""
-                          size="10"
-                          type="url"
-                          value="http://amis.baidu.com"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="cxd-Form-item cxd-Form-item--normal"
-                    data-role="form-item"
-                  >
-                    <label
-                      class="cxd-Form-label"
-                    >
-                      <span>
-                        <span
-                          class="cxd-TplField"
-                        >
-                          <span>
-                            名称
-                          </span>
-                        </span>
-                      </span>
-                    </label>
-                    <div
-                      class="cxd-Form-control cxd-TextControl"
-                    >
-                      <div
-                        class="cxd-TextControl-input"
-                      >
-                        <input
-                          autocomplete="off"
-                          class=""
-                          name="name"
-                          placeholder=""
-                          size="10"
-                          type="text"
-                          value="Amis"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="cxd-Form-item cxd-Form-item--normal"
-                    data-role="form-item"
-                  >
-                    <button
-                      class="cxd-Button cxd-Button--default cxd-Button--size-default"
-                      type="button"
-                    >
-                      <span>
-                        OpenDialog
-                      </span>
-                    </button>
-                  </div>
                 </form>
               </div>
               <div
@@ -1121,89 +1031,6 @@ exports[`Renderer:Wizard dialog 2`] = `
                     style="display: none;"
                     type="submit"
                   />
-                  <div
-                    class="cxd-Form-item cxd-Form-item--normal"
-                    data-role="form-item"
-                  >
-                    <label
-                      class="cxd-Form-label"
-                    >
-                      <span>
-                        <span
-                          class="cxd-TplField"
-                        >
-                          <span>
-                            网址
-                          </span>
-                        </span>
-                      </span>
-                    </label>
-                    <div
-                      class="cxd-Form-control cxd-TextControl"
-                    >
-                      <div
-                        class="cxd-TextControl-input"
-                      >
-                        <input
-                          autocomplete="off"
-                          class=""
-                          name="website"
-                          placeholder=""
-                          size="10"
-                          type="url"
-                          value="http://amis.baidu.com"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="cxd-Form-item cxd-Form-item--normal"
-                    data-role="form-item"
-                  >
-                    <label
-                      class="cxd-Form-label"
-                    >
-                      <span>
-                        <span
-                          class="cxd-TplField"
-                        >
-                          <span>
-                            名称
-                          </span>
-                        </span>
-                      </span>
-                    </label>
-                    <div
-                      class="cxd-Form-control cxd-TextControl"
-                    >
-                      <div
-                        class="cxd-TextControl-input"
-                      >
-                        <input
-                          autocomplete="off"
-                          class=""
-                          name="name"
-                          placeholder=""
-                          size="10"
-                          type="text"
-                          value="Amis"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="cxd-Form-item cxd-Form-item--normal"
-                    data-role="form-item"
-                  >
-                    <button
-                      class="cxd-Button cxd-Button--default cxd-Button--size-default"
-                      type="button"
-                    >
-                      <span>
-                        OpenDialog
-                      </span>
-                    </button>
-                  </div>
                 </form>
               </div>
               <div
@@ -1726,76 +1553,6 @@ exports[`Renderer:Wizard initApi reload 1`] = `
                     style="display: none;"
                     type="submit"
                   />
-                  <div
-                    class="cxd-Form-item cxd-Form-item--normal"
-                    data-role="form-item"
-                  >
-                    <label
-                      class="cxd-Form-label"
-                    >
-                      <span>
-                        <span
-                          class="cxd-TplField"
-                        >
-                          <span>
-                            网址
-                          </span>
-                        </span>
-                      </span>
-                    </label>
-                    <div
-                      class="cxd-Form-control cxd-TextControl"
-                    >
-                      <div
-                        class="cxd-TextControl-input"
-                      >
-                        <input
-                          autocomplete="off"
-                          class=""
-                          name="website"
-                          placeholder=""
-                          size="10"
-                          type="url"
-                          value="http://amis.baidu.com"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="cxd-Form-item cxd-Form-item--normal"
-                    data-role="form-item"
-                  >
-                    <label
-                      class="cxd-Form-label"
-                    >
-                      <span>
-                        <span
-                          class="cxd-TplField"
-                        >
-                          <span>
-                            名称
-                          </span>
-                        </span>
-                      </span>
-                    </label>
-                    <div
-                      class="cxd-Form-control cxd-TextControl"
-                    >
-                      <div
-                        class="cxd-TextControl-input"
-                      >
-                        <input
-                          autocomplete="off"
-                          class=""
-                          name="name"
-                          placeholder=""
-                          size="10"
-                          type="text"
-                          value="Amis"
-                        />
-                      </div>
-                    </div>
-                  </div>
                 </form>
               </div>
               <div
@@ -2001,13 +1758,6 @@ exports[`Renderer:Wizard initApi reload 2`] = `
                     style="display: none;"
                     type="submit"
                   />
-                  <span
-                    class="cxd-TplField"
-                  >
-                    <span>
-                      这是最后一步了
-                    </span>
-                  </span>
                 </form>
               </div>
               <div
@@ -2213,13 +1963,6 @@ exports[`Renderer:Wizard initApi reload 3`] = `
                     style="display: none;"
                     type="submit"
                   />
-                  <span
-                    class="cxd-TplField"
-                  >
-                    <span>
-                      这是最后一步了
-                    </span>
-                  </span>
                 </form>
               </div>
               <div
@@ -2527,86 +2270,6 @@ exports[`Renderer:Wizard initApi show loading 2`] = `
             style="display: none;"
             type="submit"
           />
-          <div
-            class="cxd-Form-item cxd-Form-item--normal is-required"
-            data-role="form-item"
-          >
-            <label
-              class="cxd-Form-label"
-            >
-              <span>
-                <span
-                  class="cxd-TplField"
-                >
-                  <span>
-                    网址
-                  </span>
-                </span>
-                <span
-                  class="cxd-Form-star"
-                >
-                  *
-                </span>
-              </span>
-            </label>
-            <div
-              class="cxd-Form-control cxd-TextControl"
-            >
-              <div
-                class="cxd-TextControl-input"
-              >
-                <input
-                  autocomplete="off"
-                  class=""
-                  name="website"
-                  placeholder=""
-                  size="10"
-                  type="url"
-                  value=""
-                />
-              </div>
-            </div>
-          </div>
-          <div
-            class="cxd-Form-item cxd-Form-item--normal is-required"
-            data-role="form-item"
-          >
-            <label
-              class="cxd-Form-label"
-            >
-              <span>
-                <span
-                  class="cxd-TplField"
-                >
-                  <span>
-                    名称
-                  </span>
-                </span>
-                <span
-                  class="cxd-Form-star"
-                >
-                  *
-                </span>
-              </span>
-            </label>
-            <div
-              class="cxd-Form-control cxd-TextControl"
-            >
-              <div
-                class="cxd-TextControl-input"
-              >
-                <input
-                  autocomplete="off"
-                  class=""
-                  name="name"
-                  placeholder=""
-                  size="10"
-                  type="text"
-                  value=""
-                />
-              </div>
-            </div>
-          </div>
         </form>
       </div>
       <div
@@ -2937,13 +2600,6 @@ exports[`Renderer:Wizard send data 1`] = `
             style="display: none;"
             type="submit"
           />
-          <span
-            class="cxd-TplField"
-          >
-            <span>
-              这是最后一步了
-            </span>
-          </span>
         </form>
       </div>
       <div
@@ -3484,13 +3140,6 @@ exports[`Renderer:Wizard target 1`] = `
                     style="display: none;"
                     type="submit"
                   />
-                  <span
-                    class="cxd-TplField"
-                  >
-                    <span>
-                      这是最后一步了
-                    </span>
-                  </span>
                 </form>
               </div>
               <div

--- a/packages/amis/__tests__/renderers/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Wizard.test.tsx.snap
@@ -10,32 +10,102 @@ exports[`Renderer:Wizard actionPrevLabel actionNextLabel actionFinishLabel class
       class="cxd-Wizard-step"
     >
       <div
-        class="cxd-Wizard-steps"
+        class="cxd--Wizard-steps"
         id="form-wizard"
       >
-        <ul>
+        <ul
+          class="cxd-Steps cxd-Steps--Placement- cxd-Steps-- cxd-Steps--horizontal"
+        >
           <li
-            class="is-complete"
+            class="cxd-StepsItem is-finish is-clickable"
           >
-            <span
-              class="cxd-Badge is-complete is-active"
+            <div
+              class="cxd-StepsItem-container"
             >
-              <icon-mock
-                classname="icon icon-check"
-                icon="check"
+              <div
+                class="cxd-StepsItem-containerTail"
               />
-            </span>
-            Step 1
+              <div
+                class="cxd-StepsItem-containerIcon is-success"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  <icon-mock
+                    classname="icon icon-check"
+                    icon="check"
+                  />
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem- is-success"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 1"
+                    >
+                      Step 1
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
           </li>
           <li
-            class="is-complete is-active"
+            class="cxd-StepsItem is-process"
           >
-            <span
-              class="cxd-Badge is-complete is-active"
+            <div
+              class="cxd-StepsItem-container"
             >
-              2
-            </span>
-            Step 2
+              <div
+                class="cxd-StepsItem-containerTail"
+              />
+              <div
+                class="cxd-StepsItem-containerIcon"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  2
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem-"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 2"
+                    >
+                      Step 2
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
           </li>
         </ul>
       </div>
@@ -61,7 +131,7 @@ exports[`Renderer:Wizard actionPrevLabel actionNextLabel actionFinishLabel class
         </form>
       </div>
       <div
-        class="cxd-Panel-footer cxd-Wizard-footer"
+        class="cxd-Wizard-footer cxd-Panel-footer"
         role="wizard-footer"
       >
         <button
@@ -135,32 +205,99 @@ exports[`Renderer:Wizard actionPrevLabel actionNextLabel actionFinishLabel class
       class="cxd-Wizard-step"
     >
       <div
-        class="cxd-Wizard-steps"
+        class="cxd--Wizard-steps"
         id="form-wizard"
       >
-        <ul>
+        <ul
+          class="cxd-Steps cxd-Steps--Placement- cxd-Steps-- cxd-Steps--horizontal"
+        >
           <li
-            class="is-complete is-active"
+            class="cxd-StepsItem is-process"
           >
-            <span
-              class="cxd-Badge is-complete is-active"
+            <div
+              class="cxd-StepsItem-container"
             >
-              1
-            </span>
-            Step 1
+              <div
+                class="cxd-StepsItem-containerTail"
+              />
+              <div
+                class="cxd-StepsItem-containerIcon"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  1
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem-"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 1"
+                    >
+                      Step 1
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
           </li>
           <li
-            class="is-complete"
+            class="cxd-StepsItem is-wait"
           >
-            <span
-              class="cxd-Badge is-complete"
+            <div
+              class="cxd-StepsItem-container"
             >
-              <icon-mock
-                classname="icon icon-check"
-                icon="check"
+              <div
+                class="cxd-StepsItem-containerTail"
               />
-            </span>
-            Step 2
+              <div
+                class="cxd-StepsItem-containerIcon"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  2
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem-"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 2"
+                    >
+                      Step 2
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
           </li>
         </ul>
       </div>
@@ -249,7 +386,7 @@ exports[`Renderer:Wizard actionPrevLabel actionNextLabel actionFinishLabel class
         </form>
       </div>
       <div
-        class="cxd-Panel-footer cxd-Wizard-footer"
+        class="cxd-Wizard-footer cxd-Panel-footer"
         role="wizard-footer"
       >
         <div
@@ -261,7 +398,7 @@ exports[`Renderer:Wizard actionPrevLabel actionNextLabel actionFinishLabel class
           </span>
         </div>
         <button
-          class="cxd-Button cxd-Button--default cxd-Button--size-default btn-lg btn-primary"
+          class="cxd-Button cxd-Button--primary cxd-Button--size-default btn-lg btn-primary"
           type="button"
         >
           <span>
@@ -323,42 +460,9 @@ exports[`Renderer:Wizard default 1`] = `
       class="cxd-Wizard-step"
     >
       <div
-        class="cxd-Wizard-steps"
+        class="cxd--Wizard-steps"
         id="form-wizard"
-      >
-        <ul>
-          <li
-            class="is-active"
-          >
-            <span
-              class="cxd-Badge is-active"
-            >
-              1
-            </span>
-            Step 1
-          </li>
-          <li
-            class=""
-          >
-            <span
-              class="cxd-Badge"
-            >
-              2
-            </span>
-            Step 2
-          </li>
-          <li
-            class=""
-          >
-            <span
-              class="cxd-Badge"
-            >
-              3
-            </span>
-            Step 3
-          </li>
-        </ul>
-      </div>
+      />
       <div
         class="cxd-Wizard-stepContent clearfix"
         role="wizard-body"
@@ -452,27 +556,6 @@ exports[`Renderer:Wizard default 1`] = `
             </div>
           </div>
         </form>
-      </div>
-      <div
-        class="cxd-Panel-footer cxd-Wizard-footer"
-        role="wizard-footer"
-      >
-        <div
-          class="cxd-Button cxd-Button--default cxd-Button--size-default is-disabled"
-          disabled=""
-        >
-          <span>
-            上一步
-          </span>
-        </div>
-        <button
-          class="cxd-Button cxd-Button--default cxd-Button--size-default"
-          type="button"
-        >
-          <span>
-            下一步
-          </span>
-        </button>
       </div>
     </div>
     <div
@@ -541,29 +624,99 @@ exports[`Renderer:Wizard dialog 1`] = `
               class="cxd-Wizard-step"
             >
               <div
-                class="cxd-Wizard-steps"
+                class="cxd--Wizard-steps"
                 id="form-wizard"
               >
-                <ul>
+                <ul
+                  class="cxd-Steps cxd-Steps--Placement- cxd-Steps-- cxd-Steps--horizontal"
+                >
                   <li
-                    class="is-active"
+                    class="cxd-StepsItem is-process"
                   >
-                    <span
-                      class="cxd-Badge is-active"
+                    <div
+                      class="cxd-StepsItem-container"
                     >
-                      1
-                    </span>
-                    Step 1
+                      <div
+                        class="cxd-StepsItem-containerTail"
+                      />
+                      <div
+                        class="cxd-StepsItem-containerIcon"
+                      >
+                        <span
+                          class="cxd-StepsItem-icon"
+                        >
+                          1
+                        </span>
+                      </div>
+                      <div
+                        class="cxd-StepsItem-containerWrapper"
+                      >
+                        <div
+                          class="cxd-StepsItem-body"
+                        >
+                          <div
+                            class="cxd-StepsItem-title cxd-StepsItem-"
+                          >
+                            <span
+                              class="cxd-StepsItem-ellText"
+                              title="Step 1"
+                            >
+                              Step 1
+                            </span>
+                          </div>
+                          <div
+                            class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                            title="undefined"
+                          >
+                            <span />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </li>
                   <li
-                    class=""
+                    class="cxd-StepsItem is-wait"
                   >
-                    <span
-                      class="cxd-Badge"
+                    <div
+                      class="cxd-StepsItem-container"
                     >
-                      2
-                    </span>
-                    Step 2
+                      <div
+                        class="cxd-StepsItem-containerTail"
+                      />
+                      <div
+                        class="cxd-StepsItem-containerIcon"
+                      >
+                        <span
+                          class="cxd-StepsItem-icon"
+                        >
+                          2
+                        </span>
+                      </div>
+                      <div
+                        class="cxd-StepsItem-containerWrapper"
+                      >
+                        <div
+                          class="cxd-StepsItem-body"
+                        >
+                          <div
+                            class="cxd-StepsItem-title cxd-StepsItem-"
+                          >
+                            <span
+                              class="cxd-StepsItem-ellText"
+                              title="Step 2"
+                            >
+                              Step 2
+                            </span>
+                          </div>
+                          <div
+                            class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                            title="undefined"
+                          >
+                            <span />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </li>
                 </ul>
               </div>
@@ -665,7 +818,7 @@ exports[`Renderer:Wizard dialog 1`] = `
                 </form>
               </div>
               <div
-                class="cxd-Panel-footer cxd-Wizard-footer"
+                class="cxd-Wizard-footer cxd-Panel-footer"
                 role="wizard-footer"
               >
                 <div
@@ -677,7 +830,7 @@ exports[`Renderer:Wizard dialog 1`] = `
                   </span>
                 </div>
                 <button
-                  class="cxd-Button cxd-Button--default cxd-Button--size-default"
+                  class="cxd-Button cxd-Button--primary cxd-Button--size-default"
                   type="button"
                 >
                   <span>
@@ -860,29 +1013,99 @@ exports[`Renderer:Wizard dialog 2`] = `
               class="cxd-Wizard-step"
             >
               <div
-                class="cxd-Wizard-steps"
+                class="cxd--Wizard-steps"
                 id="form-wizard"
               >
-                <ul>
+                <ul
+                  class="cxd-Steps cxd-Steps--Placement- cxd-Steps-- cxd-Steps--horizontal"
+                >
                   <li
-                    class="is-active"
+                    class="cxd-StepsItem is-process"
                   >
-                    <span
-                      class="cxd-Badge is-active"
+                    <div
+                      class="cxd-StepsItem-container"
                     >
-                      1
-                    </span>
-                    Step 1
+                      <div
+                        class="cxd-StepsItem-containerTail"
+                      />
+                      <div
+                        class="cxd-StepsItem-containerIcon"
+                      >
+                        <span
+                          class="cxd-StepsItem-icon"
+                        >
+                          1
+                        </span>
+                      </div>
+                      <div
+                        class="cxd-StepsItem-containerWrapper"
+                      >
+                        <div
+                          class="cxd-StepsItem-body"
+                        >
+                          <div
+                            class="cxd-StepsItem-title cxd-StepsItem-"
+                          >
+                            <span
+                              class="cxd-StepsItem-ellText"
+                              title="Step 1"
+                            >
+                              Step 1
+                            </span>
+                          </div>
+                          <div
+                            class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                            title="undefined"
+                          >
+                            <span />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </li>
                   <li
-                    class=""
+                    class="cxd-StepsItem is-wait"
                   >
-                    <span
-                      class="cxd-Badge"
+                    <div
+                      class="cxd-StepsItem-container"
                     >
-                      2
-                    </span>
-                    Step 2
+                      <div
+                        class="cxd-StepsItem-containerTail"
+                      />
+                      <div
+                        class="cxd-StepsItem-containerIcon"
+                      >
+                        <span
+                          class="cxd-StepsItem-icon"
+                        >
+                          2
+                        </span>
+                      </div>
+                      <div
+                        class="cxd-StepsItem-containerWrapper"
+                      >
+                        <div
+                          class="cxd-StepsItem-body"
+                        >
+                          <div
+                            class="cxd-StepsItem-title cxd-StepsItem-"
+                          >
+                            <span
+                              class="cxd-StepsItem-ellText"
+                              title="Step 2"
+                            >
+                              Step 2
+                            </span>
+                          </div>
+                          <div
+                            class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                            title="undefined"
+                          >
+                            <span />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </li>
                 </ul>
               </div>
@@ -984,7 +1207,7 @@ exports[`Renderer:Wizard dialog 2`] = `
                 </form>
               </div>
               <div
-                class="cxd-Panel-footer cxd-Wizard-footer"
+                class="cxd-Wizard-footer cxd-Panel-footer"
                 role="wizard-footer"
               >
                 <div
@@ -996,7 +1219,7 @@ exports[`Renderer:Wizard dialog 2`] = `
                   </span>
                 </div>
                 <button
-                  class="cxd-Button cxd-Button--default cxd-Button--size-default"
+                  class="cxd-Button cxd-Button--primary cxd-Button--size-default"
                   type="button"
                 >
                   <span>
@@ -1062,42 +1285,9 @@ exports[`Renderer:Wizard initApi default 1`] = `
       class="cxd-Wizard-step"
     >
       <div
-        class="cxd-Wizard-steps"
+        class="cxd--Wizard-steps"
         id="form-wizard"
-      >
-        <ul>
-          <li
-            class="is-active"
-          >
-            <span
-              class="cxd-Badge is-active"
-            >
-              1
-            </span>
-            Step 1
-          </li>
-          <li
-            class=""
-          >
-            <span
-              class="cxd-Badge"
-            >
-              2
-            </span>
-            Step 2
-          </li>
-          <li
-            class=""
-          >
-            <span
-              class="cxd-Badge"
-            >
-              3
-            </span>
-            Step 3
-          </li>
-        </ul>
-      </div>
+      />
       <div
         class="cxd-Wizard-stepContent clearfix"
         role="wizard-body"
@@ -1192,27 +1382,6 @@ exports[`Renderer:Wizard initApi default 1`] = `
           </div>
         </form>
       </div>
-      <div
-        class="cxd-Panel-footer cxd-Wizard-footer"
-        role="wizard-footer"
-      >
-        <div
-          class="cxd-Button cxd-Button--default cxd-Button--size-default is-disabled"
-          disabled=""
-        >
-          <span>
-            上一步
-          </span>
-        </div>
-        <button
-          class="cxd-Button cxd-Button--default cxd-Button--size-default"
-          type="button"
-        >
-          <span>
-            下一步
-          </span>
-        </button>
-      </div>
     </div>
     <div
       class="resize-sensor"
@@ -1291,29 +1460,99 @@ exports[`Renderer:Wizard initApi reload 1`] = `
               class="cxd-Wizard-step"
             >
               <div
-                class="cxd-Wizard-steps"
+                class="cxd--Wizard-steps"
                 id="form-wizard"
               >
-                <ul>
+                <ul
+                  class="cxd-Steps cxd-Steps--Placement- cxd-Steps-- cxd-Steps--horizontal"
+                >
                   <li
-                    class="is-active"
+                    class="cxd-StepsItem is-process"
                   >
-                    <span
-                      class="cxd-Badge is-active"
+                    <div
+                      class="cxd-StepsItem-container"
                     >
-                      1
-                    </span>
-                    Step 1
+                      <div
+                        class="cxd-StepsItem-containerTail"
+                      />
+                      <div
+                        class="cxd-StepsItem-containerIcon"
+                      >
+                        <span
+                          class="cxd-StepsItem-icon"
+                        >
+                          1
+                        </span>
+                      </div>
+                      <div
+                        class="cxd-StepsItem-containerWrapper"
+                      >
+                        <div
+                          class="cxd-StepsItem-body"
+                        >
+                          <div
+                            class="cxd-StepsItem-title cxd-StepsItem-"
+                          >
+                            <span
+                              class="cxd-StepsItem-ellText"
+                              title="Step 1"
+                            >
+                              Step 1
+                            </span>
+                          </div>
+                          <div
+                            class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                            title="undefined"
+                          >
+                            <span />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </li>
                   <li
-                    class=""
+                    class="cxd-StepsItem is-wait"
                   >
-                    <span
-                      class="cxd-Badge"
+                    <div
+                      class="cxd-StepsItem-container"
                     >
-                      2
-                    </span>
-                    Step 2
+                      <div
+                        class="cxd-StepsItem-containerTail"
+                      />
+                      <div
+                        class="cxd-StepsItem-containerIcon"
+                      >
+                        <span
+                          class="cxd-StepsItem-icon"
+                        >
+                          2
+                        </span>
+                      </div>
+                      <div
+                        class="cxd-StepsItem-containerWrapper"
+                      >
+                        <div
+                          class="cxd-StepsItem-body"
+                        >
+                          <div
+                            class="cxd-StepsItem-title cxd-StepsItem-"
+                          >
+                            <span
+                              class="cxd-StepsItem-ellText"
+                              title="Step 2"
+                            >
+                              Step 2
+                            </span>
+                          </div>
+                          <div
+                            class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                            title="undefined"
+                          >
+                            <span />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </li>
                 </ul>
               </div>
@@ -1402,7 +1641,7 @@ exports[`Renderer:Wizard initApi reload 1`] = `
                 </form>
               </div>
               <div
-                class="cxd-Panel-footer cxd-Wizard-footer"
+                class="cxd-Wizard-footer cxd-Panel-footer"
                 role="wizard-footer"
               >
                 <div
@@ -1414,7 +1653,7 @@ exports[`Renderer:Wizard initApi reload 1`] = `
                   </span>
                 </div>
                 <button
-                  class="cxd-Button cxd-Button--default cxd-Button--size-default"
+                  class="cxd-Button cxd-Button--primary cxd-Button--size-default"
                   type="button"
                 >
                   <span>
@@ -1493,32 +1732,102 @@ exports[`Renderer:Wizard initApi reload 2`] = `
               class="cxd-Wizard-step"
             >
               <div
-                class="cxd-Wizard-steps"
+                class="cxd--Wizard-steps"
                 id="form-wizard"
               >
-                <ul>
+                <ul
+                  class="cxd-Steps cxd-Steps--Placement- cxd-Steps-- cxd-Steps--horizontal"
+                >
                   <li
-                    class="is-complete"
+                    class="cxd-StepsItem is-finish is-clickable"
                   >
-                    <span
-                      class="cxd-Badge is-complete is-active"
+                    <div
+                      class="cxd-StepsItem-container"
                     >
-                      <icon-mock
-                        classname="icon icon-check"
-                        icon="check"
+                      <div
+                        class="cxd-StepsItem-containerTail"
                       />
-                    </span>
-                    Step 1
+                      <div
+                        class="cxd-StepsItem-containerIcon is-success"
+                      >
+                        <span
+                          class="cxd-StepsItem-icon"
+                        >
+                          <icon-mock
+                            classname="icon icon-check"
+                            icon="check"
+                          />
+                        </span>
+                      </div>
+                      <div
+                        class="cxd-StepsItem-containerWrapper"
+                      >
+                        <div
+                          class="cxd-StepsItem-body"
+                        >
+                          <div
+                            class="cxd-StepsItem-title cxd-StepsItem- is-success"
+                          >
+                            <span
+                              class="cxd-StepsItem-ellText"
+                              title="Step 1"
+                            >
+                              Step 1
+                            </span>
+                          </div>
+                          <div
+                            class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                            title="undefined"
+                          >
+                            <span />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </li>
                   <li
-                    class="is-active"
+                    class="cxd-StepsItem is-process"
                   >
-                    <span
-                      class="cxd-Badge is-active"
+                    <div
+                      class="cxd-StepsItem-container"
                     >
-                      2
-                    </span>
-                    Step 2
+                      <div
+                        class="cxd-StepsItem-containerTail"
+                      />
+                      <div
+                        class="cxd-StepsItem-containerIcon"
+                      >
+                        <span
+                          class="cxd-StepsItem-icon"
+                        >
+                          2
+                        </span>
+                      </div>
+                      <div
+                        class="cxd-StepsItem-containerWrapper"
+                      >
+                        <div
+                          class="cxd-StepsItem-body"
+                        >
+                          <div
+                            class="cxd-StepsItem-title cxd-StepsItem-"
+                          >
+                            <span
+                              class="cxd-StepsItem-ellText"
+                              title="Step 2"
+                            >
+                              Step 2
+                            </span>
+                          </div>
+                          <div
+                            class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                            title="undefined"
+                          >
+                            <span />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </li>
                 </ul>
               </div>
@@ -1544,7 +1853,7 @@ exports[`Renderer:Wizard initApi reload 2`] = `
                 </form>
               </div>
               <div
-                class="cxd-Panel-footer cxd-Wizard-footer"
+                class="cxd-Wizard-footer cxd-Panel-footer"
                 role="wizard-footer"
               >
                 <button
@@ -1635,32 +1944,102 @@ exports[`Renderer:Wizard initApi reload 3`] = `
               class="cxd-Wizard-step"
             >
               <div
-                class="cxd-Wizard-steps"
+                class="cxd--Wizard-steps"
                 id="form-wizard"
               >
-                <ul>
+                <ul
+                  class="cxd-Steps cxd-Steps--Placement- cxd-Steps-- cxd-Steps--horizontal"
+                >
                   <li
-                    class="is-complete"
+                    class="cxd-StepsItem is-finish is-clickable"
                   >
-                    <span
-                      class="cxd-Badge is-complete is-active"
+                    <div
+                      class="cxd-StepsItem-container"
                     >
-                      <icon-mock
-                        classname="icon icon-check"
-                        icon="check"
+                      <div
+                        class="cxd-StepsItem-containerTail"
                       />
-                    </span>
-                    Step 1
+                      <div
+                        class="cxd-StepsItem-containerIcon is-success"
+                      >
+                        <span
+                          class="cxd-StepsItem-icon"
+                        >
+                          <icon-mock
+                            classname="icon icon-check"
+                            icon="check"
+                          />
+                        </span>
+                      </div>
+                      <div
+                        class="cxd-StepsItem-containerWrapper"
+                      >
+                        <div
+                          class="cxd-StepsItem-body"
+                        >
+                          <div
+                            class="cxd-StepsItem-title cxd-StepsItem- is-success"
+                          >
+                            <span
+                              class="cxd-StepsItem-ellText"
+                              title="Step 1"
+                            >
+                              Step 1
+                            </span>
+                          </div>
+                          <div
+                            class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                            title="undefined"
+                          >
+                            <span />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </li>
                   <li
-                    class="is-complete is-active"
+                    class="cxd-StepsItem is-process"
                   >
-                    <span
-                      class="cxd-Badge is-complete is-active"
+                    <div
+                      class="cxd-StepsItem-container"
                     >
-                      2
-                    </span>
-                    Step 2
+                      <div
+                        class="cxd-StepsItem-containerTail"
+                      />
+                      <div
+                        class="cxd-StepsItem-containerIcon"
+                      >
+                        <span
+                          class="cxd-StepsItem-icon"
+                        >
+                          2
+                        </span>
+                      </div>
+                      <div
+                        class="cxd-StepsItem-containerWrapper"
+                      >
+                        <div
+                          class="cxd-StepsItem-body"
+                        >
+                          <div
+                            class="cxd-StepsItem-title cxd-StepsItem-"
+                          >
+                            <span
+                              class="cxd-StepsItem-ellText"
+                              title="Step 2"
+                            >
+                              Step 2
+                            </span>
+                          </div>
+                          <div
+                            class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                            title="undefined"
+                          >
+                            <span />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </li>
                 </ul>
               </div>
@@ -1686,7 +2065,7 @@ exports[`Renderer:Wizard initApi reload 3`] = `
                 </form>
               </div>
               <div
-                class="cxd-Panel-footer cxd-Wizard-footer"
+                class="cxd-Wizard-footer cxd-Panel-footer"
                 role="wizard-footer"
               >
                 <button
@@ -1764,42 +2143,9 @@ exports[`Renderer:Wizard initApi show loading 1`] = `
       class="cxd-Wizard-step"
     >
       <div
-        class="cxd-Wizard-steps"
+        class="cxd--Wizard-steps"
         id="form-wizard"
-      >
-        <ul>
-          <li
-            class=""
-          >
-            <span
-              class="cxd-Badge"
-            >
-              1
-            </span>
-            Step 1
-          </li>
-          <li
-            class=""
-          >
-            <span
-              class="cxd-Badge"
-            >
-              2
-            </span>
-            Step 2
-          </li>
-          <li
-            class=""
-          >
-            <span
-              class="cxd-Badge"
-            >
-              3
-            </span>
-            Step 3
-          </li>
-        </ul>
-      </div>
+      />
       <div
         class="cxd-Wizard-stepContent clearfix"
         role="wizard-body"
@@ -1871,42 +2217,9 @@ exports[`Renderer:Wizard initApi show loading 2`] = `
       class="cxd-Wizard-step"
     >
       <div
-        class="cxd-Wizard-steps"
+        class="cxd--Wizard-steps"
         id="form-wizard"
-      >
-        <ul>
-          <li
-            class="is-active"
-          >
-            <span
-              class="cxd-Badge is-active"
-            >
-              1
-            </span>
-            Step 1
-          </li>
-          <li
-            class=""
-          >
-            <span
-              class="cxd-Badge"
-            >
-              2
-            </span>
-            Step 2
-          </li>
-          <li
-            class=""
-          >
-            <span
-              class="cxd-Badge"
-            >
-              3
-            </span>
-            Step 3
-          </li>
-        </ul>
-      </div>
+      />
       <div
         class="cxd-Wizard-stepContent clearfix"
         role="wizard-body"
@@ -2001,27 +2314,6 @@ exports[`Renderer:Wizard initApi show loading 2`] = `
           </div>
         </form>
       </div>
-      <div
-        class="cxd-Panel-footer cxd-Wizard-footer"
-        role="wizard-footer"
-      >
-        <div
-          class="cxd-Button cxd-Button--default cxd-Button--size-default is-disabled"
-          disabled=""
-        >
-          <span>
-            上一步
-          </span>
-        </div>
-        <button
-          class="cxd-Button cxd-Button--default cxd-Button--size-default"
-          type="button"
-        >
-          <span>
-            下一步
-          </span>
-        </button>
-      </div>
     </div>
     <div
       class="resize-sensor"
@@ -2076,42 +2368,9 @@ exports[`Renderer:Wizard readOnly 1`] = `
       class="cxd-Wizard-step"
     >
       <div
-        class="cxd-Wizard-steps"
+        class="cxd--Wizard-steps"
         id="form-wizard"
-      >
-        <ul>
-          <li
-            class="is-active"
-          >
-            <span
-              class="cxd-Badge is-active"
-            >
-              1
-            </span>
-            Step 1
-          </li>
-          <li
-            class=""
-          >
-            <span
-              class="cxd-Badge"
-            >
-              2
-            </span>
-            Step 2
-          </li>
-          <li
-            class=""
-          >
-            <span
-              class="cxd-Badge"
-            >
-              3
-            </span>
-            Step 3
-          </li>
-        </ul>
-      </div>
+      />
       <div
         class="cxd-Wizard-stepContent clearfix"
         role="wizard-body"
@@ -2197,27 +2456,6 @@ exports[`Renderer:Wizard readOnly 1`] = `
           </div>
         </form>
       </div>
-      <div
-        class="cxd-Panel-footer cxd-Wizard-footer"
-        role="wizard-footer"
-      >
-        <div
-          class="cxd-Button cxd-Button--default cxd-Button--size-default is-disabled"
-          disabled=""
-        >
-          <span>
-            上一步
-          </span>
-        </div>
-        <button
-          class="cxd-Button cxd-Button--default cxd-Button--size-default"
-          type="button"
-        >
-          <span>
-            下一步
-          </span>
-        </button>
-      </div>
     </div>
     <div
       class="resize-sensor"
@@ -2272,32 +2510,102 @@ exports[`Renderer:Wizard send data 1`] = `
       class="cxd-Wizard-step"
     >
       <div
-        class="cxd-Wizard-steps"
+        class="cxd--Wizard-steps"
         id="form-wizard"
       >
-        <ul>
+        <ul
+          class="cxd-Steps cxd-Steps--Placement- cxd-Steps-- cxd-Steps--horizontal"
+        >
           <li
-            class="is-complete"
+            class="cxd-StepsItem is-finish is-clickable"
           >
-            <span
-              class="cxd-Badge is-complete is-active"
+            <div
+              class="cxd-StepsItem-container"
             >
-              <icon-mock
-                classname="icon icon-check"
-                icon="check"
+              <div
+                class="cxd-StepsItem-containerTail"
               />
-            </span>
-            Step 1
+              <div
+                class="cxd-StepsItem-containerIcon is-success"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  <icon-mock
+                    classname="icon icon-check"
+                    icon="check"
+                  />
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem- is-success"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 1"
+                    >
+                      Step 1
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
           </li>
           <li
-            class="is-complete is-active"
+            class="cxd-StepsItem is-process"
           >
-            <span
-              class="cxd-Badge is-complete is-active"
+            <div
+              class="cxd-StepsItem-container"
             >
-              2
-            </span>
-            Step 2
+              <div
+                class="cxd-StepsItem-containerTail"
+              />
+              <div
+                class="cxd-StepsItem-containerIcon"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  2
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem-"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 2"
+                    >
+                      Step 2
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
           </li>
         </ul>
       </div>
@@ -2323,7 +2631,7 @@ exports[`Renderer:Wizard send data 1`] = `
         </form>
       </div>
       <div
-        class="cxd-Panel-footer cxd-Wizard-footer"
+        class="cxd-Wizard-footer cxd-Panel-footer"
         role="wizard-footer"
       >
         <button
@@ -2397,42 +2705,146 @@ exports[`Renderer:Wizard step initApi 1`] = `
       class="cxd-Wizard-step"
     >
       <div
-        class="cxd-Wizard-steps"
+        class="cxd--Wizard-steps"
         id="form-wizard"
       >
-        <ul>
+        <ul
+          class="cxd-Steps cxd-Steps--Placement- cxd-Steps-- cxd-Steps--horizontal"
+        >
           <li
-            class="is-complete"
+            class="cxd-StepsItem is-finish is-clickable"
           >
-            <span
-              class="cxd-Badge is-complete is-active"
+            <div
+              class="cxd-StepsItem-container"
             >
-              <icon-mock
-                classname="icon icon-check"
-                icon="check"
+              <div
+                class="cxd-StepsItem-containerTail"
               />
-            </span>
-            Step 1
+              <div
+                class="cxd-StepsItem-containerIcon is-success"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  <icon-mock
+                    classname="icon icon-check"
+                    icon="check"
+                  />
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem- is-success"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 1"
+                    >
+                      Step 1
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
           </li>
           <li
-            class="is-active"
+            class="cxd-StepsItem is-process"
           >
-            <span
-              class="cxd-Badge is-active"
+            <div
+              class="cxd-StepsItem-container"
             >
-              2
-            </span>
-            Step 2
+              <div
+                class="cxd-StepsItem-containerTail"
+              />
+              <div
+                class="cxd-StepsItem-containerIcon"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  2
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem-"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 2"
+                    >
+                      Step 2
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
           </li>
           <li
-            class=""
+            class="cxd-StepsItem is-wait"
           >
-            <span
-              class="cxd-Badge"
+            <div
+              class="cxd-StepsItem-container"
             >
-              3
-            </span>
-            Step 3
+              <div
+                class="cxd-StepsItem-containerTail"
+              />
+              <div
+                class="cxd-StepsItem-containerIcon"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  3
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem-"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 3"
+                    >
+                      Step 3
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
           </li>
         </ul>
       </div>
@@ -2491,7 +2903,7 @@ exports[`Renderer:Wizard step initApi 1`] = `
         </form>
       </div>
       <div
-        class="cxd-Panel-footer cxd-Wizard-footer"
+        class="cxd-Wizard-footer cxd-Panel-footer"
         role="wizard-footer"
       >
         <button
@@ -2503,7 +2915,7 @@ exports[`Renderer:Wizard step initApi 1`] = `
           </span>
         </button>
         <button
-          class="cxd-Button cxd-Button--default cxd-Button--size-default"
+          class="cxd-Button cxd-Button--primary cxd-Button--size-default"
           type="button"
         >
           <span>
@@ -2565,7 +2977,7 @@ exports[`Renderer:Wizard steps not array 1`] = `
       class="cxd-Wizard-step"
     >
       <div
-        class="cxd-Wizard-steps"
+        class="cxd--Wizard-steps"
         id="form-wizard"
       />
       <div
@@ -2645,32 +3057,102 @@ exports[`Renderer:Wizard target 1`] = `
               class="cxd-Wizard-step"
             >
               <div
-                class="cxd-Wizard-steps"
+                class="cxd--Wizard-steps"
                 id="form-wizard"
               >
-                <ul>
+                <ul
+                  class="cxd-Steps cxd-Steps--Placement- cxd-Steps-- cxd-Steps--horizontal"
+                >
                   <li
-                    class="is-complete"
+                    class="cxd-StepsItem is-finish is-clickable"
                   >
-                    <span
-                      class="cxd-Badge is-complete is-active"
+                    <div
+                      class="cxd-StepsItem-container"
                     >
-                      <icon-mock
-                        classname="icon icon-check"
-                        icon="check"
+                      <div
+                        class="cxd-StepsItem-containerTail"
                       />
-                    </span>
-                    Step 1
+                      <div
+                        class="cxd-StepsItem-containerIcon is-success"
+                      >
+                        <span
+                          class="cxd-StepsItem-icon"
+                        >
+                          <icon-mock
+                            classname="icon icon-check"
+                            icon="check"
+                          />
+                        </span>
+                      </div>
+                      <div
+                        class="cxd-StepsItem-containerWrapper"
+                      >
+                        <div
+                          class="cxd-StepsItem-body"
+                        >
+                          <div
+                            class="cxd-StepsItem-title cxd-StepsItem- is-success"
+                          >
+                            <span
+                              class="cxd-StepsItem-ellText"
+                              title="Step 1"
+                            >
+                              Step 1
+                            </span>
+                          </div>
+                          <div
+                            class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                            title="undefined"
+                          >
+                            <span />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </li>
                   <li
-                    class="is-complete is-active"
+                    class="cxd-StepsItem is-process"
                   >
-                    <span
-                      class="cxd-Badge is-complete is-active"
+                    <div
+                      class="cxd-StepsItem-container"
                     >
-                      2
-                    </span>
-                    Step 2
+                      <div
+                        class="cxd-StepsItem-containerTail"
+                      />
+                      <div
+                        class="cxd-StepsItem-containerIcon"
+                      >
+                        <span
+                          class="cxd-StepsItem-icon"
+                        >
+                          2
+                        </span>
+                      </div>
+                      <div
+                        class="cxd-StepsItem-containerWrapper"
+                      >
+                        <div
+                          class="cxd-StepsItem-body"
+                        >
+                          <div
+                            class="cxd-StepsItem-title cxd-StepsItem-"
+                          >
+                            <span
+                              class="cxd-StepsItem-ellText"
+                              title="Step 2"
+                            >
+                              Step 2
+                            </span>
+                          </div>
+                          <div
+                            class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                            title="undefined"
+                          >
+                            <span />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </li>
                 </ul>
               </div>
@@ -2696,7 +3178,7 @@ exports[`Renderer:Wizard target 1`] = `
                 </form>
               </div>
               <div
-                class="cxd-Panel-footer cxd-Wizard-footer"
+                class="cxd-Wizard-footer cxd-Panel-footer"
                 role="wizard-footer"
               >
                 <button
@@ -2932,39 +3414,143 @@ exports[`Renderer:Wizard validate 1`] = `
       class="cxd-Wizard-step"
     >
       <div
-        class="cxd-Wizard-steps"
+        class="cxd--Wizard-steps"
         id="form-wizard"
       >
-        <ul>
+        <ul
+          class="cxd-Steps cxd-Steps--Placement- cxd-Steps-- cxd-Steps--horizontal"
+        >
           <li
-            class="is-active"
+            class="cxd-StepsItem is-process"
           >
-            <span
-              class="cxd-Badge is-active"
+            <div
+              class="cxd-StepsItem-container"
             >
-              1
-            </span>
-            Step 1
+              <div
+                class="cxd-StepsItem-containerTail"
+              />
+              <div
+                class="cxd-StepsItem-containerIcon"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  1
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem-"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 1"
+                    >
+                      Step 1
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
           </li>
           <li
-            class=""
+            class="cxd-StepsItem is-wait"
           >
-            <span
-              class="cxd-Badge"
+            <div
+              class="cxd-StepsItem-container"
             >
-              2
-            </span>
-            Step 2
+              <div
+                class="cxd-StepsItem-containerTail"
+              />
+              <div
+                class="cxd-StepsItem-containerIcon"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  2
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem-"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 2"
+                    >
+                      Step 2
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
           </li>
           <li
-            class=""
+            class="cxd-StepsItem is-wait"
           >
-            <span
-              class="cxd-Badge"
+            <div
+              class="cxd-StepsItem-container"
             >
-              3
-            </span>
-            Step 3
+              <div
+                class="cxd-StepsItem-containerTail"
+              />
+              <div
+                class="cxd-StepsItem-containerIcon"
+              >
+                <span
+                  class="cxd-StepsItem-icon"
+                >
+                  3
+                </span>
+              </div>
+              <div
+                class="cxd-StepsItem-containerWrapper"
+              >
+                <div
+                  class="cxd-StepsItem-body"
+                >
+                  <div
+                    class="cxd-StepsItem-title cxd-StepsItem-"
+                  >
+                    <span
+                      class="cxd-StepsItem-ellText"
+                      title="Step 3"
+                    >
+                      Step 3
+                    </span>
+                  </div>
+                  <div
+                    class="cxd-StepsItem-description cxd-StepsItem-ellText"
+                    title="undefined"
+                  >
+                    <span />
+                  </div>
+                </div>
+              </div>
+            </div>
           </li>
         </ul>
       </div>
@@ -3077,7 +3663,7 @@ exports[`Renderer:Wizard validate 1`] = `
         </form>
       </div>
       <div
-        class="cxd-Panel-footer cxd-Wizard-footer"
+        class="cxd-Wizard-footer cxd-Panel-footer"
         role="wizard-footer"
       >
         <div
@@ -3089,7 +3675,7 @@ exports[`Renderer:Wizard validate 1`] = `
           </span>
         </div>
         <button
-          class="cxd-Button cxd-Button--default cxd-Button--size-default"
+          class="cxd-Button cxd-Button--primary cxd-Button--size-default"
           type="button"
         >
           <span>

--- a/packages/amis/src/renderers/Wizard.tsx
+++ b/packages/amis/src/renderers/Wizard.tsx
@@ -33,7 +33,6 @@ import {ActionSchema} from './Action';
 
 import {tokenize, evalExpressionWithConditionBuilder} from 'amis-core';
 import {StepSchema} from './Steps';
-import {cloneDeep} from 'lodash';
 
 export type WizardStepSchema = Omit<FormSchema, 'type'> & StepSchema & {
   /**
@@ -1166,10 +1165,11 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
     // 这里初次渲染时，需要取props的steps
     const steps = Array.isArray(stateSteps) && stateSteps.length > 0 ?
       stateSteps :
-      cloneDeep(propsSteps).map(step => {
+      Array.isArray(propsSteps) ? [...propsSteps].map(step => {
         delete step.hiddenOn;
         return step;
-      });
+      }) : null;
+
     const step = Array.isArray(steps) ? steps[currentStep - 1] : null;
 
     return (

--- a/packages/amis/src/renderers/Wizard.tsx
+++ b/packages/amis/src/renderers/Wizard.tsx
@@ -34,6 +34,7 @@ import {ActionSchema} from './Action';
 import {tokenize, evalExpressionWithConditionBuilder} from 'amis-core';
 import {StepSchema} from './Steps';
 import isEqual from 'lodash/isEqual';
+import {omit} from 'lodash';
 
 export type WizardStepSchema = Omit<FormSchema, 'type'> &
   StepSchema & {
@@ -409,7 +410,7 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
     }
     this.setState({
       rawSteps: rawSteps.map((step, index) => ({
-        ...steps,
+        ...step,
         hiddenOn: '',
         title:
           step.title ||

--- a/packages/amis/src/renderers/Wizard.tsx
+++ b/packages/amis/src/renderers/Wizard.tsx
@@ -408,17 +408,16 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
       !hiddenFlag && rawSteps.push(steps[i]);
     }
     this.setState({
-      rawSteps: rawSteps.map((step, index) => {
-        delete step.hiddenOn;
-        return Object.assign(step, {
-          title:
-            step.title ||
-            step.label ||
-            __('Steps.step', {
-              index: index + 1
-            })
-        });
-      })
+      rawSteps: rawSteps.map((step, index) => ({
+        ...steps,
+        hiddenOn: '',
+        title:
+          step.title ||
+          step.label ||
+          __('Steps.step', {
+            index: index + 1
+          })
+      }))
     });
   }
 

--- a/packages/amis/src/renderers/Wizard.tsx
+++ b/packages/amis/src/renderers/Wizard.tsx
@@ -349,8 +349,11 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
     const props = this.props;
     const {store, fetchSuccess, fetchFailed} = props;
 
-    // 步骤steps改变
-    if (!isEqual(prevProps.steps, props.steps)) {
+    // 步骤steps、上下文数据data改变时需要执行normalizeSteps
+    if (
+      !isEqual(prevProps.steps, props.steps) ||
+      !isEqual(prevProps.data, props.data)
+    ) {
       this.normalizeSteps(props.data);
     }
 
@@ -1339,7 +1342,6 @@ export class WizardRenderer extends Wizard {
   }
 
   setData(values: object, replace?: boolean) {
-    this.normalizeSteps(values);
     return this.props.store.updateData(values, undefined, replace);
   }
 


### PR DESCRIPTION
1. wizard组件步骤条换成amis-ui的steps组件
2. amis-ui的steps组件支持onClickStep事件，支持wizard组件点击步骤后跳转
3. wizard支持withWrapPanel属性（是否包含panel边框，同form组件的withWrapPanel）
4. amis-ui支持不同区域的样式配置：stepsClassName（步骤条区域样式）、stepClassName（除去底部操作栏区域样式）、bodyClassName（表单区域样式）、footerClassName（底部操作栏样式）
5. wizard组件支持动态步骤