### PR TITLE
styles: 优化form label的line-height的计算方式

### DIFF
--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -1630,7 +1630,7 @@
   --Form-item-fontColor: var(--Form-item-color);
   --Form-item-fontSize: var(--fonts-size-7);
   --Form-item-fontWeight: var(--fonts-weight-6);
-  --Form-item-lineHeight: var(--fonts-lineHeight-2);
+  --Form-item-lineHeight: var(--fonts-lineHeight-1);
   --Form-item-star-color: var(--colors-error-5);
   --Form-item-star-size: var(--sizes-size-7);
   --Form-description-color: var(--colors-neutral-text-5);
@@ -3316,7 +3316,7 @@
   --Tag-base-paddingLeft: var(--sizes-size-5);
   --Tag-base-paddingRight: var(--sizes-size-5);
   --Tag-base-padding: var(--Tag-base-paddingTop) var(--Tag-base-paddingRight)
-   var(--Tag-base-paddingBottom) var(--Tag-base-paddingLeft);
+    var(--Tag-base-paddingBottom) var(--Tag-base-paddingLeft);
   --Tag-model-normal-top-border-color: var(--colors-neutral-line-6);
   --Tag-model-normal-top-border-width: var(--borders-width-2);
   --Tag-model-normal-top-border-style: var(--borders-style-1);

--- a/packages/amis-ui/scss/components/form/_form.scss
+++ b/packages/amis-ui/scss/components/form/_form.scss
@@ -268,6 +268,7 @@
                 var(--Form-item-fontSize)
             ) / 2
         );
+        word-break: break-word;
         line-height: var(--Form-item-lineHeight);
         margin: 0;
         margin-right: var(--Form--horizontal-label-gap);
@@ -330,6 +331,7 @@
                 var(--Form-item-fontSize)
             ) / 2
         );
+        word-break: break-word;
         line-height: var(--Form-item-lineHeight);
         margin: 0;
         margin-right: var(--Form-mode-inline-label-gap);

--- a/packages/amis-ui/scss/components/form/_form.scss
+++ b/packages/amis-ui/scss/components/form/_form.scss
@@ -262,7 +262,13 @@
       }
 
       > .#{$ns}Form-label {
-        line-height: px2rem(32px);
+        padding-top: calc(
+          (
+              var(--Form-input-height) - var(--Form-item-lineHeight) *
+                var(--Form-item-fontSize)
+            ) / 2
+        );
+        line-height: var(--Form-item-lineHeight);
         margin: 0;
         margin-right: var(--Form--horizontal-label-gap);
         flex-shrink: 0;
@@ -318,8 +324,13 @@
       vertical-align: top;
 
       > .#{$ns}Form-label {
-        height: px2rem(32px);
-        line-height: px2rem(32px);
+        padding-top: calc(
+          (
+              var(--Form-input-height) - var(--Form-item-lineHeight) *
+                var(--Form-item-fontSize)
+            ) / 2
+        );
+        line-height: var(--Form-item-lineHeight);
         margin: 0;
         margin-right: var(--Form-mode-inline-label-gap);
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5749a67</samp>

This pull request improves the appearance and alignment of form labels and inputs in `horizontal` and `inline` modes by modifying the `packages/amis-ui/scss/components/form/_form.scss` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5749a67</samp>

> _The form of doom is broken and misaligned_
> _We must adjust the padding and the line_
> _To match the input height and font sublime_
> _We fix the layout with our code divine_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5749a67</samp>

* Fix the form layout and style issues by adjusting the padding-top and line-height of the form label in horizontal and inline mode to align with the input height and font size ([link](https://github.com/baidu/amis/pull/6847/files?diff=unified&w=0#diff-f325489c306f0106cb368664288efa079f007a051f746e29ad32d88cde2abb4dL265-R271), [link](https://github.com/baidu/amis/pull/6847/files?diff=unified&w=0#diff-f325489c306f0106cb368664288efa079f007a051f746e29ad32d88cde2abb4dL321-R333)) in `_form.scss`
