### PR TITLE
feat: editor增加button图标大小选择

### DIFF
--- a/packages/amis-core/src/utils/style-helper.ts
+++ b/packages/amis-core/src/utils/style-helper.ts
@@ -34,6 +34,7 @@ export const inheritValueMap: PlainObject = {
 };
 
 interface extra {
+  important?: boolean;
   pre?: string;
   suf?: string;
 }
@@ -209,7 +210,14 @@ export function formatStyle(
             }
           } else {
             const value = style;
-            value && fn(key, value);
+            if (key === 'iconSize') {
+              fn('width', value + (weights.important ? ' !important' : ''));
+              fn('height', value + (weights.important ? ' !important' : ''));
+              fn('font-size', value + (weights.important ? ' !important' : ''));
+            } else {
+              value &&
+                fn(key, value + (weights.important ? ' !important' : ''));
+            }
           }
         }
         if (styles.length > 0) {
@@ -255,6 +263,7 @@ export function insertCustomStyle(
   if (!themeCss) {
     return;
   }
+
   const {value} = formatStyle(themeCss, classNames, id, defaultData);
   if (value) {
     insertStyle(value, id?.replace('u:', '') || uuid());

--- a/packages/amis-editor/src/plugin/Button.tsx
+++ b/packages/amis-editor/src/plugin/Button.tsx
@@ -148,6 +148,12 @@ export class ButtonPlugin extends BasePlugin {
           name: `themeCss.className.radius:${state}`,
           visibleOn: visibleOn,
           editorThemePath: `button1.size.\${size}.body.border`
+        }),
+        getSchemaTpl('theme:size', {
+          label: '图标大小',
+          name: `themeCss.iconClassName.iconSize:${state}`,
+          visibleOn: visibleOn,
+          editorThemePath: `button1.size.\${size}.body.icon-size`
         })
       ];
     };

--- a/packages/amis-editor/src/plugin/Button.tsx
+++ b/packages/amis-editor/src/plugin/Button.tsx
@@ -150,7 +150,7 @@ export class ButtonPlugin extends BasePlugin {
           editorThemePath: `button1.size.\${size}.body.border`
         }),
         getSchemaTpl('theme:size', {
-          label: '图标大小',
+          label: '图标尺寸',
           name: `themeCss.iconClassName.iconSize:${state}`,
           visibleOn: visibleOn,
           editorThemePath: `button1.size.\${size}.body.icon-size`

--- a/packages/amis-editor/src/tpl/style.tsx
+++ b/packages/amis-editor/src/tpl/style.tsx
@@ -586,6 +586,7 @@ setSchemaTpl('theme:size', (option: any = {}) => {
     type: 'amis-theme-select',
     label: false,
     name: `css.className.size`,
+    options: '${sizesOptions}',
     ...option
   };
 });

--- a/packages/amis/src/renderers/Action.tsx
+++ b/packages/amis/src/renderers/Action.tsx
@@ -811,6 +811,26 @@ export class Action extends React.Component<ActionProps, ActionState> {
       ],
       id
     );
+    insertCustomStyle(
+      themeCss || css,
+      [
+        {
+          key: 'iconClassName',
+          value: iconClassName,
+          weights: {
+            default: {
+              important: true
+            },
+            hover: {
+              important: true,
+              suf: ':not(:disabled):not(.is-disabled)'
+            },
+            active: {important: true, suf: ':not(:disabled):not(.is-disabled)'}
+          }
+        }
+      ],
+      id
+    );
 
     if (actionType !== 'email' && body) {
       return (


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de53c39</samp>

This pull request adds support for the `iconSize` property in the button and action components, and improves the style inheritance mechanism with an `important` flag. It also updates the editor plugin and theme to reflect the new property and flag.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at de53c39</samp>

> _We are the masters of the button_
> _We control the icon size_
> _We insert the custom style_
> _We defy the theme with `!important`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at de53c39</samp>

*  Add `important` property to `inheritValueMap` object to mark style values that can override other CSS rules ([link](https://github.com/baidu/amis/pull/6913/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdR37))
*  Modify `formatStyle` function to append `!important` suffix to style values and handle special case for `iconSize` key ([link](https://github.com/baidu/amis/pull/6913/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL212-R220))
*  Add schema template for `iconSize` property in `ButtonPlugin` class to allow user to select icon size from predefined options ([link](https://github.com/baidu/amis/pull/6913/files?diff=unified&w=0#diff-da2ca6c6a8ac5b6fcef2f72eb2ab705288b464dc1ddda4122cffd5f2cecf022bR151-R156), [link](https://github.com/baidu/amis/pull/6913/files?diff=unified&w=0#diff-397f3332bd17c52ed7e468360e1cfe462d1d8646110ccd681b48a6deaa608302R589))
*  Call `insertCustomStyle` function in `Action` class to insert custom style values from `iconClassName` property and apply `!important` suffix if needed ([link](https://github.com/baidu/amis/pull/6913/files?diff=unified&w=0#diff-4d89203911a9d3ef38c82118f074ad24c49244699f1f2cbb6072134908f60098R814-R833))
*  Add empty line for code formatting in `style-helper.ts` ([link](https://github.com/baidu/amis/pull/6913/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdR266))
