### PR TITLE
fix: 修复可能获取不到 attachement 里的文件名问题 Closes #6305

### DIFF
--- a/packages/amis-core/src/utils/attachmentAdpator.ts
+++ b/packages/amis-core/src/utils/attachmentAdpator.ts
@@ -13,7 +13,7 @@ export function attachmentAdpator(response: any, __: Function) {
     if (disposition && disposition.indexOf('attachment') !== -1) {
       // disposition 有可能是 attachment; filename="??.xlsx"; filename*=UTF-8''%E4%B8%AD%E6%96%87.xlsx
       // 这种情况下最后一个才是正确的文件名
-      let filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)$/;
+      let filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
 
       let matches = disposition.match(filenameRegex);
       if (matches && matches.length) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ffbbe11</samp>

Fixed a bug in `attachmentAdpator` that caused incorrect filename extraction from the `disposition` header. Modified the `filenameRegex` variable in `packages/amis-core/src/utils/attachmentAdpator.ts` to match any characters after the filename.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ffbbe11</samp>

> _`filenameRegex` changed_
> _Bug in attachment download_
> _Fixed in the fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ffbbe11</samp>

* Fix bug in extracting filename from disposition header by removing `$` from `filenameRegex` ([link](https://github.com/baidu/amis/pull/6825/files?diff=unified&w=0#diff-551407b8dbee6e727f84705450fb1b605a721f6bd10ad70c537a0caabfdd60adL16-R16))
