### PR TITLE
feat(amis-editor):增加inputText、textArea最大字数配置&修复上下文变量过长显示问题

### DIFF
--- a/packages/amis-editor-core/scss/_data-chain.scss
+++ b/packages/amis-editor-core/scss/_data-chain.scss
@@ -35,5 +35,6 @@
   &-main {
     flex-grow: 1;
     flex-basis: auto;
+    overflow-x: auto;
   }
 }

--- a/packages/amis-editor/src/plugin/Form/InputText.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputText.tsx
@@ -219,6 +219,13 @@ export class TextControlPlugin extends BasePlugin {
                   visibleOn: `${isText} || ${isPassword}`
                 }),
                 {
+                  name: 'maxLength',
+                  label: tipedLabel('最大字数', '限制输入输入最大字数量'),
+                  type: 'input-number',
+                  min: 0,
+                  step: 1
+                },
+                {
                   name: 'addOn',
                   label: tipedLabel('AddOn', '输入框左侧或右侧的附加挂件'),
                   type: 'ae-switch-more',

--- a/packages/amis-editor/src/plugin/Form/InputText.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputText.tsx
@@ -220,7 +220,7 @@ export class TextControlPlugin extends BasePlugin {
                 }),
                 {
                   name: 'maxLength',
-                  label: tipedLabel('最大字数', '限制输入输入最大字数量'),
+                  label: tipedLabel('最大字数', '限制输入最多文字数量'),
                   type: 'input-number',
                   min: 0,
                   step: 1

--- a/packages/amis-editor/src/plugin/Form/Textarea.tsx
+++ b/packages/amis-editor/src/plugin/Form/Textarea.tsx
@@ -138,7 +138,7 @@ export class TextareaControlPlugin extends BasePlugin {
               getSchemaTpl('showCounter'),
               {
                 name: 'maxLength',
-                label: tipedLabel('最大字数', '限制输入输入最大字数量'),
+                label: tipedLabel('最大字数', '限制输入最多文字数量'),
                 type: 'input-number',
                 min: 0,
                 step: 1

--- a/packages/amis-editor/src/plugin/Form/Textarea.tsx
+++ b/packages/amis-editor/src/plugin/Form/Textarea.tsx
@@ -136,6 +136,13 @@ export class TextareaControlPlugin extends BasePlugin {
                 )
               }),
               getSchemaTpl('showCounter'),
+              {
+                name: 'maxLength',
+                label: tipedLabel('最大字数', '限制输入输入最大字数量'),
+                type: 'input-number',
+                min: 0,
+                step: 1
+              },
               getSchemaTpl('labelRemark'),
               getSchemaTpl('remark'),
               getSchemaTpl('placeholder'),


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 129129f</samp>

This pull request adds the `maxLength` property to the text input and textarea components, and the `overflow-x` property to the data chain component. These changes improve the functionality, validation, and usability of the form and data chain plugins.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 129129f</samp>

> _`maxLength` added_
> _to text and textarea_
> _autumn of inputs_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 129129f</samp>

*  Add `maxLength` property to text input and textarea components to limit the number of characters entered ([link](https://github.com/baidu/amis/pull/6661/files?diff=unified&w=0#diff-707b783556eac182d54138ee29fd68b050c8998fe310ddee763b7afebeaa1691R222-R228), [link](https://github.com/baidu/amis/pull/6661/files?diff=unified&w=0#diff-dd6c595807cc19b30014ed2c9e86a2ade20b7a8f972fa84e2f11e1bbdc46a422R139-R145))
*  Render `maxLength` property as an input-number field with minimum value of 0 and step of 1 in `InputText.tsx` and `Textarea.tsx` files ([link](https://github.com/baidu/amis/pull/6661/files?diff=unified&w=0#diff-707b783556eac182d54138ee29fd68b050c8998fe310ddee763b7afebeaa1691R222-R228), [link](https://github.com/baidu/amis/pull/6661/files?diff=unified&w=0#diff-dd6c595807cc19b30014ed2c9e86a2ade20b7a8f972fa84e2f11e1bbdc46a422R139-R145))
*  Enable horizontal scrolling of data chain component when content exceeds container width by adding `overflow-x: auto` property to `.data-chain` class in `_data-chain.scss` file ([link](https://github.com/baidu/amis/pull/6661/files?diff=unified&w=0#diff-d54726eb2bc28568acbeb01944682469f2e243ec1d0d98e30c505d3bfbe7465bR38))
