### PR TITLE
editor: 外观背景支持选择图片

### DIFF
--- a/packages/amis-editor/src/plugin/Button.tsx
+++ b/packages/amis-editor/src/plugin/Button.tsx
@@ -130,6 +130,7 @@ export class ButtonPlugin extends BasePlugin {
           name: `themeCss.className.background:${state}`,
           labelMode: 'input',
           needGradient: true,
+          needImage: true,
           visibleOn: visibleOn,
           editorThemePath: `button1.type.\${level}.${state}.body.bg-color`
         }),

--- a/packages/amis-editor/src/plugin/Form/InputImage.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputImage.tsx
@@ -25,7 +25,6 @@ const inputStateFunc = (visibleOn: string, state: string) => {
       label: '文字',
       name: `${addBtnCssClassName}.color:${state}`,
       labelMode: 'input',
-      needGradient: true,
       visibleOn: visibleOn,
       editorThemePath: `${editorPath}.${state}.body.color`
     }),
@@ -34,6 +33,7 @@ const inputStateFunc = (visibleOn: string, state: string) => {
       name: `${addBtnCssClassName}.background:${state}`,
       labelMode: 'input',
       needGradient: true,
+      needImage: true,
       visibleOn: visibleOn,
       editorThemePath: `${editorPath}.${state}.body.bg-color`
     }),
@@ -41,7 +41,6 @@ const inputStateFunc = (visibleOn: string, state: string) => {
       label: '图标',
       name: `${addBtnCssClassName}.icon-color:${state}`,
       labelMode: 'input',
-      needGradient: true,
       visibleOn: visibleOn,
       editorThemePath: `${editorPath}.${state}.body.icon-color`
     })

--- a/packages/amis-editor/src/renderer/style-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/style-control/helper.tsx
@@ -52,6 +52,7 @@ export const inputStateFunc = (
       name: `${className}.background:${state}`,
       labelMode: 'input',
       needGradient: true,
+      needImage: true,
       visibleOn: visibleOn,
       editorThemePath: `${path}.${state}.body.bg-color`
     }),

--- a/packages/amis-editor/src/tpl/style.tsx
+++ b/packages/amis-editor/src/tpl/style.tsx
@@ -619,6 +619,7 @@ setSchemaTpl(
         label: '背景',
         needCustom: true,
         needGradient: true,
+        needImage: true,
         labelMode: 'input'
       }),
       getSchemaTpl('theme:shadow', {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d2fbc61</samp>

This pull request adds a new `needImage` property to the button and style control plugins, which controls whether they should have an image input field or not. It also removes the gradient feature from the image input field in the form plugin.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d2fbc61</samp>

> _No more gradient for the image field_
> _You must obey the `needImage` shield_
> _The button plugin controls your fate_
> _The style editor will seal your gate_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d2fbc61</samp>

*  Add `needImage` property to `ButtonPlugin` class to control image input visibility ([link](https://github.com/baidu/amis/pull/6854/files?diff=unified&w=0#diff-da2ca6c6a8ac5b6fcef2f72eb2ab705288b464dc1ddda4122cffd5f2cecf022bR133))
*  Remove `needGradient` property from `InputImage` component and its usage in form editor and style control editor ([link](https://github.com/baidu/amis/pull/6854/files?diff=unified&w=0#diff-196626bf3350bb7e3df1e7beed48ef308ea68210398ca53c8370932f242feae6L28), [link](https://github.com/baidu/amis/pull/6854/files?diff=unified&w=0#diff-196626bf3350bb7e3df1e7beed48ef308ea68210398ca53c8370932f242feae6L44), [link](https://github.com/baidu/amis/pull/6854/files?diff=unified&w=0#diff-297ca4d24737674d8a8228d8974f83b142234282017f76a55534d88c2863a46cR55))
*  Add `needImage` property to `InputImage` component and use it to control image input visibility in form editor and style control editor ([link](https://github.com/baidu/amis/pull/6854/files?diff=unified&w=0#diff-196626bf3350bb7e3df1e7beed48ef308ea68210398ca53c8370932f242feae6R36), [link](https://github.com/baidu/amis/pull/6854/files?diff=unified&w=0#diff-297ca4d24737674d8a8228d8974f83b142234282017f76a55534d88c2863a46cR55))
*  Add `needImage` property to `style.tsx` file and use it to control image input inclusion in style control schema ([link](https://github.com/baidu/amis/pull/6854/files?diff=unified&w=0#diff-397f3332bd17c52ed7e468360e1cfe462d1d8646110ccd681b48a6deaa608302R622))
