### PR TITLE
fix: 修复 inputTag 对 valueField 和 labelField 的适配问题

### DIFF
--- a/packages/amis/src/renderers/Form/InputTag.tsx
+++ b/packages/amis/src/renderers/Form/InputTag.tsx
@@ -164,7 +164,7 @@ export default class TagControl extends React.PureComponent<
 
   /** 处理输入的内容 */
   normalizeInputValue(inputValue: string): Option[] {
-    const {enableBatchAdd, separator} = this.props;
+    const {enableBatchAdd, separator, valueField, labelField} = this.props;
     let batchValues = [];
 
     if (enableBatchAdd && separator && typeof separator === 'string') {
@@ -173,9 +173,10 @@ export default class TagControl extends React.PureComponent<
       batchValues.push(inputValue);
     }
 
-    return batchValues
-      .filter(Boolean)
-      .map(item => ({value: item, label: item}));
+    return batchValues.filter(Boolean).map(item => ({
+      [`${valueField || 'value'}`]: item,
+      [`${labelField || 'label'}`]: item
+    }));
   }
 
   normalizeOptions(options: Option[]) {
@@ -190,12 +191,13 @@ export default class TagControl extends React.PureComponent<
 
   /** 输入的内容和存量的内容合并，过滤掉value值相同的 */
   normalizeMergedValue(inputValue: string, normalized: boolean = true) {
-    const {selectedOptions} = this.props;
+    const {selectedOptions, valueField} = this.props;
 
     const options = unionWith(
       selectedOptions.concat(),
       this.normalizeInputValue(inputValue),
-      (origin: Option, input: Option) => origin.value === input.value
+      (origin: Option, input: Option) =>
+        origin[valueField || 'value'] === input[valueField || 'value']
     );
 
     return normalized ? this.normalizeOptions(options) : options;
@@ -207,7 +209,8 @@ export default class TagControl extends React.PureComponent<
       maxTagLength,
       enableBatchAdd,
       separator,
-      onInputValidateFailed
+      onInputValidateFailed,
+      valueField
     } = this.props;
 
     const normalizedValue = this.normalizeMergedValue(
@@ -217,7 +220,7 @@ export default class TagControl extends React.PureComponent<
 
     if (max != null && isInteger(max) && normalizedValue.length > max) {
       onInputValidateFailed?.(
-        normalizedValue.map(item => item.value),
+        normalizedValue.map(item => item[valueField || 'value']),
         'max'
       );
       return false;
@@ -228,10 +231,12 @@ export default class TagControl extends React.PureComponent<
     if (
       maxTagLength != null &&
       isInteger(maxTagLength) &&
-      addedValues.some(item => item.value.length > maxTagLength)
+      addedValues.some(
+        item => item[valueField || 'value'].length > maxTagLength
+      )
     ) {
       onInputValidateFailed?.(
-        addedValues.map(item => item.value),
+        addedValues.map(item => item[valueField || 'value']),
         'maxLength'
       );
       return false;
@@ -264,10 +269,15 @@ export default class TagControl extends React.PureComponent<
       return;
     }
 
-    const {selectedOptions, onChange} = this.props;
+    const {selectedOptions, onChange, valueField} = this.props;
     const newValue = selectedOptions.concat();
 
-    if (find(newValue, item => item.value == option.value)) {
+    if (
+      find(
+        newValue,
+        item => item[valueField || 'value'] == option[valueField || 'value']
+      )
+    ) {
       return;
     }
 
@@ -371,10 +381,14 @@ export default class TagControl extends React.PureComponent<
 
   @autobind
   async handleKeyDown(evt: React.KeyboardEvent<HTMLInputElement>) {
-    const {selectedOptions, onChange, delimiter} = this.props;
+    const {selectedOptions, onChange, delimiter, labelField, valueField} =
+      this.props;
 
     const value = this.state.inputValue.trim();
-    const selectedItems = selectedOptions.concat({label: value, value});
+    const selectedItems = selectedOptions.concat({
+      [`${labelField || 'label'}`]: value,
+      [`${valueField || 'value'}`]: value
+    });
 
     if (selectedOptions.length && !value && evt.key == 'Backspace') {
       const newValueRes = this.getValue('pop');
@@ -457,7 +471,8 @@ export default class TagControl extends React.PureComponent<
       maxTagCount,
       overflowTagPopover,
       translate: __,
-      loadingConfig
+      loadingConfig,
+      valueField
     } = this.props;
 
     const finnalOptions = Array.isArray(options)
@@ -465,7 +480,8 @@ export default class TagControl extends React.PureComponent<
           options,
           item =>
             (Array.isArray(item.children) && !!item.children.length) ||
-            (item.value !== undefined && !~selectedOptions.indexOf(item)),
+            (item[valueField || 'value'] !== undefined &&
+              !~selectedOptions.indexOf(item)),
           0,
           true
         )


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ffc44e2</samp>

This pull request enhances the `InputTag` component to allow customizing the fields of the options. It updates the logic and rendering of the component to use the `valueField` and `labelField` props instead of `value` and `label`. This enables more flexibility and compatibility with different data sources.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ffc44e2</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A way to customize the `InputTag` component's fields,_
> _So that the user could choose the name and the display_
> _Of the options that the component renders and reveals._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ffc44e2</samp>

*  Support customizing the fields of the options for InputTag component by using `valueField` and `labelField` props ([link](https://github.com/baidu/amis/pull/6611/files?diff=unified&w=0#diff-4103a995836e1ba992d9983ff105ac554d14cd82653af751b39057246d3f5fb7L167-R167), [link](https://github.com/baidu/amis/pull/6611/files?diff=unified&w=0#diff-4103a995836e1ba992d9983ff105ac554d14cd82653af751b39057246d3f5fb7L176-R179), [link](https://github.com/baidu/amis/pull/6611/files?diff=unified&w=0#diff-4103a995836e1ba992d9983ff105ac554d14cd82653af751b39057246d3f5fb7L193-R200), [link](https://github.com/baidu/amis/pull/6611/files?diff=unified&w=0#diff-4103a995836e1ba992d9983ff105ac554d14cd82653af751b39057246d3f5fb7L210-R213), [link](https://github.com/baidu/amis/pull/6611/files?diff=unified&w=0#diff-4103a995836e1ba992d9983ff105ac554d14cd82653af751b39057246d3f5fb7L220-R223), [link](https://github.com/baidu/amis/pull/6611/files?diff=unified&w=0#diff-4103a995836e1ba992d9983ff105ac554d14cd82653af751b39057246d3f5fb7L231-R239), [link](https://github.com/baidu/amis/pull/6611/files?diff=unified&w=0#diff-4103a995836e1ba992d9983ff105ac554d14cd82653af751b39057246d3f5fb7L267-R280), [link](https://github.com/baidu/amis/pull/6611/files?diff=unified&w=0#diff-4103a995836e1ba992d9983ff105ac554d14cd82653af751b39057246d3f5fb7L374-R391), [link](https://github.com/baidu/amis/pull/6611/files?diff=unified&w=0#diff-4103a995836e1ba992d9983ff105ac554d14cd82653af751b39057246d3f5fb7L460-R475), [link](https://github.com/baidu/amis/pull/6611/files?diff=unified&w=0#diff-4103a995836e1ba992d9983ff105ac554d14cd82653af751b39057246d3f5fb7L468-R484)) in `packages/amis/src/renderers/Form/InputTag.tsx`
