### PR TITLE
fix(amis): NestedSelect 级联选择器搜索高亮逻辑重构

### DIFF
--- a/packages/amis-core/src/utils/dom.tsx
+++ b/packages/amis-core/src/utils/dom.tsx
@@ -1,4 +1,5 @@
 import ReactDOM from 'react-dom';
+import React from 'react';
 import getOffset from './offset';
 import getPosition from './position';
 
@@ -104,10 +105,9 @@ export function calculatePosition(
   const isAuto = placement === 'auto';
   // 兜底方向
   const autoDefaultPlacement = 'left-bottom-left-top';
-  placement =
-    isAuto
-      ? `left-bottom-left-top right-bottom-right-top left-top-left-bottom right-top-right-bottom ${autoDefaultPlacement}`
-      : placement;
+  placement = isAuto
+    ? `left-bottom-left-top right-bottom-right-top left-top-left-bottom right-top-right-bottom ${autoDefaultPlacement}`
+    : placement;
 
   let positionLeft = 0,
     positionTop = 0,
@@ -133,8 +133,13 @@ export function calculatePosition(
       // 根据之前的计算结果，使用收集的可见方向作为兜底，避免完全不可见
       if (isAuto && tests.length === 0) {
         const [_atX, _atY, _myX, _myY] = autoDefaultPlacement.split('-');
-        const {atX = _atX, atY = _atY, myX = _myX, myY = _myY} = visiblePlacement;
-        current = (activePlacement = [atX, atY, myX, myY].join('-'));
+        const {
+          atX = _atX,
+          atY = _atY,
+          myX = _myX,
+          myY = _myY
+        } = visiblePlacement;
+        current = activePlacement = [atX, atY, myX, myY].join('-');
       }
 
       let [atX, atY, myX, myY] = current.split('-');
@@ -270,4 +275,21 @@ export function getStyleNumber(element: HTMLElement, styleName: string) {
   return (
     parseInt(getComputedStyle(element).getPropertyValue(styleName), 10) || 0
   );
+}
+
+/** 根据关键字高亮显示文本内容 */
+export function renderTextByKeyword(rendererText: string, curKeyword: string) {
+  if (curKeyword && ~rendererText.indexOf(curKeyword)) {
+    const keywordStartIndex = rendererText.indexOf(curKeyword);
+    const keywordEndIndex = keywordStartIndex + curKeyword.length;
+    return (
+      <span>
+        {rendererText.substring(0, keywordStartIndex)}
+        <span className="is-keyword">{curKeyword}</span>
+        {rendererText.substring(keywordEndIndex)}
+      </span>
+    );
+  } else {
+    return rendererText;
+  }
 }

--- a/packages/amis-editor-core/scss/_rightPanel.scss
+++ b/packages/amis-editor-core/scss/_rightPanel.scss
@@ -457,4 +457,43 @@ $tooltip-bottom: '[data-tooltip][data-position=' bottom ']:hover:after';
     transform: rotate(45deg);
     background-color: #f7f7f9;
   }
+
+  &.hidden-tip {
+    &::after {
+      display: none;
+    }
+  }
+
+  &.tip-position-20p {
+    &::after {
+      left: 20%;
+    }
+  }
+
+  &.tip-position-30p {
+    &::after {
+      left: 30%;
+    }
+  }
+
+  &.tip-position-right-12 {
+    &::after {
+      left: auto;
+      right: 12px;
+    }
+  }
+
+  &.tip-position-right-55 {
+    &::after {
+      left: auto;
+      right: 55px;
+    }
+  }
+
+  &.tip-position-right-90 {
+    &::after {
+      left: auto;
+      right: 90px;
+    }
+  }
 }

--- a/packages/amis-editor/src/renderer/ButtonGroupControl.tsx
+++ b/packages/amis-editor/src/renderer/ButtonGroupControl.tsx
@@ -50,6 +50,6 @@ export default class ButtonGroupControl extends React.Component<ButtonGroupContr
   }
 }
 @FormItem({
-  type: 'button-icon-group'
+  type: 'icon-button-group'
 })
 export class ButtonGroupControlRenderer extends ButtonGroupControl {}

--- a/packages/amis-editor/src/tpl/layout.tsx
+++ b/packages/amis-editor/src/tpl/layout.tsx
@@ -256,7 +256,7 @@ setSchemaTpl(
       }
     ];
     const configSchema = {
-      type: 'button-icon-group',
+      type: 'icon-button-group',
       label:
         config?.label ||
         tipedLabel(
@@ -1498,15 +1498,12 @@ setSchemaTpl(
 // 子配置项包裹容器
 setSchemaTpl(
   'layout:wrapper-contanier',
-  (config: {
-    visibleOn?: string;
-    body: Array<any>
-  }) => {
+  (config: {visibleOn?: string; body: Array<any>}) => {
     return {
       type: 'container',
       className: 'config-wrapper-contanier',
       body: config.body,
-      visibleOn: config?.visibleOn,
+      visibleOn: config?.visibleOn
     };
   }
 );

--- a/packages/amis-ui/scss/base/_common.scss
+++ b/packages/amis-ui/scss/base/_common.scss
@@ -1,3 +1,7 @@
 .has-popover {
   position: relative;
 }
+
+.is-keyword {
+  color: var(--primary-onActive);
+}

--- a/packages/amis-ui/scss/components/_result-box.scss
+++ b/packages/amis-ui/scss/components/_result-box.scss
@@ -145,6 +145,7 @@
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
+    word-break: break-all; // 避免超长单词撑开
   }
 
   &-pc-arrow {

--- a/packages/amis/src/renderers/Form/NestedSelect.tsx
+++ b/packages/amis/src/renderers/Form/NestedSelect.tsx
@@ -25,7 +25,8 @@ import {
   OptionsControl,
   OptionsControlProps,
   RootClose,
-  ActionObject
+  ActionObject,
+  renderTextByKeyword
 } from 'amis-core';
 import {findDOMNode} from 'react-dom';
 import xor from 'lodash/xor';
@@ -216,8 +217,8 @@ export default class NestedSelectControl extends React.Component<
       options,
       hideNodePathLabel
     } = this.props;
-    const inputValue = this.state.inputValue;
-    const regexp = string2regExp(inputValue || '');
+    const inputValue = this.state.inputValue || '';
+    const regexp = string2regExp(inputValue);
 
     if (hideNodePathLabel) {
       return option[labelField || 'label'];
@@ -234,25 +235,10 @@ export default class NestedSelectControl extends React.Component<
               const label = item[labelField || 'label'];
               const value = item[valueField || 'value'];
               const isEnd = index === ancestors.length - 1;
-              const unmatchText = label.split(regexp || '');
-              let pointer = 0;
               return (
                 <span key={index}>
                   {regexp.test(value) || regexp.test(label)
-                    ? unmatchText.map((text: string, textIndex: number) => {
-                        const current = pointer;
-                        pointer += text.length || inputValue?.length || 0;
-                        return (
-                          <span
-                            key={textIndex}
-                            className={cx({
-                              'NestedSelect-optionLabel-highlight': !text
-                            })}
-                          >
-                            {text || label.slice(current, pointer)}
-                          </span>
-                        );
-                      })
+                    ? renderTextByKeyword(label, inputValue)
                     : label}
                   {!isEnd && ' / '}
                 </span>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 859466e</samp>

This pull request adds a new feature to the NestedSelect component that allows users to see the keyword they searched for highlighted in the option labels. It also refactors some existing code to improve readability and quality. The main changes are in the `dom.tsx`, `NestedSelect.tsx`, and `base/_common.scss` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 859466e</samp>

> _We render the text by keyword_
> _We highlight the span with `.is-keyword`_
> _We calculate the position with ease_
> _We dominate the NestedSelect with our skills_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 859466e</samp>

*  Add keyword highlighting feature for NestedSelect component ([link](https://github.com/baidu/amis/pull/6679/files?diff=unified&w=0#diff-558d9f2c84ced3c8c32f972218757e2c3d077c8e65f2b05c6ba82c6ff92256b0R279-R295), [link](https://github.com/baidu/amis/pull/6679/files?diff=unified&w=0#diff-1fcebdaa2adbe5d0216cf256805d1467f36c7bb328c93e173ea1a7af413d0b80R4-R7), [link](https://github.com/baidu/amis/pull/6679/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565L28-R29), [link](https://github.com/baidu/amis/pull/6679/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565L237-R241))
* Simplify and format code in `dom.tsx` ([link](https://github.com/baidu/amis/pull/6679/files?diff=unified&w=0#diff-558d9f2c84ced3c8c32f972218757e2c3d077c8e65f2b05c6ba82c6ff92256b0R2), [link](https://github.com/baidu/amis/pull/6679/files?diff=unified&w=0#diff-558d9f2c84ced3c8c32f972218757e2c3d077c8e65f2b05c6ba82c6ff92256b0L107-R110), [link](https://github.com/baidu/amis/pull/6679/files?diff=unified&w=0#diff-558d9f2c84ced3c8c32f972218757e2c3d077c8e65f2b05c6ba82c6ff92256b0L136-R142))
* Assign default value to `inputValue` variable in `NestedSelect.tsx` ([link](https://github.com/baidu/amis/pull/6679/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565L219-R221))
