### PR TITLE
chore: Nav 组件调用 isCurrentUrl 传递菜单信息

### DIFF
--- a/packages/amis/src/renderers/Nav.tsx
+++ b/packages/amis/src/renderers/Nav.tsx
@@ -888,7 +888,7 @@ const ConditionBuilderWithRemoteOptions = withRemoteConfig({
                     !!(
                       l.hasOwnProperty('to') &&
                       env &&
-                      env.isCurrentUrl(filter(l.to as string, data))
+                      env.isCurrentUrl(filter(l.to as string, data), link)
                     )
                 )
               : false) ||
@@ -899,7 +899,7 @@ const ConditionBuilderWithRemoteOptions = withRemoteConfig({
                     link.hasOwnProperty('to') &&
                     link.to !== null && // 也可能出现{to: null}的情况（独立应用）filter会把null处理成'' 那默认首页会选中很多菜单项 {to: ''}认为是有效配置
                     env &&
-                    env.isCurrentUrl(filter(link.to as string, data))
+                    env.isCurrentUrl(filter(link.to as string, data), link)
                   ));
       };
 
@@ -1338,7 +1338,7 @@ export class NavigationRenderer extends React.Component<RendererProps> {
         const {env, data} = this.props;
         const child = findTree(
           children,
-          item => env && env.isCurrentUrl(filter(item.to as string, data))
+          item => env && env.isCurrentUrl(filter(item.to as string, data), item)
         );
 
         env?.jumpTo(


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f104dd</samp>

This pull request enhances the `Nav` renderer to allow links to open in new windows. It updates the logic for finding and highlighting the active link or child based on the `jumpOut` property.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0f104dd</samp>

> _Oh, we're the coders of the `Nav` renderer_
> _And we like to make our links more clever_
> _We added a `jumpOut` property_
> _To open them in a new window, you see_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0f104dd</samp>

*  Add `link` argument to `env.isCurrentUrl` function call to check link's `jumpOut` property for active state ([link](https://github.com/baidu/amis/pull/6899/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL891-R891))
*  Add `link` argument to `findIndex` function call to find active index of `navs` array based on link's `jumpOut` property ([link](https://github.com/baidu/amis/pull/6899/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL902-R902))
*  Add `item` argument to `findTree` function call to find active child of link object based on child's `jumpOut` property ([link](https://github.com/baidu/amis/pull/6899/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL1341-R1341))
