### PR TITLE
fix:编辑器插件多余上下文

### DIFF
--- a/packages/amis-editor/src/plugin/CRUD.tsx
+++ b/packages/amis-editor/src/plugin/CRUD.tsx
@@ -1847,18 +1847,15 @@ export class CRUDPlugin extends BasePlugin {
       const jsonschema: any = {
         $id: 'crudFetchInitedData',
         type: 'object',
-        ...jsonToJsonSchema(
-          omit(data, 'selectedItems', 'unSelectedItems'),
-          (type: string, key: string) => {
-            if (type === 'array' && key === 'items') {
-              return '数据列表';
-            }
-            if (type === 'number' && key === 'count') {
-              return '总行数';
-            }
-            return key;
+        ...jsonToJsonSchema(data.responseData, (type: string, key: string) => {
+          if (type === 'array' && key === 'items') {
+            return '数据列表';
           }
-        )
+          if (type === 'number' && key === 'count') {
+            return '总行数';
+          }
+          return key;
+        })
       };
 
       scope?.removeSchema(jsonschema.$id);

--- a/packages/amis-editor/src/plugin/Form/Form.tsx
+++ b/packages/amis-editor/src/plugin/Form/Form.tsx
@@ -942,7 +942,7 @@ export class FormPlugin extends BasePlugin {
       const scope = this.manager.dataSchema.getScope(`${node.id}-${node.type}`);
       const jsonschema: any = {
         $id: 'formInitedData',
-        ...jsonToJsonSchema(data)
+        ...jsonToJsonSchema(data.responseData)
       };
 
       scope?.removeSchema(jsonschema.$id);

--- a/packages/amis-editor/src/plugin/Page.tsx
+++ b/packages/amis-editor/src/plugin/Page.tsx
@@ -370,7 +370,7 @@ export class PagePlugin extends BasePlugin {
       const scope = this.manager.dataSchema.getScope(`${node.id}-${node.type}`);
       const jsonschema: any = {
         $id: 'pageInitedData',
-        ...jsonToJsonSchema(data)
+        ...jsonToJsonSchema(data.responseData)
       };
 
       scope?.removeSchema(jsonschema.$id);

--- a/packages/amis-editor/src/plugin/Service.tsx
+++ b/packages/amis-editor/src/plugin/Service.tsx
@@ -282,7 +282,7 @@ export class ServicePlugin extends BasePlugin {
       const scope = this.manager.dataSchema.getScope(`${node.id}-${node.type}`);
       const jsonschema: any = {
         $id: 'serviceFetchInitedData',
-        ...jsonToJsonSchema(data)
+        ...jsonToJsonSchema(data.responseData)
       };
 
       scope?.removeSchema(jsonschema.$id);

--- a/packages/amis-editor/src/plugin/Wizard.tsx
+++ b/packages/amis-editor/src/plugin/Wizard.tsx
@@ -953,7 +953,7 @@ export class WizardPlugin extends BasePlugin {
       const scope = this.manager.dataSchema.getScope(`${node.id}-${node.type}`);
       const jsonschema: any = {
         $id: 'wizardInitedData',
-        ...jsonToJsonSchema(data)
+        ...jsonToJsonSchema(data.responseData)
       };
 
       scope?.removeSchema(jsonschema.$id);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77d4a0e</samp>

Refactor the schemas of various components in the amis-editor plugin to use the `responseData` property of the data object instead of the whole data object. This is to support custom response data paths for different APIs in the CRUD component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 77d4a0e</samp>

> _`responseData` wraps_
> _data objects from APIs_
> _refactor for spring_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 77d4a0e</samp>

*  Refactor CRUD, Form, Page, Service, and Wizard components to support custom response data paths for different APIs ([link](https://github.com/baidu/amis/pull/6891/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aL1850-R1858), [link](https://github.com/baidu/amis/pull/6891/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL945-R945), [link](https://github.com/baidu/amis/pull/6891/files?diff=unified&w=0#diff-4e3988acdee43b9a8f0c6fa2a99f1a94dc43fae57be0bffca0890574a1af5552L373-R373), [link](https://github.com/baidu/amis/pull/6891/files?diff=unified&w=0#diff-6a2f7c2cc26a108293bdd2d7ca6ca8d6b06acbf8e2d17424a50526d6affa6f67L285-R285), [link](https://github.com/baidu/amis/pull/6891/files?diff=unified&w=0#diff-711496a1563b112dc48228bcf44874b2484ddca346aa9da9d2d358e3c6458ac9L956-R956))
