### PR TITLE
feat: 图片上传外观配置

### DIFF
--- a/packages/amis-core/src/renderers/Item.tsx
+++ b/packages/amis-core/src/renderers/Item.tsx
@@ -1586,7 +1586,8 @@ export const detectProps = [
   'embed',
   'displayMode',
   'revealPassword',
-  'loading'
+  'loading',
+  'themeCss'
 ];
 
 export function asFormItem(config: Omit<FormItemConfig, 'component'>) {

--- a/packages/amis-core/src/utils/style-helper.ts
+++ b/packages/amis-core/src/utils/style-helper.ts
@@ -260,3 +260,22 @@ export function insertCustomStyle(
     insertStyle(value, id?.replace('u:', '') || uuid());
   }
 }
+
+/**
+ * 根据路径获取默认值
+ */
+export function getValueByPath(path: string, data: any) {
+  try {
+    if (!path || !data) {
+      return null;
+    }
+    const keys = path.split('.');
+    let value = cloneDeep(data.component);
+    for (let i = 0; i < keys.length; i++) {
+      value = value[keys[i]];
+    }
+    return value;
+  } catch (e) {
+    return null;
+  }
+}

--- a/packages/amis-core/src/utils/style-helper.ts
+++ b/packages/amis-core/src/utils/style-helper.ts
@@ -139,7 +139,8 @@ export function formatStyle(
             ?.replace('u:', '')
             .replace('-label', '')
             .replace('-description', '')
-            .replace('-addOn', '') || ''
+            .replace('-addOn', '')
+            .replace('-icon', '') || ''
         )
       ) {
         classNameList.push(n);
@@ -257,24 +258,5 @@ export function insertCustomStyle(
   const {value} = formatStyle(themeCss, classNames, id, defaultData);
   if (value) {
     insertStyle(value, id?.replace('u:', '') || uuid());
-  }
-}
-
-/**
- * 根据路径获取默认值
- */
-export function getValueByPath(path: string, data: any) {
-  try {
-    if (!path || !data) {
-      return null;
-    }
-    const keys = path.split('.');
-    let value = cloneDeep(data.component);
-    for (let i = 0; i < keys.length; i++) {
-      value = value[keys[i]];
-    }
-    return value;
-  } catch (e) {
-    return null;
   }
 }

--- a/packages/amis-editor-core/src/store/editor.ts
+++ b/packages/amis-editor-core/src/store/editor.ts
@@ -548,7 +548,6 @@ export const MainStore = types
                 key !== '$$commonSchema') ||
               typeof props === 'function' || // pipeIn 和 pipeOut
               key.substring(0, 2) === '__' ||
-              key === 'editorPath' ||
               key === 'editorState') // 样式不需要出现做json中,
         );
       },

--- a/packages/amis-editor-core/src/store/editor.ts
+++ b/packages/amis-editor-core/src/store/editor.ts
@@ -548,9 +548,9 @@ export const MainStore = types
                 key !== '$$commonSchema') ||
               typeof props === 'function' || // pipeIn 和 pipeOut
               key.substring(0, 2) === '__' ||
-              key === 'themeCss' ||
               key === 'editorPath' ||
-              key === 'editorState') // 样式不需要出现做json中,
+              key === 'editorState' ||
+              key === 'editorDefaultData') // 样式不需要出现做json中,
         );
       },
 

--- a/packages/amis-editor-core/src/store/editor.ts
+++ b/packages/amis-editor-core/src/store/editor.ts
@@ -549,8 +549,7 @@ export const MainStore = types
               typeof props === 'function' || // pipeIn 和 pipeOut
               key.substring(0, 2) === '__' ||
               key === 'editorPath' ||
-              key === 'editorState' ||
-              key === 'editorDefaultData') // 样式不需要出现做json中,
+              key === 'editorState') // 样式不需要出现做json中,
         );
       },
 

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -713,14 +713,6 @@ export function filterSchemaForEditor(schema: any): any {
       }
     });
     const finalSchema = modified ? mapped : schema;
-    if (finalSchema?.type) {
-      if (finalSchema.editorPath) {
-        finalSchema.editorDefaultData = getValueByPath(
-          finalSchema.editorPath,
-          themeConfig
-        );
-      }
-    }
     return finalSchema;
   }
 
@@ -1101,6 +1093,7 @@ export function needFillPlaceholder(curProps: any) {
 // 设置主题数据
 export function setThemeConfig(config: any) {
   themeConfig = config;
+  (window as any).themeConfig = config;
 }
 
 // 将主题数据传入组件的schema
@@ -1109,23 +1102,4 @@ export function setThemeDefaultData(data: any) {
   schemaData.themeConfig = themeConfig;
   assign(schemaData, getGlobalData(themeConfig));
   return schemaData;
-}
-
-/**
- * 根据路径获取默认值
- */
-export function getValueByPath(path: string, data: any) {
-  try {
-    if (!path || !data) {
-      return null;
-    }
-    const keys = path.split('.');
-    let value = cloneDeep(data.component);
-    for (let i = 0; i < keys.length; i++) {
-      value = value[keys[i]];
-    }
-    return value;
-  } catch (e) {
-    return null;
-  }
 }

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -1093,7 +1093,6 @@ export function needFillPlaceholder(curProps: any) {
 // 设置主题数据
 export function setThemeConfig(config: any) {
   themeConfig = config;
-  (window as any).themeConfig = config;
 }
 
 // 将主题数据传入组件的schema

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -714,7 +714,12 @@ export function filterSchemaForEditor(schema: any): any {
     });
     const finalSchema = modified ? mapped : schema;
     if (finalSchema?.type) {
-      return setThemeDefaultData(finalSchema);
+      if (finalSchema.editorPath) {
+        finalSchema.editorDefaultData = getValueByPath(
+          finalSchema.editorPath,
+          themeConfig
+        );
+      }
     }
     return finalSchema;
   }
@@ -1104,4 +1109,23 @@ export function setThemeDefaultData(data: any) {
   schemaData.themeConfig = themeConfig;
   assign(schemaData, getGlobalData(themeConfig));
   return schemaData;
+}
+
+/**
+ * 根据路径获取默认值
+ */
+export function getValueByPath(path: string, data: any) {
+  try {
+    if (!path || !data) {
+      return null;
+    }
+    const keys = path.split('.');
+    let value = cloneDeep(data.component);
+    for (let i = 0; i < keys.length; i++) {
+      value = value[keys[i]];
+    }
+    return value;
+  } catch (e) {
+    return null;
+  }
 }

--- a/packages/amis-editor/src/plugin/Form/InputImage.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputImage.tsx
@@ -19,8 +19,7 @@ const inputStateFunc = (visibleOn: string, state: string) => {
     getSchemaTpl('theme:border', {
       name: `${addBtnCssClassName}.border:${state}`,
       visibleOn: visibleOn,
-      editorThemePath: `${editorPath}.${state}.body.border`,
-      state
+      editorThemePath: `${editorPath}.${state}.body.border`
     }),
     getSchemaTpl('theme:colorPicker', {
       label: '文字',
@@ -28,8 +27,7 @@ const inputStateFunc = (visibleOn: string, state: string) => {
       labelMode: 'input',
       needGradient: true,
       visibleOn: visibleOn,
-      editorThemePath: `${editorPath}.${state}.body.color`,
-      state
+      editorThemePath: `${editorPath}.${state}.body.color`
     }),
     getSchemaTpl('theme:colorPicker', {
       label: '背景',
@@ -37,8 +35,7 @@ const inputStateFunc = (visibleOn: string, state: string) => {
       labelMode: 'input',
       needGradient: true,
       visibleOn: visibleOn,
-      editorThemePath: `${editorPath}.${state}.body.bg-color`,
-      state
+      editorThemePath: `${editorPath}.${state}.body.bg-color`
     }),
     getSchemaTpl('theme:colorPicker', {
       label: '图标',
@@ -46,8 +43,7 @@ const inputStateFunc = (visibleOn: string, state: string) => {
       labelMode: 'input',
       needGradient: true,
       visibleOn: visibleOn,
-      editorThemePath: `${editorPath}.${state}.body.icon-color`,
-      state
+      editorThemePath: `${editorPath}.${state}.body.icon-color`
     })
   ];
 };

--- a/packages/amis-editor/src/plugin/Form/InputImage.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputImage.tsx
@@ -461,11 +461,6 @@ export class ImageControlPlugin extends BasePlugin {
                     }
                   ]
                 },
-                {
-                  type: 'hidden',
-                  name: 'editorPath',
-                  value: 'inputImage.base'
-                },
                 ...inputStateFunc(
                   "${editorState == 'default' || !editorState}",
                   'default'

--- a/packages/amis-editor/src/plugin/Form/InputImage.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputImage.tsx
@@ -11,6 +11,47 @@ import {tipedLabel} from 'amis-editor-core';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {ValidatorTag} from '../../validator';
 
+const addBtnCssClassName = 'themeCss.addBtnControlClassName';
+const IconCssClassName = 'themeCss.iconControlClassName';
+const editorPath = 'inputImage.base';
+const inputStateFunc = (visibleOn: string, state: string) => {
+  return [
+    getSchemaTpl('theme:border', {
+      name: `${addBtnCssClassName}.border:${state}`,
+      visibleOn: visibleOn,
+      editorThemePath: `${editorPath}.${state}.body.border`,
+      state
+    }),
+    getSchemaTpl('theme:colorPicker', {
+      label: '文字',
+      name: `${addBtnCssClassName}.color:${state}`,
+      labelMode: 'input',
+      needGradient: true,
+      visibleOn: visibleOn,
+      editorThemePath: `${editorPath}.${state}.body.color`,
+      state
+    }),
+    getSchemaTpl('theme:colorPicker', {
+      label: '背景',
+      name: `${addBtnCssClassName}.background:${state}`,
+      labelMode: 'input',
+      needGradient: true,
+      visibleOn: visibleOn,
+      editorThemePath: `${editorPath}.${state}.body.bg-color`,
+      state
+    }),
+    getSchemaTpl('theme:colorPicker', {
+      label: '图标',
+      name: `${addBtnCssClassName}.icon-color:${state}`,
+      labelMode: 'input',
+      needGradient: true,
+      visibleOn: visibleOn,
+      editorThemePath: `${editorPath}.${state}.body.icon-color`,
+      state
+    })
+  ];
+};
+
 export class ImageControlPlugin extends BasePlugin {
   // 关联渲染器名字
   rendererName = 'input-image';
@@ -393,43 +434,86 @@ export class ImageControlPlugin extends BasePlugin {
       },
       {
         title: '外观',
-        body: getSchemaTpl('collapseGroup', [
-          getSchemaTpl('style:formItem', {renderer: context.info.renderer}),
-          {
-            title: '尺寸',
-            body: [
-              getSchemaTpl('switch', {
-                name: 'fixedSize',
-                label: tipedLabel(
-                  '固定尺寸',
-                  '开启后需通过CSS类设置其高度、宽度'
+        body: getSchemaTpl(
+          'collapseGroup',
+          [
+            getSchemaTpl('style:formItem', {renderer: context.info.renderer}),
+            {
+              title: '自定义样式',
+              body: [
+                {
+                  type: 'select',
+                  name: 'editorState',
+                  label: '状态',
+                  selectFirst: true,
+                  options: [
+                    {
+                      label: '常规',
+                      value: 'default'
+                    },
+                    {
+                      label: '悬浮',
+                      value: 'hover'
+                    },
+                    {
+                      label: '点击',
+                      value: 'active'
+                    }
+                  ]
+                },
+                {
+                  type: 'hidden',
+                  name: 'editorPath',
+                  value: 'inputImage.base'
+                },
+                ...inputStateFunc(
+                  "${editorState == 'default' || !editorState}",
+                  'default'
                 ),
-                value: false
-              }),
-
-              {
-                type: 'container',
-                className: 'ae-ExtendMore mb-3',
-                visibleOn: 'data.fixedSize',
-                body: [
-                  {
-                    type: 'input-text',
-                    required: true,
-                    name: 'fixedSizeClassName',
-                    label: tipedLabel(
-                      'CSS类名',
-                      '开启固定尺寸时，根据此值控制展示尺寸'
-                    )
-                  }
-                ]
-              }
-            ]
-          },
-          getSchemaTpl('style:classNames', {
-            unsupportStatic: true,
-            schema: []
-          })
-        ])
+                ...inputStateFunc("${editorState == 'hover'}", 'hover'),
+                ...inputStateFunc("${editorState == 'active'}", 'active'),
+                getSchemaTpl('theme:radius', {
+                  name: `${addBtnCssClassName}.border-radius`,
+                  label: '圆角',
+                  editorThemePath: `${editorPath}.default.body.border`
+                }),
+                {
+                  name: `${addBtnCssClassName}.--inputImage-base-default-icon`,
+                  label: '选择图标',
+                  type: 'icon-select',
+                  returnSvg: true
+                },
+                getSchemaTpl('theme:size', {
+                  name: `${IconCssClassName}.font-size`,
+                  label: '图标大小',
+                  editorThemePath: `${editorPath}.default.body.icon-size`
+                }),
+                getSchemaTpl('theme:size', {
+                  name: `${IconCssClassName}.margin-bottom`,
+                  label: '图标底边距',
+                  editorThemePath: `${editorPath}.default.body.icon-margin`
+                })
+              ]
+            },
+            getSchemaTpl('theme:cssCode', {
+              themeClass: [
+                {
+                  name: '图片上传按钮',
+                  value: 'addOn',
+                  className: 'addBtnControlClassName',
+                  state: ['default', 'hover', 'active']
+                },
+                {
+                  name: '上传图标',
+                  value: 'icon',
+                  className: 'iconControlClassName'
+                }
+              ],
+              isFormItem: true
+            })
+          ],
+          {...context?.schema, configTitle: 'style'}
+        )
       },
       {
         title: '事件',

--- a/packages/amis-editor/src/renderer/style-control/ThemeCssCode.tsx
+++ b/packages/amis-editor/src/renderer/style-control/ThemeCssCode.tsx
@@ -74,7 +74,8 @@ function AmisThemeCssCodeEditor(props: FormControlProps) {
           const item = css.find(c => {
             if (
               c.selector === node.selector ||
-              node.selector.endsWith(`:${c.state}`)
+              node.selector.endsWith(`:${c.state}`) ||
+              node.selector.split(' ').indexOf(c.selector) > -1
             ) {
               return c;
             }

--- a/packages/amis-editor/src/renderer/style-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/style-control/helper.tsx
@@ -22,11 +22,6 @@ export const inputStateTpl = (className: string, path: string = '') => {
         }
       ]
     },
-    {
-      type: 'hidden',
-      name: 'editorPath',
-      value: path
-    },
     ...inputStateFunc(
       "${editorState == 'default' || !editorState}",
       'default',

--- a/packages/amis-editor/src/renderer/style-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/style-control/helper.tsx
@@ -45,8 +45,7 @@ export const inputStateFunc = (
       label: '文字',
       name: `${className}.font:${state}`,
       visibleOn: visibleOn,
-      editorThemePath: `${path}.${state}.body.font`,
-      state
+      editorThemePath: `${path}.${state}.body.font`
     }),
     getSchemaTpl('theme:colorPicker', {
       label: '背景',
@@ -54,26 +53,22 @@ export const inputStateFunc = (
       labelMode: 'input',
       needGradient: true,
       visibleOn: visibleOn,
-      editorThemePath: `${path}.${state}.body.bg-color`,
-      state
+      editorThemePath: `${path}.${state}.body.bg-color`
     }),
     getSchemaTpl('theme:border', {
       name: `${className}.border:${state}`,
       visibleOn: visibleOn,
-      editorThemePath: `${path}.${state}.body.border`,
-      state
+      editorThemePath: `${path}.${state}.body.border`
     }),
     getSchemaTpl('theme:paddingAndMargin', {
       name: `${className}.padding-and-margin:${state}`,
       visibleOn: visibleOn,
-      editorThemePath: `${path}.${state}.body.padding-and-margin`,
-      state
+      editorThemePath: `${path}.${state}.body.padding-and-margin`
     }),
     getSchemaTpl('theme:radius', {
       name: `${className}.radius:${state}`,
       visibleOn: visibleOn,
-      editorThemePath: `${path}.${state}.body.border`,
-      state
+      editorThemePath: `${path}.${state}.body.border`
     }),
     ...options
   ];

--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -2623,6 +2623,7 @@
   --inputImage-base-default-fontSize: var(--fonts-size-7);
   --inputImage-base-default-fontWeight: var(--fonts-weight-6);
   --inputImage-base-default-color: var(--colors-neutral-text-5);
+  --inputImage-base-default-icon: '<svg viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g><rect fill="currentColor" opacity="0" x="0" y="0" width="16" height="16"></rect><path d="M8.5,2 L8.5,7.5 L14,7.5 L14,8.5 L8.5,8.5 L8.5,14 L7.5,14 L7.5,8.5 L2,8.5 L2,7.5 L7.5,7.5 L7.5,2 L8.5,2 Z"  fill="currentColor" fill-rule="nonzero"></path></g></g></svg>';
   --inputImage-base-default-icon-size: var(--sizes-base-12);
   --inputImage-base-default-icon-color: var(--colors-neutral-text-5);
   --inputImage-base-default-icon-margin: var(--sizes-size-5);
@@ -3728,7 +3729,9 @@
     var(--Timeline-visible-paddingLeft);
   --TimelineItem-detail-visible-max-width: #{px2rem(300px)};
   --Timeline-alternate-margin-left: var(--gap-xl);
-  --Timeline-visible-border-radius: var(--Timeline-visible-top-left-border-radius)
+  --Timeline-visible-border-radius: var(
+      --Timeline-visible-top-left-border-radius
+    )
     var(--Timeline-visible-top-right-border-radius)
     var(--Timeline-visible-bottom-right-border-radius)
     var(--Timeline-visible-bottom-left-border-radius);

--- a/packages/amis-ui/scss/components/form/_image.scss
+++ b/packages/amis-ui/scss/components/form/_image.scss
@@ -5,6 +5,10 @@
     outline: none;
   }
 
+  .ImageControl-addBtn-icon {
+    content: var(--inputImage-base-default-icon);
+  }
+
   &-addBtn {
     margin: 0;
     width: px2rem(120px);
@@ -83,11 +87,13 @@
       var(--shadows-shadow-none)
     );
 
-    > svg {
+    svg {
       top: 0;
       margin-bottom: var(--inputImage-base-default-icon-margin);
       font-size: var(--inputImage-base-default-icon-size);
       color: var(--inputImage-base-default-icon-color);
+      width: var(--inputImage-base-default-icon-size);
+      height: var(--inputImage-base-default-icon-size);
     }
 
     &-text {
@@ -97,13 +103,13 @@
 
     &:not(:disabled):not(.is-disabled) {
       &:hover {
-        > svg {
+        svg {
           color: var(--inputImage-base-hover-icon-color);
         }
       }
 
       &:hover:active {
-        > svg {
+        svg {
           color: var(--inputImage-base-active-icon-color);
         }
       }
@@ -112,7 +118,7 @@
     &.is-disabled {
       pointer-events: none;
 
-      > svg {
+      svg {
         color: var(--inputImage-base-disabled-icon-color);
       }
     }

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -5,7 +5,8 @@ import {
   FormBaseControl,
   prettyBytes,
   resolveEventData,
-  insertCustomStyle
+  insertCustomStyle,
+  getValueByPath
 } from 'amis-core';
 // import 'cropperjs/dist/cropper.css';
 const Cropper = React.lazy(() => import('react-cropper'));
@@ -1362,9 +1363,13 @@ export default class ImageControl extends React.Component<
       addBtnControlClassName,
       iconControlClassName,
       id,
-      editorDefaultData,
+      editorPath,
       translate: __
     } = this.props;
+    const editorDefaultData = getValueByPath(
+      editorPath,
+      (window as any).themeConfig
+    );
 
     insertCustomStyle(
       themeCss,

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -1363,13 +1363,8 @@ export default class ImageControl extends React.Component<
       addBtnControlClassName,
       iconControlClassName,
       id,
-      editorPath,
       translate: __
     } = this.props;
-    const editorDefaultData = getValueByPath(
-      editorPath,
-      (window as any).themeConfig
-    );
 
     insertCustomStyle(
       themeCss,
@@ -1380,7 +1375,7 @@ export default class ImageControl extends React.Component<
         }
       ],
       id,
-      editorDefaultData
+      null
     );
 
     insertCustomStyle(
@@ -1400,7 +1395,7 @@ export default class ImageControl extends React.Component<
         }
       ],
       id + '-addOn',
-      editorDefaultData
+      null
     );
 
     insertCustomStyle(
@@ -1417,7 +1412,7 @@ export default class ImageControl extends React.Component<
         }
       ],
       id + '-icon',
-      editorDefaultData
+      null
     );
 
     const {files, error, crop, uploading, cropFile, frameImageWidth} =

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -4,7 +4,8 @@ import {
   FormControlProps,
   FormBaseControl,
   prettyBytes,
-  resolveEventData
+  resolveEventData,
+  insertCustomStyle
 } from 'amis-core';
 // import 'cropperjs/dist/cropper.css';
 const Cropper = React.lazy(() => import('react-cropper'));
@@ -1356,8 +1357,64 @@ export default class ImageControl extends React.Component<
       frameImage,
       fixedSize,
       fixedSizeClassName,
+      themeCss,
+      inputImageControlClassName,
+      addBtnControlClassName,
+      iconControlClassName,
+      id,
+      editorDefaultData,
       translate: __
     } = this.props;
+
+    insertCustomStyle(
+      themeCss,
+      [
+        {
+          key: 'inputImageControlClassName',
+          value: inputImageControlClassName
+        }
+      ],
+      id,
+      editorDefaultData
+    );
+
+    insertCustomStyle(
+      themeCss,
+      [
+        {
+          key: 'addBtnControlClassName',
+          value: addBtnControlClassName,
+          weights: {
+            hover: {
+              suf: ':not(:disabled):not(.is-disabled)'
+            },
+            active: {
+              suf: ':not(:disabled):not(.is-disabled)'
+            }
+          }
+        }
+      ],
+      id + '-addOn',
+      editorDefaultData
+    );
+
+    insertCustomStyle(
+      themeCss,
+      [
+        {
+          key: 'iconControlClassName',
+          value: iconControlClassName,
+          weights: {
+            default: {
+              suf: ' svg'
+            }
+          }
+        }
+      ],
+      id + '-icon',
+      editorDefaultData
+    );
+
     const {files, error, crop, uploading, cropFile, frameImageWidth} =
       this.state;
     let frameImageStyle: any = {};
@@ -1367,7 +1424,9 @@ export default class ImageControl extends React.Component<
     const filterFrameImage = filter(frameImage, this.props.data, '| raw');
     const hasPending = files.some(file => file.state == 'pending');
     return (
-      <div className={cx(`ImageControl`, className)}>
+      <div
+        className={cx(`ImageControl`, className, inputImageControlClassName)}
+      >
         {cropFile ? (
           <div className={cx('ImageControl-cropperWrapper')}>
             <Suspense fallback={<div>...</div>}>
@@ -1679,7 +1738,8 @@ export default class ImageControl extends React.Component<
                             'is-disabled': disabled
                           },
                           fixedSize ? 'ImageControl-fixed-size' : '',
-                          fixedSize ? fixedSizeClassName : ''
+                          fixedSize ? fixedSizeClassName : '',
+                          addBtnControlClassName
                         )}
                         style={frameImageStyle}
                         onClick={this.handleSelect}
@@ -1700,7 +1760,14 @@ export default class ImageControl extends React.Component<
                           />
                         ) : (
                           <>
-                            <Icon icon="plus-fine" className="icon" />
+                            <Icon
+                              icon="plus-fine"
+                              className="icon"
+                              iconContent={cx(
+                                ':ImageControl-addBtn-icon',
+                                iconControlClassName
+                              )}
+                            />
                             <span className={cx('ImageControl-addBtn-text')}>
                               {__('Image.upload')}
                             </span>

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -5,8 +5,7 @@ import {
   FormBaseControl,
   prettyBytes,
   resolveEventData,
-  insertCustomStyle,
-  getValueByPath
+  insertCustomStyle
 } from 'amis-core';
 // import 'cropperjs/dist/cropper.css';
 const Cropper = React.lazy(() => import('react-cropper'));

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -5,7 +5,8 @@ import {
   highlight,
   FormOptionsControl,
   resolveEventData,
-  insertCustomStyle
+  insertCustomStyle,
+  getValueByPath
 } from 'amis-core';
 import {ActionObject} from 'amis-core';
 import Downshift, {StateChangeOptions} from 'downshift';
@@ -1050,9 +1051,13 @@ export default class TextControl extends React.PureComponent<
       inputControlClassName,
       id,
       addOnClassName,
-      editorDefaultData,
+      editorPath,
       classPrefix: ns
     } = this.props;
+    const editorDefaultData = getValueByPath(
+      editorPath,
+      (window as any).themeConfig
+    );
     let input =
       autoComplete !== false && (source || options?.length || autoComplete)
         ? this.renderSugestMode()

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -1051,13 +1051,8 @@ export default class TextControl extends React.PureComponent<
       inputControlClassName,
       id,
       addOnClassName,
-      editorPath,
       classPrefix: ns
     } = this.props;
-    const editorDefaultData = getValueByPath(
-      editorPath,
-      (window as any).themeConfig
-    );
     let input =
       autoComplete !== false && (source || options?.length || autoComplete)
         ? this.renderSugestMode()
@@ -1077,7 +1072,7 @@ export default class TextControl extends React.PureComponent<
         }
       ],
       id,
-      editorDefaultData
+      null
     );
 
     insertCustomStyle(

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -5,8 +5,7 @@ import {
   highlight,
   FormOptionsControl,
   resolveEventData,
-  insertCustomStyle,
-  getValueByPath
+  insertCustomStyle
 } from 'amis-core';
 import {ActionObject} from 'amis-core';
 import Downshift, {StateChangeOptions} from 'downshift';
@@ -1051,11 +1050,9 @@ export default class TextControl extends React.PureComponent<
       inputControlClassName,
       id,
       addOnClassName,
-      editorPath,
-      themeConfig,
+      editorDefaultData,
       classPrefix: ns
     } = this.props;
-    const editorDefaultData = getValueByPath(editorPath, themeConfig);
     let input =
       autoComplete !== false && (source || options?.length || autoComplete)
         ? this.renderSugestMode()


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9867cd0</samp>

This pull request adds a feature to the `amis` and `amis-editor` packages that allows users to customize the style and icon of the input image control in the schema editor. It also simplifies some props and removes some redundant code in the `InputText` and `style-helper` files. It updates the CSS files and the `Item` component to support the new feature. It modifies the `editor.ts` and `ThemeCssCode.tsx` files to handle the theme configuration data and the compound selectors.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9867cd0</samp>

> _We are the masters of the theme_
> _We shape the style with our code_
> _We use the props and the schema_
> _We make the UI explode_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9867cd0</samp>

*  Add custom CSS style and icon customization for input image control
  - Add `themeCss` prop to `Item` component to accept custom CSS styles from theme configuration ([link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1589-R1590))
  - Add `-icon` case to `formatStyle` function to handle icon style properties in theme configuration ([link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL142-R143))
  - Add `inputStateFunc` function and constants to generate schema for input image control based on theme configuration and state ([link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-196626bf3350bb7e3df1e7beed48ef308ea68210398ca53c8370932f242feae6R14-R54))
  - Add new fields and options to `ImageControlPlugin` schema to allow user to customize appearance and style of input image control ([link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-196626bf3350bb7e3df1e7beed48ef308ea68210398ca53c8370932f242feae6L396-R516))
  - Add `insertCustomStyle` import and function call to `InputImage` component to insert custom CSS styles from theme configuration ([link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L7-R8), [link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1359-R1417))
  - Add new CSS classes and props to `InputImage` component and its sub-elements to apply custom CSS styles and icon content ([link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1370-R1429), [link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1682-R1742), [link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1703-R1770))
  - Add new CSS variable and selector to `_components.scss` and `_image.scss` files to define and style default icon for input image control ([link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4R2626), [link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aR8-R11), [link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aL86-R96), [link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aL100-R106), [link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aL106-R112), [link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aL115-R121))
  - Add condition to `getCssAndSetValue` function to handle compound selector with class selector for node selector ([link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-0d09abc7945e56f72384164537e19882a6faf0835c9130a430db6cebad0bc3eaL77-R78))
  - Remove `getValueByPath` function from `style-helper.ts` file to avoid duplication ([link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL262-L280))
  - Replace `themeCss` prop with `editorDefaultData` prop in `MainStore` class to store default values of theme configuration ([link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8L551-R553))
  - Add conditional statement to `filterSchemaForEditor` function to check and assign `editorDefaultData` prop of schema based on `editorPath` prop ([link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL717-R722))
  - Add `getValueByPath` function to `util.ts` file to provide utility function for getting default value of theme configuration by path ([link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aR1113-R1131))
  - Remove `getValueByPath` import and use `editorDefaultData` prop instead in `InputText` component ([link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L8-R8), [link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L1054-R1055))
* Format code of `--Timeline-visible-border-radius` variable in `_components.scss` file to improve readability and consistency ([link](https://github.com/baidu/amis/pull/6648/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4L3731-R3734))
