### PR TITLE
fix: 修复crud 无限更新和 jsonToJsonSchema 堆栈超出问题

### DIFF
--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -1570,7 +1570,10 @@ export default class CRUD extends React.Component<CRUDProps, any> {
         newItems.splice(0, newItems.length - 1)
       );
     }
-    store.updateSelectData(newItems, newUnSelectedItems);
+    // 用 updateSelectData 导致 CRUD 无线刷新
+    // store.updateSelectData(newItems, newUnSelectedItems);
+    store.setSelectedItems(newItems);
+    store.setUnSelectedItems(newUnSelectedItems);
 
     onSelect && onSelect(newItems, newUnSelectedItems);
   }

--- a/packages/amis/src/renderers/CRUD2.tsx
+++ b/packages/amis/src/renderers/CRUD2.tsx
@@ -909,7 +909,9 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
         newItems.splice(0, newItems.length - 1)
       );
     }
-    store.updateSelectData(newItems, newUnSelectedItems);
+    // store.updateSelectData(newItems, newUnSelectedItems);
+    store.setSelectedItems(newItems);
+    store.setUnSelectedItems(newUnSelectedItems);
 
     onSelect && onSelect(newItems);
   }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1530dd5</samp>

This pull request improves the schema generation for the editor core, and fixes a bug that causes infinite refreshes for the `CRUD` and `CRUD2` components. It modifies the `jsonToJsonSchema` function in `util.ts`, and the `CRUD.tsx` and `CRUD2.tsx` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1530dd5</samp>

> _We're fixing bugs in the `CRUD` component, yo ho ho_
> _We're breaking the loop with separate setters, yo ho ho_
> _We're heaving away on the count of three_
> _We're making the schema faster and better, yo ho ho_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1530dd5</samp>

*  Fix infinite refresh bug in CRUD components by using separate setters for selected and unselected items ([link](https://github.com/baidu/amis/pull/6836/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1573-R1576), [link](https://github.com/baidu/amis/pull/6836/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL912-R914))
* Add maxDepth parameter to jsonToJsonSchema function to limit schema generation for deeply nested JSON data ([link](https://github.com/baidu/amis/pull/6836/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL936-R937))
* Skip schema generation for observable objects in jsonToJsonSchema function to avoid triggering reactions or side effects ([link](https://github.com/baidu/amis/pull/6836/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL943-R969))
