### PR TITLE
fix: 修复inputImage的receiver等参数如果使用变量无法及时获取变量最新值的问题。

### DIFF
--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -14,7 +14,11 @@ import {FileRejection, ErrorCode, DropEvent} from 'react-dropzone';
 import 'blueimp-canvastoblob';
 import find from 'lodash/find';
 import {Payload, ActionObject} from 'amis-core';
-import {buildApi} from 'amis-core';
+import {buildApi,
+  isEffectiveApi,
+  normalizeApi,
+  isApiOutdated,
+  isApiOutdatedWithData} from 'amis-core';
 import {createObject, qsstringify, guid, isEmpty, qsparse} from 'amis-core';
 import {Icon, TooltipWrapper, Button} from 'amis-ui';
 import accepts from 'attr-accept';
@@ -1913,6 +1917,20 @@ export default class ImageControl extends React.Component<
 
 @FormItem({
   type: 'input-image',
-  sizeMutable: false
+  sizeMutable: false,
+  shouldComponentUpdate: (props: any, prevProps: any) =>
+    !!isEffectiveApi(props.receiver, props.data) &&
+    (isApiOutdated(
+      props.receiver,
+      prevProps.receiver,
+      props.data,
+      prevProps.data
+    ) ||
+    isApiOutdatedWithData(
+      props.receiver,
+      prevProps.receiver,
+      props.data,
+      prevProps.data
+    ))
 })
 export class ImageControlRenderer extends ImageControl {}


### PR DESCRIPTION
fix: 修复inputImage的receiver等参数如果使用变量无法及时获取变量最新值的问题。
参照原来inputFile问题的修复代码做了处理，相关issues [#4438](https://github.com/baidu/amis/issues/4438)