### PR TITLE
fix: 修复 formulaControl 由于 name 干扰导致赋值不符合预期问题

### DIFF
--- a/packages/amis-editor/src/renderer/FormulaControl.tsx
+++ b/packages/amis-editor/src/renderer/FormulaControl.tsx
@@ -402,9 +402,11 @@ export default class FormulaControl extends React.Component<
 
     let curRendererSchema: any = null;
     if (rendererSchema) {
-      curRendererSchema = Object.assign({}, rendererSchema, data, {
+      curRendererSchema = Object.assign({}, rendererSchema, {
         type: rendererSchema.type ?? data.type,
-        name: rendererSchema.name ?? data.name ?? 'value'
+        // 目前表单项 wrapControl 还必须依赖一个 name
+        // 所以这里先随便取个名字，这里渲染的时候应该是 value 控制，而不是关联 name
+        name: 'FORMULA_CONTROL_PLACEHOLDER'
       });
 
       // 默认要剔除的字段
@@ -520,9 +522,6 @@ export default class FormulaControl extends React.Component<
     } = this.props;
 
     const {formulaPickerOpen, variables, variableMode} = this.state;
-
-    // 自身字段
-    const selfName = this.props?.data?.name;
 
     // 判断是否含有公式表达式
     const isExpr = isExpression(value);

--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -1159,13 +1159,6 @@ setSchemaTpl('nav-badge', {
 setSchemaTpl('nav-default-active', {
   type: 'ae-nav-default-active'
 });
-// 暂未使用
-setSchemaTpl('formulaControl', (schema: object = {}) => {
-  return {
-    type: 'ae-formulaControl',
-    ...schema
-  };
-});
 
 /**
  * 日期范围快捷键组件


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 760f4ed</samp>

The pull request simplifies the formula control component and removes unused code. It avoids name conflicts by using a placeholder name for the component, and deletes the `setSchemaTpl` function call and the `common.tsx` template file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 760f4ed</samp>

> _Oh we're the coders of the sea, we write the code that makes it run_
> _We don't need `setSchemaTpl`, we've changed the type and that's enough_
> _We heave away on the count of three, we fix the bugs and make it neat_
> _We use a placeholder name, we don't want conflicts in our game_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 760f4ed</samp>

* Change the formula control type from `formula` to `ae-formulaControl` to avoid conflicts with the built-in formula control (                                                        F0
