### PR TITLE
fix: options 有默认值时不触发autoFill

### DIFF
--- a/packages/amis-core/src/renderers/Options.tsx
+++ b/packages/amis-core/src/renderers/Options.tsx
@@ -346,6 +346,15 @@ export function registerOptionsControl(config: OptionsConfig) {
               this.syncAutoFill(formItem.getSelectedOptions(formItem.tmpValue))
           )
         );
+
+        if (
+          options &&
+          formItem.tmpValue &&
+          formItem.getSelectedOptions(formItem.tmpValue).length
+        ) {
+          this.syncAutoFill(formItem.getSelectedOptions(formItem.tmpValue));
+        }
+
         // 默认全选。这里会和默认值\回填值逻辑冲突，所以如果有配置source则不执行默认全选
         if (
           multiple &&


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at da77207</samp>

Add autofill support for multiple options in form items. Update `Options.tsx` to call `syncAutoFill` when options are selected.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at da77207</samp>

> _`syncAutoFill` runs_
> _when options are not empty_
> _autumn leaves cascade_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at da77207</samp>

* Add a condition to enable autofill with multiple options ([link](https://github.com/baidu/amis/pull/6911/files?diff=unified&w=0#diff-d9bf7707bf7ac9b7c40f2740fc783de7b5318386f02fd8348a8b7ef4b69717b2R349-R357))
