### PR TITLE
BCE-FE-1828 Feat【事件动作】发送请求动作，阻断条件支持获取请求结果数据

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
     "packages/amis-ui",
     "packages/amis"
   ],
-  "version": "2.9.0"
+  "version": "2.9.1"
 }

--- a/packages/amis-core/package.json
+++ b/packages/amis-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amis-core",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "amis-core",
   "main": "lib/index.js",
   "module": "esm/index.js",
@@ -45,7 +45,7 @@
     "esm"
   ],
   "dependencies": {
-    "amis-formula": "^2.9.0",
+    "amis-formula": "^2.9.1",
     "classnames": "2.3.1",
     "file-saver": "^2.0.2",
     "hoist-non-react-statics": "^3.3.2",

--- a/packages/amis-core/src/actions/Action.ts
+++ b/packages/amis-core/src/actions/Action.ts
@@ -232,14 +232,6 @@ export const runAction = async (
       false
     );
   }
-  let stopPropagation = false;
-  if (actionConfig.stopPropagation) {
-    stopPropagation = await evalExpressionWithConditionBuilder(
-      actionConfig.stopPropagation,
-      mergeData,
-      false
-    );
-  }
 
   // 动作配置
   const args = dataMapping(actionConfig.args, mergeData, key =>
@@ -249,9 +241,7 @@ export const runAction = async (
       'requestAdaptor',
       'responseData',
       'condition'
-    ].includes(
-      key
-    )
+    ].includes(key)
   );
   const afterMappingData = dataMapping(actionConfig.data, mergeData);
 
@@ -278,7 +268,7 @@ export const runAction = async (
   console.group?.(`run action ${actionConfig.actionType}`);
   console.debug(`[${actionConfig.actionType}] action args, data`, args, data);
 
-  let stoped = false;
+  let stopped = false;
   const actionResult = await actionInstrance.run(
     {
       ...actionConfig,
@@ -291,13 +281,23 @@ export const runAction = async (
   );
   // 二次确认弹窗如果取消，则终止后续动作
   if (actionConfig?.actionType === 'confirmDialog' && !actionResult) {
-    stoped = true;
+    stopped = true;
   }
+
+  let stopPropagation = false;
+  if (actionConfig.stopPropagation) {
+    stopPropagation = await evalExpressionWithConditionBuilder(
+      actionConfig.stopPropagation,
+      mergeData,
+      false
+    );
+  }
+
   console.debug(`[${actionConfig.actionType}] action end event`, event);
   console.groupEnd?.();
 
   // 阻止原有动作执行
   preventDefault && event.preventDefault();
   // 阻止后续动作执行
-  (stopPropagation || stoped) && event.stopPropagation();
+  (stopPropagation || stopped) && event.stopPropagation();
 };

--- a/packages/amis-editor/src/renderer/event-control/index.tsx
+++ b/packages/amis-editor/src/renderer/event-control/index.tsx
@@ -510,8 +510,13 @@ export class EventControl extends React.Component<
     // 收集当前事件已有ajax动作的请求返回结果作为事件变量
     let oldActions = onEvent[activeData.actionData!.eventKey].actions;
     if (activeData.type === 'update') {
-      // 编辑的时候只能拿到当前动作前面动作的事件变量
-      oldActions = oldActions.slice(0, activeData.actionData!.actionIndex);
+      // 编辑的时候只能拿到当前动作前面动作的事件变量以及当前动作事件
+      oldActions = oldActions.slice(
+        0,
+        activeData.actionData!.actionIndex !== undefined
+          ? activeData.actionData!.actionIndex + 1
+          : 0
+      );
     }
 
     const withOutputVarActions = oldActions?.filter(item => item.outputVar);

--- a/packages/amis-formula/package.json
+++ b/packages/amis-formula/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amis-formula",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "负责 amis 里面的表达式实现，内置公式，编辑器等",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/packages/amis-ui/package.json
+++ b/packages/amis-ui/package.json
@@ -3,7 +3,7 @@
   "main": "lib/index.js",
   "module": "esm/index.js",
   "types": "lib/index.d.ts",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "",
   "scripts": {
     "build": "npm run clean-dist && NODE_ENV=production rollup -c ",
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "@rc-component/mini-decimal": "^1.0.1",
-    "amis-core": "^2.9.0",
-    "amis-formula": "^2.9.0",
+    "amis-core": "^2.9.1",
+    "amis-formula": "^2.9.1",
     "classnames": "2.3.1",
     "codemirror": "^5.63.0",
     "downshift": "6.1.12",

--- a/packages/amis/package.json
+++ b/packages/amis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amis",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "一种MIS页面生成工具",
   "main": "lib/index.js",
   "module": "esm/index.js",
@@ -36,8 +36,8 @@
     }
   ],
   "dependencies": {
-    "amis-core": "^2.9.0",
-    "amis-ui": "^2.9.0",
+    "amis-core": "^2.9.1",
+    "amis-ui": "^2.9.1",
     "attr-accept": "2.2.2",
     "blueimp-canvastoblob": "2.1.0",
     "classnames": "2.3.1",


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ae333e5</samp>

This pull request enhances the action system in `amis-core` and `amis-editor` by allowing more flexibility and control over the `stopPropagation` option and the data mapping of action events.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ae333e5</samp>

> _When editing an action, you see_
> _The old actions array has a key_
> _It's the current event_
> _With its variables sent_
> _To the data mapping editor spree_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ae333e5</samp>

*  Evaluate `stopPropagation` option based on action result and merged data in `runAction` function ([link](https://github.com/baidu/amis/pull/6852/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L235-L242), [link](https://github.com/baidu/amis/pull/6852/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L294-R295), [link](https://github.com/baidu/amis/pull/6852/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L302-R302))
*  Fix typo in variable name `stopped` in `runAction` function ([link](https://github.com/baidu/amis/pull/6852/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L281-R271))
*  Reformat code to remove unnecessary line break in `runAction` function ([link](https://github.com/baidu/amis/pull/6852/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L252-R244))
*  Include current action event in `oldActions` array when editing an action in `event-control` renderer ([link](https://github.com/baidu/amis/pull/6852/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754L513-R519))
