### PR TITLE
fix: toast className fix

### DIFF
--- a/packages/amis-editor/src/renderer/event-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/event-control/helper.tsx
@@ -514,7 +514,8 @@ export const ACTION_TYPE_TREE = (manager: any): RendererPluginAction[] => {
             'position',
             'timeout',
             'closeButton',
-            'showIcon'
+            'showIcon',
+            'className'
           ],
           descDetail: (info: any) => {
             return (
@@ -3083,6 +3084,14 @@ export const getEventControlConfig = (
             params: comboArrayToObject(params)
           };
         }
+      }
+
+      if (action.actionType === 'toast') {
+        // 配置一个toast组件默认class
+        action.args = {
+          ...action.args,
+          className: 'theme-toast-action-scope'
+        };
       }
 
       // 转换下格式

--- a/packages/amis-ui/src/components/Toast.tsx
+++ b/packages/amis-ui/src/components/Toast.tsx
@@ -80,6 +80,7 @@ interface Item extends Config {
   body: string | React.ReactNode;
   level: ToastLevel;
   id: string;
+  className?: string;
   onDissmiss?: () => void;
   position?:
     | 'top-right'
@@ -145,6 +146,7 @@ export class ToastComponent extends React.Component<
         level,
         ...config,
         id: guid(),
+        className: config.className || '',
         position: config.position || (useMobileUI ? 'center' : config.position),
         timeout: config.timeout || (useMobileUI ? 3000 : undefined)
       });
@@ -230,6 +232,7 @@ export class ToastComponent extends React.Component<
                 title={item.title}
                 body={item.body}
                 level={level}
+                className={item.className}
                 timeout={toastTimeout}
                 closeButton={!mobileUI && (item.closeButton ?? closeButton)}
                 onDismiss={this.handleDismissed.bind(this, items.indexOf(item))}
@@ -266,6 +269,7 @@ interface ToastMessageProps {
   classnames: ClassNamesFn;
   translate: TranslateFn;
   allowHtml: boolean;
+  className: string;
   useMobileUI?: boolean;
 }
 
@@ -342,7 +346,8 @@ export class ToastMessage extends React.Component<
       level,
       showIcon,
       useMobileUI,
-      translate: __
+      translate: __,
+      className
     } = this.props;
     const iconName = useMobileUI ? '' : 'alert-';
 
@@ -358,9 +363,14 @@ export class ToastMessage extends React.Component<
         {(status: string) => {
           return (
             <div
-              className={cx(`Toast Toast--${level}`, fadeStyles[status], {
-                'Toast-mobile--has-icon': useMobileUI && showIcon !== false
-              })}
+              className={cx(
+                `Toast Toast--${level}`,
+                className,
+                fadeStyles[status],
+                {
+                  'Toast-mobile--has-icon': useMobileUI && showIcon !== false
+                }
+              )}
               onMouseEnter={this.handleMouseEnter}
               onMouseLeave={this.handleMouseLeave}
               onClick={closeButton ? noop : this.close}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b837c1</samp>

Add `className` property to toast messages in `Toast.tsx`. This allows the user to apply custom styles to the toast notifications.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4b837c1</samp>

> _`className` added_
> _toast messages can be styled_
> _winter or summer_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4b837c1</samp>

*  Add `className` property to `Item` interface and `ToastComponent` state to allow custom CSS class name for toast messages ([link](https://github.com/baidu/amis/pull/6704/files?diff=unified&w=0#diff-f0c28e0b3da0ef97e7e957c7b27ff27ce2a7fc4a4381af33cdcc7903bdf325c3R83), [link](https://github.com/baidu/amis/pull/6704/files?diff=unified&w=0#diff-f0c28e0b3da0ef97e7e957c7b27ff27ce2a7fc4a4381af33cdcc7903bdf325c3R149))
*  Pass `className` property from `ToastComponent` state to `ToastMessage` component as a prop ([link](https://github.com/baidu/amis/pull/6704/files?diff=unified&w=0#diff-f0c28e0b3da0ef97e7e957c7b27ff27ce2a7fc4a4381af33cdcc7903bdf325c3R235))
*  Add `className` prop to `ToastMessageProps` interface and destructure it from `ToastMessage` component props ([link](https://github.com/baidu/amis/pull/6704/files?diff=unified&w=0#diff-f0c28e0b3da0ef97e7e957c7b27ff27ce2a7fc4a4381af33cdcc7903bdf325c3R272), [link](https://github.com/baidu/amis/pull/6704/files?diff=unified&w=0#diff-f0c28e0b3da0ef97e7e957c7b27ff27ce2a7fc4a4381af33cdcc7903bdf325c3L345-R350))
*  Use `className` prop in `cx` function call to generate final CSS class name for toast message element ([link](https://github.com/baidu/amis/pull/6704/files?diff=unified&w=0#diff-f0c28e0b3da0ef97e7e957c7b27ff27ce2a7fc4a4381af33cdcc7903bdf325c3L361-R373))
