### PR TITLE
chore: 优化 scaffoldForm 实现统一用 store 来控制

### DIFF
--- a/packages/amis-core/src/renderers/Options.tsx
+++ b/packages/amis-core/src/renderers/Options.tsx
@@ -803,14 +803,16 @@ export function registerOptionsControl(config: OptionsConfig) {
         return;
       }
 
-      return formItem.loadOptions(
-        source,
-        data,
-        undefined,
-        false,
-        isInit ? setPrinstineValue : onChange,
-        setError
-      );
+      return isAlive(formItem)
+        ? formItem.loadOptions(
+            source,
+            data,
+            undefined,
+            false,
+            isInit ? setPrinstineValue : onChange,
+            setError
+          )
+        : undefined;
     }
 
     @autobind

--- a/packages/amis-editor-core/src/store/editor.ts
+++ b/packages/amis-editor-core/src/store/editor.ts
@@ -3,7 +3,8 @@ import {
   getVariable,
   mapObject,
   mapTree,
-  extendObject
+  extendObject,
+  createObject
 } from 'amis-core';
 import {cast, getEnv, Instance, types} from 'mobx-state-tree';
 import {
@@ -191,6 +192,7 @@ export const MainStore = types
     jsonSchemaUri: '',
 
     scaffoldForm: types.maybe(types.frozen<ScaffoldFormContext>()),
+    scaffoldFormStep: 0,
     scaffoldFormBuzy: false,
     scaffoldError: '',
 
@@ -997,6 +999,13 @@ export const MainStore = types
           1,
           true
         );
+      },
+
+      get scaffoldData() {
+        return createObject(self.ctx, {
+          ...(self.scaffoldForm?.value || {}),
+          __step: self.scaffoldFormStep
+        });
       }
     };
   })
@@ -1669,6 +1678,10 @@ export const MainStore = types
 
       setScaffoldBuzy(value: any) {
         self.scaffoldFormBuzy = !!value;
+      },
+
+      setScaffoldStep(value: number) {
+        self.scaffoldFormStep = value;
       },
 
       setScaffoldError(msg: string = '') {

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -50,6 +50,7 @@ import type {CardsRendererEvent} from './Cards';
 import {isPureVariable, resolveVariableAndFilter, parseQuery} from 'amis-core';
 
 import type {PaginationProps} from './Pagination';
+import {isAlive} from 'mobx-state-tree';
 
 export type CRUDBultinToolbarType =
   | 'columns-toggler'
@@ -1186,6 +1187,10 @@ export default class CRUD extends React.Component<CRUDProps, any> {
             columns: store.columns ?? columns
           })
           .then(async value => {
+            if (!isAlive(store)) {
+              return value;
+            }
+
             const {page, lastPage, data, msg, error} = store;
 
             if (isInit) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fdec473</samp>

This pull request improves the scaffolding feature of the amis-editor-core package, and fixes some bugs related to the lifecycle of the store and the formItem objects. It refactors the `ScaffoldModal` component to use the `MainStore`, enhances the `editor` store to support multi-step forms, and adds `isAlive` checks to the `CRUD` and `Options` renderers.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fdec473</samp>

> _Oh, we're the coders of the sea, and we work on the `CRUD`_
> _We check the `formItem` and the `isAlive` for good_
> _We refactor the `ScaffoldModal` and the `MainStore`_
> _And we sync the options on the scaffold form with more_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fdec473</samp>

*  Prevent errors when formItem or store objects are destroyed by adding isAlive checks ([link](https://github.com/baidu/amis/pull/6860/files?diff=unified&w=0#diff-d9bf7707bf7ac9b7c40f2740fc783de7b5318386f02fd8348a8b7ef4b69717b2L806-R815), [link](https://github.com/baidu/amis/pull/6860/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R1190-R1193))
*  Refactor ScaffoldModal component to use scaffoldFormStep property from MainStore instead of state ([link](https://github.com/baidu/amis/pull/6860/files?diff=unified&w=0#diff-85faab9f8c432f5b71f49bdb3e107d8f36edae4199b8cc13dd9b6a2b391b613dL7), [link](https://github.com/baidu/amis/pull/6860/files?diff=unified&w=0#diff-85faab9f8c432f5b71f49bdb3e107d8f36edae4199b8cc13dd9b6a2b391b613dL15-R15), [link](https://github.com/baidu/amis/pull/6860/files?diff=unified&w=0#diff-85faab9f8c432f5b71f49bdb3e107d8f36edae4199b8cc13dd9b6a2b391b613dL50-R34), [link](https://github.com/baidu/amis/pull/6860/files?diff=unified&w=0#diff-85faab9f8c432f5b71f49bdb3e107d8f36edae4199b8cc13dd9b6a2b391b613dL94-L96), [link](https://github.com/baidu/amis/pull/6860/files?diff=unified&w=0#diff-85faab9f8c432f5b71f49bdb3e107d8f36edae4199b8cc13dd9b6a2b391b613dL154-R141), [link](https://github.com/baidu/amis/pull/6860/files?diff=unified&w=0#diff-85faab9f8c432f5b71f49bdb3e107d8f36edae4199b8cc13dd9b6a2b391b613dL167-R153), [link](https://github.com/baidu/amis/pull/6860/files?diff=unified&w=0#diff-85faab9f8c432f5b71f49bdb3e107d8f36edae4199b8cc13dd9b6a2b391b613dL209-R188), [link](https://github.com/baidu/amis/pull/6860/files?diff=unified&w=0#diff-85faab9f8c432f5b71f49bdb3e107d8f36edae4199b8cc13dd9b6a2b391b613dL219-R200), [link](https://github.com/baidu/amis/pull/6860/files?diff=unified&w=0#diff-85faab9f8c432f5b71f49bdb3e107d8f36edae4199b8cc13dd9b6a2b391b613dL248-R228))
*  Add scaffoldFormStep property, scaffoldData computed property, and setScaffoldStep action to MainStore in `editor.ts` ([link](https://github.com/baidu/amis/pull/6860/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8L6-R7), [link](https://github.com/baidu/amis/pull/6860/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8R195), [link](https://github.com/baidu/amis/pull/6860/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8R1002-R1008), [link](https://github.com/baidu/amis/pull/6860/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8R1683-R1686))
