### PR TITLE
styles: 优化tag关闭按钮样式

### DIFF
--- a/packages/amis-ui/scss/components/_tag.scss
+++ b/packages/amis-ui/scss/components/_tag.scss
@@ -133,7 +133,6 @@
 
   &--close {
     margin-left: var(--Tag-close-margin);
-    margin-right: var(--Tag-close-margin);
     i {
       font-size: #{px2rem(8px)};
     }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6469dd</samp>

Removed `margin-right` from tag close button in `_tag.scss` to fix alignment and spacing issues. This improves the visual consistency of the tag component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b6469dd</samp>

> _`margin-right` gone_
> _tag component looks better_
> _autumn leaves align_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b6469dd</samp>

* Remove the margin-right property of the close button of the tag component to fix the alignment and spacing issues ([link](https://github.com/baidu/amis/pull/6700/files?diff=unified&w=0#diff-a844b290f44eac09deaef12cf441a36437078855ad4af3afc5b7fc6d9a669d76L136))
