### PR TITLE
fix: 修复 treeSelect 选项回显异常问题 Close: #6873

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jest": "^29.0.3",
     "jest-environment-jsdom": "^29.0.3",
     "js-yaml": "^4.1.0",
-    "lerna": "^5.5.2",
+    "lerna": "^6.6.2",
     "magic-string": "^0.26.7",
     "marked": "^4.2.1",
     "monaco-editor": "0.30.1",

--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -449,7 +449,7 @@ export class TreeSelector extends React.Component<
       return;
     }
 
-    if (onlyLeaf && (Array.isArray(node.children) && node.children.length)) {
+    if (onlyLeaf && Array.isArray(node.children) && node.children.length) {
       return;
     }
 
@@ -878,8 +878,10 @@ export class TreeSelector extends React.Component<
         } else if (this.isUnfolded(parent)) {
           this.relations.set(item, parent);
           // 父节点是展开的状态
-          item.level = level;
-          flattenedOptions.push(item);
+          flattenedOptions.push({
+            ...item,
+            level
+          });
         }
       }
     );
@@ -1096,7 +1098,7 @@ export class TreeSelector extends React.Component<
     const iconValue =
       item[iconField] ||
       (enableDefaultIcon !== false
-        ? (Array.isArray(item.children) && item.children.length)
+        ? Array.isArray(item.children) && item.children.length
           ? 'folder'
           : 'file'
         : false);
@@ -1159,7 +1161,9 @@ export class TreeSelector extends React.Component<
               <i
                 className={cx(
                   `Tree-itemIcon ${
-                    (Array.isArray(item.children) && item.children.length) ? 'Tree-folderIcon' : 'Tree-leafIcon'
+                    Array.isArray(item.children) && item.children.length
+                      ? 'Tree-folderIcon'
+                      : 'Tree-leafIcon'
                   }`
                 )}
                 onClick={() =>

--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -210,6 +210,7 @@ export class TreeSelector extends React.Component<
   unfolded: WeakMap<Object, boolean> = new WeakMap();
   // key: child option, value: parent option;
   relations: WeakMap<Option, Option> = new WeakMap();
+  levels: WeakMap<Option, number> = new WeakMap();
 
   dragNode: Option | null;
   dropInfo: IDropInfo | null;
@@ -285,6 +286,11 @@ export class TreeSelector extends React.Component<
         )
       });
     }
+  }
+
+  componentWillUnmount(): void {
+    // clear data
+    this.relations = this.unfolded = this.levels = new WeakMap() as any;
   }
 
   /**
@@ -877,11 +883,9 @@ export class TreeSelector extends React.Component<
           flattenedOptions.push(item);
         } else if (this.isUnfolded(parent)) {
           this.relations.set(item, parent);
+          this.levels.set(item, level);
           // 父节点是展开的状态
-          flattenedOptions.push({
-            ...item,
-            level
-          });
+          flattenedOptions.push(item);
         }
       }
     );
@@ -1102,7 +1106,7 @@ export class TreeSelector extends React.Component<
           ? 'folder'
           : 'file'
         : false);
-    const level = item.level ? item.level - 1 : 0;
+    const level = this.levels.has(item) ? this.levels.get(item)! - 1 : 0;
 
     let body = null;
 

--- a/packages/amis/src/renderers/Form/TreeSelect.tsx
+++ b/packages/amis/src/renderers/Form/TreeSelect.tsx
@@ -430,8 +430,7 @@ export default class TreeSelectControl extends React.Component<
           !find(combinedOptions, (item: Option) => item.value == option.value)
         ) {
           combinedOptions.push({
-            ...option,
-            visible: false
+            ...option
           });
         }
       });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e0ae48</samp>

Fix tree select bug with `hideRoot` option. Remove `visible` property from option object in `TreeSelect.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0e0ae48</samp>

> _`visible` gone_
> _bug in tree select fixed_
> _autumn leaves fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0e0ae48</samp>

* Fix a bug that causes the tree select component to not display the selected options when the `hideRoot` option is enabled ([link](https://github.com/baidu/amis/pull/6885/files?diff=unified&w=0#diff-9e1b32863ebd5d805fac50e10de5eb0f6e2cd1c3385b3674813bf1994426ae95L433-R433))
