### PR TITLE
fix: 修复 quickEdit 在弹窗中异常的问题

### DIFF
--- a/packages/amis/src/renderers/QuickEdit.tsx
+++ b/packages/amis/src/renderers/QuickEdit.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import {findDOMNode} from 'react-dom';
-import {RendererProps} from 'amis-core';
+import {RendererProps, noop} from 'amis-core';
 import hoistNonReactStatic from 'hoist-non-react-statics';
 import {ActionObject} from 'amis-core';
 import keycode from 'keycode';
@@ -544,8 +544,7 @@ export const HocQuickEdit =
           !onQuickChange ||
           (!(typeof quickEdit === 'object' && quickEdit?.isQuickEditFormMode) &&
             quickEditEnabled === false) ||
-          noHoc ||
-          disabled
+          noHoc
           // 此处的readOnly会导致组件值无法传递出去，如 value: "${a + b}" 这样的 value 变化需要同步到数据域
           // || readOnly
         ) {
@@ -583,16 +582,18 @@ export const HocQuickEdit =
                   ? undefined
                   : '0'
               }
-              onKeyUp={this.handleKeyUp}
+              onKeyUp={disabled ? noop : this.handleKeyUp}
             >
               <Component {...this.props} contentsOnly noHoc />
-              <span
-                key="edit-btn"
-                className={cx('Field-quickEditBtn')}
-                onClick={this.openQuickEdit}
-              >
-                <Icon icon="edit" className="icon" />
-              </span>
+              {disabled ? null : (
+                <span
+                  key="edit-btn"
+                  className={cx('Field-quickEditBtn')}
+                  onClick={this.openQuickEdit}
+                >
+                  <Icon icon="edit" className="icon" />
+                </span>
+              )}
               {this.state.isOpened ? this.renderPopOver() : null}
             </Component>
           );

--- a/packages/amis/src/renderers/QuickEdit.tsx
+++ b/packages/amis/src/renderers/QuickEdit.tsx
@@ -566,7 +566,8 @@ export const HocQuickEdit =
                 onInit: this.handleInit,
                 onChange: this.handleChange,
                 formLazyChange: false,
-                canAccessSuperData
+                canAccessSuperData,
+                disabled
               })}
             </Component>
           );


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 55cf0a4</samp>

Simplify and fix quick edit logic in `QuickEdit.tsx`. Use a utility function from `amis-core` to reduce code duplication.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 55cf0a4</samp>

> _The quick edit feature was a mess_
> _It needed some logic to compress_
> _So they imported a function_
> _From `amis-core`'s junction_
> _And now it works fine, more or less_

### Why

在弹窗中 form 中，当操作 quickEdit 弹窗时，因为 dialog 有监控，有动作执行时本身不可点，所以会下发 disabled 属性，而 quickEdit 本身的 disabled 属性变化，会导致内容重新渲染，导致内容渲染异常。

解决方法：优化 disabled 属性实现，不让子节点重新渲染

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 55cf0a4</samp>

* Imported `noop` function from `amis-core` to use as a placeholder for disabled event handlers ([link](https://github.com/baidu/amis/pull/6696/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L8-R8))
* Removed redundant and inconsistent `disabled` condition from quick edit button rendering logic ([link](https://github.com/baidu/amis/pull/6696/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L547-R547))
