### PR TITLE
fix: 向导组件onactive字体颜色不显示问题修复

### DIFF
--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -4185,7 +4185,7 @@
   --Wizard-badge-onComplete-backgroundColor: var(
     --Wizard-badge-onActive-bg-color
   );
-  --Wizard-badge-onActive-color: var(--Wizard-badge-onActive-color);
+  // --Wizard-badge-onActive-color: var(--Wizard-badge-onActive-color);
   --Wizard-badge-onComplete-color: var(--Wizard-badge-onActive-color);
 
   --Wizard-steps-bg--isComplete: var(--colors-neutral-fill-11);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a6a46f</samp>

Comment out `--Wizard-badge-onActive-color` variable in `_components.scss` to fix wizard badge text color issue. This improves the visual consistency and accessibility of the wizard component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4a6a46f</samp>

> _`--Wizard-badge` text_
> _Inherits color from parent_
> _No more clash in spring_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4a6a46f</samp>

* Fix wizard badge text color inconsistency with background color by commenting out the `--Wizard-badge-onActive-color` variable and making the text color inherit from the parent element ([link](https://github.com/baidu/amis/pull/6649/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4L4188-R4188))
