### PR TITLE
fix: nav收纳样式问题修复

### DIFF
--- a/docs/zh-CN/components/nav.md
+++ b/docs/zh-CN/components/nav.md
@@ -171,7 +171,13 @@ order: 58
         },
         {
             "label": "Nav 11",
-            "to": "?to=nav11"
+            "to": "?to=nav11",
+            "children": [
+                {
+                    "label": "Nav 13",
+                    "to": "?to=nav13"
+                }
+            ]
         },
         {
             "label": "Nav 12",

--- a/packages/amis-ui/scss/components/_menu.scss
+++ b/packages/amis-ui/scss/components/_menu.scss
@@ -433,6 +433,16 @@
       position: absolute !important;
       z-index: 1500;
       background-color: var(--Layout-light-backgroundColor);
+
+      // 横向收纳模式且有子菜单项的情况下 会显示2个展开箭头
+      // 用css隐藏1个 自适应收纳的情况下 判断不出是子菜单项还是收纳项
+      .#{$ns}Nav-Menu-submenu-title {
+        .#{$ns}Nav-Menu-item-link {
+          .#{$ns}Nav-Menu-submenu-arrow {
+            display: none;
+          }
+        }
+      }
     }
   }
 
@@ -464,6 +474,7 @@
       > .#{$ns}Nav-Menu-submenu-title {
       .#{$ns}Nav-Menu-overflowedIcon {
         margin-right: 0;
+        line-height: inherit; // 到了saas中 会被fortawesome的样式影响 因此需要覆盖一下
       }
     }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b86a1bc</samp>

This pull request enhances the menu component and its documentation in the `amis-ui` package. It fixes some visual bugs in the menu styles and adds an example of nested submenus in the `nav.md` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b86a1bc</samp>

> _We are the masters of the menu_
> _We shape the nav with our skill_
> _We fix the arrows and the icons_
> _We make it responsive at will_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b86a1bc</samp>

* Add a child menu item to the responsive collapse mode example in `nav.md` ([link](https://github.com/baidu/amis/pull/6705/files?diff=unified&w=0#diff-404786a84c4b6ba83352acecde93d2c5d2194220921cbbe260293b72236ccdbfL174-R180))
* Hide the redundant expand arrow for submenu items in the horizontal collapse mode in `_menu.scss` ([link](https://github.com/baidu/amis/pull/6705/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcR436-R445))
* Fix the alignment issue of menu icons and text in the saas environment by overriding the line-height property in `_menu.scss` ([link](https://github.com/baidu/amis/pull/6705/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcR477))
