### PR TITLE
feat: 主题编辑值继承

### DIFF
--- a/packages/amis-editor/src/plugin/Button.tsx
+++ b/packages/amis-editor/src/plugin/Button.tsx
@@ -123,7 +123,8 @@ export class ButtonPlugin extends BasePlugin {
           editorThemePath: [
             `button1.type.\${level}.${state}.body.font-color`,
             `button1.size.\${size}.body.font`
-          ]
+          ],
+          state
         }),
         getSchemaTpl('theme:colorPicker', {
           label: '背景',
@@ -131,22 +132,26 @@ export class ButtonPlugin extends BasePlugin {
           labelMode: 'input',
           needGradient: true,
           visibleOn: visibleOn,
-          editorThemePath: `button1.type.\${level}.${state}.body.bg-color`
+          editorThemePath: `button1.type.\${level}.${state}.body.bg-color`,
+          state
         }),
         getSchemaTpl('theme:border', {
           name: `themeCss.className.border:${state}`,
           visibleOn: visibleOn,
-          editorThemePath: `button1.type.\${level}.${state}.body.border`
+          editorThemePath: `button1.type.\${level}.${state}.body.border`,
+          state
         }),
         getSchemaTpl('theme:paddingAndMargin', {
           name: `themeCss.className.padding-and-margin:${state}`,
           visibleOn: visibleOn,
-          editorThemePath: `button1.size.\${size}.body.padding-and-margin`
+          editorThemePath: `button1.size.\${size}.body.padding-and-margin`,
+          state
         }),
         getSchemaTpl('theme:radius', {
           name: `themeCss.className.radius:${state}`,
           visibleOn: visibleOn,
-          editorThemePath: `button1.size.\${size}.body.border`
+          editorThemePath: `button1.size.\${size}.body.border`,
+          state
         })
       ];
     };

--- a/packages/amis-editor/src/plugin/Form/InputImage.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputImage.tsx
@@ -19,7 +19,8 @@ const inputStateFunc = (visibleOn: string, state: string) => {
     getSchemaTpl('theme:border', {
       name: `${addBtnCssClassName}.border:${state}`,
       visibleOn: visibleOn,
-      editorThemePath: `${editorPath}.${state}.body.border`
+      editorThemePath: `${editorPath}.${state}.body.border`,
+      state
     }),
     getSchemaTpl('theme:colorPicker', {
       label: '文字',
@@ -27,7 +28,8 @@ const inputStateFunc = (visibleOn: string, state: string) => {
       labelMode: 'input',
       needGradient: true,
       visibleOn: visibleOn,
-      editorThemePath: `${editorPath}.${state}.body.color`
+      editorThemePath: `${editorPath}.${state}.body.color`,
+      state
     }),
     getSchemaTpl('theme:colorPicker', {
       label: '背景',
@@ -35,7 +37,8 @@ const inputStateFunc = (visibleOn: string, state: string) => {
       labelMode: 'input',
       needGradient: true,
       visibleOn: visibleOn,
-      editorThemePath: `${editorPath}.${state}.body.bg-color`
+      editorThemePath: `${editorPath}.${state}.body.bg-color`,
+      state
     }),
     getSchemaTpl('theme:colorPicker', {
       label: '图标',
@@ -43,7 +46,8 @@ const inputStateFunc = (visibleOn: string, state: string) => {
       labelMode: 'input',
       needGradient: true,
       visibleOn: visibleOn,
-      editorThemePath: `${editorPath}.${state}.body.icon-color`
+      editorThemePath: `${editorPath}.${state}.body.icon-color`,
+      state
     })
   ];
 };

--- a/packages/amis-editor/src/renderer/style-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/style-control/helper.tsx
@@ -45,7 +45,8 @@ export const inputStateFunc = (
       label: '文字',
       name: `${className}.font:${state}`,
       visibleOn: visibleOn,
-      editorThemePath: `${path}.${state}.body.font`
+      editorThemePath: `${path}.${state}.body.font`,
+      state
     }),
     getSchemaTpl('theme:colorPicker', {
       label: '背景',
@@ -53,22 +54,26 @@ export const inputStateFunc = (
       labelMode: 'input',
       needGradient: true,
       visibleOn: visibleOn,
-      editorThemePath: `${path}.${state}.body.bg-color`
+      editorThemePath: `${path}.${state}.body.bg-color`,
+      state
     }),
     getSchemaTpl('theme:border', {
       name: `${className}.border:${state}`,
       visibleOn: visibleOn,
-      editorThemePath: `${path}.${state}.body.border`
+      editorThemePath: `${path}.${state}.body.border`,
+      state
     }),
     getSchemaTpl('theme:paddingAndMargin', {
       name: `${className}.padding-and-margin:${state}`,
       visibleOn: visibleOn,
-      editorThemePath: `${path}.${state}.body.padding-and-margin`
+      editorThemePath: `${path}.${state}.body.padding-and-margin`,
+      state
     }),
     getSchemaTpl('theme:radius', {
       name: `${className}.radius:${state}`,
       visibleOn: visibleOn,
-      editorThemePath: `${path}.${state}.body.border`
+      editorThemePath: `${path}.${state}.body.border`,
+      state
     }),
     ...options
   ];

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -1453,8 +1453,7 @@ export default class ImageControl extends React.Component<
           value: inputImageControlClassName
         }
       ],
-      id,
-      null
+      id
     );
 
     insertCustomStyle(
@@ -1473,8 +1472,7 @@ export default class ImageControl extends React.Component<
           }
         }
       ],
-      id + '-addOn',
-      null
+      id + '-addOn'
     );
 
     insertCustomStyle(
@@ -1490,8 +1488,7 @@ export default class ImageControl extends React.Component<
           }
         }
       ],
-      id + '-icon',
-      null
+      id + '-icon'
     );
 
     const {

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -5,8 +5,7 @@ import {
   highlight,
   FormOptionsControl,
   resolveEventData,
-  insertCustomStyle,
-  getValueByPath
+  insertCustomStyle
 } from 'amis-core';
 import {ActionObject} from 'amis-core';
 import Downshift, {StateChangeOptions} from 'downshift';
@@ -1071,8 +1070,7 @@ export default class TextControl extends React.PureComponent<
           }
         }
       ],
-      id,
-      null
+      id
     );
 
     insertCustomStyle(


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a214cf</samp>

This pull request refactors and updates the style helper functions and the schema templates for various input renderers and plugins in the AMIS editor. It introduces a new syntax and logic for inheriting style values based on the state of the input elements. It also removes unnecessary or outdated code and improves code readability and testability. The affected files are `style-helper.ts`, `Button.tsx`, `InputImage.tsx`, `InputText.tsx`, and `style-control/helper.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5a214cf</samp>

> _Style helpers refactored_
> _`inputStateFunc` inherits_
> _Autumn leaves of code_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5a214cf</samp>

*  Simplify and enhance the inheritance logic for style values in `style-helper.ts` ([link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL65-R65), [link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL74-R90), [link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdR96-R97), [link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL111-R112), [link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL153-R153), [link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL175-R175), [link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL252-R261))
*  Pass the `state` parameter to the `getSchemaTpl` function for various schema templates in `Button.tsx`, `InputImage.tsx`, and `helper.tsx` to handle the inheritance logic based on the state ([link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-da2ca6c6a8ac5b6fcef2f72eb2ab705288b464dc1ddda4122cffd5f2cecf022bL126-R127), [link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-da2ca6c6a8ac5b6fcef2f72eb2ab705288b464dc1ddda4122cffd5f2cecf022bL134-R154), [link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-196626bf3350bb7e3df1e7beed48ef308ea68210398ca53c8370932f242feae6L22-R23), [link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-196626bf3350bb7e3df1e7beed48ef308ea68210398ca53c8370932f242feae6L30-R32), [link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-196626bf3350bb7e3df1e7beed48ef308ea68210398ca53c8370932f242feae6L38-R41), [link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-196626bf3350bb7e3df1e7beed48ef308ea68210398ca53c8370932f242feae6L46-R50), [link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-297ca4d24737674d8a8228d8974f83b142234282017f76a55534d88c2863a46cL48-R49), [link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-297ca4d24737674d8a8228d8974f83b142234282017f76a55534d88c2863a46cL56-R76))
*  Remove the unused `defaultData` parameter and use the `insertCustomStyle` function with the new signature in `InputImage.tsx` and `InputText.tsx` ([link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1456-R1456), [link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1476-R1475), [link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1493-R1491), [link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L1074-R1073))
*  Remove the unused import of the `getValueByPath` function from `amis-core` in `InputText.tsx` ([link](https://github.com/baidu/amis/pull/6833/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L8-R8))
