### PR TITLE
feat: select弹框长度&nestSelect的弹框长度&文本优化

### DIFF
--- a/packages/amis-ui/scss/components/form/_nested-select.scss
+++ b/packages/amis-ui/scss/components/form/_nested-select.scss
@@ -2,6 +2,7 @@
   position: relative;
 
   .#{$ns}NestedSelect-menu {
+    min-width: px2rem(100px);
     padding-top: px2rem(4px);
     padding-bottom: px2rem(4px);
     box-shadow: 0 px2rem(2px) px2rem(8px) 0 rgba(7, 12, 20, 0.12);
@@ -76,6 +77,7 @@
         height: px2rem(32px);
         overflow: hidden;
         text-overflow: ellipsis;
+        white-space: nowrap;
         &.is-disabled {
           cursor: not-allowed;
           color: var(--text--muted-color);

--- a/packages/amis-ui/scss/components/form/_select.scss
+++ b/packages/amis-ui/scss/components/form/_select.scss
@@ -150,6 +150,7 @@
   .#{$ns}PopOver.#{$ns}Select-popover {
     margin-top: px2rem(4px);
     .#{$ns}Select-menu {
+      min-width: px2rem(100px);
       .#{$ns}Select-option {
         line-height: var(--select-base-default-option-line-height);
       }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 36d78a4</samp>

This pull request enhances the nested select and select components in the form module by improving their styles and functionality. It adds tooltips, adjusts widths, and refactors some code in `NestedSelect.tsx` and `_nested-select.scss`. It also sets a minimum width for the select control in `_select.scss`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 36d78a4</samp>

> _`NestedSelect` styled_
> _Better width and tooltips_
> _Autumn leaves no wrap_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 36d78a4</samp>

*  Add a minimum width of 100px to the select and nested select controls to avoid text cut-off ([link](https://github.com/baidu/amis/pull/6623/files?diff=unified&w=0#diff-ce2df941db682d3d78cc1fe8ba68e6c348681e2c7f2218a1b53bcf19b158db27R5), [link](https://github.com/baidu/amis/pull/6623/files?diff=unified&w=0#diff-76523bcea8a2970bd9ef0d5aad600399861a30059dd8da81137c0923f5eb6d07R153))
*  Add a white-space: nowrap property to the nested select option to prevent text wrapping ([link](https://github.com/baidu/amis/pull/6623/files?diff=unified&w=0#diff-ce2df941db682d3d78cc1fe8ba68e6c348681e2c7f2218a1b53bcf19b158db27R80))
*  Import the getTreeDepth function from the utils file in `NestedSelect.tsx` to calculate the menu width based on the tree depth ([link](https://github.com/baidu/amis/pull/6623/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565R9))
*  Declare and assign two properties to store the reference and the width of the outer div element of the nested select control in `NestedSelect.tsx` ([link](https://github.com/baidu/amis/pull/6623/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565R102-R103), [link](https://github.com/baidu/amis/pull/6623/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565R151))
*  Add a title attribute to the span element that renders the selected value label in `NestedSelect.tsx` to show the full path of the selected option as a tooltip ([link](https://github.com/baidu/amis/pull/6623/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565L216-R231), [link](https://github.com/baidu/amis/pull/6623/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565L246-R262))
*  Add a new method getMenuSelectMenuStyle in `NestedSelect.tsx` to return a style object that sets the width of each menu based on the control width and the tree depth ([link](https://github.com/baidu/amis/pull/6623/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565R595-R608))
*  Add a style attribute to the div elements that render the menus in `NestedSelect.tsx` to apply the getMenuSelectMenuStyle method result as the inline style ([link](https://github.com/baidu/amis/pull/6623/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565L602-R636), [link](https://github.com/baidu/amis/pull/6623/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565L725-R758))
*  Add a title attribute to the div elements that render the options in `NestedSelect.tsx` to show the full option label as a tooltip ([link](https://github.com/baidu/amis/pull/6623/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565R676-R677), [link](https://github.com/baidu/amis/pull/6623/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565L677-R711))
*  Add a ref attribute to the div element that wraps the nested select control in `NestedSelect.tsx` to assign the outTarget property as the reference to the element ([link](https://github.com/baidu/amis/pull/6623/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565L884-R917))
