### PR TITLE
fix: 修复 columnToggler 与 affixRow 总结行结合使用时的异常

### DIFF
--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -63,11 +63,11 @@ export const Column = types
     className: types.union(types.string, types.frozen())
   })
   .actions(self => ({
-    toggleToggle() {
+    toggleToggle(min = 1) {
       self.toggled = !self.toggled;
       const table = getParent(self, 2) as ITableStore;
 
-      if (!table.activeToggaleColumns.length) {
+      if (table.activeToggaleColumns.length < min) {
         self.toggled = true;
       }
 
@@ -1424,10 +1424,11 @@ export const TableStore = iRendererStore
       });
     }
 
-    function toggleAllColumns() {
+    function toggleAllColumns(min: number = 1) {
       if (self.activeToggaleColumns.length) {
         if (self.activeToggaleColumns.length === self.toggableColumns.length) {
           self.toggableColumns.map(column => column.setToggled(false));
+          toggleColumnsAtLeast(min);
         } else {
           self.toggableColumns.map(column => column.setToggled(true));
         }
@@ -1436,6 +1437,14 @@ export const TableStore = iRendererStore
         self.toggableColumns.map(column => column.setToggled(true));
       }
       persistSaveToggledColumns();
+    }
+
+    function toggleColumnsAtLeast(min: number = 1) {
+      if (self.activeToggaleColumns.length < min) {
+        for (let i = 0; i < min; i++) {
+          self.toggableColumns[i]?.setToggled(true);
+        }
+      }
     }
 
     function getPersistDataKey(columns: any[]) {
@@ -1477,6 +1486,7 @@ export const TableStore = iRendererStore
       exchange,
       addForm,
       toggleAllColumns,
+      toggleColumnsAtLeast,
       persistSaveToggledColumns,
       setSearchFormExpanded,
       toggleSearchFormExpanded,

--- a/packages/amis/src/renderers/Table/TableBody.tsx
+++ b/packages/amis/src/renderers/Table/TableBody.tsx
@@ -147,7 +147,7 @@ export class TableBody extends React.Component<TableBodyProps> {
 
   renderSummaryRow(
     position: 'prefix' | 'affix',
-    items?: Array<any>,
+    items: Array<any>,
     rowIndex?: number
   ) {
     const {
@@ -164,21 +164,15 @@ export class TableBody extends React.Component<TableBodyProps> {
       return null;
     }
 
-    const filterColumns = columns.filter(item => item.toggable);
-    const result: any[] = [];
-
-    for (let index = 0; index < filterColumns.length; index++) {
-      const item = items[filterColumns[index].rawIndex];
-      item && result.push({...item});
-    }
+    const result: any[] = items;
 
     //  如果是勾选栏，让它和下一列合并。
-    if (columns[0].type === '__checkme' && result[0]) {
+    if (columns[0]?.type === '__checkme' && result[0]) {
       result[0].colSpan = (result[0].colSpan || 1) + 1;
     }
 
     //  如果是展开栏，让它和下一列合并。
-    if (columns[0].type === '__expandme' && result[0]) {
+    if (columns[0]?.type === '__expandme' && result[0]) {
       result[0].colSpan = (result[0].colSpan || 1) + 1;
     }
 
@@ -187,7 +181,11 @@ export class TableBody extends React.Component<TableBodyProps> {
       columns.length - result.reduce((p, c) => p + (c.colSpan || 1), 0);
 
     if (appendLen) {
-      const item = result.pop();
+      const item = result.length
+        ? result.pop()
+        : {
+            type: 'plain'
+          };
       result.push({
         ...item,
         colSpan: (item.colSpan || 1) + appendLen

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -2472,6 +2472,7 @@ export default class Table extends React.Component<TableProps, object> {
       store,
       classPrefix: ns,
       classnames: cx,
+      affixRow,
       ...rest
     } = this.props;
     const __ = rest.translate;
@@ -2481,6 +2482,10 @@ export default class Table extends React.Component<TableProps, object> {
     if (!store.columnsTogglable) {
       return null;
     }
+
+    // 不能取消到比总结行要少
+    // 否则总结行将显示不全
+    const min = Math.max(Array.isArray(affixRow) ? affixRow.length : 0, 1);
 
     return (
       <ColumnToggler
@@ -2527,7 +2532,7 @@ export default class Table extends React.Component<TableProps, object> {
                 return;
               }
 
-              store.toggleAllColumns();
+              store.toggleAllColumns(min);
             }}
           >
             <Checkbox
@@ -2573,7 +2578,7 @@ export default class Table extends React.Component<TableProps, object> {
                 return;
               }
 
-              column.toggleToggle();
+              column.toggleToggle(min);
             }}
           >
             <Checkbox size="sm" classPrefix={ns} checked={column.toggled}>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 780b6d7</samp>

Added a feature to the `Table` component and the `TableStore` model to allow displaying summary rows and controlling column visibility. Fixed some bugs and improved performance in the `TableBody` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 780b6d7</samp>

> _`Table` component_
> _adds summary rows in fall_
> _`min` columns stay_

### Why

Close: https://github.com/baidu/amis/issues/6671

有总结行限制取消列的总数，不能低于总结行列数
<img width="1122" alt="image" src="https://user-images.githubusercontent.com/2698393/233604917-43d1c026-362f-4b4f-9d9c-85d1afac5ea1.png">


### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 780b6d7</samp>

*  Add `min` parameter to column toggle actions to ensure summary rows are always visible ([link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL66-R70), [link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1427-R1431), [link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR1442-R1449), [link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR1489), [link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR2475), [link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR2486-R2489), [link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2530-R2535), [link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2576-R2581))
  * Modify `toggleToggle` action of `Column` model to accept `min` and check if the number of active columns is above `min` before toggling ([link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL66-R70))
  * Modify `toggleAllColumns` action of `TableStore` model to accept `min` and pass it to `toggleToggle` action of each column ([link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1427-R1431))
  * Add `toggleColumnsAtLeast` action of `TableStore` model to ensure at least `min` columns are toggled on by looping through the first `min` columns and setting them to true ([link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR1442-R1449), [link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR1489))
  * Declare and initialize `min` variable in `Table` component to the maximum of the length of the `affixRow` prop or 1 ([link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR2486-R2489))
  * Pass `min` variable to `toggleAllColumns` action of `TableStore` model when toggle all button is clicked in `Table` component ([link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2530-R2535))
  * Pass `min` variable to `toggleToggle` action of `Column` model when column toggle button is clicked in `Table` component ([link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2576-R2581))
  * Pass `affixRow` prop to `TableStore` constructor in `Table` component to allow access to summary row data ([link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR2475))
* Simplify and fix `renderSummaryRow` method of `TableBody` component to handle empty columns and use `items` parameter directly ([link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL150-R150), [link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL167-R175), [link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL190-R188))
  * Make `items` parameter required in `renderSummaryRow` method to avoid undefined error ([link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL150-R150))
  * Use `items` parameter directly instead of filtering and mapping columns by `toggable` and `rawIndex` properties in `renderSummaryRow` method ([link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL167-R175))
  * Create and push a default item with type `plain` to `result` array if it is empty in `renderSummaryRow` method to avoid property access error ([link](https://github.com/baidu/amis/pull/6678/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL190-R188))
