### PR TITLE
fix: issues-6740: picker loadOptions 时默认查询参数名与 valueField 保持一致

### DIFF
--- a/packages/amis/src/renderers/Form/Picker.tsx
+++ b/packages/amis/src/renderers/Form/Picker.tsx
@@ -158,7 +158,7 @@ export default class PickerControl extends React.PureComponent<
     }
 
     const ctx = createObject(data, {
-      value,
+      value: value,
       [valueField || 'value']: value,
       op: 'loadOptions'
     });

--- a/packages/amis/src/renderers/Form/Picker.tsx
+++ b/packages/amis/src/renderers/Form/Picker.tsx
@@ -158,7 +158,7 @@ export default class PickerControl extends React.PureComponent<
     }
 
     const ctx = createObject(data, {
-      value: value,
+      [valueField || 'value']: value,
       op: 'loadOptions'
     });
 

--- a/packages/amis/src/renderers/Form/Picker.tsx
+++ b/packages/amis/src/renderers/Form/Picker.tsx
@@ -158,6 +158,7 @@ export default class PickerControl extends React.PureComponent<
     }
 
     const ctx = createObject(data, {
+      value,
       [valueField || 'value']: value,
       op: 'loadOptions'
     });


### PR DESCRIPTION
### What

修改 Picker fetchOptions逻辑，创建ctx时，根据 valueField 创建 ctx 中查询条件的键名

### Why

Fix #6740

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c55d899</samp>

* Add a `valueField` prop to the `Picker` component to customize the field name for the value property when loading options from a source ([link](https://github.com/baidu/amis/pull/6803/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313L161-R161))
* Preserve the original 'value' property in the context object for backward compatibility ([link](https://github.com/baidu/amis/pull/6803/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313L161-R161))
