### PR TITLE
fix(amis-editor): 修复从预览切到编辑态 toolbar, panel, 可能有原 node 节点引用读取异常问题

### DIFF
--- a/packages/amis-editor-core/src/component/Editor.tsx
+++ b/packages/amis-editor-core/src/component/Editor.tsx
@@ -122,7 +122,7 @@ export default class Editor extends Component<EditorProps> {
   readonly store: EditorStoreType;
   readonly manager: EditorManager;
   readonly mainRef = React.createRef<HTMLDivElement>();
-  unReaction: () => void;
+  toDispose: Array<Function> = [];
   lastResult: any;
   curCopySchemaData: any; // 用于记录当前复制的元素
 
@@ -176,16 +176,21 @@ export default class Editor extends Component<EditorProps> {
 
     window.addEventListener('message', this.handleMessage, false);
 
-    this.unReaction = reaction(
-      () => this.store.schemaRaw,
-      (raw: any) => {
-        this.lastResult = raw;
+    this.toDispose.push(
+      reaction(
+        () => this.store.schemaRaw,
+        (raw: any) => {
+          this.lastResult = raw;
 
-        if (this.isInternalChange) {
-          return;
+          if (this.isInternalChange) {
+            return;
+          }
+          props.onChange(raw);
         }
-        props.onChange(raw);
-      }
+      )
+    );
+    this.toDispose.push(
+      this.manager.on('preview2editor', () => this.manager.rebuild())
     );
   }
 
@@ -226,7 +231,8 @@ export default class Editor extends Component<EditorProps> {
   componentWillUnmount() {
     document.removeEventListener('keydown', this.handleKeyDown);
     window.removeEventListener('message', this.handleMessage);
-    this.unReaction();
+    this.toDispose.forEach(fn => fn());
+    this.toDispose = [];
     this.manager.dispose();
     destroy(this.store);
   }

--- a/packages/amis-editor-core/src/manager.ts
+++ b/packages/amis-editor-core/src/manager.ts
@@ -740,6 +740,7 @@ export class EditorManager {
       type: event,
       fn
     });
+    return () => this.off(event, fn);
   }
 
   off(event: string, fn: PluginEventFn) {

--- a/packages/amis-editor-core/src/plugin.ts
+++ b/packages/amis-editor-core/src/plugin.ts
@@ -594,7 +594,7 @@ export type PluginEvent<T, P = any> = {
   data?: P;
 };
 
-export type PluginEventFn = (e: PluginEvent<EventContext>) => false | void;
+export type PluginEventFn = (e: PluginEvent<EventContext>) => any;
 
 /**
  * 创建事件。


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d83dd86</samp>

Improved the editor component's reaction and listener management, and enhanced the plugin system's event handling. These changes allow the editor to rebuild itself on schema changes, and enable plugins to return any value from their event handlers.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d83dd86</samp>

> _We're the crew of the `EditorManager`_
> _We listen and we react_
> _We can dispose our hooks with ease_
> _And rebuild when the schema's cracked_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d83dd86</samp>

*  Refactor the editor component to use an array of `toDispose` functions for disposing reactions and listeners ([link](https://github.com/baidu/amis/pull/6724/files?diff=unified&w=0#diff-18115adfb822b0c3059aa7b00cc9dcab379f5c15781d48b9acca0d863d27a0edL125-R125), [link](https://github.com/baidu/amis/pull/6724/files?diff=unified&w=0#diff-18115adfb822b0c3059aa7b00cc9dcab379f5c15781d48b9acca0d863d27a0edL179-R194), [link](https://github.com/baidu/amis/pull/6724/files?diff=unified&w=0#diff-18115adfb822b0c3059aa7b00cc9dcab379f5c15781d48b9acca0d863d27a0edL229-R235), [link](https://github.com/baidu/amis/pull/6724/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fR743))
*  Add a new reaction to the editor component that rebuilds the editor when the schema changes in the preview mode ([link](https://github.com/baidu/amis/pull/6724/files?diff=unified&w=0#diff-18115adfb822b0c3059aa7b00cc9dcab379f5c15781d48b9acca0d863d27a0edL179-R194))
*  Change the return type of the plugin event handlers to `any` to enable more flexibility and control for the plugin system ([link](https://github.com/baidu/amis/pull/6724/files?diff=unified&w=0#diff-2eb003bbc6f49ecb3f8b56411f1c1d02f055f595b7d9998f326a9c7ff41cc266L597-R597))
