### PR TITLE
styles: button-group-select不限制最大宽度

### DIFF
--- a/packages/amis-ui/scss/components/_button-group.scss
+++ b/packages/amis-ui/scss/components/_button-group.scss
@@ -6,7 +6,6 @@
   > .#{$ns}Button {
     position: relative;
     flex: 0 1 auto;
-    max-width: px2rem(140px);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 33f9297</samp>

Removed `max-width` from `.btn-group` in `_button-group.scss` to fix button overflow issue. This allows button groups to use flexbox layout and fit their containers.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 33f9297</samp>

> _`max-width` removed_
> _button groups overflow no more_
> _autumn leaves flexing_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 33f9297</samp>

* Fix button group overflow issue by removing `max-width` property from `.btn-group` selector ([link](https://github.com/baidu/amis/pull/6689/files?diff=unified&w=0#diff-77c5d145544bc877664f55f072962fee43b7152e9468862cc0dcd44990f3601dL9))
