### PR TITLE
fix: 修复表达式输入框回车回显等问题

### DIFF
--- a/packages/amis-editor-core/scss/control/_textarea-formula-control.scss
+++ b/packages/amis-editor-core/scss/control/_textarea-formula-control.scss
@@ -33,6 +33,9 @@
       & > .CodeMirror {
         height: 100%;
         font-family: inherit;
+        span[class^='cm-'] {
+          color: var(--input-default-default-color);
+        }
 
         // 解决上下 pre标签中表达式浮层遮挡问题
         .CodeMirror-measure + div {
@@ -146,7 +149,7 @@
   &-text {
     display: inline-block;
     position: relative;
-    color: #fff;
+    color: #fff !important;
     cursor: pointer;
     max-width: 80px;
     min-width: 10px;

--- a/packages/amis-editor-core/scss/control/_tpl-formula-control.scss
+++ b/packages/amis-editor-core/scss/control/_tpl-formula-control.scss
@@ -45,6 +45,10 @@
         color: var(--Form-input-color);
         font-family: inherit;
 
+        span[class^='cm-'] {
+          color: var(--input-default-default-color);
+        }
+
         // 解决上下 pre标签中表达式浮层遮挡问题
         .CodeMirror-measure + div {
           z-index: inherit !important;

--- a/packages/amis-editor/src/plugin/Form/InputTag.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTag.tsx
@@ -45,6 +45,7 @@ export class TagControlPlugin extends BasePlugin {
   notRenderFormZone = true;
 
   panelTitle = '标签';
+  panelJustify = true;
 
   // 事件定义
   events: RendererPluginEvent[] = [

--- a/packages/amis-editor/src/renderer/ExpressionFormulaControl.tsx
+++ b/packages/amis-editor/src/renderer/ExpressionFormulaControl.tsx
@@ -117,6 +117,7 @@ export default class ExpressionFormulaControl extends React.Component<
   @autobind
   handleConfirm(value = '') {
     const expressionReg = /^\$\{(.*)\}$/;
+    value = value.replace(/\r\n|\r|\n/g, ' ');
     if (value && !expressionReg.test(value)) {
       value = `\${${value}}`;
     }

--- a/packages/amis-editor/src/renderer/FormulaControl.tsx
+++ b/packages/amis-editor/src/renderer/FormulaControl.tsx
@@ -363,6 +363,7 @@ export default class FormulaControl extends React.Component<
 
   @autobind
   handleConfirm(value: any) {
+    value = value.replace(/\r\n|\r|\n/g, ' ');
     const val = !value
       ? undefined
       : isExpression(value) || this.hasDateShortcutkey(value)

--- a/packages/amis-editor/src/renderer/textarea-formula/TextareaFormulaControl.tsx
+++ b/packages/amis-editor/src/renderer/textarea-formula/TextareaFormulaControl.tsx
@@ -267,6 +267,7 @@ export class TextareaFormulaControl extends React.Component<
     // 去除可能包裹的最外层的${}
     value = value.replace(/^\$\{(.*)\}$/, (match: string, p1: string) => p1);
     value = value ? `\${${value}}` : value;
+    value = value.replace(/\r\n|\r|\n/g, ' ');
     this.editorPlugin?.insertContent(value, 'expression', expressionBrace);
     this.setState({
       formulaPickerOpen: false,
@@ -291,7 +292,8 @@ export class TextareaFormulaControl extends React.Component<
       onExpressionClick: this.onExpressionClick,
       onExpressionMouseEnter: this.onExpressionMouseEnter,
       customMarkText: this.props.customMarkText,
-      onPluginInit: this.props.onPluginInit
+      onPluginInit: this.props.onPluginInit,
+      showClearIcon: true
     });
   }
 
@@ -418,7 +420,8 @@ export class TextareaFormulaControl extends React.Component<
               </a>
             </li>
             {/* 附加底部按钮菜单项 */}
-            {additionalMenus?.length &&
+            {Array.isArray(additionalMenus) &&
+              additionalMenus.length > 0 &&
               additionalMenus?.map((item, i) => {
                 return (
                   <li key={i}>


### PR DESCRIPTION
### What

- 解决表达式输入框中在表达式编辑器输入变量后先回车，在确认导致结果回显了${}的问题
- 长文本公式输入框表达式添加删除按钮
- 长文本公式输入框字体颜色调整

### Why

<!-- author to complete -->

### How

copilot:walkthrough
