### PR TITLE
fix: nav外观配置问题修复

### DIFF
--- a/packages/amis-ui/scss/components/_menu.scss
+++ b/packages/amis-ui/scss/components/_menu.scss
@@ -65,7 +65,7 @@
     color: var(--Menu-dark-fontColor-onHover);
 
     svg {
-      fill: var(--Menu-dark-fontColor-onHover);
+      fill: currentColor;
     }
   }
 }
@@ -80,7 +80,7 @@
     color: var(--Menu-light-fontColor-onActive);
 
     svg {
-      fill: var(--Menu-light-fontColor-onActive);
+      fill: currentColor;
     }
   }
 }
@@ -95,7 +95,7 @@
     color: var(--Menu-light-fontColor-onHover);
 
     svg {
-      fill: var(--Menu-light-fontColor-onHover);
+      fill: currentColor;
     }
   }
 }
@@ -121,8 +121,6 @@
   --Menu-width--collapsed: var(--Layout-aside-width-collapsed);
   --Menu-fontSize--collapsed: var(--Nav-item-collapsed-fontSize);
   --Menu-fontColor-onDisabled: var(--Nav-item-fontColor-onDisabled);
-  --Menu-item-height--vertical: #{px2rem(40px)};
-  --Menu-item-height--horizontal: var(--Nav-Item-height--horizontal);
   --Menu-Submenu-item-paddingX: var(--Nav-Item-Badge-paddingRight);
 
   --Menu-light-backgroundColor: var(--Layout-light-backgroundColor);
@@ -139,7 +137,6 @@
   --Menu-dark-backgroundColor-onHover: var(--Layout-fontColor--info);
   --Menu-dark-fontColor: var(--Layout-dark-fontColor);
   --Menu-dark-fontColor-onHover: var(--Layout-fontColor--onHover);
-  --Menu-dark-ancestor-fontColor-onActive: var(--Layout-fontColor--onActive);
   --Menu-dark-fontColor-onActive: var(--Layout-dark-fontColor);
   --Menu-dark-groupTitle-fontColor: #84868c;
   --Menu-dark-selectedIndicator-color: var(--Layout-dark-selected-color);
@@ -192,7 +189,6 @@
   }
 
   &-item-link {
-    height: var(--Nav-Item-height);
     max-width: var(--Menu-width);
     white-space: nowrap;
     overflow: hidden;
@@ -200,6 +196,8 @@
     color: inherit;
     font-size: inherit;
     flex: 1;
+    cursor: inherit;
+    font-weight: inherit;
 
     &:hover,
     &:active {
@@ -222,6 +220,7 @@
       width: var(--Tabs-linkFontSize);
       height: var(--Tabs-linkFontSize);
       vertical-align: middle;
+      fill: currentColor;
     }
   }
 
@@ -237,7 +236,6 @@
       &-collapsed {
         font-size: var(--Menu-fontSize--collapsed);
         margin: 0 auto;
-        height: var(--Menu-item-height--vertical);
       }
     }
   }
@@ -330,7 +328,7 @@
 
   &-vertical.#{$ns}Nav-Menu-sub {
     min-width: 160px;
-    margin-top: 0;
+    line-height: var(--Nav-Item-height);
     border-radius: 2px;
     box-shadow: 0 4px 5px 0 rgba(21, 26, 38, 0.06),
       0 1px 10px 0 rgba(21, 26, 38, 0.05), 0 2px 4px -1px rgba(21, 26, 38, 0.04);
@@ -341,7 +339,6 @@
     margin: 0;
     position: relative;
     padding: 0 px2rem(16px);
-    line-height: var(--Nav-Item-height);
     display: block;
     white-space: nowrap;
     overflow: hidden;
@@ -428,7 +425,6 @@
     margin: 0 16px 4px 16px;
     overflow: hidden;
     padding: 0;
-    line-height: 0;
     background-color: #ebebeb;
   }
 
@@ -453,7 +449,6 @@
   }
 
   &-horizontal {
-    height: var(--Menu-item-height--horizontal);
     border: none;
     white-space: nowrap;
     overflow: hidden;
@@ -472,23 +467,13 @@
       }
     }
 
-    & > .#{$ns}Nav-Menu-item-tooltip-wrap > .#{$ns}Nav-Menu-item,
-    & > .#{$ns}Nav-Menu-submenu > .#{$ns}Nav-Menu-submenu-title {
-      height: var(--Menu-item-height--horizontal);
-      line-height: var(--Menu-item-height--horizontal);
-
-      .#{$ns}Nav-Menu-item-link {
-        height: var(--Menu-item-height--horizontal);
-      }
-    }
-
     .#{$ns}Nav-Menu-item.#{$ns}Nav-Menu-item-selected {
       background: none;
       &:after {
         content: ' ';
         width: 100%;
         height: 2px;
-        background: var(--Menu-dark-ancestor-fontColor-onActive);
+        background: var(--Menu-light-fontColor-onActive);
         position: absolute;
         left: 0;
         bottom: 0;
@@ -501,7 +486,6 @@
     & > .#{$ns}Nav-Menu-submenu,
     & > .#{$ns}Nav-Menu-item {
       margin: 0;
-      border-bottom: 2px solid transparent;
       display: inline-block;
       vertical-align: bottom;
     }
@@ -530,23 +514,6 @@
     .#{$ns}Nav-Menu-item-label {
       vertical-align: middle;
     }
-
-    &.#{$ns}Nav-Menu-dark {
-      & > .#{$ns}Nav-Menu-item {
-        &-selected {
-          border-bottom: 2px solid var(--Menu-dark-selectedIndicator-color);
-        }
-      }
-    }
-
-    &.#{$ns}Nav-Menu-light {
-      & > .#{$ns}Nav-Menu-submenu,
-      & > .#{$ns}Nav-Menu-item {
-        &-selected {
-          border-bottom: 2px solid var(--Menu-light-selectedIndicator-color);
-        }
-      }
-    }
   }
 
   &-vertical,
@@ -560,7 +527,6 @@
       text-transform: none;
       text-rendering: auto;
       margin: 0 0 0 px2rem(10px);
-      line-height: var(--Menu-item-height--vertical);
 
       & > svg {
         top: auto;
@@ -667,7 +633,7 @@
     color: var(--Menu-fontColor-onDisabled) !important;
 
     svg {
-      fill: var(--Menu-fontColor-onDisabled) !important;
+      fill: currentColor !important;
     }
   }
 

--- a/packages/amis-ui/scss/components/_nav.scss
+++ b/packages/amis-ui/scss/components/_nav.scss
@@ -3,6 +3,11 @@
   cursor: pointer;
   background-color: var(--Layout-light-backgroundColor);
   font-size: var(--Nav-item-fontSize);
+  line-height: var(--Nav-Item-height);
+
+  &-horizontal {
+    line-height: var(--Nav-Item-height--horizontal);
+  }
 
   .#{$ns}Nav-dropIndicator {
     position: absolute;

--- a/packages/amis-ui/src/components/menu/MenuItem.tsx
+++ b/packages/amis-ui/src/components/menu/MenuItem.tsx
@@ -187,7 +187,7 @@ export class MenuItem extends React.Component<MenuItemProps> {
 
   render() {
     const {
-      className,
+      style,
       tooltipClassName,
       classnames: cx,
       label,
@@ -225,10 +225,7 @@ export class MenuItem extends React.Component<MenuItemProps> {
           className={cx('Nav-Menu-item-tooltip-wrap')}
           style={isMaxOverflow ? {} : {order}}
         >
-          <RcItem
-            {...pick(this.props, this.internalProps)}
-            className={cx(className)}
-          >
+          <RcItem {...pick(this.props, this.internalProps)} style={style}>
             {this.renderMenuItem()}
           </RcItem>
         </ul>

--- a/packages/amis-ui/src/components/menu/SubMenu.tsx
+++ b/packages/amis-ui/src/components/menu/SubMenu.tsx
@@ -209,19 +209,15 @@ export class SubMenu extends React.Component<SubMenuProps> {
   }
 
   render() {
-    const {className, popupClassName, classnames: cx, hidden} = this.props;
+    const {style, popupClassName, classnames: cx, hidden} = this.props;
 
     const isDarkTheme = this.context.themeColor === 'dark';
     return hidden ? null : (
       <RcSubMenu
         {...pick(this.props, this.internalProps)}
-        className={cx(
-          'Nav-Menu-submenu',
-          {
-            ['Nav-Menu-submenu-dark']: isDarkTheme
-          },
-          className
-        )}
+        className={cx('Nav-Menu-submenu', {
+          ['Nav-Menu-submenu-dark']: isDarkTheme
+        })}
         popupClassName={cx(
           'Nav-Menu-submenu-popup',
           {
@@ -231,6 +227,7 @@ export class SubMenu extends React.Component<SubMenuProps> {
         )}
         title={this.renderSubMenuTitle()}
         onTitleClick={this.handleSubmenuTitleActived}
+        style={style}
       />
     );
   }

--- a/packages/amis-ui/src/components/menu/index.tsx
+++ b/packages/amis-ui/src/components/menu/index.tsx
@@ -43,7 +43,6 @@ export interface NavigationItem {
   badgeClassName?: string;
   tooltipClassName?: string;
   component?: React.ReactNode;
-  // hidden?: boolean;
   permission?: string;
   persistState?: boolean;
   keepInHistory?: boolean;
@@ -546,7 +545,8 @@ export class Menu extends React.Component<MenuProps, MenuState> {
       isActive,
       collapsed,
       overflowedIndicator,
-      overflowMaxCount
+      overflowMaxCount,
+      style
     } = this.props;
 
     return list.map((item: NavigationItem, index: number) => {
@@ -576,6 +576,7 @@ export class Menu extends React.Component<MenuProps, MenuState> {
         return (
           <SubMenu
             {...item}
+            style={style}
             key={item.id}
             disabled={itemDisabled || link.loading}
             active={isActive(item)}
@@ -604,6 +605,7 @@ export class Menu extends React.Component<MenuProps, MenuState> {
           data={data}
           depth={level || 1}
           order={index}
+          style={style}
           overflowedIndicator={overflowedIndicator}
           overflowMaxCount={overflowMaxCount}
         />
@@ -614,7 +616,6 @@ export class Menu extends React.Component<MenuProps, MenuState> {
   render() {
     const {
       classPrefix,
-      className,
       classnames: cx,
       collapsed,
       themeColor,
@@ -624,6 +625,7 @@ export class Menu extends React.Component<MenuProps, MenuState> {
       prefix,
       disabled,
       draggable,
+      className,
       triggerSubMenuAction,
       direction,
       overflowedIndicator,
@@ -641,7 +643,6 @@ export class Menu extends React.Component<MenuProps, MenuState> {
     } = this.props;
     const {navigations, activeKey, defaultOpenKeys, openKeys} = this.state;
     const isDarkTheme = themeColor === 'dark';
-    // const disabledItem = findTree(navigations, item => !!item.disabled);
     const rcMode = stacked
       ? mode === 'float'
         ? 'vertical-right'

--- a/packages/amis/__tests__/renderers/__snapshots__/Nav.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Nav.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`Renderer:Nav 1`] = `
 <div>
   <div
-    class="cxd-Nav"
+    class="cxd-Nav w-md"
   >
     <ul
-      class="cxd-Nav-Menu cxd-Nav-Menu-root cxd-Nav-Menu-inline cxd-Nav-Menu-ltr w-md cxd-Nav-Menu-light cxd-Nav-Menu-expand-before"
+      class="cxd-Nav-Menu cxd-Nav-Menu-root cxd-Nav-Menu-inline cxd-Nav-Menu-ltr cxd-Nav-Menu-light cxd-Nav-Menu-expand-before"
       data-menu-list="true"
       dir="ltr"
       role="menu"
@@ -224,10 +224,10 @@ exports[`Renderer:Nav with itemActions 1`] = `
           role="page-body"
         >
           <div
-            class="cxd-Nav"
+            class="cxd-Nav w-md"
           >
             <ul
-              class="cxd-Nav-Menu cxd-Nav-Menu-root cxd-Nav-Menu-inline cxd-Nav-Menu-ltr w-md cxd-Nav-Menu-light cxd-Nav-Menu-disabled cxd-Nav-Menu-expand-before"
+              class="cxd-Nav-Menu cxd-Nav-Menu-root cxd-Nav-Menu-inline cxd-Nav-Menu-ltr cxd-Nav-Menu-light cxd-Nav-Menu-disabled cxd-Nav-Menu-expand-before"
               data-menu-list="true"
               dir="ltr"
               role="menu"
@@ -558,10 +558,10 @@ exports[`Renderer:Nav with itemActions 2`] = `
           role="page-body"
         >
           <div
-            class="cxd-Nav"
+            class="cxd-Nav w-md"
           >
             <ul
-              class="cxd-Nav-Menu cxd-Nav-Menu-root cxd-Nav-Menu-inline cxd-Nav-Menu-ltr w-md cxd-Nav-Menu-light cxd-Nav-Menu-expand-before"
+              class="cxd-Nav-Menu cxd-Nav-Menu-root cxd-Nav-Menu-inline cxd-Nav-Menu-ltr cxd-Nav-Menu-light cxd-Nav-Menu-expand-before"
               data-menu-list="true"
               dir="ltr"
               role="menu"
@@ -940,10 +940,10 @@ exports[`Renderer:Nav with itemActions 2`] = `
 exports[`Renderer:Nav with multi-level 1`] = `
 <div>
   <div
-    class="cxd-Nav"
+    class="cxd-Nav w-md"
   >
     <ul
-      class="cxd-Nav-Menu cxd-Nav-Menu-root cxd-Nav-Menu-inline cxd-Nav-Menu-ltr w-md cxd-Nav-Menu-light cxd-Nav-Menu-expand-before"
+      class="cxd-Nav-Menu cxd-Nav-Menu-root cxd-Nav-Menu-inline cxd-Nav-Menu-ltr cxd-Nav-Menu-light cxd-Nav-Menu-expand-before"
       data-menu-list="true"
       dir="ltr"
       role="menu"
@@ -1178,7 +1178,7 @@ exports[`Renderer:Nav with overflow 1`] = `
           role="page-body"
         >
           <div
-            class="cxd-Nav"
+            class="cxd-Nav cxd-Nav-horizontal"
           >
             <section
               class="cxd-Nav-Menu-overflow cxd-Nav-Menu cxd-Nav-Menu-root cxd-Nav-Menu-horizontal cxd-Nav-Menu-ltr cxd-Nav-Menu-light"
@@ -1466,7 +1466,7 @@ exports[`Renderer:Nav with source 1`] = `
 exports[`Renderer:Nav with stacked 1`] = `
 <div>
   <div
-    class="cxd-Nav"
+    class="cxd-Nav cxd-Nav-horizontal"
   >
     <ul
       class="cxd-Nav-Menu-overflow cxd-Nav-Menu cxd-Nav-Menu-root cxd-Nav-Menu-horizontal cxd-Nav-Menu-ltr cxd-Nav-Menu-light"

--- a/packages/amis/src/renderers/Nav.tsx
+++ b/packages/amis/src/renderers/Nav.tsx
@@ -704,13 +704,17 @@ export class Navigation extends React.Component<
         </span>
       );
     }
-
+    const styleConfig = buildStyle(style, data);
     return (
-      <div className={cx('Nav')} style={buildStyle(style, data)}>
+      <div
+        className={cx('Nav', className, {
+          ['Nav-horizontal']: !stacked
+        })}
+        style={styleConfig}
+      >
         <>
           {Array.isArray(links) ? (
             <Menu
-              className={className}
               navigations={this.normalizeNavigations(links, 1)}
               isActive={(link: NavigationItem, prefix: string = '') => {
                 if (link.link && typeof link.link.active !== 'undefined') {
@@ -743,6 +747,7 @@ export class Navigation extends React.Component<
               overflowItemWidth={overflow?.itemWidth}
               overflowComponent={overflow?.wrapperComponent}
               overflowStyle={overflow?.style}
+              style={styleConfig}
               expandIcon={
                 expandIcon
                   ? typeof expandIcon === 'string'


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4d13203</samp>

This pull request improves the menu and nav components in the `amis-ui` package, by simplifying and standardizing their styles, and by adding more props for customization and filtering. It also moves the `_menu.scss` file to a more appropriate location and adjusts some style values.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4d13203</samp>

> _We are the masters of the menu_
> _We wield the power of the style_
> _We purge the code of the redundant_
> _We make the nav a work of art_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4d13203</samp>

*  Change the fill color of the svg icons in the menu items to use the currentColor value, which inherits the color from the parent element, for consistency in different themes and states. ([link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL68-R68), [link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL83-R83), [link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL98-R98), [link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcR223), [link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL670-R636))
* Remove the redundant height and line-height properties of the menu items, sub items, sub menu titles, and tooltip wraps, as they are already set by the line-height of the nav item or the nav item horizontal, which are defined in the `_nav.scss` file. ([link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL124-L125), [link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL195), [link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL240), [link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL333-R331), [link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL344), [link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL431), [link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL456), [link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL475-L484), [link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL533-L549), [link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL563))
* Remove the unused menu dark ancestor font color on active variable, as the menu item color on active is now determined by the layout font color on active variable. ([link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL142))
* Set the cursor and font-weight of the nav menu item to inherit from the parent element, to avoid overriding the default styles of the rc-menu component. ([link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcR199-R200))
* Change the background color of the nav menu horizontal item selected indicator to use the menu light font color on active variable, for consistency with the text color on active in the light theme. ([link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL491-R476))
* Remove the border-bottom of the nav menu horizontal item and the nav menu item selected in the dark and light themes, as they are not needed. The border-bottom is already handled by the selected indicator, which is a pseudo-element with absolute position and height of 2px. ([link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL504), [link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL533-L549))
* Move the `_menu.scss` file from the `scss/components` folder to the `scss` folder, as it is not a component-specific style file, but a general style file for the menu feature. Add the line-height of the nav item and the nav item horizontal to the `_menu.scss` file, as they are common styles for the menu and nav components. ([link](https://github.com/baidu/amis/pull/6699/files?diff=unified&w=0#diff-3a1304ef934e1033e1f1d935ce1eee2ed355d7b693312b46ab1408f37ccd113aL6-R11))
