### PR TITLE
fix: 修复Tag组件status模式下的图标问题

### DIFF
--- a/packages/amis-ui/scss/components/_tag.scss
+++ b/packages/amis-ui/scss/components/_tag.scss
@@ -124,7 +124,7 @@
     i {
       font-size: #{px2rem(8px)};
     }
-    .icon {
+    .#{$ns}Tag-default-icon {
       width: var(--Tag-status-size);
       height: var(--Tag-status-size);
       top: 0;

--- a/packages/amis-ui/src/components/Tag.tsx
+++ b/packages/amis-ui/src/components/Tag.tsx
@@ -114,8 +114,7 @@ export class Tag extends React.Component<TagProps> {
       color,
       icon,
       style,
-      label,
-      closable
+      label
     } = this.props;
 
     const isPresetColor =
@@ -130,21 +129,29 @@ export class Tag extends React.Component<TagProps> {
       ...style
     };
 
-    const prevIcon = displayMode === 'status' && (
-      <span className={cx('Tag--prev')}>
-        {typeof icon === 'string' ? (
-          getIcon(icon) ? (
-            <Icon icon={icon} className="icon" />
-          ) : (
-            generateIcon(cx, icon, 'Icon')
-          )
-        ) : React.isValidElement(icon) ? (
-          icon
-        ) : (
-          <Icon icon="dot" className="icon" />
-        )}
-      </span>
-    );
+    let prevIcon;
+    if (displayMode === 'status') {
+      let iconItem;
+      if (icon) {
+        if (typeof icon === 'string' && getIcon(icon)) {
+          iconItem = <Icon icon={icon} className="icon" />;
+        } else {
+          iconItem = generateIcon(cx, icon, 'Icon');
+        }
+      }
+      if (!iconItem) {
+        iconItem = (
+          <Icon icon="dot" className={cx('icon', 'Tag-default-icon')} />
+        );
+      }
+
+      const prevIconStyle = customColor ? {style: {color: customColor}} : {};
+      prevIcon = (
+        <span className={cx('Tag--prev')} {...prevIconStyle}>
+          {iconItem}
+        </span>
+      );
+    }
 
     return (
       <span


### PR DESCRIPTION
- 修复图标颜色不跟随自定义color变化的问题，bug如下：
```json
{
    "type": "tag",
    "label": "状态标签",
    "displayMode": "status",
    "color": "#4096ff",
    "closable": true
}
```
<img width="226" alt="image" src="https://user-images.githubusercontent.com/16409259/232736708-f6f62b36-b43c-4352-a390-692eb7970496.png">


- 修复自定义图标过小问题
<img width="227" alt="image" src="https://user-images.githubusercontent.com/16409259/232736109-ca8a7772-7bf6-4250-983a-f73e8341f6ae.png">

- 支持新版svg图标
