### PR TITLE
fix: 修复 editor 合入后导致插件配置项失效问题

### DIFF
--- a/packages/amis-editor-core/src/manager.ts
+++ b/packages/amis-editor-core/src/manager.ts
@@ -338,7 +338,9 @@ export class EditorManager {
   ) {
     return (
       plugins?.map(klass => {
+        let options: any;
         if (Array.isArray(klass)) {
+          options = klass[1];
           klass = klass[0];
         }
 
@@ -347,7 +349,7 @@ export class EditorManager {
           new Set(['global'].concat(klass.scene || 'global'))
         );
         klass.scene = scene;
-        return klass;
+        return options ? [klass, options] : klass;
       }) || []
     );
   }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 25a3ab8</samp>

Add support for editor plugin options in `amis-editor-core`. Modify `EditorManager` and `map` to accept and pass options to plugins.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 25a3ab8</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A way to pass options to the plugins of the editor,_
> _That versatile tool of many forms and functions,_
> _Which the wise `EditorManager` oversees and controls._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 25a3ab8</samp>

*  Enable passing options to plugins in `EditorManager` constructor ([link](https://github.com/baidu/amis/pull/6800/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fL341-R343), [link](https://github.com/baidu/amis/pull/6800/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fL350-R352))
  - Assign the second element of each `plugins` array entry to a variable `options` ([link](https://github.com/baidu/amis/pull/6800/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fL341-R343))
  - Include `options` in the return value of the `map` function, or use `undefined` if not present ([link](https://github.com/baidu/amis/pull/6800/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fL350-R352))
