### PR TITLE
fix:#6757按钮二次确认后并没有触发点击事件

### DIFF
--- a/packages/amis/src/renderers/Action.tsx
+++ b/packages/amis/src/renderers/Action.tsx
@@ -977,7 +977,8 @@ export class ActionRenderer extends React.Component<ActionRendererProps> {
         // 触发渲染器事件
         const rendererEvent = await dispatchEvent(
           e as React.MouseEvent<any> | string,
-          mergedData
+          mergedData,
+          this // 保证renderer可以拿到，避免因交互设计导致的销魂情况，例如crud内itemAction
         );
 
         // 阻止原有动作执行

--- a/packages/amis/src/renderers/Action.tsx
+++ b/packages/amis/src/renderers/Action.tsx
@@ -978,7 +978,7 @@ export class ActionRenderer extends React.Component<ActionRendererProps> {
         const rendererEvent = await dispatchEvent(
           e as React.MouseEvent<any> | string,
           mergedData,
-          this // 保证renderer可以拿到，避免因交互设计导致的销魂情况，例如crud内itemAction
+          this // 保证renderer可以拿到，避免因交互设计导致的清空情况，例如crud内itemAction
         );
 
         // 阻止原有动作执行


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7085671</samp>

This change allows action renderers to access their own instance when dispatching events. This fixes a bug where item actions inside a CRUD component could lose the renderer instance. The change affects the file `packages/amis/src/renderers/Action.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7085671</samp>

> _`ActionRenderer`_
> _Passed to `dispatchEvent` / kireji_
> _Solves interaction_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7085671</samp>

*  Pass the renderer instance to `dispatchEvent` function ([link](https://github.com/baidu/amis/pull/6770/files?diff=unified&w=0#diff-4d89203911a9d3ef38c82118f074ad24c49244699f1f2cbb6072134908f60098L980-R981)) to allow access to it in item actions of CRUD component
