### PR TITLE
fix: HeadCellFilterDropdown配置source切换页面卡顿问题修复

### DIFF
--- a/packages/amis/src/renderers/Table/HeadCellFilterDropdown.tsx
+++ b/packages/amis/src/renderers/Table/HeadCellFilterDropdown.tsx
@@ -68,6 +68,8 @@ export class HeadCellFilterDropDown extends React.Component<
 
     const props = this.props;
 
+    this.sourceInvalid = false;
+
     if (
       prevProps.name !== props.name ||
       prevProps.filterable !== props.filterable ||


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b2d1153</samp>

Fix a bug in table filter dropdown where options keep loading. Use `isApiOutdated` to check if `filterable.source` is the same as before and update `sourceInvalid` state accordingly in `HeadCellFilterDropdown.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b2d1153</samp>

> _`filterableSource`_
> _same as before? Check state_
> _autumn bug is fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b2d1153</samp>

* Fix a bug where the filter dropdown would keep loading options if the last sourceInvalid was true by adding a condition to check if the filterable source prop is the same as the previous one ([link](https://github.com/baidu/amis/pull/6748/files?diff=unified&w=0#diff-584f5d22b7c0b5689df20135e76477634c65ed1a0758591485cef1c40e5dd78cR109-R118))
