### PR TITLE
feat: cherry-pick图片上传修复

### DIFF
--- a/packages/amis-core/src/renderers/Item.tsx
+++ b/packages/amis-core/src/renderers/Item.tsx
@@ -1585,7 +1585,8 @@ export const detectProps = [
   'embed',
   'displayMode',
   'revealPassword',
-  'loading'
+  'loading',
+  'themeCss'
 ];
 
 export function asFormItem(config: Omit<FormItemConfig, 'component'>) {

--- a/packages/amis-core/src/utils/style-helper.ts
+++ b/packages/amis-core/src/utils/style-helper.ts
@@ -97,7 +97,8 @@ export function formatStyle(
             ?.replace('u:', '')
             .replace('-label', '')
             .replace('-description', '')
-            .replace('-addOn', '') || ''
+            .replace('-addOn', '')
+            .replace('-icon', '') || ''
         )
       ) {
         classNameList.push(n);

--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -2512,6 +2512,7 @@
   --inputImage-base-default-fontSize: var(--fonts-size-7);
   --inputImage-base-default-fontWeight: var(--fonts-weight-6);
   --inputImage-base-default-color: var(--colors-neutral-text-5);
+  --inputImage-base-default-icon: '<svg viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g><rect fill="currentColor" opacity="0" x="0" y="0" width="16" height="16"></rect><path d="M8.5,2 L8.5,7.5 L14,7.5 L14,8.5 L8.5,8.5 L8.5,14 L7.5,14 L7.5,8.5 L2,8.5 L2,7.5 L7.5,7.5 L7.5,2 L8.5,2 Z"  fill="currentColor" fill-rule="nonzero"></path></g></g></svg>';
   --inputImage-base-default-icon-size: var(--sizes-base-12);
   --inputImage-base-default-icon-color: var(--colors-neutral-text-5);
   --inputImage-base-default-icon-margin: var(--sizes-size-5);

--- a/packages/amis-ui/scss/components/form/_image.scss
+++ b/packages/amis-ui/scss/components/form/_image.scss
@@ -5,6 +5,10 @@
     outline: none;
   }
 
+  .ImageControl-addBtn-icon {
+    content: var(--inputImage-base-default-icon);
+  }
+
   &-addBtn {
     margin: 0;
     width: px2rem(120px);
@@ -83,11 +87,13 @@
       var(--shadows-shadow-none)
     );
 
-    > svg {
+    svg {
       top: 0;
       margin-bottom: var(--inputImage-base-default-icon-margin);
       font-size: var(--inputImage-base-default-icon-size);
       color: var(--inputImage-base-default-icon-color);
+      width: var(--inputImage-base-default-icon-size);
+      height: var(--inputImage-base-default-icon-size);
     }
 
     &-text {
@@ -97,13 +103,13 @@
 
     &:not(:disabled):not(.is-disabled) {
       &:hover {
-        > svg {
+        svg {
           color: var(--inputImage-base-hover-icon-color);
         }
       }
 
       &:hover:active {
-        > svg {
+        svg {
           color: var(--inputImage-base-active-icon-color);
         }
       }
@@ -112,7 +118,7 @@
     &.is-disabled {
       pointer-events: none;
 
-      > svg {
+      svg {
         color: var(--inputImage-base-disabled-icon-color);
       }
     }

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -4,7 +4,8 @@ import {
   FormControlProps,
   FormBaseControl,
   prettyBytes,
-  resolveEventData
+  resolveEventData,
+  insertCustomStyle
 } from 'amis-core';
 // import 'cropperjs/dist/cropper.css';
 const Cropper = React.lazy(() => import('react-cropper'));
@@ -1354,8 +1355,63 @@ export default class ImageControl extends React.Component<
       frameImage,
       fixedSize,
       fixedSizeClassName,
+      themeCss,
+      inputImageControlClassName,
+      addBtnControlClassName,
+      iconControlClassName,
+      id,
       translate: __
     } = this.props;
+
+    insertCustomStyle(
+      themeCss,
+      [
+        {
+          key: 'inputImageControlClassName',
+          value: inputImageControlClassName
+        }
+      ],
+      id,
+      null
+    );
+
+    insertCustomStyle(
+      themeCss,
+      [
+        {
+          key: 'addBtnControlClassName',
+          value: addBtnControlClassName,
+          weights: {
+            hover: {
+              suf: ':not(:disabled):not(.is-disabled)'
+            },
+            active: {
+              suf: ':not(:disabled):not(.is-disabled)'
+            }
+          }
+        }
+      ],
+      id + '-addOn',
+      null
+    );
+
+    insertCustomStyle(
+      themeCss,
+      [
+        {
+          key: 'iconControlClassName',
+          value: iconControlClassName,
+          weights: {
+            default: {
+              suf: ' svg'
+            }
+          }
+        }
+      ],
+      id + '-icon',
+      null
+    );
+
     const {files, error, crop, uploading, cropFile, frameImageWidth} =
       this.state;
     let frameImageStyle: any = {};
@@ -1365,7 +1421,9 @@ export default class ImageControl extends React.Component<
     const filterFrameImage = filter(frameImage, this.props.data, '| raw');
     const hasPending = files.some(file => file.state == 'pending');
     return (
-      <div className={cx(`ImageControl`, className)}>
+      <div
+        className={cx(`ImageControl`, className, inputImageControlClassName)}
+      >
         {cropFile ? (
           <div className={cx('ImageControl-cropperWrapper')}>
             <Suspense fallback={<div>...</div>}>
@@ -1677,7 +1735,8 @@ export default class ImageControl extends React.Component<
                             'is-disabled': disabled
                           },
                           fixedSize ? 'ImageControl-fixed-size' : '',
-                          fixedSize ? fixedSizeClassName : ''
+                          fixedSize ? fixedSizeClassName : '',
+                          addBtnControlClassName
                         )}
                         style={frameImageStyle}
                         onClick={this.handleSelect}
@@ -1698,7 +1757,14 @@ export default class ImageControl extends React.Component<
                           />
                         ) : (
                           <>
-                            <Icon icon="plus-fine" className="icon" />
+                            <Icon
+                              icon="plus-fine"
+                              className="icon"
+                              iconContent={cx(
+                                ':ImageControl-addBtn-icon',
+                                iconControlClassName
+                              )}
+                            />
                             <span className={cx('ImageControl-addBtn-text')}>
                               {__('Image.upload')}
                             </span>

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -1060,7 +1060,8 @@ export default class TextControl extends React.PureComponent<
       css,
       inputControlClassName,
       id,
-      addOnClassName
+      addOnClassName,
+      classPrefix: ns
     } = this.props;
     let input =
       autoComplete !== false && (source || options?.length || autoComplete)
@@ -1080,7 +1081,8 @@ export default class TextControl extends React.PureComponent<
           }
         }
       ],
-      id
+      id,
+      null
     );
 
     insertCustomStyle(


### PR DESCRIPTION
feat: 图片上传外观配置

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fdb7e67</samp>

This pull request adds theme customization support for the input components in the `amis` library. It introduces new props and CSS variables to allow users to apply custom styles and class names to the `InputImage` and `InputText` components. It also updates the style files and the `style-helper` module to handle the new props and variables.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fdb7e67</samp>

> _We're sailing on the web with our input components_
> _We're styling them with themes and props to our content_
> _We're heaving on the `themeCss` and the `iconControlClassName`_
> _We're making them look fancy with the `formatStyle` and the `--inputImage-base-default-icon`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fdb7e67</samp>

*  Add theme customization feature for input components ([link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1588-R1589), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL100-R101), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4R2515), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aR8-R11), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aL86-R96), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aL100-R106), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aL106-R112), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aL115-R121), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L7-R8), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1357-R1414), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1368-R1426), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1680-R1739), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1701-R1767), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L1063-R1064), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L1083-R1085))
  * Add `themeCss` prop to `Item` component to pass theme object to input components ([link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1588-R1589))
  * Add `formatStyle` function case to handle `-icon` suffix in style keys ([link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL100-R101))
  * Add `--inputImage-base-default-icon` CSS variable to define default icon for image input component ([link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4R2515))
  * Import `_components.scss` file in `_image.scss` file to use CSS variables ([link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aR8-R11))
  * Modify SVG icon selectors in `_image.scss` file to match any SVG element within image input component ([link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aL86-R96), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aL100-R106), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aL106-R112), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aL115-R121))
  * Import `insertCustomStyle` function in `InputImage.tsx` and `InputText.tsx` files to insert custom style element to document head ([link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L7-R8), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L1063-R1064))
  * Add `inputImageControlClassName`, `addBtnControlClassName`, `iconControlClassName`, and `id` props to `InputImage` component and call `insertCustomStyle` function with different arguments to customize style of each part of the component ([link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1357-R1414))
  * Modify `className` prop of root element, add button element, and `Icon` component of `InputImage` component to apply custom class names ([link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1368-R1426), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1680-R1739), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1701-R1767))
  * Add `classPrefix` prop to `InputText` component and modify last argument of `insertCustomStyle` function call to use `null` instead of `undefined` ([link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L1063-R1064), [link](https://github.com/baidu/amis/pull/6723/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L1083-R1085))
