### PR TITLE
fix: imageGallary props

### DIFF
--- a/packages/amis-ui/src/components/ImageGallery.tsx
+++ b/packages/amis-ui/src/components/ImageGallery.tsx
@@ -33,7 +33,7 @@ export interface ImageGalleryProps extends ThemeProps, LocaleProps {
   modalContainer?: () => HTMLElement;
   /** 操作栏 */
   actions?: ImageAction[];
-  imageGallaryClassName: string;
+  imageGallaryClassName?: string;
 }
 
 export interface ImageGalleryState {

--- a/packages/amis/src/renderers/Image.tsx
+++ b/packages/amis/src/renderers/Image.tsx
@@ -381,6 +381,7 @@ export interface ImageFieldProps extends RendererProps {
     },
     target: any
   ) => void;
+  imageGallaryClassName?: string;
 }
 
 export class ImageField extends React.Component<ImageFieldProps, object> {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c226c5a</samp>

Added a new prop `imageGallaryClassName` to the image field and image gallery components. This enables the user to style the image gallery with a custom CSS class name.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c226c5a</samp>

> _`imageGallaryClassName`_
> _Optional prop for styling_
> _Gallery of photos_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c226c5a</samp>

*  Make `imageGallaryClassName` prop optional for image gallery component ([link](https://github.com/baidu/amis/pull/6751/files?diff=unified&w=0#diff-bed7585d0647a7896dee30a46f94d5624fba9662c725a5946ee61927fcc2d5b8L36-R36))
*  Add `imageGallaryClassName` prop to image field renderer and pass it to image gallery component ([link](https://github.com/baidu/amis/pull/6751/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9R384))
