### PR TITLE
fix:[amis-saas-11642]主题组件tag padding不生效修复

### DIFF
--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -3314,6 +3314,8 @@
   --Tag-base-paddingBottom: var(--sizes-size-0);
   --Tag-base-paddingLeft: var(--sizes-size-5);
   --Tag-base-paddingRight: var(--sizes-size-5);
+  --Tag-base-padding: var(--Tag-base-paddingTop) var(--Tag-base-paddingRight)
+   var(--Tag-base-paddingBottom) var(--Tag-base-paddingLeft);
   --Tag-model-normal-top-border-color: var(--colors-neutral-line-6);
   --Tag-model-normal-top-border-width: var(--borders-width-2);
   --Tag-model-normal-top-border-style: var(--borders-style-1);

--- a/packages/amis-ui/scss/components/_tag.scss
+++ b/packages/amis-ui/scss/components/_tag.scss
@@ -1,7 +1,7 @@
 .#{$ns}Tag {
   display: inline-flex;
   height: var(--Tag-height);
-  padding: 0 var(--gap-sm);
+  padding: var(--Tag-base-padding);
   flex-flow: row nowrap;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 781ed33</samp>

This pull request introduces a new CSS custom property `--Tag-base-padding` to simplify and unify the padding of the tag component. It also updates the tag component's style to use this property instead of a hard-coded value.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 781ed33</samp>

> _`--Tag-base-padding`_
> _A new custom property_
> _Simplifies the code_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 781ed33</samp>

* Define a new CSS custom property `--Tag-base-padding` for the tag component padding ([link](https://github.com/baidu/amis/pull/6742/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4R3317-R3318))
* Use `--Tag-base-padding` to set the padding of the tag component in `_tag.scss` ([link](https://github.com/baidu/amis/pull/6742/files?diff=unified&w=0#diff-a844b290f44eac09deaef12cf441a36437078855ad4af3afc5b7fc6d9a669d76L4-R4))
