### PR TITLE
feat(amis): DropDownButton 下拉菜单buttons支持动态解析

### DIFF
--- a/packages/amis/src/renderers/DropDownButton.tsx
+++ b/packages/amis/src/renderers/DropDownButton.tsx
@@ -15,6 +15,7 @@ import type {
   TooltipObject,
   Trigger
 } from 'amis-ui/lib/components/TooltipWrapper';
+import {resolveVariableAndFilter} from 'amis-core';
 
 export type DropdownButton =
   | (ActionSchema & {children?: Array<DropdownButton>})
@@ -183,7 +184,20 @@ export default class DropDownButton extends React.Component<
   }
 
   async open() {
-    const {dispatchEvent, data, buttons} = this.props;
+    const {
+      dispatchEvent,
+      data,
+      buttons: _buttons,
+      disabled,
+      btnDisabled
+    } = this.props;
+    if (disabled || btnDisabled) {
+      return;
+    }
+    const buttons =
+      typeof _buttons === 'string'
+        ? resolveVariableAndFilter(_buttons, data, '| raw')
+        : _buttons;
     await dispatchEvent(
       'mouseenter',
       createObject(data, {
@@ -196,10 +210,16 @@ export default class DropDownButton extends React.Component<
   }
 
   close(e?: React.MouseEvent<any>) {
+    const {buttons: _buttons, data} = this.props;
+    const buttons =
+      typeof _buttons === 'string'
+        ? resolveVariableAndFilter(_buttons, data, '| raw')
+        : _buttons;
+
     this.timer = setTimeout(() => {
       this.props.dispatchEvent(
         'mouseleave',
-        createObject(this.props.data, {items: this.props.buttons})
+        createObject(this.props.data, {items: buttons})
       );
       this.setState({
         isOpened: false
@@ -261,7 +281,7 @@ export default class DropDownButton extends React.Component<
   renderOuter() {
     const {
       render,
-      buttons,
+      buttons: _buttons,
       data,
       popOverContainer,
       classnames: cx,
@@ -274,6 +294,12 @@ export default class DropDownButton extends React.Component<
       overlayPlacement,
       trigger
     } = this.props;
+
+    const buttons =
+      typeof _buttons === 'string'
+        ? resolveVariableAndFilter(_buttons, data, '| raw')
+        : _buttons;
+
     let body = (
       <RootClose
         disabled={!this.state.isOpened}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f5229fb</samp>

Enhanced `DropDownButton` component to support dynamic buttons. Used `resolveVariableAndFilter` to parse `buttons` prop in `packages/amis/src/renderers/DropDownButton.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f5229fb</samp>

> _To make DropDownButton more clever_
> _We added dynamic rendering lever_
> _We used `resolveVariableAndFilter`_
> _To parse `buttons` without a quiver_
> _And renamed some props for good measure_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f5229fb</samp>

* Import and use `resolveVariableAndFilter` function to parse `buttons` prop of `DropDownButton` component if it is a string expression ([link](https://github.com/baidu/amis/pull/6908/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005R18), [link](https://github.com/baidu/amis/pull/6908/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L186-R200), [link](https://github.com/baidu/amis/pull/6908/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L199-R222), [link](https://github.com/baidu/amis/pull/6908/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L264-R284), [link](https://github.com/baidu/amis/pull/6908/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005R297-R302))
* Check `disabled` and `btnDisabled` props before opening dropdown menu in `open` method of `DropDownButton` component ([link](https://github.com/baidu/amis/pull/6908/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L186-R200))
* Pass parsed `buttons` prop to `mouseleave` event data in `close` method of `DropDownButton` component ([link](https://github.com/baidu/amis/pull/6908/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L199-R222))
* Rename `buttons` prop to `_buttons` to avoid confusion with local variable in `render` method of `DropDownButton` component ([link](https://github.com/baidu/amis/pull/6908/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L264-R284))
