### PR TITLE
style(amis-editor): 调高画布区高亮元素区域的层级，避免被遮挡

### DIFF
--- a/packages/amis-editor-core/scss/editor.scss
+++ b/packages/amis-editor-core/scss/editor.scss
@@ -790,7 +790,7 @@
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  z-index: 100;
+  z-index: 1000;
   pointer-events: none;
 }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 29fce80</samp>

Increased the `z-index` of the editor overlay in `editor.scss` to fix UI issues. This change makes the editor more visible and usable when editing complex pages.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 29fce80</samp>

> _Editor overlay_
> _`z-index` rises above_
> _Winter snowflakes fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 29fce80</samp>

* Increase the `z-index` of the editor overlay to prevent it from being hidden by other elements ([link](https://github.com/baidu/amis/pull/6609/files?diff=unified&w=0#diff-a655efcb1bba154f0bdcbcff35544de6ac126ba2ace65f57c008e0d1eb4c1fc9L793-R793))
