### PR TITLE
fix(amis-editor): flex-setting 改成 flex-layout-setting

### DIFF
--- a/packages/amis-editor/src/renderer/FlexSettingControl.tsx
+++ b/packages/amis-editor/src/renderer/FlexSettingControl.tsx
@@ -13,22 +13,22 @@ const directionText: any = {
   'row': ['左对齐', '右对齐', '顶部对齐', '底部对齐'],
   'column': ['顶部对齐', '底部对齐', '左对齐', '右对齐'],
   'row-reverse': ['右对齐', '左对齐', '顶部对齐', '底部对齐'],
-  'column-reverse': ['底部对齐', '顶部对齐', '左对齐', '右对齐'],
-}
+  'column-reverse': ['底部对齐', '顶部对齐', '左对齐', '右对齐']
+};
 
 const scaleX: any = {
   'row': '',
   'column': 'scaleX-90',
   'row-reverse': 'scaleX-180',
-  'column-reverse': 'scaleX-270',
-}
+  'column-reverse': 'scaleX-270'
+};
 
 const scaleY: any = {
   'row': '',
   'column': 'scaleX-270',
   'row-reverse': '',
-  'column-reverse': 'scaleX-270',
-}
+  'column-reverse': 'scaleX-270'
+};
 
 interface FlexSettingControlProps extends FormControlProps {
   onChange: (value: PlainObject) => void;
@@ -116,7 +116,7 @@ const getFlexItem = (props: FlexSettingControlProps) => {
       iconClassName: scaleY[curDirection]
     },
     {
-      label:  directionText[curDirection][3],
+      label: directionText[curDirection][3],
       value: 'flex-end',
       icon: 'aFlexEnd',
       iconClassName: scaleY[curDirection]
@@ -197,6 +197,6 @@ export default class FlexSettingControl extends React.Component<FlexSettingContr
 }
 
 @FormItem({
-  type: 'flex-setting'
+  type: 'flex-layout-setting'
 })
 export class FlexSettingControlRenderer extends FlexSettingControl {}

--- a/packages/amis-editor/src/tpl/layout.tsx
+++ b/packages/amis-editor/src/tpl/layout.tsx
@@ -1483,7 +1483,7 @@ setSchemaTpl(
     alignItems?: string;
   }) => {
     return {
-      type: 'flex-setting',
+      type: 'flex-layout-setting',
       name: config?.name || 'style',
       mode: 'vertical', // horizontal、vertical
       label: config?.label ?? false,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aeffa83</samp>

This pull request renames the `FlexSettingControlRenderer` component to `flex-layout-setting` and fixes some code style issues in the `FlexSettingControl.tsx` file. It also updates the reference to the component type in the `layout.tsx` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at aeffa83</samp>

> _We are the masters of the flex layout_
> _We bend and twist the elements to our will_
> _We fix the errors in the code with skill_
> _We change the type to `flex-layout-setting`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aeffa83</samp>

*  Rename the type of the `FlexSettingControlRenderer` component from `flex-setting` to `flex-layout-setting` to avoid confusion with the existing `flex` type ([link](https://github.com/baidu/amis/pull/6692/files?diff=unified&w=0#diff-17eb43a9df58664e640f6e9b3c72232d153c3aace1a49249c2cb5d1f6ab314a0L200-R200))
*  Update the reference to the renamed type in the `layout.tsx` file ([link](https://github.com/baidu/amis/pull/6692/files?diff=unified&w=0#diff-45bfed43c25dfce3e1aae45c4315a2b224141c06f2ca5ecc7a029ea995ac473bL1486-R1486))
*  Add semicolons at the end of the object literals for `directionText`, `scaleX`, and `scaleY` in the `FlexSettingControl.tsx` file to follow the code style and avoid potential syntax errors ([link](https://github.com/baidu/amis/pull/6692/files?diff=unified&w=0#diff-17eb43a9df58664e640f6e9b3c72232d153c3aace1a49249c2cb5d1f6ab314a0L16-R17), [link](https://github.com/baidu/amis/pull/6692/files?diff=unified&w=0#diff-17eb43a9df58664e640f6e9b3c72232d153c3aace1a49249c2cb5d1f6ab314a0L23-R24), [link](https://github.com/baidu/amis/pull/6692/files?diff=unified&w=0#diff-17eb43a9df58664e640f6e9b3c72232d153c3aace1a49249c2cb5d1f6ab314a0L30-R31))
*  Remove an extra space before the `directionText` variable in the `FlexSettingControl.tsx` file to improve the code readability and consistency ([link](https://github.com/baidu/amis/pull/6692/files?diff=unified&w=0#diff-17eb43a9df58664e640f6e9b3c72232d153c3aace1a49249c2cb5d1f6ab314a0L119-R119))
