### PR TITLE
fix:发送请求动作，阻断条件支持获取请求结果数据

### DIFF
--- a/packages/amis-core/src/actions/Action.ts
+++ b/packages/amis-core/src/actions/Action.ts
@@ -232,14 +232,6 @@ export const runAction = async (
       false
     );
   }
-  let stopPropagation = false;
-  if (actionConfig.stopPropagation) {
-    stopPropagation = await evalExpressionWithConditionBuilder(
-      actionConfig.stopPropagation,
-      mergeData,
-      false
-    );
-  }
 
   // 动作配置
   const args = dataMapping(actionConfig.args, mergeData, key =>
@@ -249,9 +241,7 @@ export const runAction = async (
       'requestAdaptor',
       'responseData',
       'condition'
-    ].includes(
-      key
-    )
+    ].includes(key)
   );
   const afterMappingData = dataMapping(actionConfig.data, mergeData);
 
@@ -278,7 +268,7 @@ export const runAction = async (
   console.group?.(`run action ${actionConfig.actionType}`);
   console.debug(`[${actionConfig.actionType}] action args, data`, args, data);
 
-  let stoped = false;
+  let stopped = false;
   const actionResult = await actionInstrance.run(
     {
       ...actionConfig,
@@ -291,7 +281,16 @@ export const runAction = async (
   );
   // 二次确认弹窗如果取消，则终止后续动作
   if (actionConfig?.actionType === 'confirmDialog' && !actionResult) {
-    stoped = true;
+    stopped = true;
+  }
+
+  let stopPropagation = false;
+  if (actionConfig.stopPropagation) {
+    stopPropagation = await evalExpressionWithConditionBuilder(
+      actionConfig.stopPropagation,
+      mergeData,
+      false
+    );
   }
   console.debug(`[${actionConfig.actionType}] action end event`, event);
   console.groupEnd?.();
@@ -299,5 +298,5 @@ export const runAction = async (
   // 阻止原有动作执行
   preventDefault && event.preventDefault();
   // 阻止后续动作执行
-  (stopPropagation || stoped) && event.stopPropagation();
+  (stopPropagation || stopped) && event.stopPropagation();
 };

--- a/packages/amis-editor/src/renderer/event-control/index.tsx
+++ b/packages/amis-editor/src/renderer/event-control/index.tsx
@@ -511,8 +511,13 @@ export class EventControl extends React.Component<
     // 收集当前事件已有ajax动作的请求返回结果作为事件变量
     let oldActions = onEvent[activeData.actionData!.eventKey].actions;
     if (activeData.type === 'update') {
-      // 编辑的时候只能拿到当前动作前面动作的事件变量
-      oldActions = oldActions.slice(0, activeData.actionData!.actionIndex);
+      // 编辑的时候只能拿到当前动作前面动作的事件变量以及当前动作事件
+      oldActions = oldActions.slice(
+        0,
+        activeData.actionData!.actionIndex !== undefined
+          ? activeData.actionData!.actionIndex + 1
+          : 0
+      );
     }
 
     const withOutputVarActions = oldActions?.filter(item => item.outputVar);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 065f50d</samp>

This pull request improves the functionality and usability of the action system in `amis-core` and `amis-editor`. It allows conditional stopping of actions based on expressions, and fixes a bug that prevented editing event variables for existing actions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 065f50d</samp>

> _To edit event actions with ease_
> _We fixed a bug in `EventControl` please_
> _We added a slice_
> _And checked for undefined twice_
> _Now the event variables won't tease_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 065f50d</samp>

* Fix a bug in the `EventControl` class that caused event variables to be missing when editing an action ([link](https://github.com/baidu/amis/pull/6856/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754L514-R520))
* Move the evaluation of the `actionConfig.stopPropagation` expression to after the current action is run and the data is merged in the `runAction` function in `Action.ts` ([link](https://github.com/baidu/amis/pull/6856/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L235-L242), [link](https://github.com/baidu/amis/pull/6856/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L294-R294))
* Rename the variable `stoped` to `stopped` to fix a typo in the `runAction` function in `Action.ts` ([link](https://github.com/baidu/amis/pull/6856/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L281-R271), [link](https://github.com/baidu/amis/pull/6856/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L302-R301))
* Reformat the code of the `runAction` function in `Action.ts` to improve readability and consistency ([link](https://github.com/baidu/amis/pull/6856/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L252-R244))
