### PR TITLE
fix: 配置面板&快速构建弹窗组件字体统一

### DIFF
--- a/packages/amis-editor-core/scss/_mixin.scss
+++ b/packages/amis-editor-core/scss/_mixin.scss
@@ -89,7 +89,7 @@
 
 @mixin panel-sm-content {
   --Form-fontSize: #{$Editor-right-panel-font-size};
-  --ColorPicker-fontSize: var($Editor-right-panel-font-size);
+  --ColorPicker-fontSize: #{$Editor-right-panel-font-size};
   --fontSizeBase: #{$Editor-right-panel-font-size};
   --Form-item-fontSize: #{$Editor-right-panel-font-size};
   --Button--md-fontSize: #{$Editor-right-panel-font-size};
@@ -98,4 +98,18 @@
   --Form-input-lineHeight: #{$Editor-right-panel-line-height};
   --InputGroup-select-borderColor: #{$Editor-right-panel-border-color};
   --Form-input-borderColor: #{$Editor-right-panel-border-color};
+
+  --checkbox-checkbox-default-fontSize: #{$Editor-right-panel-font-size};
+  --select-base-default-fontSize: #{$Editor-right-panel-font-size};
+  --input-default-default-fontSize: #{$Editor-right-panel-font-size};
+  --button-size-default-fontSize: #{$Editor-right-panel-font-size};
+  --link-fontSize: #{$Editor-right-panel-font-size};
+  --link-onHover-fontSize: #{$Editor-right-panel-font-size};
+  --link-disabled-fontSize: #{$Editor-right-panel-font-size};
+  --link-onClick-fontSize: #{$Editor-right-panel-font-size};
+  --radio-default-default-fontSize: #{$Editor-right-panel-font-size};
+  --select-base-default-option-fontSize: #{$Editor-right-panel-font-size};
+  --Tabs--line-fontSize: #{$Editor-right-panel-font-size};
+  --Tabs--line-active-fontSize: #{$Editor-right-panel-font-size};
+  --Tabs--line-hover-fontSize: #{$Editor-right-panel-font-size};
 }

--- a/packages/amis-editor-core/scss/_rightPanel.scss
+++ b/packages/amis-editor-core/scss/_rightPanel.scss
@@ -5,8 +5,7 @@ $category-2-height: px2rem(32px);
 $tooltip-bottom: '[data-tooltip][data-position=' bottom ']:hover:after';
 
 .editor-right-panel {
-  --select-base-default-fontSize: 12px;
-  --fonts-size-7: 12px;
+  @include panel-sm-content();
 
   position: relative;
   flex: 0 0 auto;
@@ -449,7 +448,7 @@ $tooltip-bottom: '[data-tooltip][data-position=' bottom ']:hover:after';
 
   &::after {
     display: block;
-    content: "";
+    content: '';
     height: 12px;
     width: 12px;
     position: absolute;

--- a/packages/amis-editor-core/scss/control/_api-control.scss
+++ b/packages/amis-editor-core/scss/control/_api-control.scss
@@ -82,6 +82,7 @@
       margin: #{px2rem(16px)} 0 #{px2rem(24px)};
 
       .ae-ApiControl-form {
+        @include panel-sm-content();
         .ae-ApiControl-tabContent {
           max-height: 560px;
           overflow-x: hidden;

--- a/packages/amis-editor-core/scss/editor.scss
+++ b/packages/amis-editor-core/scss/editor.scss
@@ -1712,6 +1712,9 @@ div.ae-DragImage {
     margin-right: 0;
   }
 }
+.ae-scaffoldForm-Modal {
+  @include panel-sm-content();
+}
 
 .ae-Scaffold-Modal {
   width: px2rem(700px);

--- a/packages/amis-editor-core/src/component/ScaffoldModal.tsx
+++ b/packages/amis-editor-core/src/component/ScaffoldModal.tsx
@@ -225,6 +225,7 @@ export class ScaffoldModal extends React.Component<
         contentClassName={scaffoldFormContext?.className}
         show={!!scaffoldFormContext}
         onHide={store.closeScaffoldForm}
+        className="ae-scaffoldForm-Modal"
         closeOnEsc={!store.scaffoldFormBuzy}
       >
         <div className={cx('Modal-header')}>

--- a/packages/amis-editor/src/plugin/Cards.tsx
+++ b/packages/amis-editor/src/plugin/Cards.tsx
@@ -90,7 +90,7 @@ export class CardsPlugin extends BasePlugin {
               children: (
                 <div className="m-b">
                   <Button
-                    level="success"
+                    level="primary"
                     size="sm"
                     block
                     onClick={this.editDetail.bind(this, context.id)}

--- a/packages/amis-editor/src/plugin/Tag.tsx
+++ b/packages/amis-editor/src/plugin/Tag.tsx
@@ -146,7 +146,6 @@ export class TagPlugin extends BasePlugin {
                 label: '模式',
                 name: 'displayMode',
                 value: 'normal',
-                size: 'md',
                 options: [
                   {
                     label: '普通',


### PR DESCRIPTION
### What
目前页面设计器右侧面板以及快速构建弹窗中有一些字体不统一，需要统一成12px

### Why

<!-- author to complete -->

### How

copilot:walkthrough
