### PR TITLE
fix: nav收纳图标样式问题修复

### DIFF
--- a/packages/amis/src/renderers/Nav.tsx
+++ b/packages/amis/src/renderers/Nav.tsx
@@ -103,7 +103,7 @@ export interface NavOverflow {
 
   /**
    * 菜单触发按钮的图标
-   * @default "fa fa-ellipsis"
+   * @default "fa fa-ellipsis-h"
    */
   overflowIndicator?: SchemaIcon;
 
@@ -597,7 +597,7 @@ export class Navigation extends React.Component<
       if (isOverflow) {
         const {
           maxVisibleCount,
-          overflowIndicator = 'fa fa-ellipsis',
+          overflowIndicator = 'fa fa-ellipsis-h',
           overflowLabel,
           overflowClassName
         } = link.overflow;
@@ -613,7 +613,7 @@ export class Navigation extends React.Component<
                     {getIcon(overflowIndicator!) ? (
                       <Icon icon={overflowIndicator} className="icon" />
                     ) : (
-                      generateIcon(cx, overflowIndicator, 'Nav-itemIcon')
+                      generateIcon(cx, overflowIndicator, 'Nav-item-icon')
                     )}
                     {overflowLabel && isObject(overflowLabel)
                       ? render('nav-overflow-label', overflowLabel)
@@ -690,7 +690,7 @@ export class Navigation extends React.Component<
     let overflowedIndicator = null;
     if (overflow && isObject(overflow) && overflow.enable) {
       const {
-        overflowIndicator = 'fa fa-ellipsis',
+        overflowIndicator = 'fa fa-ellipsis-h',
         overflowLabel,
         overflowClassName
       } = overflow;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 36f1722</samp>

Improved the navigation menu UI by changing the overflow icon. Modified the `Nav.tsx` file to use a horizontal ellipsis instead of a vertical one.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 36f1722</samp>

> _We're sailing on the web with a mighty code_
> _We're changing icons as we go along the road_
> _We'll make the menu look so neat and tidy_
> _With a horizontal ellipsis on the `overflow`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 36f1722</samp>

*  Changed the default overflow icon from `fa fa-ellipsis` to `fa fa-ellipsis-h` for horizontal navigation menus ([link](https://github.com/baidu/amis/pull/6821/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL106-R106), [link](https://github.com/baidu/amis/pull/6821/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL600-R600), [link](https://github.com/baidu/amis/pull/6821/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL693-R693))
*  Renamed the class name of the overflow icon from `Nav-itemIcon` to `Nav-item-icon` to follow the naming convention ([link](https://github.com/baidu/amis/pull/6821/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL616-R616))
