### PR TITLE
feat: select下拉框开启本地搜索时支持自定义检索函数

### DIFF
--- a/docs/zh-CN/components/form/select.md
+++ b/docs/zh-CN/components/form/select.md
@@ -585,6 +585,64 @@ _多选_
 }
 ```
 
+### 自定义搜索函数
+
+默认通过[match-sorter](https://github.com/kentcdodds/match-sorter)搜索过滤 value,label 中的值
+
+可通过`filterOption`自定义搜索过滤函数
+
+```schema: scope="body"
+{
+  "type": "form",
+  "api": "/api/mock2/form/saveForm",
+  "body": [
+    {
+      "label": "带搜索",
+      "type": "select",
+      "name": "a",
+      "selectMode": "chained",
+      "searchable": true,
+      "filterOption": "return options.filter(({value, label, weapon}) => value?.includes(inputValue) || label?.includes(inputValue) || weapon?.includes(inputValue));",
+      "sortable": true,
+      "multiple": true,
+      "options": [
+        {
+          "label": "诸葛亮",
+          "value": "zhugeliang",
+          "weapon": "翡翠仙扇"
+        },
+        {
+          "label": "曹操",
+          "value": "caocao",
+          "weapon": "幻影双刃"
+        },
+        {
+          "label": "钟无艳",
+          "value": "zhongwuyan",
+          "weapon": "破岳震天锤"
+        },
+
+        {
+          "label": "李白",
+          "value": "libai",
+          "weapon": "青丝缠月剑"
+        },
+        {
+          "label": "韩信",
+          "value": "hanxin",
+          "weapon": "龙吟穿云枪"
+        },
+        {
+          "label": "云中君",
+          "value": "yunzhongjun",
+          "weapon": "飘渺云影剑"
+        }
+      ]
+    }
+  ]
+}
+```
+
 ### 延时加载
 
 选型设置 defer: true，结合配置组件层的 `deferApi` 来实现。
@@ -1140,6 +1198,7 @@ leftOptions 动态加载，默认 source 接口是返回 options 部分，而 le
 | creatable                | `boolean`                                                                         | `false`                                                                            | [新增选项](./options#%E5%89%8D%E7%AB%AF%E6%96%B0%E5%A2%9E-creatable)                                                                                                                                         |
 | multiple                 | `boolean`                                                                         | `false`                                                                            | [多选](./options#多选-multiple)                                                                                                                                                                              |
 | searchable               | `boolean`                                                                         | `false`                                                                            | [检索](./options#检索-searchable)                                                                                                                                                                            |
+| filterOption             | `string`                                                                          | `(options: Option[], inputValue: string, option: {keys: string[]}) => Option[]`    |                                                                                                                                                                                                              |
 | createBtnLabel           | `string`                                                                          | `"新增选项"`                                                                       | [新增选项](./options#%E6%96%B0%E5%A2%9E%E9%80%89%E9%A1%B9)                                                                                                                                                   |
 | addControls              | Array<[表单项](./formitem)>                                                       |                                                                                    | [自定义新增表单项](./options#%E8%87%AA%E5%AE%9A%E4%B9%89%E6%96%B0%E5%A2%9E%E8%A1%A8%E5%8D%95%E9%A1%B9-addcontrols)                                                                                           |
 | addApi                   | [API](../../docs/types/api)                                                       |                                                                                    | [配置新增选项接口](./options#%E9%85%8D%E7%BD%AE%E6%96%B0%E5%A2%9E%E6%8E%A5%E5%8F%A3-addapi)                                                                                                                  |

--- a/packages/amis-ui/src/components/Select.tsx
+++ b/packages/amis-ui/src/components/Select.tsx
@@ -16,7 +16,6 @@ import {PopOver} from 'amis-core';
 import TooltipWrapper from './TooltipWrapper';
 import Downshift, {ControllerStateAndHelpers} from 'downshift';
 import {closeIcon, Icon} from './icons';
-// @ts-ignore
 import {matchSorter} from 'match-sorter';
 import {
   noop,
@@ -46,6 +45,15 @@ import BasePopover, {PopOverOverlay} from './PopOverContainer';
 import type {TooltipObject} from '../components/TooltipWrapper';
 
 export {Option, Options};
+
+export const defaultFilterOption = (
+  options: Option[],
+  inputValue: string,
+  option: {keys: string[]},
+  matchFn = matchSorter
+): Option[] => matchFn(options, inputValue, option);
+
+export type FilterOption = typeof defaultFilterOption;
 
 export interface OptionProps {
   className?: string;
@@ -375,6 +383,11 @@ interface SelectProps
    * 收纳标签的Popover配置
    */
   overflowTagPopover?: TooltipObject;
+
+  /**
+   * 检索函数
+   */
+  filterOption?: FilterOption;
 }
 
 interface SelectState {
@@ -573,15 +586,22 @@ export class Select extends React.Component<SelectProps, SelectState> {
       simpleValue,
       checkAllBySearch,
       labelField,
-      valueField
+      valueField,
+      filterOption = defaultFilterOption
     } = this.props;
+
     const inputValue = this.state.inputValue;
     let {selection} = this.state;
     let filtedOptions: Array<Option> =
       inputValue && checkAllBySearch !== false
-        ? matchSorter(options, inputValue, {
-            keys: [labelField || 'label', valueField || 'value']
-          })
+        ? filterOption(
+            options,
+            inputValue,
+            {
+              keys: [labelField || 'label', valueField || 'value']
+            },
+            matchSorter
+          )
         : options.concat();
     const optionsValues = filtedOptions.map(option => option.value);
     const selectionValues = selection.map(select => select.value);
@@ -973,6 +993,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
       mobileClassName,
       virtualThreshold = 100,
       useMobileUI = false,
+      filterOption = defaultFilterOption,
       overlay
     } = this.props;
     const {selection} = this.state;
@@ -981,9 +1002,14 @@ export class Select extends React.Component<SelectProps, SelectState> {
     let checkedPartial = false;
     let filtedOptions: Array<Option> = (
       inputValue && isOpen && !loadOptions
-        ? matchSorter(options, inputValue, {
-            keys: [labelField || 'label', valueField || 'value']
-          })
+        ? filterOption(
+            options,
+            inputValue,
+            {
+              keys: [labelField || 'label', valueField || 'value']
+            },
+            matchSorter
+          )
         : options.concat()
     ).filter((option: Option) => !option.hidden && option.visible !== false);
     const enableVirtualRender =

--- a/packages/amis-ui/src/components/Select.tsx
+++ b/packages/amis-ui/src/components/Select.tsx
@@ -49,9 +49,8 @@ export {Option, Options};
 export const defaultFilterOption = (
   options: Option[],
   inputValue: string,
-  option: {keys: string[]},
-  matchFn = matchSorter
-): Option[] => matchFn(options, inputValue, option);
+  option: {keys: string[]}
+): Option[] => matchSorter(options, inputValue, option);
 
 export type FilterOption = typeof defaultFilterOption;
 
@@ -594,14 +593,9 @@ export class Select extends React.Component<SelectProps, SelectState> {
     let {selection} = this.state;
     let filtedOptions: Array<Option> =
       inputValue && checkAllBySearch !== false
-        ? filterOption(
-            options,
-            inputValue,
-            {
-              keys: [labelField || 'label', valueField || 'value']
-            },
-            matchSorter
-          )
+        ? filterOption(options, inputValue, {
+            keys: [labelField || 'label', valueField || 'value']
+          })
         : options.concat();
     const optionsValues = filtedOptions.map(option => option.value);
     const selectionValues = selection.map(select => select.value);
@@ -1002,14 +996,9 @@ export class Select extends React.Component<SelectProps, SelectState> {
     let checkedPartial = false;
     let filtedOptions: Array<Option> = (
       inputValue && isOpen && !loadOptions
-        ? filterOption(
-            options,
-            inputValue,
-            {
-              keys: [labelField || 'label', valueField || 'value']
-            },
-            matchSorter
-          )
+        ? filterOption(options, inputValue, {
+            keys: [labelField || 'label', valueField || 'value']
+          })
         : options.concat()
     ).filter((option: Option) => !option.hidden && option.visible !== false);
     const enableVirtualRender =

--- a/packages/amis/__tests__/renderers/Form/select.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/select.test.tsx
@@ -900,3 +900,42 @@ test('should call the user filterOption if it is provided', async () => {
     keys: ['label', 'value']
   });
 });
+
+test('should call the string style user filterOption if it is provided', async () => {
+  const options = [
+    {
+      label: 'label1',
+      value: 'value1',
+      comment: 'comment1'
+    },
+    {
+      label: 'label2',
+      value: 'value2',
+      comment: 'comment2'
+    }
+  ];
+
+  const {debug} = render(
+    amisRender(
+      {
+        type: 'select',
+        name: 'select',
+        searchable: true,
+        filterOption: "return [{label: 'label3', value: 'value3'}]",
+        options
+      },
+      {},
+      makeEnv()
+    )
+  );
+
+  const select = screen.getByText('请选择');
+  fireEvent.click(select);
+  fireEvent.change(screen.getByPlaceholderText('搜索'), {
+    target: {value: 'comment'}
+  });
+
+  await waitFor(() => {
+    expect(screen.getByText('label3')).toBeInTheDocument();
+  });
+});

--- a/packages/amis/__tests__/renderers/Form/select.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/select.test.tsx
@@ -859,3 +859,44 @@ test('Renderer:select value contains delimiter when single', async () => {
       .innerHTML
   ).toEqual('ALabel');
 });
+
+test('should call the user filterOption if it is provided', async () => {
+  const filterOption = jest.fn().mockImplementation(options => options);
+  const options = [
+    {
+      label: 'label1',
+      value: 'value1',
+      comment: 'comment1'
+    },
+    {
+      label: 'label2',
+      value: 'value2',
+      comment: 'comment2'
+    }
+  ];
+
+  const {debug} = render(
+    amisRender(
+      {
+        type: 'select',
+        name: 'select',
+        searchable: true,
+        filterOption,
+        options
+      },
+      {},
+      makeEnv()
+    )
+  );
+
+  const select = screen.getByText('请选择');
+  fireEvent.click(select);
+  fireEvent.change(screen.getByPlaceholderText('搜索'), {
+    target: {value: 'comment'}
+  });
+
+  expect(filterOption).toBeCalled();
+  expect(filterOption).toBeCalledWith(options, 'comment', {
+    keys: ['label', 'value']
+  });
+});

--- a/packages/amis/__tests__/renderers/Form/transfer.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/transfer.test.tsx
@@ -649,7 +649,7 @@ test('Renderer:transfer follow left mode', async () => {
   expect(container).toMatchSnapshot();
 });
 
-test.only('should call custom filterOption if it is provided', async () => {
+test('should call the custom filterOption if it is provided', async () => {
   const filterOption = jest.fn().mockImplementation(options => options);
   const options = [
     {
@@ -664,7 +664,7 @@ test.only('should call custom filterOption if it is provided', async () => {
     }
   ];
 
-  const {container, findByText, debug} = render(
+  render(
     amisRender(
       {
         label: '树型展示',
@@ -686,13 +686,101 @@ test.only('should call custom filterOption if it is provided', async () => {
     target: {value: '翡翠仙扇'}
   });
 
-  // 300 毫秒才行
   await wait(300);
 
   expect(filterOption).toBeCalledTimes(1);
   expect(filterOption).toBeCalledWith(options, '翡翠仙扇', {
     keys: ['label', 'value']
   });
+});
+
+test('should call the string style custom filterOption if it is provided', async () => {
+  const options = [
+    {
+      label: '法师',
+      children: [
+        {
+          label: '诸葛亮',
+          value: 'zhugeliang',
+          weapon: '翡翠仙扇'
+        }
+      ]
+    }
+  ];
+
+  render(
+    amisRender(
+      {
+        label: '树型展示',
+        type: 'transfer',
+        name: 'transfer4',
+        selectMode: 'tree',
+        searchable: true,
+        filterOption: 'return [];',
+        options
+      },
+      {},
+      makeEnv({})
+    )
+  );
+
+  const input = screen.getByPlaceholderText('请输入关键字');
+
+  expect(screen.getByText('诸葛亮')).toBeInTheDocument();
+  fireEvent.change(input, {
+    target: {value: '翡翠仙扇'}
+  });
+
+  await wait(300);
+
+  expect(screen.queryByText('诸葛亮')).not.toBeInTheDocument();
+});
+
+test('should call the notify function with error message if the filterOption is not a valid function', async () => {
+  const options = [
+    {
+      label: '法师',
+      children: [
+        {
+          label: '诸葛亮',
+          value: 'zhugeliang',
+          weapon: '翡翠仙扇'
+        }
+      ]
+    }
+  ];
+
+  const mockNotify = jest.fn().mockImplementation(options => options);
+
+  render(
+    amisRender(
+      {
+        label: '树型展示',
+        type: 'transfer',
+        name: 'transfer4',
+        selectMode: 'tree',
+        searchable: true,
+        filterOption: 10086,
+        options
+      },
+      {},
+      {notify: mockNotify}
+    )
+  );
+
+  const input = screen.getByPlaceholderText('请输入关键字');
+
+  expect(screen.getByText('诸葛亮')).toBeInTheDocument();
+  fireEvent.change(input, {
+    target: {value: '翡翠仙扇'}
+  });
+
+  await wait(300);
+
+  expect(mockNotify).toBeCalledTimes(1);
+  expect(mockNotify).toBeCalledWith('error', '自定义检索函数不符合要求');
+
+  mockNotify.mockClear();
 });
 
 test('Renderer:transfer group mode with virtual', async () => {

--- a/packages/amis/__tests__/renderers/Form/transfer.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/transfer.test.tsx
@@ -15,7 +15,7 @@
  * 12. 关联模式虚拟滚动
  */
 
-import {fireEvent, render, waitFor} from '@testing-library/react';
+import {fireEvent, render, waitFor, screen} from '@testing-library/react';
 import '../../../src';
 import {render as amisRender} from '../../../src';
 import {makeEnv, formatStyleObject, wait} from '../../helper';
@@ -647,6 +647,52 @@ test('Renderer:transfer follow left mode', async () => {
   expect(dom).not.toBeNull();
   expect(dom?.getAttribute('title')).toEqual('战士');
   expect(container).toMatchSnapshot();
+});
+
+test.only('should call custom filterOption if it is provided', async () => {
+  const filterOption = jest.fn().mockImplementation(options => options);
+  const options = [
+    {
+      label: '法师',
+      children: [
+        {
+          label: '诸葛亮',
+          value: 'zhugeliang',
+          weapon: '翡翠仙扇'
+        }
+      ]
+    }
+  ];
+
+  const {container, findByText, debug} = render(
+    amisRender(
+      {
+        label: '树型展示',
+        type: 'transfer',
+        name: 'transfer4',
+        selectMode: 'tree',
+        searchable: true,
+        filterOption: filterOption,
+        options
+      },
+      {},
+      makeEnv({})
+    )
+  );
+
+  const input = screen.getByPlaceholderText('请输入关键字');
+
+  fireEvent.change(input, {
+    target: {value: '翡翠仙扇'}
+  });
+
+  // 300 毫秒才行
+  await wait(300);
+
+  expect(filterOption).toBeCalledTimes(1);
+  expect(filterOption).toBeCalledWith(options, '翡翠仙扇', {
+    keys: ['label', 'value']
+  });
 });
 
 test('Renderer:transfer group mode with virtual', async () => {

--- a/packages/amis/src/renderers/Form/Select.tsx
+++ b/packages/amis/src/renderers/Form/Select.tsx
@@ -24,7 +24,6 @@ import type {SchemaClassName} from '../../Schema';
 import type {TooltipObject} from 'amis-ui/lib/components/TooltipWrapper';
 import type {PopOverOverlay} from 'amis-ui/lib/components/PopOverContainer';
 import {supportStatic} from './StaticHoc';
-import type {FilterOption} from 'amis-ui/src/components/Select';
 
 /**
  * Select 下拉选择框。
@@ -152,7 +151,10 @@ export interface SelectControlSchema
      */
     align?: 'left' | 'center' | 'right';
 
-    filterOption?: 'string' | FilterOption;
+    /**
+     * 检索函数
+     */
+    filterOption?: 'string';
   };
 }
 
@@ -499,13 +501,7 @@ export default class SelectControl extends React.Component<SelectProps, any> {
             options={options}
             filterOption={
               typeof filterOption === 'string'
-                ? str2function(
-                    filterOption,
-                    'options',
-                    'inputValue',
-                    'option',
-                    'matchFn'
-                  )
+                ? str2function(filterOption, 'options', 'inputValue', 'option')
                 : filterOption
             }
             loadOptions={

--- a/packages/amis/src/renderers/Form/Select.tsx
+++ b/packages/amis/src/renderers/Form/Select.tsx
@@ -5,7 +5,8 @@ import {
   OptionsControlProps,
   Option,
   FormOptionsControl,
-  resolveEventData
+  resolveEventData,
+  str2function
 } from 'amis-core';
 import {normalizeOptions} from 'amis-core';
 import find from 'lodash/find';
@@ -23,6 +24,7 @@ import type {SchemaClassName} from '../../Schema';
 import type {TooltipObject} from 'amis-ui/lib/components/TooltipWrapper';
 import type {PopOverOverlay} from 'amis-ui/lib/components/PopOverContainer';
 import {supportStatic} from './StaticHoc';
+import type {FilterOption} from 'amis-ui/src/components/Select';
 
 /**
  * Select 下拉选择框。
@@ -149,6 +151,8 @@ export interface SelectControlSchema
      * 下拉框 Popover 的对齐方式
      */
     align?: 'left' | 'center' | 'right';
+
+    filterOption?: 'string' | FilterOption;
   };
 }
 
@@ -460,6 +464,7 @@ export default class SelectControl extends React.Component<SelectProps, any> {
       env,
       useMobileUI,
       overlay,
+      filterOption,
       ...rest
     } = this.props;
 
@@ -492,6 +497,17 @@ export default class SelectControl extends React.Component<SelectProps, any> {
             ref={this.inputRef}
             value={selectedOptions}
             options={options}
+            filterOption={
+              typeof filterOption === 'string'
+                ? str2function(
+                    filterOption,
+                    'options',
+                    'inputValue',
+                    'option',
+                    'matchFn'
+                  )
+                : filterOption
+            }
             loadOptions={
               isEffectiveApi(autoComplete) ? this.lazyloadRemote : undefined
             }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fe47230</samp>

This pull request adds a new feature to the Select component and renderer of amis, which allows the user to provide a custom function for filtering the options based on the search input and the checkAllBySearch flag. It also fixes a minor linting issue and exports some utility functions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fe47230</samp>

> _Select component_
> _Custom `filterOption` now_
> _Autumn of choices_

### Why

<!-- author to complete -->
select下拉框,开启本地搜索时支持自定义检索函数

需要自定义slect下拉框的过滤函数,比如通过拼音首字母进行过滤.

但官方硬编码了过滤函数,导致无法进行扩展.

将内置的过滤函数做为默认函数,同时暴露`filterOption`接口以供用户自定义过滤函数.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fe47230</samp>

*  Remove unnecessary TypeScript ignore comment ([link](https://github.com/baidu/amis/pull/6897/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL19))
*  Add and export FilterOption type and defaultFilterOption function for Select component ([link](https://github.com/baidu/amis/pull/6897/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecR49-R57))
*  Add filterOption prop to Select component and use it for checkAllBySearch and normal search features ([link](https://github.com/baidu/amis/pull/6897/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecR386-R390), [link](https://github.com/baidu/amis/pull/6897/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL576-R604), [link](https://github.com/baidu/amis/pull/6897/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL984-R1012))
*  Add filterOption property to Select renderer and pass it to Select component ([link](https://github.com/baidu/amis/pull/6897/files?diff=unified&w=0#diff-c7760ca9aa73a2f50ab38d37db37be041410cbe37e16009b875be388d452ca31R154-R155), [link](https://github.com/baidu/amis/pull/6897/files?diff=unified&w=0#diff-c7760ca9aa73a2f50ab38d37db37be041410cbe37e16009b875be388d452ca31R467), [link](https://github.com/baidu/amis/pull/6897/files?diff=unified&w=0#diff-c7760ca9aa73a2f50ab38d37db37be041410cbe37e16009b875be388d452ca31R500-R510))
*  Import str2function utility and FilterOption type in `Select.tsx` renderer ([link](https://github.com/baidu/amis/pull/6897/files?diff=unified&w=0#diff-c7760ca9aa73a2f50ab38d37db37be041410cbe37e16009b875be388d452ca31L8-R9), [link](https://github.com/baidu/amis/pull/6897/files?diff=unified&w=0#diff-c7760ca9aa73a2f50ab38d37db37be041410cbe37e16009b875be388d452ca31R27))
*  Pass filterOption prop to Select component in Checkboxes component ([link](https://github.com/baidu/amis/pull/6897/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecR996))
