### PR TITLE
feat: ui 组件用法支持监听内部渲染的事件动作

### DIFF
--- a/docs/zh-CN/extend/ui-library.md
+++ b/docs/zh-CN/extend/ui-library.md
@@ -48,6 +48,69 @@ let amisJSON = {
 
 这个例子中我们监听了 3 个事件，输入框数据变化、表单提交、按钮点击，然后在这些地方使用代码实现特殊功能。
 
+## 监听广播事件
+
+> 3.0.0 以后引入
+
+amis 从 1.7.0 版本开始支持了[事件动作](../concepts/event-action)，各个组件内部也陆续补充了很多事件（可以查看每个组件文档的最底下，有事件表说明）。像这类事件也是可以监听的，分为两步来实现：第一步监听组件事件做广播动作、第二步最外层监听广播事件写业务逻辑。
+
+配置 form 事件动作，当表单提交成功后，广播一个 `formSubmited` 事件。
+
+```js
+let amisJSON = {
+  type: 'page',
+  title: '表单页面',
+  body: [
+    {
+      type: 'form',
+      mode: 'horizontal',
+      onEvent: {
+        submitSucc: {
+          actions: [
+            {
+              actionType: 'broadcast',
+              args: {
+                eventName: 'formSubmited'
+              }
+            }
+          ]
+        }
+      },
+      body: [
+        {
+          label: 'Name',
+          type: 'input-text',
+          name: 'name'
+        },
+        {
+          type: 'submit',
+          label: 'Submit'
+        }
+      ]
+    }
+  ]
+};
+```
+
+渲染 amis 的时候通过 `onBroadcast` 监听内部广播。
+
+```tsx
+import {render as renderAmis} 'amis';
+
+function DemoComponent() {
+  function handleBroadcast(type: string, rawEvent: any, data: any) {
+    console.log(type);
+    if (type === 'formSubmited') {
+      console.log('内部表单提交了');
+    }
+  }
+
+  return <div>
+    {renderAmis(amisJSON, {onBroadcast: handleBroadcast})}
+  </div>
+};
+```
+
 ## 使用 amis 公共方法
 
 amis 对外还提供了一些方法，比如弹出消息通知，可以通过 `amisRequire('amis')` 获取到这些 amis 对外提供的方法。

--- a/packages/amis-core/src/factory.tsx
+++ b/packages/amis-core/src/factory.tsx
@@ -24,7 +24,7 @@ import find from 'lodash/find';
 import {LocaleProps} from './locale';
 import {HocStoreFactory} from './WithStore';
 import type {RendererEnv} from './env';
-import {OnEventProps} from './utils/renderer-event';
+import {OnEventProps, RendererEvent} from './utils/renderer-event';
 import {Placeholder} from './renderers/Placeholder';
 
 export interface TestFunc {
@@ -76,6 +76,7 @@ export interface RendererProps extends ThemeProps, LocaleProps, OnEventProps {
   style?: {
     [propName: string]: any;
   };
+  onBroadcast?: (type: string, rawEvent: RendererEvent<any>, ctx: any) => any;
   [propName: string]: any;
 }
 

--- a/packages/amis-core/src/utils/renderer-event.ts
+++ b/packages/amis-core/src/utils/renderer-event.ts
@@ -157,6 +157,8 @@ export async function dispatchEvent(
     broadcast
   );
 
+  broadcast && renderer.props.onBroadcast?.(e as string, broadcast, data);
+
   if (!broadcast) {
     const eventConfig = renderer?.props?.onEvent?.[eventName];
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fb84024</samp>

This pull request adds a new feature to the renderer components of amis, allowing them to communicate with each other through broadcast events. It updates the `RendererProps` interface, the `dispatchEvent` utility function, and the UI library documentation to support this feature. It also includes an example of using broadcast events in a form and a page component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fb84024</samp>

> _`onBroadcast` prop_
> _lets renderers catch events_
> _from inner components_

### Why

amis 当 ui 组件使用时，需要一种机制能够监控内部组件事件。

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fb84024</samp>

*  Add `onBroadcast` prop to `RendererProps` interface to allow custom logic for broadcast events from internal components ([link](https://github.com/baidu/amis/pull/6635/files?diff=unified&w=0#diff-f32fad412c5300ebd34ca8f39d2d60e882c3db418757ced49c3a79af4f22f2ebL27-R27), [link](https://github.com/baidu/amis/pull/6635/files?diff=unified&w=0#diff-f32fad412c5300ebd34ca8f39d2d60e882c3db418757ced49c3a79af4f22f2ebR79))
*  Modify `dispatchEvent` function to check for `broadcast` property in event actions and call `onBroadcast` prop with event type, object, and data ([link](https://github.com/baidu/amis/pull/6635/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6R160-R161))
*  Update documentation of UI library with a new section on how to use `onBroadcast` prop and `broadcast` action, and provide an example with form and page components ([link](https://github.com/baidu/amis/pull/6635/files?diff=unified&w=0#diff-05f723f3d06b726660e2cf87fcf9bb8803cf62d26768b084c450f8d558c5fcceR51-R113))
