### PR TITLE
fix:修复searchbox组件无法绑定事件的问题

### DIFF
--- a/packages/amis-editor/src/plugin/SearchBox.tsx
+++ b/packages/amis-editor/src/plugin/SearchBox.tsx
@@ -52,9 +52,12 @@ export class SearchBoxPlugin extends BasePlugin {
       description: '点击搜索图标时触发',
       dataSchema: [
         {
-          'event.data.keywords': {
-            type: 'string',
-            title: '搜索内容'
+          type: 'object',
+          properties: {
+            'event.data.value': {
+              type: 'string',
+              title: '搜索内容'
+            }
           }
         }
       ]
@@ -65,13 +68,12 @@ export class SearchBoxPlugin extends BasePlugin {
       description: '输入框值变化时触发',
       dataSchema: [
         {
-          'event.data.keywords': {
-            type: 'string',
-            title: '搜索内容'
-          },
-          'event.data.value': {
-            type: 'string',
-            title: '搜索内容' // 和keywords值相同
+          type: 'object',
+          properties: {
+            'event.data.value': {
+              type: 'string',
+              title: '搜索内容'
+            }
           }
         }
       ]
@@ -82,13 +84,12 @@ export class SearchBoxPlugin extends BasePlugin {
       description: '输入框获取焦点时触发',
       dataSchema: [
         {
-          'event.data.keywords': {
-            type: 'string',
-            title: '搜索内容'
-          },
-          'event.data.value': {
-            type: 'string',
-            title: '搜索内容' // 和keywords值相同
+          type: 'object',
+          properties: {
+            'event.data.value': {
+              type: 'string',
+              title: '搜索内容'
+            }
           }
         }
       ]
@@ -99,13 +100,12 @@ export class SearchBoxPlugin extends BasePlugin {
       description: '输入框失去焦点时触发',
       dataSchema: [
         {
-          'event.data.keywords': {
-            type: 'string',
-            title: '搜索内容'
-          },
-          'event.data.value': {
-            type: 'string',
-            title: '搜索内容' // 和keywords值相同
+          type: 'object',
+          properties: {
+            'event.data.value': {
+              type: 'string',
+              title: '搜索内容'
+            }
           }
         }
       ]


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 03f8ba9</samp>

Simplified the `dataSchema` property of the `SearchBoxPlugin` class in `SearchBox.tsx` to improve search box functionality and events.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 03f8ba9</samp>

> _We're sailing on the code sea, me hearties, yo ho ho_
> _We're searching for the best way to make our plugin glow_
> _We've simplified the `dataSchema`, now it's clear and neat_
> _We'll heave away and test it on the count of three, repeat_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 03f8ba9</samp>

*  Simplify the `dataSchema` property of the `SearchBoxPlugin` class to use an object type with a single property `event.data.value` instead of an array with two properties `event.data.keywords` and `event.data.value` in `SearchBox.tsx` ([link](https://github.com/baidu/amis/pull/6732/files?diff=unified&w=0#diff-c3168ebace6edd66037a2e0850be6a8ebc778f6a53e5ff7a7b33b7beb1ac3cd7L55-R60), [link](https://github.com/baidu/amis/pull/6732/files?diff=unified&w=0#diff-c3168ebace6edd66037a2e0850be6a8ebc778f6a53e5ff7a7b33b7beb1ac3cd7L68-R76), [link](https://github.com/baidu/amis/pull/6732/files?diff=unified&w=0#diff-c3168ebace6edd66037a2e0850be6a8ebc778f6a53e5ff7a7b33b7beb1ac3cd7L85-R92), [link](https://github.com/baidu/amis/pull/6732/files?diff=unified&w=0#diff-c3168ebace6edd66037a2e0850be6a8ebc778f6a53e5ff7a7b33b7beb1ac3cd7L102-R108))
