### PR TITLE
chore: 调整amis内网发布脚本

### DIFF
--- a/publish-to-internal.sh
+++ b/publish-to-internal.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 set -e
 
-npm run build --workspaces
+npm run build --workspace=amis-formula --workspace=amis-core --workspace=amis-ui --workspace=amis
 
 rm -rf npm
-mkdir npm
+mkdir -p npm/packages
 
 # 如果有问题可以注释掉这两行，不知道为啥会导致 cp -rf 挂掉
 # rm -rf packages/amis/node_modules/.bin
 # rm -rf packages/amis-ui/node_modules/.bin
 
-cp -rf packages npm
+cp -r packages/{amis-formula,amis-core,amis-ui,amis} npm/packages
 cp package.json npm
 
 # 记录last commit，便于区分内网版本包之间的差异


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 156b19c</samp>

Optimized the `publish-to-internal.sh` script to speed up the internal publishing process and save disk space. Only the necessary packages are built and copied to the `npm` folder.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 156b19c</samp>

> _Sing, O Muse, of the swift and skillful coder_
> _Who optimized the script of publish-to-internal_
> _And made it build and copy only what was needed_
> _To send the packages to the npm of the gods_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 156b19c</samp>

*  Modify the build command to only build the specified workspaces ([link](https://github.com/baidu/amis/pull/6669/files?diff=unified&w=0#diff-335c91875d2dd80ffea4b48ed5f1012e0e1951255464e483421cc70079bcccd8L4-R7))
*  Replace the copy command to only copy the specified packages and create a subfolder called packages ([link](https://github.com/baidu/amis/pull/6669/files?diff=unified&w=0#diff-335c91875d2dd80ffea4b48ed5f1012e0e1951255464e483421cc70079bcccd8L13-R13))
