### PR TITLE
fix: ConditionBuilder组件RHS defaultValue未生效问题

### DIFF
--- a/packages/amis-ui/src/components/condition-builder/Item.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Item.tsx
@@ -93,8 +93,18 @@ export class ConditionItem extends React.Component<ConditionItemProps> {
 
   @autobind
   handleOperatorChange(op: OperatorType) {
-    const value = {...this.props.value, op: op, right: undefined};
-    this.props.onChange(value, this.props.index);
+    const {fields, value, index, onChange} = this.props;
+    const leftFieldSchema: FieldSimple = findTree(
+      fields,
+      (i: FieldSimple) => i.name === (value?.left as ExpressionField)?.field
+    ) as FieldSimple;
+    const result = {
+      ...value,
+      op: op,
+      right: leftFieldSchema?.defaultValue
+    };
+
+    onChange(result, index);
   }
 
   @autobind


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4bfca33</samp>

Fixed a bug in the condition builder component that caused the right value to be lost when changing operators. Modified `Item.tsx` to use the default value of the left field schema as the right value when the operator is changed.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4bfca33</samp>

> _`handleOperatorChange`_
> _Sets `right` to default value_
> _Avoids data loss_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4bfca33</samp>

* Set the right value of the condition to the default value of the left field schema when the operator is changed, to avoid losing the right value when switching between operators that require different types of operands ([link](https://github.com/baidu/amis/pull/6829/files?diff=unified&w=0#diff-bd3cef1dd1adf5cbac8db6825eccda213b5450966cc365712f22a32093048fc6L96-R107))
* Use destructuring to access the props more concisely in the `handleOperatorChange` method ([link](https://github.com/baidu/amis/pull/6829/files?diff=unified&w=0#diff-bd3cef1dd1adf5cbac8db6825eccda213b5450966cc365712f22a32093048fc6L96-R107))
