### PR TITLE
feat: inputTree 支持 heightAuto 属性支持高度自动撑开

### DIFF
--- a/docs/zh-CN/components/form/input-tree.md
+++ b/docs/zh-CN/components/form/input-tree.md
@@ -1096,6 +1096,7 @@ true        false        false      [{label: 'A/B/C', value: 'a/b/c'},{label: 'A
 | virtualThreshold       | `number`                                     | `100`            | 在选项数量超过多少时开启虚拟渲染                                                                                                     |
 | menuTpl                | `string`                                     |                  | 选项自定义渲染 HTML 片段                                                                                                             | `2.8.0`                      |
 | enableDefaultIcon      | `boolean`                                    | `true`           | 是否为选项添加默认的前缀 Icon，父节点默认为`folder`，叶节点默认为`file`                                                              | `2.8.0`                      |
+| heightAuto             | `boolean`                                    | `false`          | 默认高度会有个 maxHeight，即超过一定高度就会内部滚动，如果希望自动增长请设置此属性                                                   | `3.0.0`                      |
 
 ## 事件表
 

--- a/examples/components/CRUD/Aside.jsx
+++ b/examples/components/CRUD/Aside.jsx
@@ -9,9 +9,11 @@ export default {
       {
         type: 'input-tree',
         name: 'cat',
-        inputClassName: 'no-border',
+        inputClassName: 'no-border no-padder mt-1',
+        heightAuto: true,
         submitOnChange: true,
         selectFirst: true,
+        inputOnly: true,
         options: [
           {
             label: '分类1',
@@ -269,8 +271,7 @@ export default {
                   },
                   {
                     type: 'html',
-                    html:
-                      '<p>添加其他 <span>Html 片段</span> 需要支持变量替换（todo）.</p>'
+                    html: '<p>添加其他 <span>Html 片段</span> 需要支持变量替换（todo）.</p>'
                   }
                 ]
               }

--- a/packages/amis-ui/scss/components/form/_tree.scss
+++ b/packages/amis-ui/scss/components/form/_tree.scss
@@ -2,13 +2,6 @@
   border: 1px solid var(--inputTree-border-color);
   padding: 6px 12px;
   border-radius: 2px;
-  max-height: var(--Tree-max-height);
-  overflow: auto;
-
-  &.h-full {
-    max-height: none;
-    overflow: visible;
-  }
 
   &.no-border {
     border: 0;
@@ -31,6 +24,11 @@
   & > .#{$ns}Tree {
     max-height: var(--Tree-max-height);
     overflow: auto;
+  }
+
+  &.h-auto > .#{$ns}Tree {
+    max-height: none;
+    overflow: visible;
   }
 }
 

--- a/packages/amis/src/renderers/Form/InputTree.tsx
+++ b/packages/amis/src/renderers/Form/InputTree.tsx
@@ -152,6 +152,11 @@ export interface TreeControlSchema extends FormOptionsSchema {
      */
     sticky?: boolean;
   };
+
+  /**
+   * 高度自动增长？
+   */
+  heightAuto?: boolean;
 }
 
 export interface TreeProps
@@ -371,7 +376,8 @@ export default class TreeControl extends React.Component<TreeProps, TreeState> {
       menuTpl,
       enableDefaultIcon,
       searchable,
-      searchConfig = {}
+      searchConfig = {},
+      heightAuto
     } = this.props;
     let {highlightTxt} = this.props;
     const {filteredOptions, keyword} = this.state;
@@ -439,7 +445,8 @@ export default class TreeControl extends React.Component<TreeProps, TreeState> {
     return (
       <div
         className={cx(`${ns}TreeControl`, className, treeContainerClassName, {
-          'is-sticky': searchable && searchConfig?.sticky
+          'is-sticky': searchable && searchConfig?.sticky,
+          'h-auto': heightAuto
         })}
       >
         <Spinner


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b7942f2</samp>

This pull request enhances the input-tree component by adding a `heightAuto` property that lets it adjust its height based on the content. It also updates the documentation and the example code to reflect this new feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b7942f2</samp>

> _`input-tree` grows_
> _with `heightAuto` option_
> _autumn leaves scroll by_

### Why

Close: https://github.com/baidu/amis/issues/6639

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b7942f2</samp>

*  Add `heightAuto` property to input-tree component to control its height behavior ([link](https://github.com/baidu/amis/pull/6651/files?diff=unified&w=0#diff-6c550b0b3ff27a6cd7f6b20bd77be5c5c561fcc25dfb3ba9e52e8df94df0af2eR1099), [link](https://github.com/baidu/amis/pull/6651/files?diff=unified&w=0#diff-527e78ca6789f4f47200b93123fe7f7884acc6890540c2616a3bc4cf4f41cd2bR155-R159), [link](https://github.com/baidu/amis/pull/6651/files?diff=unified&w=0#diff-527e78ca6789f4f47200b93123fe7f7884acc6890540c2616a3bc4cf4f41cd2bL374-R380), [link](https://github.com/baidu/amis/pull/6651/files?diff=unified&w=0#diff-527e78ca6789f4f47200b93123fe7f7884acc6890540c2616a3bc4cf4f41cd2bL442-R449), [link](https://github.com/baidu/amis/pull/6651/files?diff=unified&w=0#diff-336249700e93e82be1613415e7b5266a2144796bd2df1ce3a74ec2079edaf1ebL5-R5), [link](https://github.com/baidu/amis/pull/6651/files?diff=unified&w=0#diff-336249700e93e82be1613415e7b5266a2144796bd2df1ce3a74ec2079edaf1ebR28-R32))
*  Update example code of input-tree component in `Aside.jsx` to demonstrate the usage of `heightAuto`, `inputOnly` and `mt-1` properties ([link](https://github.com/baidu/amis/pull/6651/files?diff=unified&w=0#diff-42c3d410578677612ca4b35fd069e888e59de46f73e9c92cec4dbdf4a56925ebL12-R16), [link](https://github.com/baidu/amis/pull/6651/files?diff=unified&w=0#diff-42c3d410578677612ca4b35fd069e888e59de46f73e9c92cec4dbdf4a56925ebL272-R274))
