### PR TITLE
feat: editor导出拖动组件

### DIFF
--- a/packages/amis-editor-core/src/index.ts
+++ b/packages/amis-editor-core/src/index.ts
@@ -38,6 +38,7 @@ import {ContainerWrapper} from './component/ContainerWrapper';
 import type {EditorStoreType} from './store/editor';
 import {AvailableRenderersPlugin} from './plugin/AvailableRenderers';
 import ShortcutKey from './component/base/ShortcutKey';
+import WidthDraggableContainer from './component/base/WidthDraggableContainer';
 
 export default Editor;
 
@@ -58,5 +59,6 @@ export {
   EditorStoreType,
   ContainerWrapper,
   AvailableRenderersPlugin,
-  ShortcutKey
+  ShortcutKey,
+  WidthDraggableContainer,
 };


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 26443dc</samp>

Added a new component for resizing elements in the editor. The `WidthDraggableContainer` component can be used as a renderer or a wrapper in `packages/amis-editor-core`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 26443dc</samp>

> _`WidthDraggableContainer`_
> _Adjusts children by dragging_
> _A flexible core_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 26443dc</samp>

* Import and export the `WidthDraggableContainer` component, which allows resizing the width of its children by dragging the border ([link](https://github.com/baidu/amis/pull/6641/files?diff=unified&w=0#diff-6449992cb2efe3e6317741966a096ae7ba3f6ca4f8063fe6ed43ac552479b905R41), [link](https://github.com/baidu/amis/pull/6641/files?diff=unified&w=0#diff-6449992cb2efe3e6317741966a096ae7ba3f6ca4f8063fe6ed43ac552479b905L61-R63))
