### PR TITLE
chore: 修改组件导入方式

### DIFF
--- a/packages/amis-ui/src/components/AssociatedSelection.tsx
+++ b/packages/amis-ui/src/components/AssociatedSelection.tsx
@@ -12,7 +12,6 @@ import {themeable} from 'amis-core';
 import {uncontrollable} from 'amis-core';
 import GroupedSelection from './GroupedSelection';
 import TableSelection from './TableSelection';
-import GroupedSelecton from './GroupedSelection';
 import ChainedSelection from './ChainedSelection';
 import {Icon} from './icons';
 import {localeable} from 'amis-core';
@@ -154,7 +153,7 @@ export class AssociatedSelection extends BaseSelection<
               loadingConfig={loadingConfig}
             />
           ) : (
-            <GroupedSelecton
+            <GroupedSelection
               option2value={this.leftOption2Value}
               options={leftOptions}
               value={this.state.leftValue}

--- a/packages/amis-ui/src/components/UserSelect.tsx
+++ b/packages/amis-ui/src/components/UserSelect.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import {eachTree, Payload, themeable, ThemeProps} from 'amis-core';
 import {LocaleProps, localeable} from 'amis-core';
-import {ResultBox} from '.';
+import ResultBox from './ResultBox';
 import type {Option} from 'amis-core';
 import Sortable from 'sortablejs';
 import PopUp from './PopUp';

--- a/packages/amis-ui/src/components/UserTabSelect.tsx
+++ b/packages/amis-ui/src/components/UserTabSelect.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import {themeable, ThemeProps} from 'amis-core';
 import {LocaleProps, localeable} from 'amis-core';
-import {ResultBox} from '.';
+import ResultBox from './ResultBox';
 import UserSelect from './UserSelect';
 import type {Option} from 'amis-core';
 import Sortable from 'sortablejs';

--- a/packages/amis-ui/src/components/index.tsx
+++ b/packages/amis-ui/src/components/index.tsx
@@ -18,7 +18,6 @@ import Avatar from './Avatar';
 import Button from './Button';
 import Breadcrumb from './Breadcrumb';
 import Checkbox from './Checkbox';
-import Checkboxes from './Selection';
 import Collapse from './Collapse';
 import CollapseGroup from './CollapseGroup';
 import DatePicker from './DatePicker';
@@ -142,7 +141,7 @@ export {
   Button,
   Breadcrumb,
   Checkbox,
-  Checkboxes,
+  Selection as Checkboxes,
   Collapse,
   CollapseGroup,
   DatePicker,


### PR DESCRIPTION
这个PR对功能没有任何影响

我们在使用`amis`来搭建自己的低代码平台，最近在`amis`代码基础上二次开发一个组件分包的功能。使用`vite`的库模式来将组件分开打包以便可以按需引用来减少包的体积。在开发过程中这些"不太合群"的导入方式对我造成了一些困扰，当然可以在插件中特殊处理咯，但是修改这些"不太合群"的导入方式会更简单些，并且同一个组件被引入多次或者出现循环引入也会降低可维护性