### PR TITLE
fix: InputImage裁剪后图片上传失效问题

### DIFF
--- a/packages/amis-core/src/utils/api.ts
+++ b/packages/amis-core/src/utils/api.ts
@@ -458,7 +458,12 @@ export function wrapFetcher(
       debug('api', 'after requestAdaptor', api);
     }
 
-    if (api.data && (hasFile(api.data) || api.dataType === 'form-data')) {
+    if (
+      api.data &&
+      (api.data instanceof FormData ||
+        hasFile(api.data) ||
+        api.dataType === 'form-data')
+    ) {
       api.data =
         api.data instanceof FormData
           ? api.data


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6862c0e</samp>

Added a new prop `fileField` to the `InputFile` and `InputImage` components, to allow customizing the file field name in the form data. Improved the type safety and flexibility of the `wrapFetcher` and `hasFile` functions in `api.ts`. Moved the `hasFile` function from `helper.ts` to `api.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6862c0e</samp>

> _Sing, O Muse, of the skillful `InputFile` component,_
> _That can send many files to the server with ease,_
> _And of the wise `wrapFetcher` function, its helper,_
> _That adapts to different file fields as it please._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6862c0e</samp>

*  Change the `options` parameter type of `wrapFetcher` function to `Record<string, any>` for better type checking ([link](https://github.com/baidu/amis/pull/6605/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL452-R456))
*  Add `fileField` parameter to `wrapFetcher` function and `hasFile` function to allow customizing the file field name in `FormData` object ([link](https://github.com/baidu/amis/pull/6605/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL461-R468), [link](https://github.com/baidu/amis/pull/6605/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1250-R1254))
*  Move `hasFile` function from `helper.ts` to `api.ts` to avoid circular dependencies and make it more accessible ([link](https://github.com/baidu/amis/pull/6605/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1250-R1254))
*  Update `InputFile` and `InputImage` components to destructure and pass `fileField` prop to `wrapFetcher` function ([link](https://github.com/baidu/amis/pull/6605/files?diff=unified&w=0#diff-5797b78d8d3f6d8899dfdb4fdebd4cf26bfb055b5b98c285726d6b8cad948b33L1220-R1220), [link](https://github.com/baidu/amis/pull/6605/files?diff=unified&w=0#diff-5797b78d8d3f6d8899dfdb4fdebd4cf26bfb055b5b98c285726d6b8cad948b33L1242-R1242), [link](https://github.com/baidu/amis/pull/6605/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1204-R1205))
