### PR TITLE
chore: 梳理 conditionBuilder 代码

### DIFF
--- a/packages/amis-ui/src/components/condition-builder/Item.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Item.tsx
@@ -5,7 +5,8 @@ import {
   ConditionBuilderFuncs,
   ConditionFieldFunc,
   ConditionBuilderField,
-  FieldSimple
+  FieldSimple,
+  CustomField
 } from './types';
 import {
   ThemeProps,
@@ -14,7 +15,8 @@ import {
   localeable,
   LocaleProps,
   findTree,
-  noop
+  noop,
+  getVariable
 } from 'amis-core';
 import {Icon} from '../icons';
 
@@ -103,13 +105,9 @@ export class ConditionItem extends React.Component<ConditionItemProps> {
     onChange(value, this.props.index);
   }
 
-  handleRightSubChange(
-    isCustom: boolean,
-    index: number | string,
-    rightValue: any
-  ) {
+  handleRightSubChange(index: number | string, rightValue: any) {
     let origin;
-    if (isCustom) {
+    if (typeof index === 'string') {
       origin = Object.assign({}, this.props.value?.right) as PlainObject;
       origin[index] = rightValue;
     } else {
@@ -333,7 +331,7 @@ export class ConditionItem extends React.Component<ConditionItemProps> {
             valueField={field}
             value={(value.right as Array<ExpressionComplex>)?.[0]}
             data={data}
-            onChange={this.handleRightSubChange.bind(this, false, 0)}
+            onChange={this.handleRightSubChange.bind(this, 0)}
             fields={fields}
             allowedTypes={
               field?.valueTypes ||
@@ -353,7 +351,7 @@ export class ConditionItem extends React.Component<ConditionItemProps> {
             valueField={field}
             value={(value.right as Array<ExpressionComplex>)?.[1]}
             data={data}
-            onChange={this.handleRightSubChange.bind(this, false, 1)}
+            onChange={this.handleRightSubChange.bind(this, 1)}
             fields={fields}
             allowedTypes={
               field?.valueTypes ||
@@ -374,10 +372,10 @@ export class ConditionItem extends React.Component<ConditionItemProps> {
               config={config}
               op={op}
               funcs={funcs}
-              valueField={schema}
-              value={value.right}
+              valueField={{...field, value: schema} as CustomField}
+              value={getVariable(value.right as any, schema.name)}
               data={data}
-              onChange={this.handleRightSubChange.bind(this, true, schema.name)}
+              onChange={this.handleRightSubChange.bind(this, schema.name)}
               fields={fields}
               allowedTypes={
                 field?.valueTypes ||

--- a/packages/amis-ui/src/components/condition-builder/Value.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Value.tsx
@@ -149,15 +149,6 @@ export class Value extends React.Component<ValueProps> {
             }
           )
         : null;
-    } else {
-      const res = value ?? (field as any).defaultValue;
-      input = renderEtrValue
-        ? renderEtrValue(field, {
-            data,
-            onChange,
-            value: res ? res[(field as any).name] : res
-          })
-        : null;
     }
 
     return <div className={cx('CBValue')}>{input}</div>;

--- a/packages/amis-ui/src/components/condition-builder/Value.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Value.tsx
@@ -141,7 +141,8 @@ export class Value extends React.Component<ValueProps> {
     } else if (field.type === 'custom') {
       input = renderEtrValue
         ? renderEtrValue(
-            {...field.value, name: field.name},
+            {...field.value, name: 'TMP_WHATEVER_NAME'}, // name 随便输入，应该是 value 传入的为主，目前表单项内部逻辑还有问题先传一个 name
+
             {
               data,
               onChange,

--- a/packages/amis/src/renderers/Form/ConditionBuilder.tsx
+++ b/packages/amis/src/renderers/Form/ConditionBuilder.tsx
@@ -88,7 +88,7 @@ export default class ConditionBuilderControl extends React.PureComponent<Conditi
   renderEtrValue(schema: Schema, data: any) {
     return this.props.render(
       'inline',
-      Object.assign(schema, {label: false}),
+      Object.assign(schema, {label: false, inputOnly: true}),
       data
     );
   }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 307d4fd</samp>

The pull request improves the rendering and handling of custom fields in the `ConditionBuilder` component. It refactors the `ConditionItem` component in `Item.tsx`, removes unnecessary code from `Value.tsx`, and adds a new prop to the schema object in `ConditionBuilder.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 307d4fd</samp>

> _Sing, O Muse, of the skillful coder who refactored_
> _The `ConditionItem` component, to make it more compact and ordered._
> _He imported the `CustomField` type, the `getVariable` function too,_
> _And added the `inputOnly` prop, to render the inline component true._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 307d4fd</samp>

*  Simplify `handleRightSubChange` method of `ConditionItem` component by removing `isCustom` parameter and using `index` parameter to distinguish between custom and non-custom fields ([link](https://github.com/baidu/amis/pull/6624/files?diff=unified&w=0#diff-bd3cef1dd1adf5cbac8db6825eccda213b5450966cc365712f22a32093048fc6L8-R9),[link](https://github.com/baidu/amis/pull/6624/files?diff=unified&w=0#diff-bd3cef1dd1adf5cbac8db6825eccda213b5450966cc365712f22a32093048fc6L17-R19),[link](https://github.com/baidu/amis/pull/6624/files?diff=unified&w=0#diff-bd3cef1dd1adf5cbac8db6825eccda213b5450966cc365712f22a32093048fc6L106-R110),[link](https://github.com/baidu/amis/pull/6624/files?diff=unified&w=0#diff-bd3cef1dd1adf5cbac8db6825eccda213b5450966cc365712f22a32093048fc6L336-R334),[link](https://github.com/baidu/amis/pull/6624/files?diff=unified&w=0#diff-bd3cef1dd1adf5cbac8db6825eccda213b5450966cc365712f22a32093048fc6L356-R354),[link](https://github.com/baidu/amis/pull/6624/files?diff=unified&w=0#diff-bd3cef1dd1adf5cbac8db6825eccda213b5450966cc365712f22a32093048fc6L377-R378))
*  Pass custom field object as `CustomField` type and use `getVariable` function to get value of custom field from right expression in `ConditionItem` component ([link](https://github.com/baidu/amis/pull/6624/files?diff=unified&w=0#diff-bd3cef1dd1adf5cbac8db6825eccda213b5450966cc365712f22a32093048fc6L8-R9),[link](https://github.com/baidu/amis/pull/6624/files?diff=unified&w=0#diff-bd3cef1dd1adf5cbac8db6825eccda213b5450966cc365712f22a32093048fc6L17-R19),[link](https://github.com/baidu/amis/pull/6624/files?diff=unified&w=0#diff-bd3cef1dd1adf5cbac8db6825eccda213b5450966cc365712f22a32093048fc6L377-R378))
*  Remove unused code that rendered custom field value using `renderEtrValue` prop in `Value` component ([link](https://github.com/baidu/amis/pull/6624/files?diff=unified&w=0#diff-3157122d98c25f17ff8d96042468d09f17a5b91ec601c8f5688b30e0c93c7dfdL152-L160))
*  Add `inputOnly` prop to schema object passed to `render` method in `ConditionBuilder` renderer to avoid rendering label and wrapper of inline component ([link](https://github.com/baidu/amis/pull/6624/files?diff=unified&w=0#diff-906d9e2040ad748797a336a0c4d855343ddbea4da6ce81fc12ad100683f27827L91-R91))
