### PR TITLE
fix: 修复Tree添加元素问题

### DIFF
--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -612,9 +612,10 @@ export class TreeSelector extends React.Component<
           const result = [] as Option[];
 
           for (let option of this.state.flattenedOptions) {
-            result.push(option);
             if (option === parent) {
               result.push({...option, isAdding: true});
+            } else {
+              result.push(option);
             }
           }
           this.setState({flattenedOptions: result});


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 61a2819</samp>

Fix duplicate options bug in `TreeSelector` component. Update `Tree.tsx` to push options to result array only once.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 61a2819</samp>

> _`TreeSelector` bug_
> _Duplicate options appear_
> _Fixed by moving `push`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 61a2819</samp>

* Fix a bug that caused duplicate options in `TreeSelector` ([link](https://github.com/baidu/amis/pull/6616/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L615-R618))
