### PR TITLE
fix: 「事件动作」变量赋值 - 页面/内存变量选择添加变量类型

### DIFF
--- a/packages/amis-core/src/utils/renderer-event.ts
+++ b/packages/amis-core/src/utils/renderer-event.ts
@@ -118,7 +118,7 @@ export const bindEvent = (renderer: any) => {
             actions: listener.actions
           });
       }
-      if (!listener && listeners[key].actions.length) {
+      if (!listener && listeners[key].actions?.length) {
         rendererEventListeners.push({
           renderer,
           type: key,

--- a/packages/amis-editor/src/renderer/event-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/event-control/helper.tsx
@@ -182,6 +182,90 @@ export const SUPPORT_DISABLED_CMPTS = [
   // 'card2'
 ];
 
+// 用于变量赋值 页面变量和内存变量的树选择器中，支持展示变量类型
+const getCustomNodeTreeSelectSchema = (opts: Object) => ({
+  type: 'tree-select',
+  name: 'path',
+  label: '内存变量',
+  multiple: false,
+  mode: 'horizontal',
+  required: true,
+  placeholder: '请选择变量',
+  showIcon: false,
+  size: 'lg',
+  hideRoot: false,
+  rootLabel: '内存变量',
+  options: [],
+  menuTpl: {
+    type: 'flex',
+    className: 'p-1',
+    items: [
+      {
+        type: 'container',
+        body: [
+          {
+            type: 'tpl',
+            tpl: '${label}',
+            inline: true,
+            wrapperComponent: ''
+          }
+        ],
+        style: {
+          display: 'flex',
+          flexWrap: 'nowrap',
+          alignItems: 'center',
+          position: 'static',
+          overflowY: 'auto',
+          flex: '0 0 auto'
+        },
+        wrapperBody: false,
+        isFixedHeight: true
+      },
+      {
+        type: 'container',
+        body: [
+          {
+            type: 'tpl',
+            tpl: '${type}',
+            inline: true,
+            wrapperComponent: '',
+            style: {
+              background: '#f5f5f5',
+              paddingLeft: '8px',
+              paddingRight: '8px',
+              borderRadius: '4px'
+            }
+          }
+        ],
+        size: 'xs',
+        style: {
+          display: 'flex',
+          flexWrap: 'nowrap',
+          alignItems: 'center',
+          position: 'static',
+          overflowY: 'auto',
+          flex: '0 0 auto'
+        },
+        wrapperBody: false,
+        isFixedHeight: true,
+        isFixedWidth: false
+      }
+    ],
+    style: {
+      position: 'relative',
+      inset: 'auto',
+      flexWrap: 'nowrap',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      height: '24px',
+      overflowY: 'hidden'
+    },
+    isFixedHeight: true,
+    isFixedWidth: false
+  },
+  ...opts
+});
+
 export const ACTION_TYPE_TREE = (manager: any): RendererPluginAction[] => {
   const variableManager = manager?.variableManager;
   /** 变量列表 */
@@ -1557,20 +1641,11 @@ export const ACTION_TYPE_TREE = (manager: any): RendererPluginAction[] => {
                     type: 'wrapper',
                     className: 'p-none',
                     body: [
-                      {
-                        type: 'tree-select',
-                        name: 'path',
+                      getCustomNodeTreeSelectSchema({
                         label: '页面变量',
-                        multiple: false,
-                        mode: 'horizontal',
-                        required: true,
-                        placeholder: '请选择变量',
-                        showIcon: false,
-                        size: 'lg',
-                        hideRoot: false,
                         rootLabel: '页面变量',
                         options: pageVariableOptions
-                      },
+                      }),
                       {
                         type: 'input-formula',
                         name: 'value',
@@ -1599,20 +1674,9 @@ export const ACTION_TYPE_TREE = (manager: any): RendererPluginAction[] => {
                     type: 'wrapper',
                     className: 'p-none',
                     body: [
-                      {
-                        type: 'tree-select',
-                        name: 'path',
-                        label: '内存变量',
-                        multiple: false,
-                        mode: 'horizontal',
-                        required: true,
-                        placeholder: '请选择变量',
-                        showIcon: false,
-                        size: 'lg',
-                        hideRoot: false,
-                        rootLabel: '内存变量',
+                      getCustomNodeTreeSelectSchema({
                         options: variableOptions
-                      },
+                      }),
                       {
                         type: 'input-formula',
                         name: 'value',


### PR DESCRIPTION
### What

变量赋值动作中，当选择页面变量或内存变量时通过树组件无法展示变量类型，本次提交将对树节点添加变量类型

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1660606</samp>

*  Add a new function `getCustomNodeTreeSelectSchema` to create a schema object for a `tree-select` component with a custom `menuTpl` property ([link](https://github.com/baidu/amis/pull/6771/files?diff=unified&w=0#diff-f55d29e93a330da662e7a91960e5ed88c12f80e9e38564d3a4497ff543da26b8R185-R268))
*  Use the new function to simplify the schema objects for the `tree-select` components that select page and memory variables in the event control panel ([link](https://github.com/baidu/amis/pull/6771/files?diff=unified&w=0#diff-f55d29e93a330da662e7a91960e5ed88c12f80e9e38564d3a4497ff543da26b8L1560-R1649), [link](https://github.com/baidu/amis/pull/6771/files?diff=unified&w=0#diff-f55d29e93a330da662e7a91960e5ed88c12f80e9e38564d3a4497ff543da26b8L1602-R1680))
*  Add an optional chaining operator to check if the `actions` property of the `listeners[key]` object exists before accessing its `length` property in `renderer-event.ts` ([link](https://github.com/baidu/amis/pull/6771/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6L121-R121))
*  Remove the console log statement that prints the `variableOptions` array in `event-control/helper.tsx` ([link](https://github.com/baidu/amis/pull/6771/files?diff=unified&w=0#diff-f55d29e93a330da662e7a91960e5ed88c12f80e9e38564d3a4497ff543da26b8R274))
