### PR TITLE
fix(editor): 主题数据不应该被保存下来

### DIFF
--- a/packages/amis-editor-core/src/component/factory.tsx
+++ b/packages/amis-editor-core/src/component/factory.tsx
@@ -13,7 +13,12 @@ import {EditorNodeContext, EditorNodeType} from '../store/node';
 import {EditorManager} from '../manager';
 import flatten from 'lodash/flatten';
 import {render as reactRender, unmountComponentAtNode} from 'react-dom';
-import {autobind, diff} from '../util';
+import {
+  autobind,
+  deleteThemeConfigData,
+  diff,
+  setThemeDefaultData
+} from '../util';
 import {createObject} from 'amis-core';
 import {CommonConfigWrapper} from './CommonConfigWrapper';
 import type {Schema} from 'amis';
@@ -296,13 +301,15 @@ function SchemaFrom({
     };
   }
 
-  const finalValue = pipeIn ? pipeIn(value) : value;
+  const finalValue = setThemeDefaultData(pipeIn ? pipeIn(value) : value);
 
   return render(
     schema,
     {
       onFinished: async (newValue: any) => {
-        newValue = pipeOut ? await pipeOut(newValue) : newValue;
+        newValue = deleteThemeConfigData(
+          pipeOut ? await pipeOut(newValue) : newValue
+        );
         const diffValue = diff(value, newValue);
         onChange(newValue, diffValue);
       },

--- a/packages/amis-editor-core/src/store/editor.ts
+++ b/packages/amis-editor-core/src/store/editor.ts
@@ -18,7 +18,6 @@ import {
   needDefaultWidth,
   guid,
   addStyleClassName,
-  setThemeDefaultData,
   appTranslate
 } from '../../src/util';
 import {
@@ -530,8 +529,7 @@ export const MainStore = types
       getValueOf(id: string) {
         const schema = JSONGetById(self.schema, id);
         const data = JSONPipeOut(schema, false);
-        const res = setThemeDefaultData(data);
-        return res;
+        return data;
       },
 
       get valueWithoutHiddenProps() {

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -42,6 +42,7 @@ export {
 };
 
 export let themeConfig: any = {};
+export let themeOptionsData: any = {};
 
 export function __uri(id: string) {
   return id;
@@ -1093,13 +1094,14 @@ export function needFillPlaceholder(curProps: any) {
 // 设置主题数据
 export function setThemeConfig(config: any) {
   themeConfig = config;
+  themeOptionsData = getGlobalData(themeConfig);
 }
 
 // 将主题数据传入组件的schema
 export function setThemeDefaultData(data: any) {
   const schemaData = cloneDeep(data);
   schemaData.themeConfig = themeConfig;
-  assign(schemaData, getGlobalData(themeConfig));
+  assign(schemaData, themeOptionsData);
   return schemaData;
 }
 
@@ -1111,16 +1113,9 @@ export function deleteThemeConfigData(data: any) {
   const schemaData = cloneDeep(data);
 
   delete schemaData.themeConfig;
-  delete schemaData.borderRadiusOptions;
-  delete schemaData.borderStyleOptions;
-  delete schemaData.borderWidthOptions;
-  delete schemaData.fontFamilyOptions;
-  delete schemaData.fontSizeOptions;
-  delete schemaData.fontWeightOptions;
-  delete schemaData.lineHeightOptions;
-  delete schemaData.shadowOptions;
-  delete schemaData.sizesOptions;
-  delete schemaData.colorOptions;
+  Object.keys(themeOptionsData).forEach(key => {
+    delete schemaData[key];
+  });
 
   return schemaData;
 }

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -1102,3 +1102,25 @@ export function setThemeDefaultData(data: any) {
   assign(schemaData, getGlobalData(themeConfig));
   return schemaData;
 }
+
+// 删除主题的配置数据
+export function deleteThemeConfigData(data: any) {
+  if (!data) {
+    return data;
+  }
+  const schemaData = cloneDeep(data);
+
+  delete schemaData.themeConfig;
+  delete schemaData.borderRadiusOptions;
+  delete schemaData.borderStyleOptions;
+  delete schemaData.borderWidthOptions;
+  delete schemaData.fontFamilyOptions;
+  delete schemaData.fontSizeOptions;
+  delete schemaData.fontWeightOptions;
+  delete schemaData.lineHeightOptions;
+  delete schemaData.shadowOptions;
+  delete schemaData.sizesOptions;
+  delete schemaData.colorOptions;
+
+  return schemaData;
+}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c7d5703</samp>

Added theme configuration support to `SchemaForm` component in `amis-editor-core`. Removed unnecessary code and added a utility function to handle theme data.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c7d5703</samp>

> _We'll hoist the sail with `SchemaForm`_
> _And make it look so fine_
> _We'll delete the `themeConfigData`_
> _On the count of three, we'll heave and haul_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c7d5703</samp>

* Import and use `deleteThemeConfigData` and `setThemeDefaultData` functions in `factory.tsx` to handle theme configuration data for the `SchemaForm` component ([link](https://github.com/baidu/amis/pull/6722/files?diff=unified&w=0#diff-5bcb2370bda7a8f3b1b692f3d568f62e4fd6aadd951424c0b7340c1ef5f40fe1L16-R21), [link](https://github.com/baidu/amis/pull/6722/files?diff=unified&w=0#diff-5bcb2370bda7a8f3b1b692f3d568f62e4fd6aadd951424c0b7340c1ef5f40fe1L299-R304), [link](https://github.com/baidu/amis/pull/6722/files?diff=unified&w=0#diff-5bcb2370bda7a8f3b1b692f3d568f62e4fd6aadd951424c0b7340c1ef5f40fe1L305-R312))
* Remove unnecessary usage of `setThemeDefaultData` function in `editor.ts` to avoid modifying the schema object in the store ([link](https://github.com/baidu/amis/pull/6722/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8L21), [link](https://github.com/baidu/amis/pull/6722/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8L533-R532))
* Add `deleteThemeConfigData` function to `util.ts` to provide a utility for removing theme configuration data from the schema object ([link](https://github.com/baidu/amis/pull/6722/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aR1105-R1126))
