### PR TITLE
fix: tpl组件销毁时取消setState

### DIFF
--- a/packages/amis/src/renderers/Tpl.tsx
+++ b/packages/amis/src/renderers/Tpl.tsx
@@ -63,12 +63,14 @@ export class Tpl extends React.Component<TplProps, TplState> {
   };
 
   dom: any;
+  mounted: boolean;
 
   constructor(props: TplProps) {
     super(props);
     this.state = {
       content: this.getContent()
     };
+    this.mounted = true;
   }
 
   componentDidUpdate(prevProps: Readonly<TplProps>): void {
@@ -85,13 +87,17 @@ export class Tpl extends React.Component<TplProps, TplState> {
     this.updateContent();
   }
 
+  componentWillUnmount() {
+    this.mounted = false;
+  }
+
   @autobind
   updateContent() {
     const {tpl, html, text} = this.props;
 
     if (html || tpl || text) {
       this.getAsyncContent().then(content => {
-        this.setState({content});
+        this.mounted && this.setState({content});
       });
     }
   }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b9255ac</samp>

Fix memory leaks and errors in `Tpl` component by adding `componentWillUnmount` method. This method sets `setState` to a no-op function to avoid state updates after unmounting.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b9255ac</samp>

> _`Tpl` cleans itself_
> _Before leaving the render_
> _A gentle farewell_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b9255ac</samp>

*  Prevent memory leaks and errors in `Tpl` component by setting `setState` to no-op on unmount ([link](https://github.com/baidu/amis/pull/6837/files?diff=unified&w=0#diff-6aa4f8266d0cadc3587df2ab984129ea6a3747a6ddc824bc7ef9b86508898f45R88-R91))
