### PR TITLE
fix: 修复transfer系列组件在自定义valueField的情况下统计信息和全选按钮失效以及自定义labelField不能正常显示的问题

### DIFF
--- a/packages/amis-ui/src/components/Selection.tsx
+++ b/packages/amis-ui/src/components/Selection.tsx
@@ -28,6 +28,7 @@ export interface BaseSelectionProps extends ThemeProps, LocaleProps {
   multiple?: boolean;
   clearable?: boolean;
   labelField?: string;
+  valueField?: string;
   onChange?: (value: Array<any> | any) => void;
   onDeferLoad?: (option: Option) => void;
   onLeftDeferLoad?: (option: Option, leftOptions: Option) => void;

--- a/packages/amis-ui/src/components/TabsTransfer.tsx
+++ b/packages/amis-ui/src/components/TabsTransfer.tsx
@@ -166,7 +166,9 @@ export class TabsTransfer extends React.Component<
       itemHeight,
       virtualThreshold,
       onlyChildren,
-      loadingConfig
+      loadingConfig,
+      valueField = 'value',
+      labelField = 'label'
     } = this.props;
     const options = searchResult || [];
     const mode = searchResultMode;
@@ -206,6 +208,8 @@ export class TabsTransfer extends React.Component<
                 })
             : undefined
         }
+        valueField={valueField}
+        labelField={labelField}
       />
     ) : mode === 'chained' ? (
       <ChainedCheckboxes
@@ -226,6 +230,8 @@ export class TabsTransfer extends React.Component<
         }
         itemHeight={itemHeight}
         virtualThreshold={virtualThreshold}
+        valueField={valueField}
+        labelField={labelField}
       />
     ) : (
       <ListCheckboxes
@@ -246,6 +252,8 @@ export class TabsTransfer extends React.Component<
         }
         itemHeight={itemHeight}
         virtualThreshold={virtualThreshold}
+        valueField={valueField}
+        labelField={labelField}
       />
     );
   }
@@ -332,7 +340,9 @@ export class TabsTransfer extends React.Component<
       itemHeight,
       virtualThreshold,
       onlyChildren,
-      loadingConfig
+      loadingConfig,
+      valueField = 'value',
+      labelField = 'label'
     } = this.props;
 
     return option.selectMode === 'table' ? (
@@ -349,6 +359,8 @@ export class TabsTransfer extends React.Component<
         cellRender={cellRender}
         itemHeight={itemHeight}
         virtualThreshold={virtualThreshold}
+        valueField={valueField}
+        labelField={labelField}
       />
     ) : option.selectMode === 'tree' ? (
       <Tree
@@ -376,6 +388,8 @@ export class TabsTransfer extends React.Component<
         }
         itemHeight={itemHeight}
         virtualThreshold={virtualThreshold}
+        valueField={valueField}
+        labelField={labelField}
       />
     ) : option.selectMode === 'chained' ? (
       <ChainedCheckboxes
@@ -399,6 +413,8 @@ export class TabsTransfer extends React.Component<
         }
         itemHeight={itemHeight}
         virtualThreshold={virtualThreshold}
+        valueField={valueField}
+        labelField={labelField}
       />
     ) : option.selectMode === 'associated' ? (
       <AssociatedCheckboxes
@@ -426,6 +442,8 @@ export class TabsTransfer extends React.Component<
         }
         itemHeight={itemHeight}
         virtualThreshold={virtualThreshold}
+        valueField={valueField}
+        labelField={labelField}
       />
     ) : (
       <ListCheckboxes
@@ -448,6 +466,8 @@ export class TabsTransfer extends React.Component<
         }
         itemHeight={itemHeight}
         virtualThreshold={virtualThreshold}
+        valueField={valueField}
+        labelField={labelField}
       />
     );
   }

--- a/packages/amis-ui/src/components/TabsTransferPicker.tsx
+++ b/packages/amis-ui/src/components/TabsTransferPicker.tsx
@@ -44,6 +44,7 @@ export class TransferPicker extends React.Component<TabsTransferPickerProps> {
       className,
       onChange,
       size,
+      labelField = 'label',
       ...rest
     } = this.props;
 
@@ -71,6 +72,7 @@ export class TransferPicker extends React.Component<TabsTransferPickerProps> {
                   onChange(value);
                 }
               }}
+              labelField={labelField}
             />
           );
         }}
@@ -91,6 +93,9 @@ export class TransferPicker extends React.Component<TabsTransferPickerProps> {
             onResultClick={onClick}
             placeholder={__('Select.placeholder')}
             disabled={disabled}
+            itemRender={option => (
+              <span>{(option && option[labelField]) || 'undefiend'}</span>
+            )}
           >
             <span className={cx('TransferPicker-icon')}>
               <Icon icon="pencil" className="icon" />

--- a/packages/amis-ui/src/components/Transfer.tsx
+++ b/packages/amis-ui/src/components/Transfer.tsx
@@ -479,6 +479,7 @@ export class Transfer<
       cellRender,
       multiple,
       labelField,
+      valueField = 'value',
       virtualThreshold,
       itemHeight,
       virtualListHeight,
@@ -503,6 +504,7 @@ export class Transfer<
         option2value={option2value}
         cellRender={cellRender}
         itemRender={optionItemRender}
+        valueField={valueField}
         multiple={multiple}
         virtualThreshold={virtualThreshold}
         itemHeight={itemHeight}
@@ -526,6 +528,7 @@ export class Transfer<
         onlyChildren={onlyChildren ?? !isTreeDeferLoad}
         itemRender={optionItemRender}
         labelField={labelField}
+        valueField={valueField}
         virtualThreshold={virtualThreshold}
         itemHeight={itemHeight}
         checkAllLabel={checkAllLabel}
@@ -543,6 +546,7 @@ export class Transfer<
         itemRender={optionItemRender}
         multiple={multiple}
         labelField={labelField}
+        valueField={valueField}
         virtualThreshold={virtualThreshold}
         itemHeight={itemHeight}
         virtualListHeight={virtualListHeight}
@@ -561,6 +565,7 @@ export class Transfer<
         itemRender={optionItemRender}
         multiple={multiple}
         labelField={labelField}
+        valueField={valueField}
         virtualThreshold={virtualThreshold}
         itemHeight={itemHeight}
         virtualListHeight={virtualListHeight}
@@ -590,6 +595,7 @@ export class Transfer<
       multiple,
       noResultsText,
       labelField,
+      valueField = 'value',
       virtualThreshold,
       itemHeight,
       virtualListHeight,
@@ -633,6 +639,7 @@ export class Transfer<
         multiple={multiple}
         cascade={true}
         labelField={labelField}
+        valueField={valueField}
         virtualThreshold={virtualThreshold}
         itemHeight={itemHeight}
         loadingConfig={loadingConfig}
@@ -651,6 +658,7 @@ export class Transfer<
         itemRender={optionItemRender}
         multiple={multiple}
         labelField={labelField}
+        valueField={valueField}
         virtualThreshold={virtualThreshold}
         itemHeight={itemHeight}
         virtualListHeight={virtualListHeight}
@@ -675,6 +683,7 @@ export class Transfer<
         itemRender={optionItemRender}
         multiple={multiple}
         labelField={labelField}
+        valueField={valueField}
         virtualThreshold={virtualThreshold}
         itemHeight={itemHeight}
         virtualListHeight={virtualListHeight}
@@ -694,6 +703,7 @@ export class Transfer<
         itemRender={optionItemRender}
         multiple={multiple}
         labelField={labelField}
+        valueField={valueField}
         virtualThreshold={virtualThreshold}
         itemHeight={itemHeight}
         virtualListHeight={virtualListHeight}

--- a/packages/amis-ui/src/components/Transfer.tsx
+++ b/packages/amis-ui/src/components/Transfer.tsx
@@ -135,13 +135,15 @@ export class Transfer<
     | 'statistics'
     | 'virtualThreshold'
     | 'checkAllLabel'
+    | 'valueField'
   > = {
     multiple: true,
     resultListModeFollowSelect: false,
     selectMode: 'list',
     statistics: true,
     virtualThreshold: 100,
-    checkAllLabel: 'Select.checkAll'
+    checkAllLabel: 'Select.checkAll',
+    valueField: 'value'
   };
 
   state: TransferState = {
@@ -230,11 +232,11 @@ export class Transfer<
 
   // 全选，给予动作全选使用
   selectAll() {
-    const {options, option2value, onChange} = this.props;
+    const {options, option2value, onChange, valueField = 'value'} = this.props;
     const availableOptions = flattenTree(options).filter(
       (option, index, list) =>
         !option.disabled &&
-        option.value !== void 0 &&
+        option[valueField] !== void 0 &&
         list.indexOf(option) === index
     );
     let newValue: string | Options = option2value
@@ -307,10 +309,11 @@ export class Transfer<
   );
 
   getFlattenArr(options: Array<Option>) {
+    const {valueField = 'value'} = this.props;
     return flattenTree(options).filter(
       (option, index, list) =>
         !option.disabled &&
-        option.value !== void 0 &&
+        option[valueField] !== void 0 &&
         list.indexOf(option) === index
     );
   }
@@ -318,29 +321,29 @@ export class Transfer<
   // 树搜索处理
   @autobind
   handleSearchTreeChange(values: Array<Option>, searchOptions: Array<Option>) {
-    const {onChange, value} = this.props;
+    const {onChange, value, valueField = 'value'} = this.props;
     const searchAvailableOptions = this.getFlattenArr(searchOptions);
 
     const useArr = intersectionWith(
       searchAvailableOptions,
       values,
-      (a, b) => a.value === b.value
+      (a, b) => a[valueField] === b[valueField]
     );
     const unuseArr = differenceWith(
       searchAvailableOptions,
       values,
-      (a, b) => a.value === b.value
+      (a, b) => a[valueField] === b[valueField]
     );
 
     const newArr: Array<Option> = [];
     Array.isArray(value) &&
       value.forEach((item: Option) => {
-        if (!unuseArr.find(v => v.value === item.value)) {
+        if (!unuseArr.find(v => v[valueField] === item[valueField])) {
           newArr.push(item);
         }
       });
     useArr.forEach(item => {
-      if (!newArr.find(v => v.value === item.value)) {
+      if (!newArr.find(v => v[valueField] === item[valueField])) {
         newArr.push(item);
       }
     });
@@ -804,8 +807,9 @@ export class Transfer<
       showArrow,
       resultListModeFollowSelect,
       selectMode = 'list',
-      translate: __
-    } = this.props;
+      translate: __,
+      valueField = 'value'
+    } = this.props as any;
     const {searchResult} = this.state;
 
     this.valueArray = BaseSelection.value2array(value, options, option2value);
@@ -813,7 +817,7 @@ export class Transfer<
     this.availableOptions = flattenTree(searchResult ?? options).filter(
       (option, index, list) =>
         !option.disabled &&
-        option.value !== void 0 &&
+        option[valueField] !== void 0 &&
         list.indexOf(option) === index
     );
 

--- a/packages/amis-ui/src/components/TransferPicker.tsx
+++ b/packages/amis-ui/src/components/TransferPicker.tsx
@@ -50,6 +50,7 @@ export class TransferPicker extends React.Component<TransferPickerProps> {
       onChange,
       size,
       borderMode,
+      labelField = 'label',
       ...rest
     } = this.props;
 
@@ -64,6 +65,7 @@ export class TransferPicker extends React.Component<TransferPickerProps> {
               {...rest}
               {...states}
               value={value}
+              labelField={labelField}
               onChange={(value: any, optionModified) => {
                 if (optionModified) {
                   let options = mapTree(rest.options, item => {
@@ -98,6 +100,9 @@ export class TransferPicker extends React.Component<TransferPickerProps> {
             placeholder={__('Select.placeholder')}
             disabled={disabled}
             borderMode={borderMode}
+            itemRender={option => (
+              <span>{(option && option[labelField]) || 'undefined'}</span>
+            )}
           >
             <span className={cx('TransferPicker-icon')}>
               <Icon icon="pencil" className="icon" />

--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -1204,6 +1204,7 @@ export class TreeSelector extends React.Component<
                     index,
                     multiple: multiple,
                     checked: checked,
+                    labelField: labelField,
                     onChange: () => this.handleCheck(item, !checked),
                     disabled: disabled || item.disabled
                   })

--- a/packages/amis/src/renderers/Form/TabsTransfer.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransfer.tsx
@@ -300,6 +300,8 @@ export class TabsTransferRenderer extends BaseTabsTransferRenderer<TabsTransferP
       virtualThreshold,
       onlyChildren,
       loadingConfig,
+      valueField = 'value',
+      labelField = 'label',
       data
     } = this.props;
 
@@ -328,6 +330,8 @@ export class TabsTransferRenderer extends BaseTabsTransferRenderer<TabsTransferP
             toNumber(itemHeight) > 0 ? toNumber(itemHeight) : undefined
           }
           virtualThreshold={virtualThreshold}
+          labelField={labelField}
+          valueField={valueField}
           ctx={data}
         />
 

--- a/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
@@ -104,7 +104,9 @@ export class TabsTransferPickerRenderer extends BaseTabsTransferRenderer<TabsTra
       leftOptions,
       itemHeight,
       virtualThreshold,
-      loadingConfig
+      loadingConfig,
+      labelField = 'label',
+      valueField = 'value'
     } = this.props;
 
     return (
@@ -135,6 +137,8 @@ export class TabsTransferPickerRenderer extends BaseTabsTransferRenderer<TabsTra
             toNumber(itemHeight) > 0 ? toNumber(itemHeight) : undefined
           }
           virtualThreshold={virtualThreshold}
+          labelField={labelField}
+          valueField={valueField}
         />
 
         <Spinner

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -387,7 +387,7 @@ export class BaseTransferRenderer<
 
   @autobind
   optionItemRender(option: Option, states: ItemRenderStates) {
-    const {menuTpl, render, data} = this.props;
+    const {menuTpl, render, data, labelField = 'label'} = this.props;
 
     if (menuTpl) {
       return render(`item/${states.index}`, menuTpl, {
@@ -395,7 +395,7 @@ export class BaseTransferRenderer<
       });
     }
 
-    return BaseSelection.itemRender(option, states);
+    return BaseSelection.itemRender(option, {labelField, ...states});
   }
 
   @autobind

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -498,6 +498,7 @@ export class BaseTransferRenderer<
       resultSearchable = false,
       statistics,
       labelField,
+      valueField,
       virtualThreshold,
       itemHeight,
       loadingConfig,
@@ -552,6 +553,7 @@ export class BaseTransferRenderer<
           resultSearchPlaceholder={resultSearchPlaceholder}
           statistics={statistics}
           labelField={labelField}
+          valueField={valueField}
           optionItemRender={this.optionItemRender}
           resultItemRender={this.resultItemRender}
           onSelectAll={this.onSelectAll}

--- a/packages/amis/src/renderers/Form/TransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TransferPicker.tsx
@@ -83,7 +83,9 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
       borderMode,
       itemHeight,
       virtualThreshold,
-      loadingConfig
+      loadingConfig,
+      labelField = 'label',
+      valueField = 'value'
     } = this.props;
 
     // 目前 LeftOptions 没有接口可以动态加载
@@ -127,6 +129,8 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
           resultItemRender={this.resultItemRender}
           onFocus={() => this.dispatchEvent('focus')}
           onBlur={() => this.dispatchEvent('blur')}
+          labelField={labelField}
+          valueField={valueField}
           itemHeight={
             toNumber(itemHeight) > 0 ? toNumber(itemHeight) : undefined
           }


### PR DESCRIPTION
### What
#### 修复问题1：
```json
{
  "type": "page",
  "title": "标题",
  "body": {
    "type": "form",
    "body": {
      "type": "transfer",
      "name": "abc",
      "options": [
        {
          "id": "1",
          "name": "张三"
        },
        {
          "id": "2",
          "name": "李四"
        }
      ],
      "valueField": "id",
      "labelField": "name",
      "multiple": true,
      "searchable": true
    }
  }
}
```

如上schema，统计信息会显示0/0，并且多选按钮不可点击，经检查是amis-ui的transfer组件中对选项的处理写死了读取value字段，但是在transfer的render中又允许自定义valueField，所以这里补全相关逻辑

#### 修复问题2: 
还是上面的schema，搜索的时候以选中的值不能正确的显示以及check

#### 修复问题3:
```json
{
  "type": "page",
  "title": "标题",
  "body": {
    "type": "form",
    "body": {
      "type": "transfer-picker",
      "name": "abc",
      "selectMode": "tree",
      "options": [
        {
          "id": "1",
          "name": "张三"
        },
        {
          "id": "2",
          "name": "李四"
        }
      ],
      "valueField": "id",
      "labelField": "name",
      "multiple": true,
      "searchable": true
    }
  }
}
```
如上schema，选择值后，选择框内的显示为undefined

#### 修复问题4:
上面的schema显示错误，类似于问题1和2

#### 修复问题5、6：
上面问题在TabsTransfer和TabsTransferPicker中有类似表现

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1302902</samp>

This pull request adds support for customizing the field names for the option value and label in various selection and transfer components and renderers. It introduces the `valueField` and `labelField` props to the components and renderers, and passes them to the sub-components that need them. It also sets some default values for these props in some cases. This improves the flexibility and consistency of the components and renderers, and allows the user to use different data sources with different field names. The affected files are `TabsTransfer.tsx`, `TabsTransferPicker.tsx`, `Transfer.tsx`, `TransferPicker.tsx`, `Selection.tsx`, and `Tree.tsx` in the `packages/amis-ui/src/components` directory, and `TabsTransfer.tsx`, `TabsTransferPicker.tsx`, `Transfer.tsx`, and `TransferPicker.tsx` in the `packages/amis/src/renderers/Form` directory.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1302902</samp>

> _`valueField` and `labelField` are the keys to your fate_
> _Customize your options, don't let them dictate_
> _Unleash the power of the transfer list_
> _Make your selection, resist and persist_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1302902</samp>

*  Add a new optional prop `valueField` to the selection components and renderers to allow customizing the field name of the option value ([link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-ba63d39ad70a1c34ad20fbabdac0ec1361040e7e45d3abe4d7c7e19d6f133384R31), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70R138), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-07debd2e776c043c2635a6714d9622ad216538a5d1a7d75a982e41f30e711e71R501))
*  Use the `valueField` prop to access and compare the option value, instead of hard-coding the `value` field, in the `Transfer` and `TabsTransfer` components and renderers ([link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644L169-R171), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644L335-R345),    [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L144-R146), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L233-R239), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L310-R316), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L321-R324), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L327-R335), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L338-R346), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L816-R830), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-36d4a19803ba21094b5aee307abb8b8c5cad04fcb3c373082cddf1566b591f21R303-R304), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-b3d9a4cde668e595a9e905f6d4ce38b014991a0a41b16a89c9297934d9ea5334L107-R109), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-07debd2e776c043c2635a6714d9622ad216538a5d1a7d75a982e41f30e711e71L390-R390), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-b5e07e34c62b71ba2aa268d6e62e8c9c6db92b4f3d71609f840bf806f3a41c15L86-R88))
*  Pass the `valueField` prop to the sub-components that render the transfer list or the picker, such as `Transfer`, `TabsTransfer`, `TransferPicker`, and `TabsTransferPicker` ([link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644R211-R212), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644R233-R234), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644R255-R256), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644R362-R363), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644R391-R392), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644R416-R417), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644R445-R446), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644R469-R470), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70R507), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70R531), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70R549), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70R568), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70R642), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70R661), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70R686), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70R706), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-36d4a19803ba21094b5aee307abb8b8c5cad04fcb3c373082cddf1566b591f21R333-R334), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-b3d9a4cde668e595a9e905f6d4ce38b014991a0a41b16a89c9297934d9ea5334R140-R141), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-07debd2e776c043c2635a6714d9622ad216538a5d1a7d75a982e41f30e711e71L398-R398), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-07debd2e776c043c2635a6714d9622ad216538a5d1a7d75a982e41f30e711e71R556), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-b5e07e34c62b71ba2aa268d6e62e8c9c6db92b4f3d71609f840bf806f3a41c15R132-R133))
*  Add a new optional prop `labelField` to the selection components and renderers to allow customizing the field name of the option label ([link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-a87b5fefcecf03bc281f87d2402169d06880c1a19e4da76de947087a889b7688R47), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-a9a06490081b771f1ebb55275e4e4b031629faf71a6626f516c4db2701c2ff36R53))
*  Use the `labelField` prop to access and display the option label, instead of hard-coding the `label` field, in the `BaseSelection`, `TransferPicker`, `TabsTransferPicker`, and `TreeSelector` components and renderers ([link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-a87b5fefcecf03bc281f87d2402169d06880c1a19e4da76de947087a889b7688R75), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-a87b5fefcecf03bc281f87d2402169d06880c1a19e4da76de947087a889b7688R96-R98), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-a9a06490081b771f1ebb55275e4e4b031629faf71a6626f516c4db2701c2ff36R68), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-a9a06490081b771f1ebb55275e4e4b031629faf71a6626f516c4db2701c2ff36R103-R105), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7R1207), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-07debd2e776c043c2635a6714d9622ad216538a5d1a7d75a982e41f30e711e71L390-R390), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-07debd2e776c043c2635a6714d9622ad216538a5d1a7d75a982e41f30e711e71L398-R398))
*  Pass the `labelField` prop to the sub-components that render the selection list or the tree selector, such as `BaseSelection` and `TreeSelector` ([link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-a87b5fefcecf03bc281f87d2402169d06880c1a19e4da76de947087a889b7688R75), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-a9a06490081b771f1ebb55275e4e4b031629faf71a6626f516c4db2701c2ff36R68), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7R1207), [link](https://github.com/baidu/amis/pull/6904/files?diff=unified&w=0#diff-07debd2e776c043c2635a6714d9622ad216538a5d1a7d75a982e41f30e711e71L398-R398))
