### PR TITLE
fix: 修复select弹框因为最小为100px导致的curd分页下拉的显示问题

### DIFF
--- a/packages/amis-ui/scss/components/form/_select.scss
+++ b/packages/amis-ui/scss/components/form/_select.scss
@@ -150,7 +150,6 @@
   .#{$ns}PopOver.#{$ns}Select-popover {
     margin-top: px2rem(4px);
     .#{$ns}Select-menu {
-      min-width: px2rem(100px);
       .#{$ns}Select-option {
         line-height: var(--select-base-default-option-line-height);
       }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 695a026</samp>

Removed `min-width` from `.amis-select` class in `form/_select.scss` to fix select component width issues.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 695a026</samp>

> _`min-width` removed_
> _select components can breathe_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 695a026</samp>

* Remove `min-width` property from `.amis-select` class to fix select component width issues ([link](https://github.com/baidu/amis/pull/6881/files?diff=unified&w=0#diff-76523bcea8a2970bd9ef0d5aad600399861a30059dd8da81137c0923f5eb6d07L153))
