### PR TITLE
fix:#6294动作列表为空的情况下广播失效问题

### DIFF
--- a/packages/amis-core/src/utils/renderer-event.ts
+++ b/packages/amis-core/src/utils/renderer-event.ts
@@ -109,15 +109,16 @@ export const bindEvent = (renderer: any) => {
               item.renderer === listener.renderer && item.type === listener.type
             )
         );
-        rendererEventListeners.push({
-          renderer,
-          type: key,
-          debounce: listener.debounce || null,
-          weight: listener.weight || 0,
-          actions: listener.actions
-        });
+        listener.actions.length &&
+          rendererEventListeners.push({
+            renderer,
+            type: key,
+            debounce: listener.debounce || null,
+            weight: listener.weight || 0,
+            actions: listener.actions
+          });
       }
-      if (!listener) {
+      if (!listener && listeners[key].actions.length) {
         rendererEventListeners.push({
           renderer,
           type: key,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4eb9183</samp>

Optimize renderer event system by avoiding adding empty listeners. Check if `listener.actions` or `listeners[key].actions` are not empty before pushing to `rendererEventListeners` in `renderer-event.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4eb9183</samp>

> _`listener` array_
> _only push if not empty_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4eb9183</samp>

* Optimize the performance of the renderer event system by avoiding adding unnecessary listeners that have no actions defined ([link](https://github.com/baidu/amis/pull/6763/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6L112-R121),                            F0L222
