### PR TITLE
feat: export-excel 支持 label 使用 tpl Closes #5811

### DIFF
--- a/examples/components/CRUD/ExportCSVExcel.jsx
+++ b/examples/components/CRUD/ExportCSVExcel.jsx
@@ -141,7 +141,7 @@ export default {
     columns: [
       {
         name: 'icon',
-        label: '图标',
+        label: '<%= "图标" %>',
         type: 'image'
       },
       {

--- a/packages/amis/src/renderers/Table/exportExcel.ts
+++ b/packages/amis/src/renderers/Table/exportExcel.ts
@@ -128,7 +128,7 @@ export async function exportExcel(
     : columns;
 
   const firstRowLabels = filteredColumns.map(column => {
-    return column.label;
+    return filter(column.label, data);
   });
   const firstRow = worksheet.getRow(1);
   firstRow.values = firstRowLabels;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee7bce2</samp>

This pull request improves the export functionality of the table renderer in `amis`. It allows the user to customize the label of the icon column and fixes a bug that caused the exported excel file to have inconsistent labels with the rendered table.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ee7bce2</samp>

> _`label` now dynamic_
> _filter and template support_
> _autumn of bugs, gone_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ee7bce2</samp>

*  Support internationalization in icon column label by using a template string ([link](https://github.com/baidu/amis/pull/6824/files?diff=unified&w=0#diff-77b473f79a97cfa505ba4f7f306487c5a1d3fda83053e968d30ac472a7f9e936L144-R144))
*  Fix column label mismatch in excel export by using the filter function to render variables or expressions ([link](https://github.com/baidu/amis/pull/6824/files?diff=unified&w=0#diff-8814befa6c6247c465ab39fa28f3db15c2280e238d8254286fa1f29d29500c51L131-R131))
