### PR TITLE
feat: tabsTransfer tab title 支持模版

### DIFF
--- a/packages/amis-ui/src/components/TabsTransfer.tsx
+++ b/packages/amis-ui/src/components/TabsTransfer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {autobind} from 'amis-core';
+import {autobind, createObject, filter} from 'amis-core';
 import Tabs, {Tab} from './Tabs';
 import InputBox from './InputBox';
 import TableCheckboxes from './TableSelection';
@@ -256,7 +256,8 @@ export class TabsTransfer extends React.Component<
       placeholder,
       activeKey,
       classnames: cx,
-      translate: __
+      translate: __,
+      data
     } = this.props;
     const showOptions = options.filter(item => item.visible !== false);
 
@@ -279,7 +280,10 @@ export class TabsTransfer extends React.Component<
           <Tab
             eventKey={index}
             key={index}
-            title={option.label || option.title}
+            title={filter(
+              option.label || option.title,
+              createObject(data, option)
+            )}
             className="TabsTransfer-tab"
           >
             {option.searchable ? (

--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -1246,7 +1246,7 @@ export class TreeSelector extends React.Component<
 
     return (
       <li
-        key={item[valueField]}
+        key={`${item[valueField || 'value']}-${index}`}
         className={cx(`Tree-item ${itemClassName || ''}`, {
           'Tree-item--isLeaf': isLeaf,
           'is-child': this.relations.get(item)


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 75ab428</samp>

The pull request enhances the `TabsTransfer` and `Tree` components in `amis-ui`. It allows using data variables in the tab titles of `TabsTransfer`, and fixes a possible key duplication issue in `Tree`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 75ab428</samp>

> _We are the masters of the tree_
> _We forge the keys of destiny_
> _We wield the power of the tabs_
> _We shape the data with our crafts_

### Why

close: https://github.com/baidu/amis/issues/6598

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 75ab428</samp>

* Import `createObject` and `filter` functions from `amis-core` to render tab titles with data variables ([link](https://github.com/baidu/amis/pull/6614/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644L2-R2))
* Destructure `data` prop from `TabsTransfer` component props and pass it to `filter` function ([link](https://github.com/baidu/amis/pull/6614/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644L259-R260))
* Use `filter` function to interpolate data variables in tab title and `createObject` function to create new data object with option as context ([link](https://github.com/baidu/amis/pull/6614/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644L282-R286))
* Change `key` prop of `Tree-item` component to include index and value field of item, to avoid duplicate keys when value field is not unique ([link](https://github.com/baidu/amis/pull/6614/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1249-R1249))
