### PR TITLE
fix: input-excel 忽略 hidden 的 worksheet

### DIFF
--- a/packages/amis/src/renderers/Form/InputExcel.tsx
+++ b/packages/amis/src/renderers/Form/InputExcel.tsx
@@ -143,16 +143,9 @@ export default class ExcelControl extends React.PureComponent<
           }
         });
       } else {
-        let worksheet;
-        for (const sheet of workbook.worksheets) {
-          const sheetState = sheet.state || 'visible';
-          // hidden 的不处理
-          if (sheetState === 'hidden') {
-            continue;
-          }
-          worksheet = sheet;
-          break;
-        }
+        const worksheet = workbook.worksheets.find(
+          (sheet: any) => sheet.state !== 'hidden'
+        );
 
         if (parseImage) {
           const images = this.readImages(worksheet, workbook);

--- a/packages/amis/src/renderers/Form/InputExcel.tsx
+++ b/packages/amis/src/renderers/Form/InputExcel.tsx
@@ -143,7 +143,16 @@ export default class ExcelControl extends React.PureComponent<
           }
         });
       } else {
-        const worksheet = workbook.worksheets[0];
+        let worksheet;
+        for (const sheet of workbook.worksheets) {
+          const sheetState = sheet.state || 'visible';
+          // hidden 的不处理
+          if (sheetState === 'hidden') {
+            continue;
+          }
+          worksheet = sheet;
+          break;
+        }
 
         if (parseImage) {
           const images = this.readImages(worksheet, workbook);

--- a/packages/amis/src/renderers/Form/InputExcel.tsx
+++ b/packages/amis/src/renderers/Form/InputExcel.tsx
@@ -124,6 +124,11 @@ export default class ExcelControl extends React.PureComponent<
       let sheetsResult: any = [];
       if (allSheets) {
         workbook.eachSheet((worksheet: any) => {
+          const sheetState = worksheet.state || 'visible';
+          // hidden 的不处理
+          if (sheetState === 'hidden') {
+            return;
+          }
           if (parseImage) {
             sheetsResult.push({
               sheetName: worksheet.name,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2adb235</samp>

Fix Excel import bug with hidden worksheets. Skip hidden worksheets in `handleDrop` function of `InputExcel` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2adb235</samp>

> _`handleDrop` checks_
> _Hidden worksheets are skipped_
> _A bug fixed in fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2adb235</samp>

* Skip processing hidden worksheets when importing Excel files to avoid errors or unexpected results ([link](https://github.com/baidu/amis/pull/6874/files?diff=unified&w=0#diff-00c90e9ef78976a7a5e149e452bb31a9c2ba2d9ed42e895cedbc4b2a5673603dR127-R131))
