### PR TITLE
fix: Form开启columnCount后inline表单项展示错误问题; chore(editor): 表单控件可设置预设布局

### DIFF
--- a/packages/amis-core/src/renderers/Item.tsx
+++ b/packages/amis-core/src/renderers/Item.tsx
@@ -890,6 +890,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
           {
             'is-inline': !!rest.inline && !mobileUI,
             'is-error': model && !model.valid,
+            'is-full': size === 'full',
             [`Form-control--withSize Form-control--size${ucFirst(
               controlSize
             )}`]:
@@ -1728,6 +1729,7 @@ export function asFormItem(config: Omit<FormItemConfig, 'component'>) {
                     {
                       'is-inline': !!rest.inline && !mobileUI,
                       'is-error': model && !model.valid,
+                      'is-full': size === 'full',
                       [`Form-control--withSize Form-control--size${ucFirst(
                         controlSize
                       )}`]:

--- a/packages/amis-editor-core/src/builder/ApiBuilder.ts
+++ b/packages/amis-editor-core/src/builder/ApiBuilder.ts
@@ -578,15 +578,19 @@ class APIBuilder extends DSBuilder {
     });
   }
 
-  public resolveSimpleFilterSchema(config: {setting: any}) {
-    const {setting} = config;
+  public resolveSimpleFilterSchema(config: {
+    setting: any;
+    size?: 'xs' | 'sm' | 'md' | 'lg' | 'full';
+  }) {
+    const {setting, size} = config;
     const fields = setting.simpleQueryFields || [];
     return fields
       .filter((i: any) => i.checked)
       .map((field: any) => ({
         type: field.inputType,
         name: field.name,
-        label: field.label
+        label: field.label,
+        size
       }));
   }
 

--- a/packages/amis-editor-core/src/builder/DSBuilder.ts
+++ b/packages/amis-editor-core/src/builder/DSBuilder.ts
@@ -230,7 +230,10 @@ export abstract class DSBuilder {
     feat?: DSFeatureType;
   }): SchemaObject[];
 
-  abstract resolveSimpleFilterSchema(config: {setting: any}): SchemaObject[];
+  abstract resolveSimpleFilterSchema(config: {
+    setting: any;
+    size?: 'xs' | 'sm' | 'md' | 'lg' | 'full';
+  }): SchemaObject[];
 
   abstract resolveAdvancedFilterSchema(config: {
     setting: any;

--- a/packages/amis-editor/src/plugin/CRUD2.tsx
+++ b/packages/amis-editor/src/plugin/CRUD2.tsx
@@ -305,7 +305,7 @@ const FilterTypes: Array<FeatOption> = [
         type: 'form',
         mode: 'inline',
         behavior: 'SimpleQuery',
-        body: builder.resolveSimpleFilterSchema({setting}) || [],
+        body: builder.resolveSimpleFilterSchema({setting, size: 'full'}) || [],
         actions: [
           {
             type: 'submit',

--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -81,11 +81,13 @@ setSchemaTpl(
   (config: {
     // 是不是独立表单，没有可以集成的内容
     isForm: boolean;
+    /** 预设布局 */
+    defaultValue?: 'inline' | 'horizontal' | 'normal' | '';
   }) => ({
     label: '布局',
     name: 'mode',
     type: 'select',
-    pipeIn: defaultValue(''),
+    pipeIn: defaultValue(config?.defaultValue ?? ''),
     options: [
       {
         label: '内联',

--- a/packages/amis-ui/scss/components/form/_form.scss
+++ b/packages/amis-ui/scss/components/form/_form.scss
@@ -413,11 +413,27 @@
   flex-wrap: wrap;
   margin-left: calc(var(--Form-group-gutterWidth) / -2);
   margin-right: calc(var(--Form-group-gutterWidth) / -2);
+
   > .#{$ns}Form-item {
     flex-shrink: 0;
     flex-grow: 1;
     padding-left: calc(var(--Form-group-gutterWidth) / 2);
     padding-right: calc(var(--Form-group-gutterWidth) / 2);
+
+    &.#{$ns}Form-item--inline {
+      /* 设置columnCount之后，margin-right自动计算，如果设置了会导致flex自动wrap */
+      margin-right: unset;
+      display: inline-flex;
+
+      & > .#{$ns}Form-value {
+        flex: 1;
+
+        /* 如果size设置了full就占满剩余空间 */
+        .#{$ns}Form-control:first-child.is-full {
+          width: -webkit-fill-available;
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 18a3856</samp>

This pull request adds a new feature to allow form items to fill the remaining space in the inline mode, and allows customizing the size of the form controls in the simple filter schema of different data sources. It also improves the layout and appearance of the form component in inline mode, and adds a new parameter to control the default value of the `mode` prop. It modifies several files in the `amis-core`, `amis-editor-core`, `amis-ui`, and `amis-editor` packages.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 18a3856</samp>

> _Oh we are the coders of the AMIS editor_
> _We make the forms and filters look much better_
> _We add the `size` and `mode` to the schema_
> _And we pull the ropes on the count of three_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 18a3856</samp>

*  Add `is-full` CSS class to form items and controls to fill remaining space in inline mode ([link](https://github.com/baidu/amis/pull/6662/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8R893), [link](https://github.com/baidu/amis/pull/6662/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8R1732), [link](https://github.com/baidu/amis/pull/6662/files?diff=unified&w=0#diff-9535aa7ed3a9f30ed832ccc42c80ff7c484ffedeae2d2454d8d4e6d88b58073cL589-R593), [link](https://github.com/baidu/amis/pull/6662/files?diff=unified&w=0#diff-f162c189df375d2178fe291db3819b5020ed44dd8ecf188faf5655cd4687e5b1L308-R308), [link](https://github.com/baidu/amis/pull/6662/files?diff=unified&w=0#diff-f325489c306f0106cb368664288efa079f007a051f746e29ad32d88cde2abb4dR422-R436))
*  Add `size` parameter to `resolveSimpleFilterSchema` method to control form control width in simple filter schema ([link](https://github.com/baidu/amis/pull/6662/files?diff=unified&w=0#diff-9535aa7ed3a9f30ed832ccc42c80ff7c484ffedeae2d2454d8d4e6d88b58073cL581-R585), [link](https://github.com/baidu/amis/pull/6662/files?diff=unified&w=0#diff-36b81f503f5e5745d6c3fcfc23710221aa6746133e0eb82bcc9670faf6afe2e4L233-R236))
*  Add `defaultValue` parameter to function that returns schema for `mode` prop of form component ([link](https://github.com/baidu/amis/pull/6662/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05L84-R90))
*  Add empty line to `_form.scss` file for readability ([link](https://github.com/baidu/amis/pull/6662/files?diff=unified&w=0#diff-f325489c306f0106cb368664288efa079f007a051f746e29ad32d88cde2abb4dR416))
