### PR TITLE
feat: editor 表单项支持单独配置label宽度

### DIFF
--- a/packages/amis-editor/src/tpl/style.tsx
+++ b/packages/amis-editor/src/tpl/style.tsx
@@ -466,6 +466,10 @@ setSchemaTpl('theme:form-label', () => {
   return {
     title: 'Label样式',
     body: [
+      getSchemaTpl('theme:select', {
+        label: '宽度',
+        name: 'labelWidth'
+      }),
       getSchemaTpl('theme:font', {
         label: '文字',
         name: 'themeCss.labelClassName.font:default',
@@ -493,6 +497,18 @@ setSchemaTpl('theme:form-description', () => {
         name: 'themeCss.descriptionClassName.padding-and-margin:default'
       })
     ]
+  };
+});
+
+// 尺寸选择器
+setSchemaTpl('theme:select', (option: any = {}) => {
+  return {
+    mode: 'default',
+    type: 'amis-theme-select',
+    label: '尺寸',
+    name: `themeCss.className.size:default`,
+    options: '${sizesOptions}',
+    ...option
   };
 });
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 27a0cec</samp>

Add schema templates for theme select components in `style.tsx`. These templates allow the user to adjust the label width and size of form items in the editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 27a0cec</samp>

> _`theme select` forms_
> _customize label and size_
> _autumn leaves vary_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 27a0cec</samp>

*  Add schema templates for theme select components that allow choosing label width and size of form items ([link](https://github.com/baidu/amis/pull/6693/files?diff=unified&w=0#diff-397f3332bd17c52ed7e468360e1cfe462d1d8646110ccd681b48a6deaa608302R469-R472), [link](https://github.com/baidu/amis/pull/6693/files?diff=unified&w=0#diff-397f3332bd17c52ed7e468360e1cfe462d1d8646110ccd681b48a6deaa608302R503-R514))
