### PR TITLE
fix: 修复 hash query 解析问题

### DIFF
--- a/packages/amis-core/src/utils/helper.ts
+++ b/packages/amis-core/src/utils/helper.ts
@@ -1771,10 +1771,12 @@ export function parseQuery(
     (location && location?.search && qsparse(location.search.substring(1))) ||
     (window.location.search && qsparse(window.location.search.substring(1)));
   /* 处理hash中的query */
-  const hashQuery =
-    window.location?.hash && typeof window.location?.hash === 'string'
-      ? qsparse(window.location.hash.replace(/^#.*\?/gi, ''))
-      : {};
+  const hash = window.location?.hash;
+  let hashQuery = {};
+  let idx = -1;
+  if (typeof hash === 'string' && ~(idx = hash.indexOf('?'))) {
+    hashQuery = qsparse(hash.substring(idx + 1));
+  }
   const normalizedQuery = isPlainObject(query) ? query : {};
 
   return merge(normalizedQuery, hashQuery);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dc1b01b</samp>

Improved hash query parsing in `parseQuery` function. Fixed issue #2509 by using `indexOf` instead of regex to find the query part in the hash.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at dc1b01b</samp>

> _`parseQuery` changed_
> _Hash queries now handled well_
> _Autumn bug fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dc1b01b</samp>

* Fix hash query parsing in `parseQuery` function ([link](https://github.com/baidu/amis/pull/6910/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1774-R1779))
