### PR TITLE
fix:LIst单行点击事件上下文补全更多信息

### DIFF
--- a/packages/amis/src/renderers/List.tsx
+++ b/packages/amis/src/renderers/List.tsx
@@ -1133,7 +1133,7 @@ export class ListItem extends React.Component<ListItemProps> {
     onAction?.(
       e,
       hasClickActions ? undefined : itemAction,
-      hasClickActions ? item : this.props.data
+      hasClickActions ? item : item.locals
     );
 
     // itemAction, itemClick事件和checkOnItemClick为互斥关系

--- a/packages/amis/src/renderers/List.tsx
+++ b/packages/amis/src/renderers/List.tsx
@@ -1133,7 +1133,7 @@ export class ListItem extends React.Component<ListItemProps> {
     onAction?.(
       e,
       hasClickActions ? undefined : itemAction,
-      hasClickActions ? item : item?.data
+      hasClickActions ? item : this.props.data
     );
 
     // itemAction, itemClick事件和checkOnItemClick为互斥关系


### PR DESCRIPTION
List单行点击操作时，在item.data里得不到对的行index信息，但在list按钮操作时是对的；
参考list按钮操作里的对象赋值，通过this.props.data替换item.data，this.props.data中含有对的index信息。