### PR TITLE
fix:crud fetchinited异步

### DIFF
--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -1185,12 +1185,12 @@ export default class CRUD extends React.Component<CRUDProps, any> {
             syncResponse2Query,
             columns: store.columns ?? columns
           })
-          .then(value => {
+          .then(async value => {
             const {page, lastPage, data, msg, error} = store;
 
             if (isInit) {
               // 初始化请求完成
-              const rendererEvent = dispatchEvent?.(
+              const rendererEvent = await dispatchEvent?.(
                 'fetchInited',
                 createObject(this.props.data, {
                   responseData: value.ok ? data ?? {} : value,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e68be08</samp>

Fixed a bug in `CRUD` renderer where `fetchInited` event was not fired correctly. Added `await` keyword to `dispatchEvent` call in `fetchInitData` method of `CRUD.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e68be08</samp>

> _`fetchInitData` waits_
> _`dispatchEvent` promise_
> _Autumn bug is fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e68be08</samp>

*  Await `dispatchEvent` promise to fix `fetchInited` bug ([link](https://github.com/baidu/amis/pull/6845/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1188-R1193))
