### PR TITLE
chore: 调整表格数据上下文

### DIFF
--- a/packages/amis-core/src/store/list.ts
+++ b/packages/amis-core/src/store/list.ts
@@ -39,9 +39,14 @@ export const Item = types
     },
 
     get locals(): any {
+      const listStore = getParent(self, 2) as IListStore;
       return createObject(
-        extendObject((getParent(self, 2) as IListStore).data, {
-          index: self.index
+        extendObject(listStore.data, {
+          index: self.index,
+
+          // 只有table时，也可以获取选中行
+          selectedItems: listStore.selectedItems.map(item => item.data),
+          unSelectedItems: listStore.unSelectedItems.map(item => item.data)
         }),
         self.data
       );

--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -174,12 +174,17 @@ export const Row = types
         children = self.children.map(item => item.locals);
       }
 
+      const table = getParent(self, self.depth * 2) as ITableStore;
       const parent = getParent(self, 2) as ITableStore;
       return createObject(
         extendObject((getParent(self, self.depth * 2) as ITableStore).data, {
           index: self.index,
           // todo 以后再支持多层，目前先一层
-          parent: parent.storeType === Row.name ? parent.data : undefined
+          parent: parent.storeType === Row.name ? parent.data : undefined,
+
+          // 只有table时，也可以获取选中行
+          selectedItems: table.selectedRows.map(item => item.data),
+          unSelectedItems: table.unSelectedRows.map(item => item.data)
         }),
         children
           ? {

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -2277,13 +2277,7 @@ export default class Table extends React.Component<TableProps, object> {
       // 操作列不下发loading，否则会导致操作栏里面的所有按钮都出现loading
       loading: column.type === 'operation' ? false : props.loading,
       btnDisabled: store.dragging,
-      data: this.props.selectable
-        ? extendObject(item.locals, {
-            // 只有table时，也可以获取选中行
-            selectedItems: store.selectedRows.map(item => item.data),
-            unSelectedItems: store.unSelectedRows.map(item => item.data)
-          })
-        : item.locals,
+      data: item.locals,
       value: column.name
         ? resolveVariable(
             column.name,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5c2a5e</samp>

This pull request improves the handling of selected and unselected rows in the table renderer. It adds `selectedItems` and `unSelectedItems` to the row store in `packages/amis-core/src/store/table.ts` and removes them from the row data extension in `packages/amis/src/renderers/Table/index.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c5c2a5e</samp>

> _`selectedItems`_
> _No more redundant data_
> _Row store is smarter_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c5c2a5e</samp>

*  Add `selectedItems` and `unSelectedItems` properties to row data in table store to store the data objects of the selected and unselected rows in the table ([link](https://github.com/baidu/amis/pull/6906/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR177), [link](https://github.com/baidu/amis/pull/6906/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL182-R187))
* Remove redundant extension of row data with the same properties in `Table/index.tsx` to simplify data passing and avoid conflicts ([link](https://github.com/baidu/amis/pull/6906/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2280-R2280))
