### PR TITLE
chore: GridNav 支持配置 contentClassName 配置列表项内容 className close: #6865

### DIFF
--- a/docs/zh-CN/components/grid-nav.md
+++ b/docs/zh-CN/components/grid-nav.md
@@ -351,6 +351,7 @@ order: 54
 | type                | `string`        | `grid-nav` |                                                          |
 | className           | `string`        |            | 外层 CSS 类名                                            |
 | itemClassName       | `string`        |            | 列表项 css 类名                                          |
+| contentClassName    | `string`        |            | 列表项内容 css 类名                                      |
 | value               | `Array<object>` |            | 图片数组                                                 |
 | source              | `string`        |            | 数据源                                                   |
 | square              | `boolean`       |            | 是否将列表项固定为正方形                                 |
@@ -367,7 +368,3 @@ order: 54
 | options.link        | `string`        |            | 内部页面路径或外部跳转 URL 地址，优先级高于 clickAction  |
 | options.blank       | `boolean`       |            | 是否新页面打开，link 为 url 时有效                       |
 | options.clickAction | `ActionSchema`  |            | 列表项点击交互 详见 [Action](./action)                   |
-
-```
-
-```

--- a/index.html
+++ b/index.html
@@ -56,8 +56,17 @@
         );
         document.head.appendChild(link);
       });
+
+      // helper 放在末尾提高优先级
+      const helper = document.createElement('link');
+      helper.setAttribute('rel', 'stylesheet');
+      helper.setAttribute(
+        'href',
+        new URL(`./packages/amis-ui/scss/helper.scss`, import.meta.url).href
+      );
+      document.head.appendChild(helper);
     </script>
-    <link rel="stylesheet" href="./packages/amis-ui/scss/helper.scss" />
+    <!-- <link rel="stylesheet" href="./packages/amis-ui/scss/helper.scss" /> -->
   </head>
 
   <body>

--- a/packages/amis-ui/src/components/GridNav.tsx
+++ b/packages/amis-ui/src/components/GridNav.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, {useMemo} from 'react';
-import {ClassNamesFn} from 'amis-core';
+import {ClassName, ClassNamesFn} from 'amis-core';
 import {Badge, BadgeProps} from './Badge';
 
 export type GridNavDirection = 'horizontal' | 'vertical';
@@ -27,7 +27,7 @@ export interface GridNavProps {
   /** 列数	 */
   columnNum?: number;
   className?: string;
-  itemClassName?: string;
+  itemClassName?: ClassName;
   classnames: ClassNamesFn;
   style?: React.CSSProperties;
   children?: React.ReactNode | Array<React.ReactNode>;
@@ -40,9 +40,9 @@ export interface GridNavItemProps {
   text?: string | React.ReactNode;
   /** 图标名称或图片链接	 */
   icon?: string | React.ReactNode;
-  className?: string;
+  className?: ClassName;
   style?: React.CSSProperties;
-  contentClassName?: string;
+  contentClassName?: ClassName;
   contentStyle?: React.CSSProperties;
   children?: React.ReactNode;
   classnames: ClassNamesFn;

--- a/packages/amis/src/renderers/GridNav.tsx
+++ b/packages/amis/src/renderers/GridNav.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Renderer, RendererProps} from 'amis-core';
+import {ClassName, Renderer, RendererProps} from 'amis-core';
 import {autobind, getPropValue} from 'amis-core';
 import {isPureVariable, resolveVariableAndFilter} from 'amis-core';
 import {
@@ -64,7 +64,12 @@ export interface ListSchema extends BaseSchema {
   /**
    * 列表项类名
    */
-  itemClassName?: string;
+  itemClassName?: ClassName;
+
+  /**
+   * 列表项内容类名
+   */
+  contentClassName?: ClassName;
 
   /**
    * 静态图片列表配置
@@ -154,8 +159,15 @@ export default class List extends React.Component<ListProps, object> {
   }
 
   render() {
-    const {itemClassName, style, source, data, options, classnames} =
-      this.props;
+    const {
+      itemClassName,
+      style,
+      contentClassName,
+      source,
+      data,
+      options,
+      classnames
+    } = this.props;
 
     let value = getPropValue(this.props);
     let list: any = [];
@@ -185,6 +197,7 @@ export default class List extends React.Component<ListProps, object> {
               item.clickAction || item.link ? this.handleClick(item) : undefined
             }
             className={itemClassName}
+            contentClassName={contentClassName}
             text={item.text}
             icon={item.icon}
             classnames={classnames}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 558a6b8</samp>

This pull request improves the `GridNav` component and its documentation in several ways. It adds a new property to customize the content class name, uses the `ClassName` type for more flexible class names, and fixes a style issue in the documentation. It also updates the `docs/zh-CN/components/grid-nav.md` file to reflect the changes and correct a formatting error.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 558a6b8</samp>

> _Oh, we're the coders of the `amis` crew_
> _And we work on the docs and the UI too_
> _We load the `helper.scss` on the fly_
> _And we customize the `GridNav` with a sigh_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 558a6b8</samp>

*  Add `contentClassName` property to `GridNav` and `GridNavItem` components to allow custom css class name for list item content ([link](https://github.com/baidu/amis/pull/6868/files?diff=unified&w=0#diff-b8a56df9b8e67c7c8fcdfccd72c0d94b9e893f583e681f456ce007beeb5fb8faR354), [link](https://github.com/baidu/amis/pull/6868/files?diff=unified&w=0#diff-2389ce8e13bcaacf719bff6003c45c124d542e51f45a6298fb41feb0b770d2b7L43-R45), [link](https://github.com/baidu/amis/pull/6868/files?diff=unified&w=0#diff-68e0c5a9cb6ecdba45ec1eb207cdefd825db45ecb8c4b97eeed627e93727c236L67-R74), [link](https://github.com/baidu/amis/pull/6868/files?diff=unified&w=0#diff-68e0c5a9cb6ecdba45ec1eb207cdefd825db45ecb8c4b97eeed627e93727c236L157-R170), [link](https://github.com/baidu/amis/pull/6868/files?diff=unified&w=0#diff-68e0c5a9cb6ecdba45ec1eb207cdefd825db45ecb8c4b97eeed627e93727c236R200))
*  Update `itemClassName` and `className` properties of `GridNav` and `GridNavItem` components to use `ClassName` type instead of `string` to allow object values ([link](https://github.com/baidu/amis/pull/6868/files?diff=unified&w=0#diff-2389ce8e13bcaacf719bff6003c45c124d542e51f45a6298fb41feb0b770d2b7L7-R7), [link](https://github.com/baidu/amis/pull/6868/files?diff=unified&w=0#diff-2389ce8e13bcaacf719bff6003c45c124d542e51f45a6298fb41feb0b770d2b7L30-R30), [link](https://github.com/baidu/amis/pull/6868/files?diff=unified&w=0#diff-68e0c5a9cb6ecdba45ec1eb207cdefd825db45ecb8c4b97eeed627e93727c236L2-R2))
*  Fix style issue with `GridNav` component in documentation by loading `helper.scss` file dynamically and increasing its priority ([link](https://github.com/baidu/amis/pull/6868/files?diff=unified&w=0#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L59-R69))
*  Remove empty code block from `grid-nav.md` file in documentation ([link](https://github.com/baidu/amis/pull/6868/files?diff=unified&w=0#diff-b8a56df9b8e67c7c8fcdfccd72c0d94b9e893f583e681f456ce007beeb5fb8faL370-L373))
