### PR TITLE
docs: 避免文档搜索框被主题样式影响 Closes #6389

### DIFF
--- a/examples/components/DocSearch.jsx
+++ b/examples/components/DocSearch.jsx
@@ -164,7 +164,7 @@ export default class DocSearch extends React.Component {
           show={this.state.show}
           position={'right'}
         >
-          <div className={`${this.props.theme.ns}TextControl-input search-bar`}>
+          <div className={`search-bar`}>
             <Icon icon="search" className="icon" />
             <input
               ref={this.ref}

--- a/examples/style.scss
+++ b/examples/style.scss
@@ -949,15 +949,22 @@ body {
 
   .search-bar {
     padding: 22px 20px;
-    border: 0;
     border-bottom: 1px solid #e8ebee;
     border-radius: 0;
     font-size: 16px;
     font-weight: 500;
+    display: flex;
 
     > .icon-search {
       margin-right: 10px;
       top: 1px;
+    }
+    > input {
+      flex-basis: 1.875rem;
+      flex-grow: 1;
+      border: none;
+      outline: none;
+      width: 100%;
     }
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 04a8ecf</samp>

The pull request enhances the `search-bar` component in the `examples` folder by applying flexbox and customizing the `input` style in `style.scss`, and by simplifying the `search-bar` div element in `DocSearch.jsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 04a8ecf</samp>

> _Oh we're the crew of the `search-bar` ship_
> _And we sail the web with skill and wit_
> _We flex our boxes and style our `input`s_
> _And we don't need no theme class bits_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 04a8ecf</samp>

*  Simplify and improve the responsiveness of the search bar component in `DocSearch.jsx` and `style.scss` ([link](https://github.com/baidu/amis/pull/6819/files?diff=unified&w=0#diff-e4de93838f8b15d1590cc1d90d799524d948902bc66f5506321bc10ed9904dbdL167-R167), [link](https://github.com/baidu/amis/pull/6819/files?diff=unified&w=0#diff-5d2b68cc0a68b9c83dbd9a4863a25b3e26e41c1aabd539c99682be211b834471L952-R956), [link](https://github.com/baidu/amis/pull/6819/files?diff=unified&w=0#diff-5d2b68cc0a68b9c83dbd9a4863a25b3e26e41c1aabd539c99682be211b834471R962-R968))
  * Remove the redundant theme class name from the `search-bar` div element in `DocSearch.jsx` ([link](https://github.com/baidu/amis/pull/6819/files?diff=unified&w=0#diff-e4de93838f8b15d1590cc1d90d799524d948902bc66f5506321bc10ed9904dbdL167-R167))
  * Add a `display: flex` property to the `search-bar` style rule in `style.scss` to make the search bar adapt to different screen sizes and devices ([link](https://github.com/baidu/amis/pull/6819/files?diff=unified&w=0#diff-5d2b68cc0a68b9c83dbd9a4863a25b3e26e41c1aabd539c99682be211b834471L952-R956))
  * Add an `input` style rule to the `search-bar` style rule in `style.scss` to customize the appearance and behavior of the input element inside the search bar ([link](https://github.com/baidu/amis/pull/6819/files?diff=unified&w=0#diff-5d2b68cc0a68b9c83dbd9a4863a25b3e26e41c1aabd539c99682be211b834471R962-R968))
