### PR TITLE
feat: render 支持传入 context 数据在弹窗数据映射后依然可访问

### DIFF
--- a/docs/zh-CN/start/getting-started.md
+++ b/docs/zh-CN/start/getting-started.md
@@ -111,6 +111,8 @@ amis.embed(
 
 可以通过 props 里的 data 属性来赋予 amis 顶层数据域的值，类似下面的例子。
 
+> 3.1.0 开始可以传入 context 数据，无论哪层都可以使用到这个里面的数据。适合用来传递一些平台数据。
+
 ```js
 let amis = amisRequire('amis/embed');
 let amisJSON = {
@@ -123,6 +125,12 @@ let amisJSON = {
 let amisScoped = amis.embed('#root', amisJSON, {
   data: {
     myData: 'amis'
+  },
+  context: {
+    amisUser: {
+      id: 1,
+      name: 'test user'
+    }
   }
 });
 ```

--- a/examples/components/SchemaRender.jsx
+++ b/examples/components/SchemaRender.jsx
@@ -255,6 +255,13 @@ export default function (schema, schemaProps, showCode, envOverrides) {
           schema,
           {
             ...(isPlainObject(schemaProps) ? schemaProps : {}),
+            context: {
+              // 上下文信息，无论那层可以获取到这个
+              amisUser: {
+                id: 1,
+                name: 'AMIS User'
+              }
+            },
             location,
             theme,
             locale

--- a/packages/amis-core/src/Root.tsx
+++ b/packages/amis-core/src/Root.tsx
@@ -15,6 +15,8 @@ import {RootStoreContext} from './WithRootStore';
 export interface RootRenderProps {
   location?: Location;
   theme?: string;
+  data?: Record<string, any>;
+  locale?: string;
   [propName: string]: any;
 }
 
@@ -35,6 +37,8 @@ export interface RootWrapperProps {
   schema: SchemaNode;
   rootStore: IRendererStore;
   theme: string;
+  data?: Record<string, any>;
+  context?: Record<string, any>;
   [propName: string]: any;
 }
 
@@ -64,6 +68,7 @@ export class Root extends React.Component<RootProps> {
       pathPrefix,
       location,
       data,
+      context,
       locale,
       translate,
       ...rest
@@ -123,6 +128,7 @@ export class Root extends React.Component<RootProps> {
                       resolveDefinitions={this.resolveDefinitions}
                       location={location}
                       data={data}
+                      context={context}
                       env={env}
                       classnames={theme.classnames}
                       classPrefix={theme.classPrefix}

--- a/packages/amis-core/src/RootRenderer.tsx
+++ b/packages/amis-core/src/RootRenderer.tsx
@@ -14,6 +14,8 @@ import {normalizeApi} from './utils/api';
 
 export interface RootRendererProps extends RootProps {
   location?: any;
+  data?: Record<string, any>;
+  context?: Record<string, any>;
   render: (region: string, schema: any, props: any) => React.ReactNode;
 }
 
@@ -32,6 +34,7 @@ export class RootRenderer extends React.Component<RootRendererProps> {
       parentId: ''
     }) as IRootStore;
 
+    this.store.setContext(props.context);
     this.store.initData(props.data);
     this.store.updateLocation(props.location, this.props.env?.parseLocation);
 
@@ -61,6 +64,10 @@ export class RootRenderer extends React.Component<RootRendererProps> {
 
     if (props.location !== prevProps.location) {
       this.store.updateLocation(props.location);
+    }
+
+    if (props.context !== prevProps.context) {
+      this.store.setContext(props.context);
     }
   }
 

--- a/packages/amis-core/src/WithStore.tsx
+++ b/packages/amis-core/src/WithStore.tsx
@@ -35,6 +35,8 @@ export function HocStoreFactory(renderer: {
       store?: IIRendererStore;
       data?: RendererData;
       scope?: RendererData;
+      rootStore: any;
+      topStore: any;
     };
 
     @observer
@@ -66,6 +68,7 @@ export function HocStoreFactory(renderer: {
           storeType: renderer.storeType,
           parentId: this.props.store ? this.props.store.id : ''
         }) as IIRendererStore;
+        store.setTopStore(props.topStore);
         this.store = store;
 
         const extendsData =
@@ -167,7 +170,7 @@ export function HocStoreFactory(renderer: {
         return data as object;
       }
 
-      componentDidUpdate(prevProps: RendererProps) {
+      componentDidUpdate(prevProps: Props) {
         const props = this.props;
         const store = this.store;
         const shouldSync = renderer.shouldSyncSuperStore?.(
@@ -290,7 +293,10 @@ export function HocStoreFactory(renderer: {
         const store = this.store;
 
         this.unReaction?.();
-        isAlive(store) && rootStore.removeStore(store);
+        if (isAlive(store)) {
+          store.setTopStore(null);
+          rootStore.removeStore(store);
+        }
 
         // @ts-ignore
         delete this.store;

--- a/packages/amis-core/src/envOverwrite.ts
+++ b/packages/amis-core/src/envOverwrite.ts
@@ -9,11 +9,6 @@ const isMobile = (window as any).matchMedia?.('(max-width: 768px)').matches
 
 // 这里不能用 addSchemaFilter 是因为还需要更深层的替换，比如 select 里的 options
 export const envOverwrite = (schema: any, locale?: string) => {
-  if (schema.mobile && isMobile) {
-    Object.assign(schema, schema.mobile);
-    delete schema.mobile;
-  }
-
   if (locale) {
     let schemaNodes = findObjectsWithKey(schema, locale);
     for (let schemaNode of schemaNodes) {

--- a/packages/amis-core/src/index.tsx
+++ b/packages/amis-core/src/index.tsx
@@ -199,46 +199,87 @@ export function render(
   options: RenderOptions = {},
   pathPrefix: string = ''
 ): JSX.Element {
+  return (
+    <AMISRenderer
+      {...props}
+      schema={schema}
+      pathPrefix={pathPrefix}
+      options={options}
+    />
+  );
+}
+
+function AMISRenderer({
+  schema,
+  options,
+  pathPrefix,
+  ...props
+}: RootRenderProps & {
+  schema: Schema;
+  options: RenderOptions;
+  pathPrefix: string;
+}) {
   let locale = props.locale || getDefaultLocale();
   // 兼容 locale 的不同写法
-  locale = locale.replace('_', '-');
-  locale = locale === 'en' ? 'en-US' : locale;
-  locale = locale === 'zh' ? 'zh-CN' : locale;
-  locale = locale === 'cn' ? 'zh-CN' : locale;
-  const translate = props.translate || makeTranslator(locale);
-  let store = stores[options.session || 'global'];
+  locale =
+    locale === 'en'
+      ? 'en-US'
+      : locale === 'zh' || locale === 'cn'
+      ? 'zh-CN'
+      : locale.replace('_', '-');
 
-  // 根据环境覆盖 schema，这个要在最前面做，不然就无法覆盖 validations
-  envOverwrite(schema, locale);
+  const translate = React.useCallback(
+    function () {
+      const fn = props.translate || makeTranslator(locale);
+      return fn.apply(null, arguments);
+    },
+    [locale, props.translate]
+  );
+  const store = React.useMemo(() => {
+    let store = stores[options.session || 'global'];
 
-  if (!store) {
-    options = {
-      ...defaultOptions,
-      ...options,
-      fetcher: options.fetcher
-        ? wrapFetcher(options.fetcher, options.tracker)
-        : defaultOptions.fetcher,
-      confirm: promisify(
-        options.confirm || defaultOptions.confirm || window.confirm
-      ),
-      locale,
-      translate
-    } as any;
+    if (!store) {
+      options = {
+        ...defaultOptions,
+        ...options,
+        fetcher: options.fetcher
+          ? wrapFetcher(options.fetcher, options.tracker)
+          : defaultOptions.fetcher,
+        confirm: promisify(
+          options.confirm || defaultOptions.confirm || window.confirm
+        ),
+        locale,
+        translate
+      } as any;
 
-    if (options.enableAMISDebug) {
-      // 因为里面还有 render
-      setTimeout(() => {
-        enableDebug();
-      }, 10);
+      if (options.enableAMISDebug) {
+        // 因为里面还有 render
+        setTimeout(() => {
+          enableDebug();
+        }, 10);
+      }
+
+      store = RendererStore.create({}, options);
+      stores[options.session || 'global'] = store;
+    } else {
+      // 更新 env
+      const env = getEnv(store);
+      Object.assign(env, {
+        ...options,
+        fetcher: options.fetcher
+          ? wrapFetcher(options.fetcher, options.tracker)
+          : env.fetcher,
+        confirm: options.confirm ? promisify(options.confirm) : env.confirm,
+        locale,
+        translate
+      });
     }
 
-    store = RendererStore.create({}, options);
-    stores[options.session || 'global'] = store;
-  }
+    (window as any).amisStore = store; // 为了方便 debug.
+    return store;
+  }, Object.keys(options).concat(Object.values(options)).concat(locale));
 
-  (window as any).amisStore = store; // 为了方便 debug.
   const env = getEnv(store);
-
   let theme = props.theme || options.theme || 'cxd';
   if (theme === 'default') {
     theme = 'cxd';
@@ -255,6 +296,8 @@ export function render(
     props.useMobileUI = true;
   }
 
+  // 根据环境覆盖 schema，这个要在最前面做，不然就无法覆盖 validations
+  envOverwrite(schema, locale);
   schema = replaceText(schema, options.replaceText, env.replaceTextIgnoreKeys);
 
   return (

--- a/packages/amis-core/src/store/iRenderer.ts
+++ b/packages/amis-core/src/store/iRenderer.ts
@@ -11,6 +11,8 @@ import {dataMapping} from '../utils/tpl-builtin';
 import {SimpleMap} from '../utils/SimpleMap';
 import {StoreNode} from './node';
 import {IScopedContext} from '../Scoped';
+import {IRootStore} from './root';
+import {createObjectFromChain, extractObjectChain} from '../utils';
 
 export const iRendererStore = StoreNode.named('iRendererStore')
   .props({
@@ -38,8 +40,13 @@ export const iRendererStore = StoreNode.named('iRendererStore')
     const dialogCallbacks = new SimpleMap<(result?: any) => void>();
     let dialogScoped: IScopedContext | null = null;
     let drawerScoped: IScopedContext | null = null;
+    let top: IRootStore | null = null;
 
     return {
+      setTopStore(value: any) {
+        top = value;
+      },
+
       initData(data: object = {}, skipSetPristine = false) {
         self.initedAt = Date.now();
 
@@ -149,18 +156,19 @@ export const iRendererStore = StoreNode.named('iRendererStore')
         callback?: (ret: any) => void,
         scoped?: IScopedContext
       ) {
-        let proto = ctx.__super ? ctx.__super : self.data;
-
+        const chain = extractObjectChain(ctx);
+        chain.length === 1 && chain.unshift(self.data);
         if (additonal) {
-          proto = createObject(proto, additonal);
+          chain.splice(chain.length - 1, 0, additonal);
         }
 
-        const data = createObject(proto, {
-          ...ctx
-        });
+        const data = createObjectFromChain(chain);
 
         if (self.action.dialog && self.action.dialog.data) {
-          self.dialogData = dataMapping(self.action.dialog.data, data);
+          self.dialogData = createObjectFromChain([
+            top?.context,
+            dataMapping(self.action.dialog.data, data)
+          ]);
 
           const clonedAction = {
             ...self.action,
@@ -196,18 +204,19 @@ export const iRendererStore = StoreNode.named('iRendererStore')
         callback?: (ret: any) => void,
         scoped?: IScopedContext
       ) {
-        let proto = ctx.__super ? ctx.__super : self.data;
-
+        const chain = extractObjectChain(ctx);
+        chain.length === 1 && chain.unshift(self.data);
         if (additonal) {
-          proto = createObject(proto, additonal);
+          chain.splice(chain.length - 1, 0, additonal);
         }
 
-        const data = createObject(proto, {
-          ...ctx
-        });
+        const data = createObjectFromChain(chain);
 
         if (self.action.drawer.data) {
-          self.drawerData = dataMapping(self.action.drawer.data, data);
+          self.drawerData = createObjectFromChain([
+            top?.context,
+            dataMapping(self.action.drawer.data, data)
+          ]);
 
           const clonedAction = {
             ...self.action,

--- a/packages/amis-core/src/utils/object.ts
+++ b/packages/amis-core/src/utils/object.ts
@@ -30,6 +30,32 @@ export function createObject(
   return obj;
 }
 
+export function extractObjectChain(value: any) {
+  const result: Array<object> = value ? [value] : [];
+  while (value?.__super) {
+    result.unshift(value.__super);
+    value = value.__super;
+  }
+  return result;
+}
+
+export function createObjectFromChain(chain: Array<object>) {
+  return chain
+    .filter(item => item)
+    .reduce((proto, value) =>
+      Object.assign(
+        Object.create(proto || Object.prototype, {
+          __super: {
+            value: proto || Object.prototype,
+            writable: false,
+            enumerable: false
+          }
+        }),
+        value
+      )
+    );
+}
+
 export function cloneObject(target: any, persistOwnProps: boolean = true) {
   const obj =
     target && target.__super


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bd9b3df</samp>

This pull request adds a new feature to pass `context` data to the AMIS renderer and its components, and improves the data handling and rendering performance by using data chains. It also updates the documentation and the examples to demonstrate the usage of this feature. Additionally, it refactors the `render` function and the `envOverwrite` function, and fixes a minor type error.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bd9b3df</samp>

> _We're passing data and context to the root and the wrapper_
> _We're using data chains to handle the query and the render_
> _We're overwriting env and extracting object chains_
> _Heave ho, me hearties, we're sailing with `amis-core`!_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bd9b3df</samp>

*  Add the `context` property to the root and renderer components and stores, allowing the passing of platform data to any layer of the schema ([link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-cecdf20aaa84e6464093def72aee232955ad9649b13e7187284dfb7176b3cdacR114-R115), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-cecdf20aaa84e6464093def72aee232955ad9649b13e7187284dfb7176b3cdacR128-R133), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-ac1a60d172a301e9d64fda64e449666942e49e0d61ebfae939cb54dab34f887dR258-R264), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-3ded26fd057d2575fbf9dd5795c9b87e45082d2edea40cf24bc0edb86495dbc7R18-R19), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-3ded26fd057d2575fbf9dd5795c9b87e45082d2edea40cf24bc0edb86495dbc7R40-R41), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-3ded26fd057d2575fbf9dd5795c9b87e45082d2edea40cf24bc0edb86495dbc7R71), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-3ded26fd057d2575fbf9dd5795c9b87e45082d2edea40cf24bc0edb86495dbc7R131), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-4cba0119d1b827598fb03c9a62c9380b173776edc7267f0eb7577a50b3d7bb22R17-R18), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-4cba0119d1b827598fb03c9a62c9380b173776edc7267f0eb7577a50b3d7bb22R37), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-4cba0119d1b827598fb03c9a62c9380b173776edc7267f0eb7577a50b3d7bb22R68-R71), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-986f77f6313d9ce4a6c7ea5544b98efca9db732d961567b86c048d66e9df1c50L14-R42), )
*  Refactor the `render` function in `index.tsx` to extract the `AMISRenderer` component and override the schema based on the environment ([link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-ed2759a19afd843ed555f6c368bef12e2d0dab8b1b113f0ff059a4575bad00c2L202-R282), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-ed2759a19afd843ed555f6c368bef12e2d0dab8b1b113f0ff059a4575bad00c2R299-R300), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-dd2c28625f8a3b0bdf1d3e2e0b8b650f67af03785e123359a9dc02685040ed74L12-L16))
*  Add the `top` variable and the `setTopStore` method to the renderer store, storing and setting the top store reference for the renderer store ([link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-bda8cf53fd9e2519263119f3191cfc57b424d5d9307441736c080a609f6e40f8L41-R49),  [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acR38-R39), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acR71), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL293-R299))
*  Replace the `createObject` and `extendObject` functions with the `createObjectFromChain` and `extractObjectChain` functions, creating and extracting the data chain from the context and query ([link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-bda8cf53fd9e2519263119f3191cfc57b424d5d9307441736c080a609f6e40f8R14-R15), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-bda8cf53fd9e2519263119f3191cfc57b424d5d9307441736c080a609f6e40f8L152-R171), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-bda8cf53fd9e2519263119f3191cfc57b424d5d9307441736c080a609f6e40f8L199-R219), [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-986f77f6313d9ce4a6c7ea5544b98efca9db732d961567b86c048d66e9df1c50R4),  [link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-59e272ba9fc180f46d655081bd34bd278fa2930abbbc286d4e8701145ab0f263R33-R58))
*  Fix a typo in the `StoreFactory` class in `WithStore.tsx`, changing the `RendererProps` type to the `Props` type for the `componentDidUpdate` method ([link](https://github.com/baidu/amis/pull/6905/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL170-R173))
