### PR TITLE
styles: 优化number组件handle出现后的样式

### DIFF
--- a/packages/amis-ui/scss/components/form/_number.scss
+++ b/packages/amis-ui/scss/components/form/_number.scss
@@ -48,12 +48,6 @@
       var(--inputNumber-base-hover-bottom-right-border-radius)
       var(--inputNumber-base-hover-bottom-left-border-radius);
     background: var(--inputNumber-base-hover-bg-color);
-    .#{$ns}Number-input {
-      padding-right: calc(
-        var(--Number-handler-width) +
-          var(--inputNumber-base-default-paddingRight)
-      );
-    }
   }
 
   &-focused {
@@ -202,6 +196,10 @@
       border-left: px2rem(1px) solid var(--Form-input-borderColor);
       width: var(--Number-handler-width);
       height: 100%;
+      // 为了实现handle出现后，不遮挡内容，自然的留出padding的位置的效果
+      outline: var(--inputNumber-base-default-paddingRight)
+        var(--inputNumber-base-default-bg-color)
+        solid;
     }
 
     &-handler {

--- a/packages/amis/__tests__/renderers/Picker.test.tsx
+++ b/packages/amis/__tests__/renderers/Picker.test.tsx
@@ -143,6 +143,7 @@ test('Renderer:Picker with pickerSchema & valueField & labelField & multiple & v
   expect(fetcher).toHaveBeenCalled;
   expect(fetcher.mock.calls[0][0].query).toEqual({
     op: 'loadOptions',
+    id: 'a,b',
     value: 'a,b'
   });
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9350be6</samp>

This pull request improves the appearance and usability of the number input component in the amis-ui package. It removes unnecessary padding and adds an outline to the `.amis-Number-input` class in `packages/amis-ui/scss/components/form/_number.scss`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9350be6</samp>

> _No more padding, no more lies_
> _We see the number handler in our eyes_
> _Outline the input, make it clear_
> _We are the masters of the `.amis-Number-input` here_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9350be6</samp>

* Remove padding-right from number input to prevent misalignment with border ([link](https://github.com/baidu/amis/pull/6813/files?diff=unified&w=0#diff-2d2d06fd2ff23d6b8188a2c30801dc1ce399d20535c5c07bd40a2f6b1e8286c8L51-L56))
* Add outline to number input to create fake padding-right effect with same background color ([link](https://github.com/baidu/amis/pull/6813/files?diff=unified&w=0#diff-2d2d06fd2ff23d6b8188a2c30801dc1ce399d20535c5c07bd40a2f6b1e8286c8R199-R202))
