### PR TITLE
fix: 修复 mock api 跨域问题

### DIFF
--- a/mock/cfc/index.js
+++ b/mock/cfc/index.js
@@ -56,7 +56,7 @@ function mockResponse(event, context, callback) {
 function createHeaders(headers) {
   let referer = '';
 
-  if (/^(https?\:\/\/[^:\/]+(?:\:\d+)?\/)/i.test(headers['referer'])) {
+  if (/^(https?\:\/\/[^:\/]+(?:\:\d+)?\/)/i.test(headers['Referer'])) {
     referer = RegExp.$1.replace(/\/$/, '');
   }
 
@@ -64,6 +64,7 @@ function createHeaders(headers) {
     'Content-Type': 'Application/json',
     'Access-Control-Allow-Headers': 'x-requested-with,content-type',
     'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS,HEAD',
-    'Access-Control-Allow-Origin': referer ? `${referer}` : '*'
+    'Access-Control-Allow-Origin': referer ? `${referer}` : '*',
+    'Access-Control-Allow-Credentials': 'true'
   };
 }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0677354</samp>

Improved CORS policy for mock CFC service. Fixed `Referer` header check and enabled credentials for cross-origin requests in `mock/cfc/index.js`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0677354</samp>

> _To handle cross-origin requests_
> _The mock CFC code was a mess_
> _It checked `Referer`_
> _But case did not matter_
> _Now it's fixed with a CORS policy express_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0677354</samp>

* Fix the case sensitivity of the `Referer` header for CORS policy ([link](https://github.com/baidu/amis/pull/6797/files?diff=unified&w=0#diff-6be4c0e3c0a7b01f8c07505496742b63fc742f6f49a2ce31bd0a1d3ba40b3b1fL59-R59))
* Allow cross-origin requests to send credentials ([link](https://github.com/baidu/amis/pull/6797/files?diff=unified&w=0#diff-6be4c0e3c0a7b01f8c07505496742b63fc742f6f49a2ce31bd0a1d3ba40b3b1fL67-R68))
