### PR TITLE
fix: 修复 inputTable ui 组件删除中间数据后修改后面的行导致数据混乱的问题

### DIFF
--- a/packages/amis-ui/src/components/Combo.tsx
+++ b/packages/amis-ui/src/components/Combo.tsx
@@ -326,7 +326,13 @@ export function ComboItem({
   classnames: cx,
   formRef
 }: ComboItemProps) {
-  const methods = useSubForm(value, translate, data => update(index, data));
+  const indexRef = React.useRef(index);
+  React.useEffect(() => {
+    indexRef.current = index;
+  }, [index]);
+  const methods = useSubForm(value, translate, (data: any) =>
+    update(indexRef.current!, data)
+  );
   React.useEffect(() => {
     formRef?.(methods, index);
     return () => {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 96b9395</samp>

This pull request enhances the `InputTable` and `Combo` components that use the `useFieldArray` hook to manage dynamic arrays of subforms. It fixes the index mismatch issue when updating the items asynchronously, and uses the item id as the key for better stability and compatibility. It affects the files `InputTable.tsx` and `Combo.tsx` in the `amis-ui` package.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 96b9395</samp>

> _To manage a dynamic array_
> _We use `useFieldArray` hook_
> _But the index may change_
> _And cause some strange_
> _Behavior when we try to update a `ComboItem` or `InputTable` book_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 96b9395</samp>

*  Add `indexRef` variable to `ComboItem` and `InputTableRow` components to avoid index mismatch issue when updating items asynchronously ([link](https://github.com/baidu/amis/pull/6892/files?diff=unified&w=0#diff-36f970680bec71e24902089b8d0de6bad7530541f5b387a0b69dbb612f9f0dc4L329-R336), [link](https://github.com/baidu/amis/pull/6892/files?diff=unified&w=0#diff-1f9793007ec2226c2395e166c3eb6a5deeffdebb1c22da36d0b2572b616b509dL278-R292))
*  Use item id instead of index as key to store and access subform methods in `InputTable` component and pass it to `formRef` prop ([link](https://github.com/baidu/amis/pull/6892/files?diff=unified&w=0#diff-1f9793007ec2226c2395e166c3eb6a5deeffdebb1c22da36d0b2572b616b509dL80-R84), [link](https://github.com/baidu/amis/pull/6892/files?diff=unified&w=0#diff-1f9793007ec2226c2395e166c3eb6a5deeffdebb1c22da36d0b2572b616b509dL266-R267))
*  Use `setValue` function from `useFormContext` hook to update item value in `lightUpdate` function in `InputTable` component, instead of using internal methods of `useFieldArray` hook ([link](https://github.com/baidu/amis/pull/6892/files?diff=unified&w=0#diff-1f9793007ec2226c2395e166c3eb6a5deeffdebb1c22da36d0b2572b616b509dL146-R146), [link](https://github.com/baidu/amis/pull/6892/files?diff=unified&w=0#diff-1f9793007ec2226c2395e166c3eb6a5deeffdebb1c22da36d0b2572b616b509dL152-R157))
