### PR TITLE
fix: 修复 closeOnOutSide 点击有鼠标移动时关闭逻辑不正确的问题 Close: #6775

### DIFF
--- a/packages/amis-ui/src/components/Modal.tsx
+++ b/packages/amis-ui/src/components/Modal.tsx
@@ -159,22 +159,12 @@ export class Modal extends React.Component<ModalProps, ModalState> {
       this.handleEnter();
       this.handleEntered();
     }
-
-    document.body.addEventListener('click', this.handleRootClickCapture, true);
-    document.body.addEventListener('click', this.handleRootClick);
   }
 
   componentWillUnmount() {
     if (this.props.show) {
       this.handleExited();
     }
-
-    document.body.removeEventListener('click', this.handleRootClick);
-    document.body.removeEventListener(
-      'click',
-      this.handleRootClickCapture,
-      true
-    );
   }
 
   handleEnter = () => {
@@ -191,10 +181,35 @@ export class Modal extends React.Component<ModalProps, ModalState> {
   handleEntered = () => {
     const onEntered = this.props.onEntered;
 
+    document.body.addEventListener(
+      'mousedown',
+      this.handleRootMouseDownCapture,
+      true
+    );
+    document.body.addEventListener(
+      'mouseup',
+      this.handleRootMouseUpCapture,
+      true
+    );
+    document.body.addEventListener('mouseup', this.handleRootMouseUp);
+
     onEntered && onEntered();
   };
   handleExited = () => {
     const onExited = this.props.onExited;
+
+    document.body.removeEventListener('mouseup', this.handleRootMouseUp);
+    document.body.removeEventListener(
+      'mousedown',
+      this.handleRootMouseDownCapture,
+      true
+    );
+    document.body.removeEventListener(
+      'mouseup',
+      this.handleRootMouseUpCapture,
+      true
+    );
+
     onExited && onExited();
     setTimeout(() => {
       if (!document.querySelector('.amis-dialog-widget')) {
@@ -216,7 +231,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
   };
 
   @autobind
-  handleRootClickCapture(e: MouseEvent) {
+  handleRootMouseDownCapture(e: MouseEvent) {
     const target = e.target as HTMLElement;
     const {closeOnOutside, classPrefix: ns} = this.props;
     const isLeftButton =
@@ -233,7 +248,18 @@ export class Modal extends React.Component<ModalProps, ModalState> {
   }
 
   @autobind
-  handleRootClick(e: MouseEvent) {
+  handleRootMouseUpCapture(e: MouseEvent) {
+    // mousedown 的时候不在弹窗里面，则不需要判断了
+    if (!this.isRootClosed) {
+      return;
+    }
+
+    // 再判断 mouseup 的时候是不是在弹窗里面
+    this.handleRootMouseDownCapture(e);
+  }
+
+  @autobind
+  handleRootMouseUp(e: MouseEvent) {
     const {onHide} = this.props;
     this.isRootClosed && !e.defaultPrevented && onHide(e);
   }

--- a/packages/amis/src/renderers/Dialog.tsx
+++ b/packages/amis/src/renderers/Dialog.tsx
@@ -105,6 +105,11 @@ export interface DialogSchema extends BaseSchema {
    * 是否显示 spinner
    */
   showLoading?: boolean;
+
+  /**
+   * 是否显示蒙层
+   */
+  overlay?: boolean;
 }
 
 export type DialogSchemaBase = Omit<DialogSchema, 'type'>;
@@ -145,7 +150,8 @@ export default class Dialog extends React.Component<DialogProps> {
     'showCloseButton',
     'showErrorMsg',
     'actions',
-    'popOverContainer'
+    'popOverContainer',
+    'overlay'
   ];
   static defaultProps = {
     title: 'Dialog.title',
@@ -532,7 +538,8 @@ export default class Dialog extends React.Component<DialogProps> {
       classnames: cx,
       classPrefix,
       translate: __,
-      loadingConfig
+      loadingConfig,
+      overlay
     } = {
       ...this.props,
       ...store.schema
@@ -560,6 +567,7 @@ export default class Dialog extends React.Component<DialogProps> {
         }
         enforceFocus={false}
         disabled={store.loading}
+        overlay={overlay}
       >
         {title && typeof title === 'string' ? (
           <div className={cx('Modal-header', headerClassName)}>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 366b4d8</samp>

This pull request improves the behavior and usability of the `Drawer` and `Modal` components and the `Dialog` renderer. It fixes a bug that caused the `Drawer` to close unexpectedly, changes the event handling of both `Drawer` and `Modal` to avoid conflicts, and adds a new option to control the overlay of the `Dialog`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 366b4d8</samp>

> _`Drawer` and `Modal`_
> _listen to mouse events now_
> _fixing some glitches_

### Why

Close: #6775

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 366b4d8</samp>

*  Replace click events with mousedown and mouseup events for closing Drawer and Modal components on outside events ([link](https://github.com/baidu/amis/pull/6830/files?diff=unified&w=0#diff-af434e78c73360a5d5fe4788da3162224190222f4cdb9c9bf02550e01d000163L74-L76), [link](https://github.com/baidu/amis/pull/6830/files?diff=unified&w=0#diff-af434e78c73360a5d5fe4788da3162224190222f4cdb9c9bf02550e01d000163L97-L103), [link](https://github.com/baidu/amis/pull/6830/files?diff=unified&w=0#diff-af434e78c73360a5d5fe4788da3162224190222f4cdb9c9bf02550e01d000163R113-R125), [link](https://github.com/baidu/amis/pull/6830/files?diff=unified&w=0#diff-af434e78c73360a5d5fe4788da3162224190222f4cdb9c9bf02550e01d000163R131-R143), [link](https://github.com/baidu/amis/pull/6830/files?diff=unified&w=0#diff-af434e78c73360a5d5fe4788da3162224190222f4cdb9c9bf02550e01d000163L150-R166), [link](https://github.com/baidu/amis/pull/6830/files?diff=unified&w=0#diff-af434e78c73360a5d5fe4788da3162224190222f4cdb9c9bf02550e01d000163L168-R195), [link](https://github.com/baidu/amis/pull/6830/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L162-L164), [link](https://github.com/baidu/amis/pull/6830/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L171-L177), [link](https://github.com/baidu/amis/pull/6830/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L194-R212), [link](https://github.com/baidu/amis/pull/6830/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L219-R234), [link](https://github.com/baidu/amis/pull/6830/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L236-R262)). This fixes an issue where the components would close unexpectedly when clicking on some elements inside them. The changes affect the `Drawer.tsx` and `Modal.tsx` files in the `packages/amis-ui/src/components` directory.
