### PR TITLE
amis-saas-10292 fix: 属性表组件，新增属性页面渲染报错

### DIFF
--- a/packages/amis-editor/src/plugin/Property.tsx
+++ b/packages/amis-editor/src/plugin/Property.tsx
@@ -95,6 +95,11 @@ export class PropertyPlugin extends BasePlugin {
             multiLine: true,
             draggable: true,
             addButtonText: '新增',
+            scaffold: {
+              label: '',
+              content: '',
+              span: 1
+            },
             items: [
               getSchemaTpl('propertyLabel'),
               getSchemaTpl('propertyContent'),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30931358/231929192-bf899405-d45c-4891-b9b8-e66ee744e9e5.png)
![image](https://user-images.githubusercontent.com/30931358/231929846-2b43fa1c-519d-4418-8f8d-b69e679c8bb4.png)

属性列表组件配置面板，点击新增属性，页面报错，预览状态正常。

原因：点击新增属性时，combo组件会新增个空对象，属性表组件渲染时拿不到content（属性值）、label（属性名）。
解决方法：editor点击新增属性时，给个默认值。