### PR TITLE
fix: issue-6546: spinner icon 属性无效问题

### DIFF
--- a/docs/zh-CN/components/spinner.md
+++ b/docs/zh-CN/components/spinner.md
@@ -196,22 +196,22 @@ body: {
 }
 ```
 
-在这个例子中，`service` 会先进入 `loading` ，5秒后 `page` 组件开始 `loading`
+在这个例子中，`service` 会先进入 `loading` ，5 秒后 `page` 组件开始 `loading`
 
 ## 属性表
 
-| 属性名               | 类型                                      | 默认值    | 说明                                                                                                                                                                |
-| -------------------- | ----------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| type                 | `string`                                  | `spinner` | 指定为 Spinner 渲染器                                                                                                                                               |
-| show                 | `boolean`                                 | `true`    | 是否显示 spinner 组件                                                                                                                                               |
-| className            | `string`                                  |           | spinner 图标父级标签的自定义 class                                                                                                                                  |
-| spinnerClassName     | `string`                                  |           | 组件中 icon 所在标签的自定义 class                                                                                                                                  |
-| spinnerWrapClassName | `string`                                  |           | 作为容器使用时组件最外层标签的自定义 class                                                                                                                          |
-| size                 | `string`                                  |           | 组件大小 `sm` `lg`                                                                                                                                                  |
-| icon                 | `string`                                  |           | 组件图标，可以是`amis`内置图标，也可以是字体图标或者网络图片链接，作为 ui 库使用时也可以是自定义组件                                                                |
-| tip                  | `string`                                  |           | 配置组件文案，例如`加载中...`                                                                                                                                       |
-| tipPlacement         | `top`, `right`, `bottom`, `left`          | `bottom`  | 配置组件 `tip` 相对于 `icon` 的位置                                                                                                                                 |
-| delay                | `number`                                  | `0`       | 配置组件显示延迟的时间（毫秒）                                                                                                                                      |
-| overlay              | `boolean`                                 | `true`    | 配置组件显示 spinner 时是否显示遮罩层                                                                                                                               |
-| body                 | [SchemaNode](../../docs/types/schemanode) |           | 作为容器使用时，被包裹的内容                                                                                                                                        |
-| loadingConfig        | `{root?: string}`                         |           | 为 `Spinner` 指定挂载的容器, `root` 是一个selector，在拥有`Spinner`的组件上都可以通过传递`loadingConfig`改变Spinner的挂载位置，开启后，会强制开启属性`overlay=true` |
+| 属性名               | 类型                                      | 默认值    | 说明                                                                                                                                                                                     |
+| -------------------- | ----------------------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type                 | `string`                                  | `spinner` | 指定为 Spinner 渲染器                                                                                                                                                                    |
+| show                 | `boolean`                                 | `true`    | 是否显示 spinner 组件                                                                                                                                                                    |
+| className            | `string`                                  |           | spinner 图标父级标签的自定义 class                                                                                                                                                       |
+| spinnerClassName     | `string`                                  |           | 组件中 icon 所在标签的自定义 class                                                                                                                                                       |
+| spinnerWrapClassName | `string`                                  |           | 作为容器使用时组件最外层标签的自定义 class                                                                                                                                               |
+| size                 | `string`                                  |           | 组件大小 `sm` `lg`                                                                                                                                                                       |
+| icon                 | `string`                                  |           | 组件图标，可以是`amis`内置图标，也可以是字体图标或者网络图片链接，作为 ui 库使用时也可以是自定义组件                                                                                     |
+| tip                  | `string`                                  |           | 配置组件文案，例如`加载中...`                                                                                                                                                            |
+| tipPlacement         | `top`, `right`, `bottom`, `left`          | `bottom`  | 配置组件 `tip` 相对于 `icon` 的位置                                                                                                                                                      |
+| delay                | `number`                                  | `0`       | 配置组件显示延迟的时间（毫秒）                                                                                                                                                           |
+| overlay              | `boolean`                                 | `true`    | 配置组件显示 spinner 时是否显示遮罩层                                                                                                                                                    |
+| body                 | [SchemaNode](../../docs/types/schemanode) |           | 作为容器使用时，被包裹的内容                                                                                                                                                             |
+| loadingConfig        | `{root?: string}`                         |           | 为 `Spinner` 指定挂载的容器, `root` 是一个 selector，在拥有`Spinner`的组件上都可以通过传递`loadingConfig`改变 Spinner 的挂载位置，开启后，会强制开启属性`overlay=true`，并且`icon`会失效 |

--- a/packages/amis-ui/src/components/Spinner.tsx
+++ b/packages/amis-ui/src/components/Spinner.tsx
@@ -193,8 +193,8 @@ export class Spinner extends React.Component<
       tipPlacement = '',
       loadingConfig
     } = this.props;
-    // 调整挂载位置时使用默认loading
-    const icon = loadingConfig?.root ? iconConfig : '';
+    // 定义了挂载位置时只能使用默认icon
+    const icon = loadingConfig?.root ? undefined : iconConfig;
     const isCustomIcon = icon && React.isValidElement(icon);
     const timeout = {enter: delay, exit: 0};
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d7472e</samp>

This pull request changes the `Spinner` component and its documentation to support a new `loadingConfig` option that allows specifying a `root` selector for the loading indicator. This option overrides the `icon` and `overlay` properties of the `Spinner` component and uses the default icon and overlay.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6d7472e</samp>

> _`loadingConfig` changed_
> _`Spinner` ignores `icon` now_
> _Fall leaves are spinning_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6d7472e</samp>

* Implement new behavior for `Spinner` component when `loadingConfig` has a `root` property ([link](https://github.com/baidu/amis/pull/6665/files?diff=unified&w=0#diff-93c59378c01b812a14f36a08b02bfb24a7439b92273cfa7f827f29588f45630bL196-R197), [link](https://github.com/baidu/amis/pull/6665/files?diff=unified&w=0#diff-5e0c3d9e8d807c37acbabd8e314c08fbc8e972c969e0f2961e28269b85ba0409L199-R217))
  - Ignore `icon` property and use default icon in `Spinner.tsx` ([link](https://github.com/baidu/amis/pull/6665/files?diff=unified&w=0#diff-93c59378c01b812a14f36a08b02bfb24a7439b92273cfa7f827f29588f45630bL196-R197))
  - Force `overlay` property to be `true` in `Spinner.tsx` ([link](https://github.com/baidu/amis/pull/6665/files?diff=unified&w=0#diff-93c59378c01b812a14f36a08b02bfb24a7439b92273cfa7f827f29588f45630bL196-R197))
  - Update documentation of `loadingConfig` property in `spinner.md` ([link](https://github.com/baidu/amis/pull/6665/files?diff=unified&w=0#diff-5e0c3d9e8d807c37acbabd8e314c08fbc8e972c969e0f2961e28269b85ba0409L199-R217))
