### PR TITLE
docs: registerFilter 的方法名不要加 -  Closes #5958

### DIFF
--- a/docs/zh-CN/concepts/data-mapping.md
+++ b/docs/zh-CN/concepts/data-mapping.md
@@ -1833,6 +1833,8 @@ ${xxx|filter1|filter2|...}
 
 amis npm 包里面暴露了 `registerFilter` 方法，通过它可以添加自己的过滤器逻辑。
 
+> 注意方法名不要出现 - 号，比如 a-b，要改成 a_b
+
 如：
 
 ```ts
@@ -1850,12 +1852,12 @@ registerFilter('count', (input: string) =>
 ```ts
 import {registerFilter} from 'amis';
 
-registerFilter('my-replace', (input: string, search: string, repalceWith) =>
+registerFilter('my_replace', (input: string, search: string, repalceWith) =>
   typeof input === 'string' ? input.replace(search, repalceWith) : input
 );
 ```
 
-用法为 `${xxxx|my-replace:aaaa:bbbb}`
+用法为 `${xxxx|my_replace:aaaa:bbbb}`
 
 ### 在 JS SDK 中自定义过滤器
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3df8f17</samp>

This pull request improves the documentation on custom filters in data mapping, and corrects a code example. It replaces hyphens with underscores in the filter names to avoid syntax errors.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3df8f17</samp>

> _If you want to map data with flair_
> _You should read the docs on custom filters_
> _But beware of the hyphens_
> _They might cause syntax problems_
> _So use underscores like `my_replace` instead_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3df8f17</samp>

* Add a note to warn users not to use hyphens in custom filter names and use underscores instead ([link](https://github.com/baidu/amis/pull/6883/files?diff=unified&w=0#diff-31f3393ef39668e7792376fcf2248a798978de77fb3aecb54cc09c35bfc7d37dR1836-R1837))
* Update the example code and usage of the custom filter `my-replace` to use underscores instead of hyphens ([link](https://github.com/baidu/amis/pull/6883/files?diff=unified&w=0#diff-31f3393ef39668e7792376fcf2248a798978de77fb3aecb54cc09c35bfc7d37dL1853-R1860))
