### PR TITLE
feat(amis-editor): 增加layout:wrapper-contanier，用于实现子配置项包裹效果

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     }
   },
   "lint-staged": {
-    "{packages,examples}/{src,examples}/**/**/*.{tsx,jsx,ts}": [
+    "{packages,examples}/**/{src,examples}/**/**/*.{tsx,jsx,ts}": [
       "prettier --write"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,16 @@
     "publish-to-internal": "sh ./publish-to-internal.sh",
     "stylelint": "npx stylelint 'packages/**/*.scss'"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "{packages,examples}/{src,examples}/**/**/*.{tsx,jsx,ts}": [
+      "prettier --write"
+    ]
+  },
   "dependencies": {
     "postcss": "^8.4.14",
     "qs": "6.9.7"
@@ -58,6 +68,7 @@
     "fis3-preprocessor-js-require-css": "^0.1.3",
     "fis3-preprocessor-js-require-file": "^0.1.3",
     "husky": "^8.0.0",
+    "lint-staged": "^12.1.2",
     "jest": "^29.0.3",
     "jest-environment-jsdom": "^29.0.3",
     "js-yaml": "^4.1.0",

--- a/packages/amis-editor-core/package.json
+++ b/packages/amis-editor-core/package.json
@@ -83,8 +83,6 @@
     "concurrently": "^6.2.0",
     "css-loader": "^6.2.0",
     "faker": "^5.5.3",
-    "husky": "^7.0.0",
-    "lint-staged": "^12.1.2",
     "mini-css-extract-plugin": "^2.3.0",
     "postcss-import": "^14.1.0",
     "postcss-minify": "^1.1.0",

--- a/packages/amis-editor-core/scss/_rightPanel.scss
+++ b/packages/amis-editor-core/scss/_rightPanel.scss
@@ -438,3 +438,24 @@ $tooltip-bottom: '[data-tooltip][data-position=' bottom ']:hover:after';
 .right-panel-pop {
   @include panel-sm-content();
 }
+
+// 包裹样式
+.config-wrapper-contanier {
+  position: relative;
+  margin: -8px auto 12px auto;
+  padding: 12px 8px;
+  background-color: #f7f7f9;
+  border-radius: 2px;
+
+  &::after {
+    display: block;
+    content: "";
+    height: 12px;
+    width: 12px;
+    position: absolute;
+    top: -6px;
+    left: 12px;
+    transform: rotate(45deg);
+    background-color: #f7f7f9;
+  }
+}

--- a/packages/amis-editor/package.json
+++ b/packages/amis-editor/package.json
@@ -74,8 +74,6 @@
     "concurrently": "^6.2.0",
     "css-loader": "^6.2.0",
     "faker": "^5.5.3",
-    "husky": "^7.0.0",
-    "lint-staged": "^12.1.2",
     "mini-css-extract-plugin": "^2.3.0",
     "prettier": "^2.2.1",
     "react": "^18.2.0",

--- a/packages/amis-editor/src/tpl/layout.tsx
+++ b/packages/amis-editor/src/tpl/layout.tsx
@@ -1494,3 +1494,19 @@ setSchemaTpl(
     };
   }
 );
+
+// 子配置项包裹容器
+setSchemaTpl(
+  'layout:wrapper-contanier',
+  (config: {
+    visibleOn?: string;
+    body: Array<any>
+  }) => {
+    return {
+      type: 'container',
+      className: 'config-wrapper-contanier',
+      body: config.body,
+      visibleOn: config?.visibleOn,
+    };
+  }
+);

--- a/packages/amis/package.json
+++ b/packages/amis/package.json
@@ -35,11 +35,6 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }
   ],
-  "lint-staged": {
-    "{src,examples}/**/**/*.{tsx,jsx,ts}": [
-      "prettier --write"
-    ]
-  },
   "dependencies": {
     "amis-core": "^2.9.0",
     "amis-ui": "^2.9.0",
@@ -118,13 +113,11 @@
     "fs-walk": "0.0.2",
     "glob": "^7.2.0",
     "history": "^4.7.2",
-    "husky": "^7.0.4",
     "jest": "^29.0.3",
     "jest-canvas-mock": "^2.3.0",
     "jest-environment-jsdom": "^29.0.3",
     "js-yaml": "^4.1.0",
     "json5": "^2.2.1",
-    "lint-staged": "^12.3.3",
     "marked": ">=4.0.12",
     "mkdirp": "^1.0.4",
     "moment-timezone": "^0.5.34",


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 260898c</samp>

This pull request adds code formatting and style checks to the project using `husky`, `lint-staged`, and `prettier`. It also removes unnecessary configurations and dependencies from some `package.json` files. Additionally, it improves the UI and UX of the AMIS editor by adding a new SCSS class and a new schema template for the layout configuration.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 260898c</samp>

> _`husky` and `lint`_
> _clean and format the code base_
> _autumn of redundancy_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 260898c</samp>

*  Add husky and lint-staged configurations to enforce code formatting and style consistency using prettier ([link](https://github.com/baidu/amis/pull/6647/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R29-R38),[link](https://github.com/baidu/amis/pull/6647/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R71))
*  Remove husky and lint-staged from individual packages to avoid duplication and version conflicts ([link](https://github.com/baidu/amis/pull/6647/files?diff=unified&w=0#diff-a4748fb9fe2d46502c7750a6b7c1cf5b4421968cea8501b3a9aaccb825ca35ecL86-L87),[link](https://github.com/baidu/amis/pull/6647/files?diff=unified&w=0#diff-7ae8386aceb47f61a4a2b316c8113f28fa64c584162ac38e128559bda675b242L77-L78),[link](https://github.com/baidu/amis/pull/6647/files?diff=unified&w=0#diff-b49028542a3bb14de6e47e46a9f09f23ffeff3afea2a17d5ddace75726a33e12L38-L42),[link](https://github.com/baidu/amis/pull/6647/files?diff=unified&w=0#diff-b49028542a3bb14de6e47e46a9f09f23ffeff3afea2a17d5ddace75726a33e12L121),[link](https://github.com/baidu/amis/pull/6647/files?diff=unified&w=0#diff-b49028542a3bb14de6e47e46a9f09f23ffeff3afea2a17d5ddace75726a33e12L127))
*  Add a new SCSS class and a schema template for the layout configuration container in the AMIS editor ([link](https://github.com/baidu/amis/pull/6647/files?diff=unified&w=0#diff-69d1923eb31930c821a1b40db55dc2ee5d56f27a957b81e9a080bed77905a7baR441-R461),[link](https://github.com/baidu/amis/pull/6647/files?diff=unified&w=0#diff-45bfed43c25dfce3e1aae45c4315a2b224141c06f2ca5ecc7a029ea995ac473bL1497-R1511))
