### PR TITLE
fix: 修复 ScopedContext 的 getComponentById 在 SPA环境下查找组件不准确问题

### DIFF
--- a/packages/amis-core/src/Scoped.tsx
+++ b/packages/amis-core/src/Scoped.tsx
@@ -113,23 +113,27 @@ function createScopedTools(
     },
 
     getComponentById(id: string) {
-      let root: AliasIScopedContext = this;
-      // 找到顶端scoped
-      while (root.parent) {
-        root = root.parent;
-      }
+      let current: AliasIScopedContext = this;
 
-      // 向下查找
       let component = undefined;
-      findTree([root], (item: TreeItem) =>
+      const finder = (item: TreeItem) =>
         item.getComponents().find((cmpt: ScopedComponentType) => {
           if (cmpt.props.id === id) {
             component = cmpt;
             return true;
           }
           return false;
-        })
-      ) as ScopedComponentType | undefined;
+        });
+
+      // 先向下查找
+      findTree([current], finder) as ScopedComponentType | undefined;
+
+      // 再逆向查找
+      while (current.parent && !component) {
+        finder(current.parent) as ScopedComponentType | undefined;
+        current = current.parent;
+      }
+
       return component;
     },
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3e406d7</samp>

Simplified and enhanced the `getComponentById` function in `Scoped.tsx` to allow finding components by id in both directions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3e406d7</samp>

> _There once was a function called `getComponentById`_
> _That searched for a component in a scope that was wide_
> _But the code was complex and hard to debug_
> _So the author refactored and gave it a hug_
> _Now it supports bidirectional search and is simplified_

### Why

Fix #6709 

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3e406d7</samp>

* Refactor `getComponentById` function to use a `current` variable and a `finder` function ([link](https://github.com/baidu/amis/pull/6807/files?diff=unified&w=0#diff-b2a2713e66ce0dcac88d294eb3a363249f0364d755ce255cf7b3ead775bfbf36L116-R119))
* Modify `getComponentById` function to perform a bidirectional search from the current and parent scoped contexts ([link](https://github.com/baidu/amis/pull/6807/files?diff=unified&w=0#diff-b2a2713e66ce0dcac88d294eb3a363249f0364d755ce255cf7b3ead775bfbf36L131-R136))
