### PR TITLE
styles: 优化部分表单组件报错边框颜色

### DIFF
--- a/packages/amis-ui/scss/components/form/_color.scss
+++ b/packages/amis-ui/scss/components/form/_color.scss
@@ -44,6 +44,11 @@
     box-shadow: var(--Form-input-boxShadow);
   }
 
+  .is-error > & {
+    border-color: var(--Form-input-onError-borderColor);
+    background: var(--Form-input-onError-bg);
+  }
+
   &.is-disabled {
     background: var(--ColorPicker-onDisabled-bg);
     color: var(--ColorPicker-onDisabled-color);

--- a/packages/amis-ui/scss/components/form/_date-range.scss
+++ b/packages/amis-ui/scss/components/form/_date-range.scss
@@ -64,6 +64,11 @@
     }
   }
 
+  .is-error > & {
+    border-color: var(--Form-input-onError-borderColor);
+    background: var(--Form-input-onError-bg);
+  }
+
   .#{$ns}DateRangePicker-input {
     border: none;
     border-bottom: var(--DateRangePicker-activeCursor-height) solid transparent;

--- a/packages/amis-ui/scss/components/form/_date.scss
+++ b/packages/amis-ui/scss/components/form/_date.scss
@@ -88,6 +88,11 @@
     }
   }
 
+  .is-error > & {
+    border-color: var(--Form-input-onError-borderColor);
+    background: var(--Form-input-onError-bg);
+  }
+
   &.is-disabled {
     background: var(--inputDate-disabled-bg-color);
     border-width: var(--inputDate-disabled-top-border-width)

--- a/packages/amis-ui/scss/components/form/_number.scss
+++ b/packages/amis-ui/scss/components/form/_number.scss
@@ -246,6 +246,11 @@
     color: var(--Number-handler-onDisabled-color);
   }
 
+  .is-error > & {
+    border-color: var(--Form-input-onError-borderColor);
+    background: var(--Form-input-onError-bg);
+  }
+
   &-disabled {
     border-color: var(--Form-input-onDisabled-borderColor);
     .#{$ns}Number-input {

--- a/packages/amis-ui/scss/components/form/_tag.scss
+++ b/packages/amis-ui/scss/components/form/_tag.scss
@@ -104,6 +104,10 @@
       }
     }
   }
+  &.is-error > .#{$ns}ResultBox {
+    border-color: var(--Form-input-onError-borderColor);
+    background: var(--Form-input-onError-bg);
+  }
 }
 
 .#{$ns}TagControl-popover {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aa6716a</samp>

Add error state styles for various form input components. Use custom CSS variables for consistent theming of border and background colors.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at aa6716a</samp>

> _`error` styles added_
> _for various input types_
> _autumn leaves turn red_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aa6716a</samp>

*  Add style rules for form input components when they have an error state ([link](https://github.com/baidu/amis/pull/6799/files?diff=unified&w=0#diff-e9e46ff9da7275b5c2ca4204cd00a298096d31a8f1190c07864cb2c0c3715851R47-R51), [link](https://github.com/baidu/amis/pull/6799/files?diff=unified&w=0#diff-4cccd18a26b3b4642be4181008a79e07997c97aae5b1610eb870e7378d7cc0d8R67-R71), [link](https://github.com/baidu/amis/pull/6799/files?diff=unified&w=0#diff-d267ee90adbe799090d37bbfb500f74e0c0f2c43b69a97553a25c732ad58ca02R91-R95), [link](https://github.com/baidu/amis/pull/6799/files?diff=unified&w=0#diff-2d2d06fd2ff23d6b8188a2c30801dc1ce399d20535c5c07bd40a2f6b1e8286c8R249-R253), [link](https://github.com/baidu/amis/pull/6799/files?diff=unified&w=0#diff-d1f8b5779cfb8b283419981c1db41a02a38e7f60ad2c126b91ee692ecd44b075R107-R110))
