### PR TITLE
editor：修复预览态弹框主题不生效问题

### DIFF
--- a/packages/amis-editor/src/renderer/event-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/event-control/helper.tsx
@@ -375,7 +375,8 @@ export const ACTION_TYPE_TREE = (manager: any): RendererPluginAction[] => {
                 body: '对，你刚刚点击了',
                 showCloseButton: true,
                 showErrorMsg: true,
-                showLoading: true
+                showLoading: true,
+                className: 'app-popover'
               }),
               asFormItem: true,
               visibleOn: 'data.groupType === "dialog"',
@@ -405,7 +406,8 @@ export const ACTION_TYPE_TREE = (manager: any): RendererPluginAction[] => {
               required: true,
               pipeIn: defaultValue({
                 title: '抽屉标题',
-                body: '对，你刚刚点击了'
+                body: '对，你刚刚点击了',
+                className: 'app-popover'
               }),
               asFormItem: true,
               visibleOn: 'data.groupType === "drawer"',

--- a/packages/amis-editor/src/tpl/style.tsx
+++ b/packages/amis-editor/src/tpl/style.tsx
@@ -466,6 +466,10 @@ setSchemaTpl('theme:form-label', () => {
   return {
     title: 'Label样式',
     body: [
+      getSchemaTpl('theme:select', {
+        label: '宽度',
+        name: 'labelWidth'
+      }),
       getSchemaTpl('theme:font', {
         label: '文字',
         name: 'themeCss.labelClassName.font:default',
@@ -493,6 +497,18 @@ setSchemaTpl('theme:form-description', () => {
         name: 'themeCss.descriptionClassName.padding-and-margin:default'
       })
     ]
+  };
+});
+
+// 尺寸选择器
+setSchemaTpl('theme:select', (option: any = {}) => {
+  return {
+    mode: 'default',
+    type: 'amis-theme-select',
+    label: '尺寸',
+    name: `themeCss.className.size:default`,
+    options: '${sizesOptions}',
+    ...option
   };
 });
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 476717b</samp>

Added a theme selector and improved the styling of dialog and drawer components in `amis-editor`. This enhances the user experience and customization options of the editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 476717b</samp>

> _We're sailing on the code sea, me hearties, yo ho ho_
> _We're making the editor look nice and smooth, yo ho ho_
> _We're adding `className` to `dialog` and `drawer`, yo ho ho_
> _We're heaving on the `theme:select` on the count of three, yo ho ho_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 476717b</samp>

*  Add `className: 'app-popover'` to `dialog` and `drawer` components in `ACTION_TYPE_TREE` to apply custom style ([link](https://github.com/baidu/amis/pull/6694/files?diff=unified&w=0#diff-f55d29e93a330da662e7a91960e5ed88c12f80e9e38564d3a4497ff543da26b8L378-R379), [link](https://github.com/baidu/amis/pull/6694/files?diff=unified&w=0#diff-f55d29e93a330da662e7a91960e5ed88c12f80e9e38564d3a4497ff543da26b8L408-R410))
*  Create and define `theme:select` schema template and `amis-theme-select` component type to allow user to choose label width of form items in `style.tsx` ([link](https://github.com/baidu/amis/pull/6694/files?diff=unified&w=0#diff-397f3332bd17c52ed7e468360e1cfe462d1d8646110ccd681b48a6deaa608302R469-R472), [link](https://github.com/baidu/amis/pull/6694/files?diff=unified&w=0#diff-397f3332bd17c52ed7e468360e1cfe462d1d8646110ccd681b48a6deaa608302R503-R514))
