### PR TITLE
fix: 列表选择器弹窗样式修复

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Picker.tsx
+++ b/packages/amis-editor/src/plugin/Form/Picker.tsx
@@ -45,7 +45,8 @@ export class PickerControlPlugin extends BasePlugin {
         label: '选项B',
         value: 'B'
       }
-    ]
+    ],
+    modalClassName: 'app-popover'
   };
   previewSchema: any = {
     type: 'form',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a15366</samp>

Added a new option to customize the modal style of the picker component in the form editor plugin. The `modalClassName` property can be used to specify a custom CSS class name for the `Picker` modal dialog in `Picker.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5a15366</samp>

> _`modalClassName`_
> _A new option for the picker_
> _Style it as you wish_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5a15366</samp>

* Add `modalClassName` property to `PickerControlPlugin` options to enable custom modal style for picker component ([link](https://github.com/baidu/amis/pull/6736/files?diff=unified&w=0#diff-f2a58f8b179455b31f463e8a24eeab71bfc764efc43a3eaa40b332cc8bc1467eL48-R49))
