### PR TITLE
chore:简化resolveEventData调用

### DIFF
--- a/packages/amis-core/src/renderers/Options.tsx
+++ b/packages/amis-core/src/renderers/Options.tsx
@@ -483,8 +483,7 @@ export function registerOptionsControl(config: OptionsConfig) {
         eventName,
         resolveEventData(
           this.props,
-          {value: eventData, options, items: options}, // 为了保持名字统一
-          'value'
+          {value: eventData, options, items: options} // 为了保持名字统一
         )
       );
       // 返回阻塞标识

--- a/packages/amis-core/src/utils/renderer-event.ts
+++ b/packages/amis-core/src/utils/renderer-event.ts
@@ -252,7 +252,11 @@ export const getRendererEventListeners = () => {
  * @param data
  * @param valueKey
  */
-export const resolveEventData = (props: any, data: any, valueKey?: string) => {
+export const resolveEventData = (
+  props: any,
+  data: any,
+  valueKey: string = 'value'
+) => {
   return createObject(
     props.data,
     props.name && valueKey

--- a/packages/amis/src/renderers/Form/ChainedSelect.tsx
+++ b/packages/amis/src/renderers/Form/ChainedSelect.tsx
@@ -190,7 +190,7 @@ export default class ChainedSelectControl extends React.Component<
 
               const rendererEvent = await dispatchEvent(
                 'change',
-                resolveEventData(this.props, {value: valueRes}, 'value')
+                resolveEventData(this.props, {value: valueRes})
               );
 
               if (rendererEvent?.prevented) {
@@ -244,7 +244,7 @@ export default class ChainedSelectControl extends React.Component<
 
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(this.props, {value: valueRes}, 'value')
+      resolveEventData(this.props, {value: valueRes})
     );
 
     if (rendererEvent?.prevented) {

--- a/packages/amis/src/renderers/Form/Checkbox.tsx
+++ b/packages/amis/src/renderers/Form/Checkbox.tsx
@@ -83,7 +83,7 @@ export default class CheckboxControl extends React.Component<
     const {dispatchEvent, onChange} = this.props;
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(this.props, {value: eventData}, 'value')
+      resolveEventData(this.props, {value: eventData})
     );
 
     if (rendererEvent?.prevented) {

--- a/packages/amis/src/renderers/Form/Combo.tsx
+++ b/packages/amis/src/renderers/Form/Combo.tsx
@@ -594,14 +594,10 @@ export default class ComboControl extends React.Component<ComboProps> {
     // todo:这里的数据结构与表单项最终类型不一致，需要区分是否多选、是否未input-kv or input-kvs
     const rendererEvent = await dispatchEvent(
       'add',
-      resolveEventData(
-        this.props,
-        {
-          value:
-            flat && joinValues ? value.join(delimiter || ',') : cloneDeep(value)
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        value:
+          flat && joinValues ? value.join(delimiter || ',') : cloneDeep(value)
+      })
     );
 
     if (rendererEvent?.prevented) {
@@ -652,18 +648,12 @@ export default class ComboControl extends React.Component<ComboProps> {
     // todo:这里的数据结构与表单项最终类型不一致，需要区分是否多选、是否未input-kv or input-kvs
     const rendererEvent = await dispatchEvent(
       'delete',
-      resolveEventData(
-        this.props,
-        {
-          key,
-          value:
-            flat && joinValues
-              ? value.join(delimiter || ',')
-              : cloneDeep(value),
-          item: value[key]
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        key,
+        value:
+          flat && joinValues ? value.join(delimiter || ',') : cloneDeep(value),
+        item: value[key]
+      })
     );
 
     if (rendererEvent?.prevented) {

--- a/packages/amis/src/renderers/Form/DiffEditor.tsx
+++ b/packages/amis/src/renderers/Form/DiffEditor.tsx
@@ -143,7 +143,7 @@ export class DiffEditor extends React.Component<DiffEditorProps, any> {
 
     const rendererEvent = await dispatchEvent(
       'focus',
-      resolveEventData(this.props, {value}, 'value')
+      resolveEventData(this.props, {value})
     );
 
     if (rendererEvent?.prevented) {
@@ -162,7 +162,7 @@ export class DiffEditor extends React.Component<DiffEditorProps, any> {
 
     const rendererEvent = await dispatchEvent(
       'blur',
-      resolveEventData(this.props, {value}, 'value')
+      resolveEventData(this.props, {value})
     );
 
     if (rendererEvent?.prevented) {
@@ -259,7 +259,7 @@ export class DiffEditor extends React.Component<DiffEditorProps, any> {
 
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(this.props, {value}, 'value')
+      resolveEventData(this.props, {value})
     );
 
     if (rendererEvent?.prevented) {

--- a/packages/amis/src/renderers/Form/Editor.tsx
+++ b/packages/amis/src/renderers/Form/Editor.tsx
@@ -191,7 +191,7 @@ export default class EditorControl extends React.Component<EditorProps, any> {
 
     const rendererEvent = await dispatchEvent(
       'focus',
-      resolveEventData(this.props, {value}, 'value')
+      resolveEventData(this.props, {value})
     );
 
     if (rendererEvent?.prevented) {
@@ -210,7 +210,7 @@ export default class EditorControl extends React.Component<EditorProps, any> {
 
     const rendererEvent = await dispatchEvent(
       'blur',
-      resolveEventData(this.props, {value}, 'value')
+      resolveEventData(this.props, {value})
     );
 
     if (rendererEvent?.prevented) {
@@ -225,7 +225,7 @@ export default class EditorControl extends React.Component<EditorProps, any> {
 
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(this.props, {value: e}, 'value')
+      resolveEventData(this.props, {value: e})
     );
 
     if (rendererEvent?.prevented) {

--- a/packages/amis/src/renderers/Form/InputDate.tsx
+++ b/packages/amis/src/renderers/Form/InputDate.tsx
@@ -431,7 +431,7 @@ export default class DateControl extends React.PureComponent<
   @autobind
   dispatchEvent(e: React.SyntheticEvent<HTMLElement>) {
     const {dispatchEvent, value} = this.props;
-    dispatchEvent(e, resolveEventData(this.props, {value}, 'value'));
+    dispatchEvent(e, resolveEventData(this.props, {value}));
   }
 
   // 动作
@@ -454,7 +454,7 @@ export default class DateControl extends React.PureComponent<
     const {dispatchEvent} = this.props;
     const dispatcher = dispatchEvent(
       'change',
-      resolveEventData(this.props, {value: nextValue}, 'value')
+      resolveEventData(this.props, {value: nextValue})
     );
     if (dispatcher?.prevented) {
       return;

--- a/packages/amis/src/renderers/Form/InputDateRange.tsx
+++ b/packages/amis/src/renderers/Form/InputDateRange.tsx
@@ -202,7 +202,7 @@ export default class DateRangeControl extends React.Component<DateRangeProps> {
   dispatchEvent(eventName: string) {
     const {dispatchEvent, data, value} = this.props;
 
-    dispatchEvent(eventName, resolveEventData(this.props, {value}, 'value'));
+    dispatchEvent(eventName, resolveEventData(this.props, {value}));
   }
 
   // 动作
@@ -225,7 +225,7 @@ export default class DateRangeControl extends React.Component<DateRangeProps> {
     const {dispatchEvent, data} = this.props;
     const dispatcher = dispatchEvent(
       'change',
-      resolveEventData(this.props, {value: nextValue}, 'value')
+      resolveEventData(this.props, {value: nextValue})
     );
     if (dispatcher?.prevented) {
       return;

--- a/packages/amis/src/renderers/Form/InputExcel.tsx
+++ b/packages/amis/src/renderers/Form/InputExcel.tsx
@@ -168,7 +168,7 @@ export default class ExcelControl extends React.PureComponent<
     const {dispatchEvent, data} = this.props;
     return await dispatchEvent(
       eventName,
-      resolveEventData(this.props, {value: eventData}, 'value')
+      resolveEventData(this.props, {value: eventData})
     );
   }
 

--- a/packages/amis/src/renderers/Form/InputNumber.tsx
+++ b/packages/amis/src/renderers/Form/InputNumber.tsx
@@ -287,7 +287,7 @@ export default class NumberControl extends React.Component<
   async dispatchEvent(eventName: string) {
     const {dispatchEvent, value} = this.props;
 
-    dispatchEvent(eventName, resolveEventData(this.props, {value}, 'value'));
+    dispatchEvent(eventName, resolveEventData(this.props, {value}));
   }
 
   async handleChange(inputValue: any) {
@@ -296,7 +296,7 @@ export default class NumberControl extends React.Component<
     const resultValue = clearValueOnEmpty && value === '' ? undefined : value;
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(this.props, {value: resultValue}, 'value')
+      resolveEventData(this.props, {value: resultValue})
     );
     if (rendererEvent?.prevented) {
       return;

--- a/packages/amis/src/renderers/Form/InputRange.tsx
+++ b/packages/amis/src/renderers/Form/InputRange.tsx
@@ -392,13 +392,9 @@ export class Input extends React.Component<RangeItemProps, any> {
 
     const rendererEvent = await dispatchEvent(
       'blur',
-      resolveEventData(
-        this.props,
-        {
-          value
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        value
+      })
     );
 
     if (rendererEvent?.prevented) {
@@ -417,13 +413,9 @@ export class Input extends React.Component<RangeItemProps, any> {
 
     const rendererEvent = await dispatchEvent(
       'focus',
-      resolveEventData(
-        this.props,
-        {
-          value
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        value
+      })
     );
 
     if (rendererEvent?.prevented) {
@@ -582,13 +574,9 @@ export default class RangeControl extends React.PureComponent<
 
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(
-        this.props,
-        {
-          value: result
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        value: result
+      })
     );
 
     if (rendererEvent?.prevented) {

--- a/packages/amis/src/renderers/Form/InputRating.tsx
+++ b/packages/amis/src/renderers/Form/InputRating.tsx
@@ -111,7 +111,7 @@ export default class RatingControl extends React.Component<RatingProps, any> {
 
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(this.props, {value}, 'value')
+      resolveEventData(this.props, {value})
     );
 
     if (rendererEvent?.prevented) {

--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -230,7 +230,7 @@ export interface TableState {
 }
 
 export type FormTableRendererEvent =
-  'add'
+  | 'add'
   | 'addConfirm'
   | 'addSuccess'
   | 'addFail'
@@ -315,8 +315,8 @@ export default class FormTable extends React.Component<TableProps, TableState> {
     // 如果static为true 或 disabled为true，
     // 则删掉正在新增 或 编辑的那一行
     if (
-      props.$schema.disabled !== nextProps.$schema.disabled
-      || props.$schema.static !== nextProps.$schema.static
+      props.$schema.disabled !== nextProps.$schema.disabled ||
+      props.$schema.static !== nextProps.$schema.static
     ) {
       const items = this.state.items.filter(item => !item.__isPlaceholder);
       toUpdate = {
@@ -532,10 +532,7 @@ export default class FormTable extends React.Component<TableProps, TableState> {
       } else {
         return this.addItem(items.length - 1, false);
       }
-    } else if (
-      actionType === 'remove' ||
-      actionType === 'delete'
-    ) {
+    } else if (actionType === 'remove' || actionType === 'delete') {
       if (!valueField) {
         return env.alert(__('Table.valueField'));
       } else if (!action.payload) {
@@ -556,11 +553,14 @@ export default class FormTable extends React.Component<TableProps, TableState> {
         }
       });
 
-      this.setState({
+      this.setState(
+        {
           items
-      }, () => {
-        onChange?.(items);
-      });
+        },
+        () => {
+          onChange?.(items);
+        }
+      );
 
       return;
     }
@@ -692,14 +692,10 @@ export default class FormTable extends React.Component<TableProps, TableState> {
     const {items} = this.state;
     const rendererEvent = await dispatchEvent(
       eventName,
-      resolveEventData(
-        this.props,
-        {
-          value: [...items],
-          ...eventData
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        value: [...items],
+        ...eventData
+      })
     );
 
     return !!rendererEvent?.prevented;
@@ -747,7 +743,10 @@ export default class FormTable extends React.Component<TableProps, TableState> {
     };
     const isNew = !!item.__isPlaceholder;
     const confirmEventName = isNew ? 'addConfirm' : 'editConfirm';
-    let isPrevented = await this.dispatchEvent(confirmEventName, {index: this.state.editIndex, item});
+    let isPrevented = await this.dispatchEvent(confirmEventName, {
+      index: this.state.editIndex,
+      item
+    });
     if (isPrevented) {
       return;
     }
@@ -765,7 +764,11 @@ export default class FormTable extends React.Component<TableProps, TableState> {
     if (remote && !remote.ok) {
       env.notify('error', apiMsg ?? (remote.msg || __('saveFailed')));
       const failEventName = isNew ? 'addFail' : 'editFail';
-      this.dispatchEvent(failEventName, {index: this.state.editIndex, item, error: remote});
+      this.dispatchEvent(failEventName, {
+        index: this.state.editIndex,
+        item,
+        error: remote
+      });
       return;
     } else if (remote && remote.ok) {
       item = merge(
@@ -790,7 +793,10 @@ export default class FormTable extends React.Component<TableProps, TableState> {
           return;
         }
         const successEventName = isNew ? 'addSuccess' : 'editSuccess';
-        this.dispatchEvent(successEventName, {index: this.state.editIndex, item});
+        this.dispatchEvent(successEventName, {
+          index: this.state.editIndex,
+          item
+        });
       }
     );
   }
@@ -993,7 +999,10 @@ export default class FormTable extends React.Component<TableProps, TableState> {
               }
             };
       });
-    } else if (isStatic !== true && (props.addable || props.editable || isCreateMode)) {
+    } else if (
+      isStatic !== true &&
+      (props.addable || props.editable || isCreateMode)
+    ) {
       columns = columns.map(column => {
         const quickEdit =
           !isCreateMode && column.hasOwnProperty('quickEditOnUpdate')
@@ -1017,7 +1026,8 @@ export default class FormTable extends React.Component<TableProps, TableState> {
             };
       });
 
-      !isStatic && props.editable &&
+      !isStatic &&
+        props.editable &&
         btns.push({
           children: ({
             key,
@@ -1068,79 +1078,84 @@ export default class FormTable extends React.Component<TableProps, TableState> {
             )
         });
 
-      !isStatic && btns.push({
-        children: ({
-          key,
-          rowIndex,
-          offset
-        }: {
-          key: any;
-          rowIndex: number;
-          offset: number;
-        }) =>
-          this.state.editIndex === rowIndex + offset ? (
-            <Button
-              classPrefix={ns}
-              size="sm"
-              key={key}
-              level="link"
-              tooltip={__('save')}
-              tooltipContainer={
-                env && env.getModalContainer ? env.getModalContainer : undefined
-              }
-              onClick={this.confirmEdit}
-            >
-              {props.confirmBtnIcon ? (
-                typeof props.confirmBtnIcon === 'string' ? (
-                  <Icon icon={props.confirmBtnIcon} className="icon" />
-                ) : (
-                  generateIcon(props.classnames, props.confirmBtnIcon)
-                )
-              ) : null}
-              {props.confirmBtnLabel ? (
-                <span>{props.confirmBtnLabel}</span>
-              ) : null}
-            </Button>
-          ) : null
-      });
+      !isStatic &&
+        btns.push({
+          children: ({
+            key,
+            rowIndex,
+            offset
+          }: {
+            key: any;
+            rowIndex: number;
+            offset: number;
+          }) =>
+            this.state.editIndex === rowIndex + offset ? (
+              <Button
+                classPrefix={ns}
+                size="sm"
+                key={key}
+                level="link"
+                tooltip={__('save')}
+                tooltipContainer={
+                  env && env.getModalContainer
+                    ? env.getModalContainer
+                    : undefined
+                }
+                onClick={this.confirmEdit}
+              >
+                {props.confirmBtnIcon ? (
+                  typeof props.confirmBtnIcon === 'string' ? (
+                    <Icon icon={props.confirmBtnIcon} className="icon" />
+                  ) : (
+                    generateIcon(props.classnames, props.confirmBtnIcon)
+                  )
+                ) : null}
+                {props.confirmBtnLabel ? (
+                  <span>{props.confirmBtnLabel}</span>
+                ) : null}
+              </Button>
+            ) : null
+        });
 
-      !isStatic && btns.push({
-        children: ({
-          key,
-          rowIndex,
-          offset
-        }: {
-          key: any;
-          rowIndex: number;
-          offset: number;
-        }) =>
-          this.state.editIndex === rowIndex + offset ? (
-            <Button
-              classPrefix={ns}
-              size="sm"
-              key={key}
-              level="link"
-              tooltip={__('cancel')}
-              tooltipContainer={
-                env && env.getModalContainer ? env.getModalContainer : undefined
-              }
-              onClick={this.cancelEdit}
-            >
-              {props.cancelBtnIcon ? (
-                typeof props.cancelBtnIcon === 'string' ? (
-                  <Icon icon={props.cancelBtnIcon} className="icon" />
-                ) : (
-                  generateIcon(props.classnames, props.cancelBtnIcon)
-                )
-              ) : null}
-              {props.cancelBtnLabel ? (
-                <span>{props.cancelBtnLabel}</span>
-              ) : null}
-            </Button>
-          ) : null
-      });
-    }
-    else {
+      !isStatic &&
+        btns.push({
+          children: ({
+            key,
+            rowIndex,
+            offset
+          }: {
+            key: any;
+            rowIndex: number;
+            offset: number;
+          }) =>
+            this.state.editIndex === rowIndex + offset ? (
+              <Button
+                classPrefix={ns}
+                size="sm"
+                key={key}
+                level="link"
+                tooltip={__('cancel')}
+                tooltipContainer={
+                  env && env.getModalContainer
+                    ? env.getModalContainer
+                    : undefined
+                }
+                onClick={this.cancelEdit}
+              >
+                {props.cancelBtnIcon ? (
+                  typeof props.cancelBtnIcon === 'string' ? (
+                    <Icon icon={props.cancelBtnIcon} className="icon" />
+                  ) : (
+                    generateIcon(props.classnames, props.cancelBtnIcon)
+                  )
+                ) : null}
+                {props.cancelBtnLabel ? (
+                  <span>{props.cancelBtnLabel}</span>
+                ) : null}
+              </Button>
+            ) : null
+        });
+    } else {
       columns = columns.map(column => {
         const render = getRendererByName(column?.type);
         if (!!render?.isFormItem) {
@@ -1150,7 +1165,7 @@ export default class FormTable extends React.Component<TableProps, TableState> {
               ...column,
               isFormMode: true
             }
-          }
+          };
         }
         return column;
       });
@@ -1316,25 +1331,31 @@ export default class FormTable extends React.Component<TableProps, TableState> {
         }
       });
 
-      const data = mergeWith({}, origin, diff, (
-        objValue: any,
-        srcValue: any,
-        key: string,
-        object: any,
-        source: any,
-        stack: any
-      ) => {
-        // 只对第一层做处理，如果不是combo，并且是数组，直接采用diff的值
-        if (
-          stack.size === 0
-          && comboNames.indexOf(key) === -1
-          && Array.isArray(objValue)
-          && Array.isArray(srcValue)) {
-          return srcValue;
+      const data = mergeWith(
+        {},
+        origin,
+        diff,
+        (
+          objValue: any,
+          srcValue: any,
+          key: string,
+          object: any,
+          source: any,
+          stack: any
+        ) => {
+          // 只对第一层做处理，如果不是combo，并且是数组，直接采用diff的值
+          if (
+            stack.size === 0 &&
+            comboNames.indexOf(key) === -1 &&
+            Array.isArray(objValue) &&
+            Array.isArray(srcValue)
+          ) {
+            return srcValue;
+          }
+          // 直接return，默认走的mergeWith自身的merge
+          return;
         }
-        // 直接return，默认走的mergeWith自身的merge
-        return;
-      });
+      );
 
       items = spliceTree(items, indexes, 1, data);
       this.entries.set(data, this.entries.get(origin) || this.entityId++);
@@ -1482,7 +1503,9 @@ export default class FormTable extends React.Component<TableProps, TableState> {
       label: __('Table.add'),
       icon: 'fa fa-plus',
       disabled: footerAddBtnDisabled,
-      ...(footerAddBtnDisabled ? {disabledTip: __('Table.addButtonDisabledTip')} : {})
+      ...(footerAddBtnDisabled
+        ? {disabledTip: __('Table.addButtonDisabledTip')}
+        : {})
     };
 
     if (footerAddBtn !== undefined) {
@@ -1530,16 +1553,17 @@ export default class FormTable extends React.Component<TableProps, TableState> {
             // onPristineChange: this.handlePristineChange
           }
         )}
-        {(!isStatic && addable &&
+        {(!isStatic &&
+          addable &&
           showFooterAddBtn !== false &&
           (!maxLength || maxLength > items.length)) ||
         showPager ? (
           <div className={cx('InputTable-toolbar')}>
-            {addable && showFooterAddBtn !== false ? (
-              render('button', footerAddBtnSchema, {
-                onClick: () => this.addItem(this.state.items.length)
-              })
-            ) : null}
+            {addable && showFooterAddBtn !== false
+              ? render('button', footerAddBtnSchema, {
+                  onClick: () => this.addItem(this.state.items.length)
+                })
+              : null}
 
             {showPager
               ? render(
@@ -1571,12 +1595,19 @@ export class TableControlRenderer extends FormTable {
       // 如果setValue动作传入了index，更新指定索引的值
       const items = [...this.state.items];
       items.splice(index, 1, value);
-      this.setState({items}, () => {this.emitValue()});
+      this.setState({items}, () => {
+        this.emitValue();
+      });
     } else {
       // 如果setValue动作没有传入index，则直接替换组件数据
-      this.setState({
-        items: [...value]
-      }, () => {this.emitValue()});
+      this.setState(
+        {
+          items: [...value]
+        },
+        () => {
+          this.emitValue();
+        }
+      );
     }
   }
 
@@ -1635,7 +1666,8 @@ export class TableControlRenderer extends FormTable {
             !valueField ||
             !find(
               items,
-              item => item[valueField as string] == toAdd[i - 1][valueField as string]
+              item =>
+                item[valueField as string] == toAdd[i - 1][valueField as string]
             )
           ) {
             items.splice(pushIndex, 0, toAdd[i - 1]);
@@ -1683,7 +1715,10 @@ export class TableControlRenderer extends FormTable {
       }
       // 删除api
       if (isEffectiveApi(deleteApi, createObject(ctx, {deletedItems}))) {
-        const payload = await env.fetcher(deleteApi, createObject(ctx, {deletedItems}));
+        const payload = await env.fetcher(
+          deleteApi,
+          createObject(ctx, {deletedItems})
+        );
         if (payload && !payload.ok) {
           env.notify(
             'error',
@@ -1693,26 +1728,35 @@ export class TableControlRenderer extends FormTable {
           return;
         }
       }
-      this.setState({
-        items: rawItems
-      }, () => {
-        onChange?.(rawItems);
-      });
+      this.setState(
+        {
+          items: rawItems
+        },
+        () => {
+          onChange?.(rawItems);
+        }
+      );
       return;
     } else if (actionType === 'clear') {
-      this.setState({
-        items: []
-      }, () => {
-        onChange?.([]);
-      });
+      this.setState(
+        {
+          items: []
+        },
+        () => {
+          onChange?.([]);
+        }
+      );
       return;
     } else if (actionType === 'reset') {
       const newItems = Array.isArray(resetValue) ? resetValue : [];
-      this.setState({
-        items: newItems
-      }, () => {
-        onChange?.(newItems);
-      });
+      this.setState(
+        {
+          items: newItems
+        },
+        () => {
+          onChange?.(newItems);
+        }
+      );
       return;
     }
     return super.doAction(action as ActionObject, ctx, ...rest);

--- a/packages/amis/src/renderers/Form/InputTag.tsx
+++ b/packages/amis/src/renderers/Form/InputTag.tsx
@@ -148,15 +148,11 @@ export default class TagControl extends React.PureComponent<
     const {dispatchEvent, options} = this.props;
     const rendererEvent = await dispatchEvent(
       eventName,
-      resolveEventData(
-        this.props,
-        {
-          options,
-          items: options, // 为了保持名字统一
-          ...eventData
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        options,
+        items: options, // 为了保持名字统一
+        ...eventData
+      })
     );
     // 返回阻塞标识
     return !!rendererEvent?.prevented;

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -310,13 +310,9 @@ export default class TextControl extends React.PureComponent<
     const {dispatchEvent, value} = this.props;
     const rendererEvent = await dispatchEvent(
       'click',
-      resolveEventData(
-        this.props,
-        {
-          value
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        value
+      })
     );
 
     if (rendererEvent?.prevented) {
@@ -338,13 +334,9 @@ export default class TextControl extends React.PureComponent<
 
     const rendererEvent = await dispatchEvent(
       'focus',
-      resolveEventData(
-        this.props,
-        {
-          value
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        value
+      })
     );
 
     if (rendererEvent?.prevented) {
@@ -370,13 +362,9 @@ export default class TextControl extends React.PureComponent<
 
     const rendererEvent = await dispatchEvent(
       'blur',
-      resolveEventData(
-        this.props,
-        {
-          value
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        value
+      })
     );
 
     if (rendererEvent?.prevented) {
@@ -391,7 +379,7 @@ export default class TextControl extends React.PureComponent<
     const {creatable, multiple, onChange, dispatchEvent} = this.props;
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(this.props, {value}, 'value')
+      resolveEventData(this.props, {value})
     );
 
     if (rendererEvent?.prevented) {
@@ -455,7 +443,7 @@ export default class TextControl extends React.PureComponent<
 
       const rendererEvent = await dispatchEvent(
         'enter',
-        resolveEventData(this.props, {value}, 'value')
+        resolveEventData(this.props, {value})
       );
 
       if (rendererEvent?.prevented) {
@@ -571,7 +559,7 @@ export default class TextControl extends React.PureComponent<
 
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(this.props, {value}, 'value')
+      resolveEventData(this.props, {value})
     );
 
     if (rendererEvent?.prevented) {

--- a/packages/amis/src/renderers/Form/InputTree.tsx
+++ b/packages/amis/src/renderers/Form/InputTree.tsx
@@ -266,7 +266,7 @@ export default class TreeControl extends React.Component<TreeProps, TreeState> {
 
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(this.props, {value}, 'value')
+      resolveEventData(this.props, {value})
     );
 
     if (rendererEvent?.prevented) {

--- a/packages/amis/src/renderers/Form/MatrixCheckboxes.tsx
+++ b/packages/amis/src/renderers/Form/MatrixCheckboxes.tsx
@@ -281,7 +281,7 @@ export default class MatrixCheckbox extends React.Component<
 
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(this.props, {value: value.concat()}, 'value')
+      resolveEventData(this.props, {value: value.concat()})
     );
     if (rendererEvent?.prevented) {
       return;

--- a/packages/amis/src/renderers/Form/NestedSelect.tsx
+++ b/packages/amis/src/renderers/Form/NestedSelect.tsx
@@ -1,8 +1,19 @@
 import React from 'react';
-import {ResultBox, Spinner,Icon, PopUp, Checkbox, Cascader, SpinnerExtraProps} from 'amis-ui';
 import {
-  Overlay, resolveEventData,
-  PopOver, Option, Options,
+  ResultBox,
+  Spinner,
+  Icon,
+  PopUp,
+  Checkbox,
+  Cascader,
+  SpinnerExtraProps
+} from 'amis-ui';
+import {
+  Overlay,
+  resolveEventData,
+  PopOver,
+  Option,
+  Options,
   autobind,
   flattenTree,
   filterTree,
@@ -136,7 +147,7 @@ export default class NestedSelectControl extends React.Component<
     const {dispatchEvent} = this.props;
     const rendererEvent = await dispatchEvent(
       eventName,
-      resolveEventData(this.props, eventData, 'value')
+      resolveEventData(this.props, eventData)
     );
     // 返回阻塞标识
     return !!rendererEvent?.prevented;

--- a/packages/amis/src/renderers/Form/Picker.tsx
+++ b/packages/amis/src/renderers/Form/Picker.tsx
@@ -288,11 +288,7 @@ export default class PickerControl extends React.PureComponent<
     const option = multiple ? items : items[0];
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(
-        this.props,
-        {value, option, selectedItems: option},
-        'value'
-      )
+      resolveEventData(this.props, {value, option, selectedItems: option})
     );
     if (rendererEvent?.prevented) {
       return;

--- a/packages/amis/src/renderers/Form/Radios.tsx
+++ b/packages/amis/src/renderers/Form/Radios.tsx
@@ -73,16 +73,12 @@ export default class RadiosControl extends React.Component<RadiosProps, any> {
 
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(
-        this.props,
-        {
-          value,
-          options,
-          items: options, // 为了保持名字统一
-          selectedItems: option
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        value,
+        options,
+        items: options, // 为了保持名字统一
+        selectedItems: option
+      })
     );
     if (rendererEvent?.prevented) {
       return;

--- a/packages/amis/src/renderers/Form/Select.tsx
+++ b/packages/amis/src/renderers/Form/Select.tsx
@@ -274,18 +274,14 @@ export default class SelectControl extends React.Component<SelectProps, any> {
     // 触发渲染器事件
     const rendererEvent = await dispatchEvent(
       eventName,
-      resolveEventData(
-        this.props,
-        {
-          options,
-          items: options, // 为了保持名字统一
-          value: ['onEdit', 'onDelete'].includes(event)
-            ? eventData
-            : eventData && eventData.value,
-          selectedItems: multiple ? selectedOptions : selectedOptions[0]
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        options,
+        items: options, // 为了保持名字统一
+        value: ['onEdit', 'onDelete'].includes(event)
+          ? eventData
+          : eventData && eventData.value,
+        selectedItems: multiple ? selectedOptions : selectedOptions[0]
+      })
     );
     if (rendererEvent?.prevented) {
       return;
@@ -308,16 +304,12 @@ export default class SelectControl extends React.Component<SelectProps, any> {
 
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(
-        this.props,
-        {
-          value: newValue,
-          options,
-          items: options, // 为了保持名字统一
-          selectedItems: value
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        value: newValue,
+        options,
+        items: options, // 为了保持名字统一
+        selectedItems: value
+      })
     );
     if (rendererEvent?.prevented) {
       return;

--- a/packages/amis/src/renderers/Form/Switch.tsx
+++ b/packages/amis/src/renderers/Form/Switch.tsx
@@ -73,7 +73,7 @@ export default class SwitchControl extends React.Component<SwitchProps, any> {
     const {dispatchEvent, onChange} = this.props;
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(this.props, {value: checked}, 'value')
+      resolveEventData(this.props, {value: checked})
     );
     if (rendererEvent?.prevented) {
       return;
@@ -83,11 +83,7 @@ export default class SwitchControl extends React.Component<SwitchProps, any> {
   }
 
   getResult() {
-    const {
-      classnames: cx,
-      onText,
-      offText,
-    } = this.props;
+    const {classnames: cx, onText, offText} = this.props;
     const on = isObject(onText)
       ? generateIcon(cx, onText.icon, 'Switch-icon')
       : onText;
@@ -98,11 +94,7 @@ export default class SwitchControl extends React.Component<SwitchProps, any> {
   }
 
   renderBody(children: any) {
-    const {
-      classnames: cx,
-      option,
-      optionAtLeft
-    } = this.props;
+    const {classnames: cx, option, optionAtLeft} = this.props;
 
     const Option = <span className={cx('Switch-option')}>{option}</span>;
     return (
@@ -115,11 +107,8 @@ export default class SwitchControl extends React.Component<SwitchProps, any> {
   }
 
   renderStatic() {
-    const {
-      value,
-      trueValue,
-    } = this.props;
-    
+    const {value, trueValue} = this.props;
+
     const {on = '开', off = '关'} = this.getResult();
     const body = <span>{value === trueValue ? on : off}</span>;
     return this.renderBody(body);
@@ -137,7 +126,7 @@ export default class SwitchControl extends React.Component<SwitchProps, any> {
       trueValue,
       falseValue,
       onChange,
-      disabled,
+      disabled
     } = this.props;
 
     const {on, off} = this.getResult();

--- a/packages/amis/src/renderers/Form/TabsTransfer.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransfer.tsx
@@ -218,15 +218,11 @@ export class BaseTabsTransferRenderer<
     // 触发渲染器事件
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(
-        this.props,
-        {
-          value: newValue,
-          options,
-          items: options // 为了保持名字统一
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        value: newValue,
+        options,
+        items: options // 为了保持名字统一
+      })
     );
     if (rendererEvent?.prevented) {
       return;

--- a/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
@@ -47,7 +47,7 @@ export class TabsTransferPickerRenderer extends BaseTabsTransferRenderer<TabsTra
   @autobind
   dispatchEvent(name: string) {
     const {dispatchEvent, value} = this.props;
-    dispatchEvent(name, resolveEventData(this.props, {value}, 'value'));
+    dispatchEvent(name, resolveEventData(this.props, {value}));
   }
 
   @autobind

--- a/packages/amis/src/renderers/Form/Textarea.tsx
+++ b/packages/amis/src/renderers/Form/Textarea.tsx
@@ -109,7 +109,7 @@ export default class TextAreaControl extends React.Component<
   handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
     const {onChange, dispatchEvent} = this.props;
 
-    dispatchEvent('change', resolveEventData(this.props, {value: e}, 'value'));
+    dispatchEvent('change', resolveEventData(this.props, {value: e}));
 
     onChange && onChange(e);
   }
@@ -125,7 +125,7 @@ export default class TextAreaControl extends React.Component<
       async () => {
         const rendererEvent = await dispatchEvent(
           'focus',
-          resolveEventData(this.props, {value}, 'value')
+          resolveEventData(this.props, {value})
         );
 
         if (rendererEvent?.prevented) {
@@ -151,7 +151,7 @@ export default class TextAreaControl extends React.Component<
 
         const rendererEvent = await dispatchEvent(
           'blur',
-          resolveEventData(this.props, {value}, 'value')
+          resolveEventData(this.props, {value})
         );
 
         if (rendererEvent?.prevented) {

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -277,15 +277,11 @@ export class BaseTransferRenderer<
     // 触发渲染器事件
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(
-        this.props,
-        {
-          value: newValue,
-          options,
-          items: options // 为了保持名字统一
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        value: newValue,
+        options,
+        items: options // 为了保持名字统一
+      })
     );
     if (rendererEvent?.prevented) {
       return;

--- a/packages/amis/src/renderers/Form/TransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TransferPicker.tsx
@@ -44,7 +44,7 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
   @autobind
   dispatchEvent(name: string) {
     const {dispatchEvent, value} = this.props;
-    dispatchEvent(name, resolveEventData(this.props, {value}, 'value'));
+    dispatchEvent(name, resolveEventData(this.props, {value}));
   }
 
   // 动作

--- a/packages/amis/src/renderers/Form/TreeSelect.tsx
+++ b/packages/amis/src/renderers/Form/TreeSelect.tsx
@@ -236,12 +236,12 @@ export default class TreeSelectControl extends React.Component<
 
   handleFocus(e: any) {
     const {dispatchEvent, value} = this.props;
-    dispatchEvent('focus', resolveEventData(this.props, {value}, 'value'));
+    dispatchEvent('focus', resolveEventData(this.props, {value}));
   }
 
   handleBlur(e: any) {
     const {dispatchEvent, value, data} = this.props;
-    dispatchEvent('blur', resolveEventData(this.props, {value}, 'value'));
+    dispatchEvent('blur', resolveEventData(this.props, {value}));
   }
 
   handleKeyPress(e: React.KeyboardEvent) {
@@ -486,7 +486,7 @@ export default class TreeSelectControl extends React.Component<
 
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(this.props, {value}, 'value')
+      resolveEventData(this.props, {value})
     );
 
     if (rendererEvent?.prevented) {

--- a/packages/amis/src/renderers/Form/UserSelect.tsx
+++ b/packages/amis/src/renderers/Form/UserSelect.tsx
@@ -191,15 +191,11 @@ export default class UserSelectControl extends React.Component<
 
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(
-        this.props,
-        {
-          value: newValue,
-          options,
-          items: options // 为了保持名字统一
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        value: newValue,
+        options,
+        items: options // 为了保持名字统一
+      })
     );
     if (rendererEvent?.prevented) {
       return;

--- a/packages/amis/src/renderers/SearchBox.tsx
+++ b/packages/amis/src/renderers/SearchBox.tsx
@@ -119,13 +119,9 @@ export class SearchBoxRenderer extends React.Component<
 
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(
-        this.props,
-        {
-          value
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        value
+      })
     );
 
     if (rendererEvent?.prevented) {
@@ -171,7 +167,7 @@ export class SearchBoxRenderer extends React.Component<
     const {dispatchEvent} = this.props;
     dispatchEvent(
       name,
-      resolveEventData(this.props, {value: this.state.value}, 'value')
+      resolveEventData(this.props, {value: this.state.value})
     );
   }
 

--- a/packages/amis/src/renderers/Tabs.tsx
+++ b/packages/amis/src/renderers/Tabs.tsx
@@ -640,13 +640,9 @@ export default class Tabs extends React.Component<TabsProps, TabsState> {
 
     const rendererEvent = await dispatchEvent(
       'change',
-      resolveEventData(
-        this.props,
-        {
-          value: tab?.hash ? tab?.hash : key + 1
-        },
-        'value'
-      )
+      resolveEventData(this.props, {
+        value: tab?.hash ? tab?.hash : key + 1
+      })
     );
     if (rendererEvent?.prevented) {
       return;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 755cb50</samp>

Simplified the event data resolution for various form renderers by making `valueKey` an optional parameter in the `resolveEventData` function. Removed unnecessary `valueKey` arguments from function calls in several files. Applied prettier formatting to some files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 755cb50</samp>

> _No more valueKey, no more lies_
> _We simplify the code, we cut the ties_
> _Resolve the event data with ease_
> _We dispatch the event, we do as we please_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 755cb50</samp>

*  Simplify the `resolveEventData` function usage by making the `valueKey` parameter optional and default to `'value'` ([link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6L255-R259))
*  Remove the `valueKey` argument from the `resolveEventData` function calls in various renderers ([link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-d9bf7707bf7ac9b7c40f2740fc783de7b5318386f02fd8348a8b7ef4b69717b2L486-R486), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-49e8e0d126c05b212be5134e3e5cc7e7533258b2d5637c0a775d1a9ae3993a4aL193-R193), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-49e8e0d126c05b212be5134e3e5cc7e7533258b2d5637c0a775d1a9ae3993a4aL247-R247), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-a06dc3359649299cf1b9ba523fa517351f75faa0677be87e569622ce86834425L86-R86), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L597-R600), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L655-R656), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5ea6188310ac5c7ac30a6da095a1ecfe92e2bd94c7a6f440d21a1309fab7d981L146-R146), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5ea6188310ac5c7ac30a6da095a1ecfe92e2bd94c7a6f440d21a1309fab7d981L165-R165), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5ea6188310ac5c7ac30a6da095a1ecfe92e2bd94c7a6f440d21a1309fab7d981L262-R262), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-7d9ce42b628323f3b90cf60aee6be1232f4d69c00ee9541c75a72a65ed87428dL194-R194), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-7d9ce42b628323f3b90cf60aee6be1232f4d69c00ee9541c75a72a65ed87428dL213-R213), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-7d9ce42b628323f3b90cf60aee6be1232f4d69c00ee9541c75a72a65ed87428dL228-R228), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-00c90e9ef78976a7a5e149e452bb31a9c2ba2d9ed42e895cedbc4b2a5673603dL171-R171), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL695-R698), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-4103a995836e1ba992d9983ff105ac554d14cd82653af751b39057246d3f5fb7L151-R155), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565L139-R150))
*  Remove the unused `valueKey` argument from the `dispatchEvent` function calls in various renderers ([link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-56835df54b63fc25653bc9cb41f895a4e75843bbbf719028fbcc740ae394a94fL434-R434), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-56835df54b63fc25653bc9cb41f895a4e75843bbbf719028fbcc740ae394a94fL457-R457), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-6a9d63c3962b312f04344a4c28956690724f3f476fe6b8f2802501fc10b28ce2L205-R205), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-6a9d63c3962b312f04344a4c28956690724f3f476fe6b8f2802501fc10b28ce2L228-R228), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685L290-R290), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685L299-R299), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-1cc263ed7b5f9385af4c3b91ead6471259bb7683f677c90867f665c26ea39665L395-R397), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-1cc263ed7b5f9385af4c3b91ead6471259bb7683f677c90867f665c26ea39665L420-R418), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-1cc263ed7b5f9385af4c3b91ead6471259bb7683f677c90867f665c26ea39665L585-R579), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-aee3a6989d221cd220047dc0b8339e5099adb9d4f73340963265767426875ce5L114-R114), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L313-R315), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L341-R339), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L373-R367), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L394-R382), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L458-R446), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L574-R562), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-527e78ca6789f4f47200b93123fe7f7884acc6890540c2616a3bc4cf4f41cd2bL269-R269), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-16126ba031130af96a31c9835fdd517359a756fc39c6c8d3fcb798e36306d2e8L284-R284), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313L291-R291))
*  Reformat the code in `packages/amis/src/renderers/Form/InputTable.tsx` to follow the prettier formatting rules for logical expressions, function calls, conditional expressions, equality comparisons, semicolons, and type unions ([link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL233-R233), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL318-R319), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL535-R535), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL559-R563), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL750-R749), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL768-R771), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL793-R799), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL996-R1005), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1020-R1030), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1071-R1158), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1153-R1168), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1319-R1358), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1485-R1508), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1533-R1566), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1574-R1610), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1638-R1670), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1686-R1721), [link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1696-R1759))
*  Reformat the imports in `packages/amis/src/renderers/Form/NestedSelect.tsx` to follow the prettier formatting rules for imports ([link](https://github.com/baidu/amis/pull/6613/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565L2-R16))
