### PR TITLE
fix:js动作提示错误

### DIFF
--- a/packages/amis-editor/src/locale/zh-CN.ts
+++ b/packages/amis-editor/src/locale/zh-CN.ts
@@ -2486,7 +2486,7 @@ extendLocale('zh-CN', {
   'c7f16d729f3bca8f6936416884a74fb8': '自定义JS',
   '1b5a6299ef404c1f7b4292c290b80f55': '通过JavaScript自定义动作逻辑',
   '9bef5e571702130c5710af4ee2c27455':
-    "/* 自定义JS使用说明：\n  * 1.动作执行函数doAction，可以执行所有类型的动作\n  * 2.通过上下文对象context可以获取当前组件实例，例如context.props可以获取该组件相关属性\n  * 3.事件对象event，在doAction之后执行event.stopPropagation = true;可以阻止后续动作执行\n*/\nconst myMsg = '我是自定义JS';\ndoAction({\n  actionType: 'toast',\n  args: {\n    msg: myMsg\n  }\n});\n",
+    "/* 自定义JS使用说明：\n  * 1.动作执行函数doAction，可以执行所有类型的动作\n  * 2.通过上下文对象context可以获取当前组件实例，例如context.props可以获取该组件相关属性\n  * 3.事件对象event，在doAction之后执行event.stopPropagation();可以阻止后续动作执行\n*/\nconst myMsg = '我是自定义JS';\ndoAction({\n  actionType: 'toast',\n  args: {\n    msg: myMsg\n  }\n});\n",
   '9a2ee7044ff04234a8892a13583d14b6': '变量值',
   '186c8d63db1c09c38bcfd048fb15846e': '滚动至上一张',
   'd9b6b8e29d63ac6bb7a0381e994ebcb5': '返回前一步',

--- a/packages/amis-editor/src/renderer/event-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/event-control/helper.tsx
@@ -1810,7 +1810,7 @@ export const ACTION_TYPE_TREE = (manager: any): RendererPluginAction[] => {
             value: `/* 自定义JS使用说明：
   * 1.动作执行函数doAction，可以执行所有类型的动作
   * 2.通过上下文对象context可以获取当前组件实例，例如context.props可以获取该组件相关属性
-  * 3.事件对象event，在doAction之后执行event.stopPropagation = true;可以阻止后续动作执行
+  * 3.事件对象event，在doAction之后执行event.stopPropagation();可以阻止后续动作执行
 */
 const myMsg = '我是自定义JS';
 doAction({


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 72e627e</samp>

Fix incorrect comments in custom JS code examples for event control renderer in `amis-editor`. The comments suggested using an invalid syntax for `stopPropagation` method, which is corrected to match the actual code and the English locale file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 72e627e</samp>

> _`stopPropagation`_
> _Fixing comments in JS code_
> _Autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 72e627e</samp>

*  Fix the comment in the custom JS code example for the event control renderer to use the correct syntax for `stopPropagation` ([link](https://github.com/baidu/amis/pull/6762/files?diff=unified&w=0#diff-9e925b8db379ee8f266ec0584740022963147c44a66c3ddf0dfcc82e874a131aL2489-R2489), [link](https://github.com/baidu/amis/pull/6762/files?diff=unified&w=0#diff-f55d29e93a330da662e7a91960e5ed88c12f80e9e38564d3a4497ff543da26b8L1813-R1813))
*  Update the `zh-CN.ts` locale file to match the fixed comment in the `helper.tsx` file ([link](https://github.com/baidu/amis/pull/6762/files?diff=unified&w=0#diff-9e925b8db379ee8f266ec0584740022963147c44a66c3ddf0dfcc82e874a131aL2489-R2489))
