### PR TITLE
chore: expose getIconNames Close: #6831

### DIFF
--- a/packages/amis-ui/src/components/icons.tsx
+++ b/packages/amis-ui/src/components/icons.tsx
@@ -118,6 +118,10 @@ const iconFactory: {
   [propName: string]: React.ElementType<{}>;
 } = {};
 
+export function getIconNames() {
+  return Object.keys(iconFactory);
+}
+
 export function getIcon(key: string) {
   return iconFactory[key];
 }

--- a/packages/amis-ui/src/components/index.tsx
+++ b/packages/amis-ui/src/components/index.tsx
@@ -76,7 +76,7 @@ import PickerContainer from './PickerContainer';
 import InputJSONSchema from './json-schema';
 import {Badge, withBadge} from './Badge';
 import type {BadgeObject} from './Badge';
-import {getIcon, Icon, registerIcon} from './icons';
+import {getIcon, getIconNames, Icon, registerIcon} from './icons';
 import {withRemoteConfig} from './WithRemoteConfig';
 import type {RemoteOptionsProps} from './WithRemoteConfig';
 import ConditionBuilder from './condition-builder';
@@ -224,6 +224,7 @@ export {
   UserSelect,
   UserTabSelect,
   getIcon,
+  getIconNames,
   registerIcon,
   Badge,
   HeadCellDropDown,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad94d66</samp>

Added a `getIconNames` function to `icons.tsx` and exported it in `index.tsx` to enable icon selection in other modules. This function allows the icon picker component to display the registered icons.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ad94d66</samp>

> _`getIconNames` is the key to the gate_
> _The gate of the icon picker's fate_
> _Choose your symbol from the array_
> _Or face the doom of the UI's decay_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ad94d66</samp>

*  Add `getIconNames` function to return an array of registered icon names ([link](https://github.com/baidu/amis/pull/6870/files?diff=unified&w=0#diff-1db9a23d0ea625849dbe5c523e7ccab192bfa73c87891759c8a7de36e2d874efR121-R124))
*  Import and export `getIconNames` function in `./components` module ([link](https://github.com/baidu/amis/pull/6870/files?diff=unified&w=0#diff-c6d3bec4b8c445413c8368cecf0a2c9f8a89a118aecdac2be05753f29bd20cacL79-R79), [link](https://github.com/baidu/amis/pull/6870/files?diff=unified&w=0#diff-c6d3bec4b8c445413c8368cecf0a2c9f8a89a118aecdac2be05753f29bd20cacR227))
