### PR TITLE
fix: nav收纳图标、独立应用相关问题

### DIFF
--- a/packages/amis/src/renderers/Nav.tsx
+++ b/packages/amis/src/renderers/Nav.tsx
@@ -103,7 +103,7 @@ export interface NavOverflow {
 
   /**
    * 菜单触发按钮的图标
-   * @default "fa fa-ellipsis"
+   * @default "fa fa-ellipsis-h"
    */
   overflowIndicator?: SchemaIcon;
 
@@ -597,7 +597,7 @@ export class Navigation extends React.Component<
       if (isOverflow) {
         const {
           maxVisibleCount,
-          overflowIndicator = 'fa fa-ellipsis',
+          overflowIndicator = 'fa fa-ellipsis-h',
           overflowLabel,
           overflowClassName
         } = link.overflow;
@@ -613,7 +613,7 @@ export class Navigation extends React.Component<
                     {getIcon(overflowIndicator!) ? (
                       <Icon icon={overflowIndicator} className="icon" />
                     ) : (
-                      generateIcon(cx, overflowIndicator, 'Nav-itemIcon')
+                      generateIcon(cx, overflowIndicator, 'Nav-item-icon')
                     )}
                     {overflowLabel && isObject(overflowLabel)
                       ? render('nav-overflow-label', overflowLabel)
@@ -690,7 +690,7 @@ export class Navigation extends React.Component<
     let overflowedIndicator = null;
     if (overflow && isObject(overflow) && overflow.enable) {
       const {
-        overflowIndicator = 'fa fa-ellipsis',
+        overflowIndicator = 'fa fa-ellipsis-h',
         overflowLabel,
         overflowClassName
       } = overflow;

--- a/packages/amis/src/renderers/Nav.tsx
+++ b/packages/amis/src/renderers/Nav.tsx
@@ -897,6 +897,7 @@ const ConditionBuilderWithRemoteOptions = withRemoteConfig({
                   evalExpression(link.activeOn as string, location)
                 : !!(
                     link.hasOwnProperty('to') &&
+                    link.to !== null && // 也可能出现{to: null}的情况（独立应用）filter会把null处理成'' 那默认首页会选中很多菜单项 {to: ''}认为是有效配置
                     env &&
                     env.isCurrentUrl(filter(link.to as string, data))
                   ));


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a7dce4</samp>

Improved the appearance and consistency of navigation menu icons in `Nav.tsx`. Fixed a potential bug with null links.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8a7dce4</samp>

> _Oh we're the crew of the GitHub ship, and we code with skill and pride_
> _We review each pull request with care, and we don't let bugs slide_
> _We change the icons as we need, and we fix the class names too_
> _And we comment on the `link.to`, so we know just what to do_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a7dce4</samp>

*  Change the default icon for horizontal navigation menus from `fa fa-ellipsis` to `fa fa-ellipsis-h` in the `NavOverflow` interface and the `Navigation` class ([link](https://github.com/baidu/amis/pull/6863/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL106-R106), [link](https://github.com/baidu/amis/pull/6863/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL600-R600), [link](https://github.com/baidu/amis/pull/6863/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL693-R693))
*  Rename the class name of the icon generated by the `generateIcon` function from `Nav-itemIcon` to `Nav-item-icon` for consistency ([link](https://github.com/baidu/amis/pull/6863/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL616-R616))
*  Add a comment to explain the logic of checking the `link.to` property in the `ConditionBuilderWithRemoteOptions` function, which prevents the default homepage from being selected by many menu items ([link](https://github.com/baidu/amis/pull/6863/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bR900))
