### PR TITLE
fix(amis-editor-core): 调整editor默认值公式编辑器中获取amis对应渲染器上下文的方法

### DIFF
--- a/packages/amis-editor-core/src/component/IFramePreview.tsx
+++ b/packages/amis-editor-core/src/component/IFramePreview.tsx
@@ -234,11 +234,6 @@ export default class IFramePreview extends React.Component<IFramePreviewProps> {
 
     let info = manager.getEditorInfo(renderer!, path, schema);
 
-    // 更新 Editor 中的 amisStore
-    if (props && props.store && props.store.data) {
-      manager.updateAMISContext(props.store.data);
-    }
-
     info &&
       (renderer = {
         ...renderer,

--- a/packages/amis-editor-core/src/component/Preview.tsx
+++ b/packages/amis-editor-core/src/component/Preview.tsx
@@ -443,11 +443,6 @@ export default class Preview extends Component<PreviewProps> {
 
     let info = manager.getEditorInfo(renderer!, path, schema);
 
-    // 更新 Editor 中的 amisStore
-    if (props && props.store && props.store.data) {
-      manager.updateAMISContext(props.store.data);
-    }
-
     info &&
       (renderer = {
         ...renderer,

--- a/packages/amis-editor-core/src/manager.ts
+++ b/packages/amis-editor-core/src/manager.ts
@@ -161,9 +161,6 @@ export class EditorManager {
   private clipboardData: string;
   readonly hackIn: any;
 
-  // 用于记录amis渲染器的上下文数据
-  amisStore: Object = {};
-
   // 广播事件集
   readonly broadcasts: RendererPluginEvent[] = [];
   // 插件事件集
@@ -376,13 +373,6 @@ export class EditorManager {
       }
 
       this.buildRenderers();
-    }
-  }
-
-  // 更新amis渲染器上下文
-  updateAMISContext(amisStore: Object) {
-    if (amisStore) {
-      this.amisStore = amisStore;
     }
   }
 

--- a/packages/amis-editor/src/renderer/FormulaControl.tsx
+++ b/packages/amis-editor/src/renderer/FormulaControl.tsx
@@ -489,12 +489,16 @@ export default class FormulaControl extends React.Component<
 
   @autobind
   getContextData() {
+    let curContextData = this.props.data?.__super?.__props__?.data;
+
+    if (!curContextData) {
+      const curComp = this.props.node?.getComponent();
+      if (curComp?.props?.data) {
+        curContextData = curComp.props.data;
+      }
+    }
     // 当前数据域
-    return (
-      this.props.data?.__super?.__props__?.data ||
-      this.props.manager?.amisStore ||
-      {}
-    );
+    return curContextData;
   }
 
   render() {
@@ -514,6 +518,7 @@ export default class FormulaControl extends React.Component<
       render,
       ...rest
     } = this.props;
+
     const {formulaPickerOpen, variables, variableMode} = this.state;
 
     // 自身字段


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 121b3c3</samp>

This pull request removes some unused or redundant code from the `EditorManager`, `IFramePreview`, and `Preview` components, and fixes a bug in the `FormulaControl` component that affected the data context for the formula editor. These changes improve the code quality and the preview functionality of the amis-editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 121b3c3</samp>

> _No more amisStore, no more data bugs_
> _We rip out the code that was useless and old_
> _We fix the formula logic, we make it clear and bold_
> _We are the masters of the editor, we control the preview mode_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 121b3c3</samp>

*  Remove the code that updates the editor's amisStore with the props.store.data from both `IFramePreview.tsx` and `Preview.tsx` components to fix a bug that causes the preview to render incorrectly when the data changes ([link](https://github.com/baidu/amis/pull/6746/files?diff=unified&w=0#diff-acafbdd055d55bdea83368e433e85e8c5d1831c9af33a8e21501cd24ac33128cL237-L241), [link](https://github.com/baidu/amis/pull/6746/files?diff=unified&w=0#diff-d9b508133ad06e8946597f0255a1b4529b6fb9f0c2bf3c170e0fcef582fff0e9L446-L450))
* Remove the amisStore property and the updateAMISContext method from the EditorManager class to clean up the unused code and avoid confusion ([link](https://github.com/baidu/amis/pull/6746/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fL164-L166), [link](https://github.com/baidu/amis/pull/6746/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fL382-L388))
* Modify the getContextData method in the `FormulaControl.tsx` component to improve the logic of getting the current data context for the formula editor, using the node.getComponent().props.data path as a fallback when the props.data.__super.__props__.data path is not available ([link](https://github.com/baidu/amis/pull/6746/files?diff=unified&w=0#diff-ce07d539e9ec5eccae74ef6ee3032524b9a77ca3519a9f600cf3065ceaced70bL492-R501))
* Add an empty line to the `FormulaControl.tsx` component to improve the code readability and formatting ([link](https://github.com/baidu/amis/pull/6746/files?diff=unified&w=0#diff-ce07d539e9ec5eccae74ef6ee3032524b9a77ca3519a9f600cf3065ceaced70bR521))
