### PR TITLE
fix(amis): flex组件alignItems默认值改为stretch,和flex默认行为保持一致.

### DIFF
--- a/packages/amis-editor-core/src/manager.ts
+++ b/packages/amis-editor-core/src/manager.ts
@@ -635,7 +635,7 @@ export class EditorManager {
    * 备注3: 建议优先使用当前选中组件ID（this.store.activeId）来更新属性配置面板;
    * @param pluginType 组件类型
    */
-  updateConfigPanel(pluginType: string) {
+  updateConfigPanel(pluginType?: string) {
     const {activeId, getSchema, getNodeById} = this.store;
     let curPluginType = pluginType;
 
@@ -867,6 +867,9 @@ export class EditorManager {
     ) {
       // 布局能力提升: 点击插入新元素，当wrapper为空插入布局容器时，自动改为置换，避免过多层级
       this.replaceChild(curActiveId, curElemSchema);
+      setTimeout(() => {
+        this.updateConfigPanel();
+      }, 0);
       return;
     }
 

--- a/packages/amis/__tests__/renderers/__snapshots__/Flex.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Flex.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Renderer:flex 1`] = `
 <div>
   <div
-    style="display: flex; flex-direction: row; justify-content: center; align-items: center; align-content: center;"
+    style="display: flex; flex-direction: row; justify-content: center; align-items: stretch; align-content: center;"
   >
     <span
       class="cxd-TplField"
@@ -62,7 +62,7 @@ exports[`Renderer:flex justify 1`] = `
             </span>
           </span>
           <div
-            style="display: flex; flex-direction: row; justify-content: center; align-items: center; align-content: center;"
+            style="display: flex; flex-direction: row; justify-content: center; align-items: stretch; align-content: center;"
           >
             <span
               class="cxd-TplField"
@@ -103,7 +103,7 @@ exports[`Renderer:flex justify 1`] = `
             </span>
           </span>
           <div
-            style="display: flex; flex-direction: row; justify-content: flex-start; align-items: center; align-content: center;"
+            style="display: flex; flex-direction: row; justify-content: flex-start; align-items: stretch; align-content: center;"
           >
             <span
               class="cxd-TplField"
@@ -144,7 +144,7 @@ exports[`Renderer:flex justify 1`] = `
             </span>
           </span>
           <div
-            style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; align-content: center;"
+            style="display: flex; flex-direction: row; justify-content: flex-end; align-items: stretch; align-content: center;"
           >
             <span
               class="cxd-TplField"
@@ -185,7 +185,7 @@ exports[`Renderer:flex justify 1`] = `
             </span>
           </span>
           <div
-            style="display: flex; flex-direction: row; justify-content: space-around; align-items: center; align-content: center;"
+            style="display: flex; flex-direction: row; justify-content: space-around; align-items: stretch; align-content: center;"
           >
             <span
               class="cxd-TplField"
@@ -226,7 +226,7 @@ exports[`Renderer:flex justify 1`] = `
             </span>
           </span>
           <div
-            style="display: flex; flex-direction: row; justify-content: space-between; align-items: center; align-content: center;"
+            style="display: flex; flex-direction: row; justify-content: space-between; align-items: stretch; align-content: center;"
           >
             <span
               class="cxd-TplField"
@@ -267,7 +267,7 @@ exports[`Renderer:flex justify 1`] = `
             </span>
           </span>
           <div
-            style="display: flex; flex-direction: row; justify-content: space-evenly; align-items: center; align-content: center;"
+            style="display: flex; flex-direction: row; justify-content: space-evenly; align-items: stretch; align-content: center;"
           >
             <span
               class="cxd-TplField"

--- a/packages/amis/src/renderers/Flex.tsx
+++ b/packages/amis/src/renderers/Flex.tsx
@@ -81,7 +81,7 @@ export default class Flex extends React.Component<FlexProps, object> {
   static defaultProps: Partial<FlexProps> = {
     direction: 'row',
     justify: 'center',
-    alignItems: 'center',
+    alignItems: 'stretch',
     alignContent: 'center'
   };
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e1a3e2b</samp>

Fixed a flex layout bug in `Flex.tsx` and improved its responsiveness. Changed the `alignItems` style of the flex container to `stretch` to make the flex items fill the available height.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e1a3e2b</samp>

> _`alignItems` changed_
> _Flex items fill the container_
> _Autumn leaves stretch out_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e1a3e2b</samp>

* Fixed flex items height bug by changing `alignItems` to `stretch` ([link](https://github.com/baidu/amis/pull/6841/files?diff=unified&w=0#diff-3c803fbe826ef61d46f35e8fa870aaf229c1bb83bad98847a11f8d70b3bd7095L84-R84))
