### PR TITLE
fix: table2和crud2属性对齐

### DIFF
--- a/packages/amis-core/src/store/table2.ts
+++ b/packages/amis-core/src/store/table2.ts
@@ -211,7 +211,7 @@ export const TableStore2 = ServiceStore.named('TableStore2')
     pageNo: 1,
     pageSize: 10,
     dragging: false,
-    rowSelectionKeyField: 'key'
+    rowSelectionKeyField: 'id'
   })
   .views(self => {
     function getToggable() {
@@ -526,16 +526,16 @@ export const TableStore2 = ServiceStore.named('TableStore2')
       updateSelectedRows(self.rows, selectedKeys);
     }
 
-    function updateExpanded(expandedRowKeys: Array<any>, keyField?: string) {
+    function updateExpanded(expandedRowKeys: Array<any>, keyField: string) {
       self.expandedRowKeys.clear();
 
       eachTree(self.rows, item => {
-        if (~expandedRowKeys.indexOf(item.pristine[keyField || 'key'])) {
-          self.expandedRowKeys.push(item.pristine[keyField || 'key']);
+        if (~expandedRowKeys.indexOf(item.pristine[keyField])) {
+          self.expandedRowKeys.push(item.pristine[keyField]);
         } else if (
-          find(expandedRowKeys, a => a && a == item.pristine[keyField || 'key'])
+          find(expandedRowKeys, a => a && a == item.pristine[keyField])
         ) {
-          self.expandedRowKeys.push(item.pristine[keyField || 'key']);
+          self.expandedRowKeys.push(item.pristine[keyField]);
         }
       });
     }

--- a/packages/amis-ui/src/components/table/index.tsx
+++ b/packages/amis-ui/src/components/table/index.tsx
@@ -581,13 +581,13 @@ export class Table extends React.PureComponent<TableProps, TableState> {
     // 展开行变化时触发
     if (!isEqual(prevState.expandedRowKeys, this.state.expandedRowKeys)) {
       if (this.props.expandable) {
-        const {onExpandedRowsChange, keyField} = this.props.expandable;
+        const {onExpandedRowsChange} = this.props.expandable;
         const expandedRows: Array<any> = [];
         this.state.dataSource.forEach(item => {
           if (
             find(
               this.state.expandedRowKeys,
-              key => key == item[keyField || 'key']
+              key => key == item[this.getExpandableKeyField()]
             )
           ) {
             expandedRows.push(item);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 78f70c0</samp>

This pull request improves the consistency and reliability of the table store model and the table components that use it, by using a configurable key field for row selection and expansion. It also restores some CRUD features for the `Table2` component that were missing or broken. It fixes some minor code issues and typos in the process.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 78f70c0</samp>

> _Sing, O Muse, of the cunning refactorer who changed the table store_
> _And made the `keyField` parameter a mighty shield against errors_
> _He also wrought a new design for the `Table2` component and schema_
> _And gave them power to handle CRUD and expandable rows with ease_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 78f70c0</samp>

*  Change the default value of `rowSelectionKeyField` in the `TableStore2` model from `key` to `id`, to match the default `keyField` in the `TableSchema2` interface and the `Table` component ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292L214-R214))
*  Make the `keyField` parameter of the `updateExpanded` action in the `TableStore2` model mandatory, to avoid using a fallback value of `key` that might not match the actual key field of the data ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292L529-R538))
*  Remove the `keyField` prop from the `componentDidUpdate` method of the `Table` component, since it is not used ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L584-R584))
*  Replace the `keyField` prop with a call to the `getExpandableKeyField` method in the `componentDidUpdate` method of the `Table` component, to get the key field for the expandable rows ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L590-R590))
*  Update the comment for the `keyField` prop of the `TableSchema2` interface, to reflect that it is used for both row selection and expandable rows, and that the default value is `id` ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L298-R298))
*  Remove the `primaryField` prop from the `TableSchema2` interface, since it is redundant with the `keyField` prop and might cause confusion ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L343-L347))
*  Add the `selectable`, `multiple` and `primaryField` props to the `TableSchema2` interface, to support the original CRUD attributes for row selection and quick edit ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R366-R380))
*  Add the `defaultProps` static property to the `Table2` component, to set the default value of `keyField` to `id` ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R433-R436))
*  Add the `primaryField` prop to the `Table2` component, and use it as a fallback value for the `rowSelectionKeyField` in the `store.update` call, to support the original CRUD attribute for row selection and quick edit ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L429-R455), [link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L591-R614))
*  Declare the `expandableKeyField` variable in the `syncRows` method of the `Table2` component, to store the key field for the expandable rows ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R541-R542))
*  Replace the `props?.expandable?.keyField || 'key'` expression with the `expandableKeyField` variable in the `syncRows` method of the `Table2` component, to use the consistent key field for the expandable rows ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L530-R553), [link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L538-R561))
*  Add the `keyField` prop to the `renderToolbar` and `handleQuickChange` methods of the `Table2` component, to use it for the data key field ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R937), [link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L990-R1012))
*  Declare the `key` variable in the `renderToolbar` method of the `Table2` component, to store the key field for the data, either from the `primaryField` prop or the `keyField` prop or the default value of `id` ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L924-R948))
*  Replace the `primaryField || 'id'` expression with the `key` variable in the `renderToolbar` method of the `Table2` component, to use the consistent key field for the data ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L932-R957))
*  Replace the `['id', primaryField!]` array with the `[keyField, primaryField!]` array in the `handleQuickChange` method of the `Table2` component, to use the consistent key field for the data ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1020-R1042), [link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1028-R1050))
*  Add the `primaryField` prop to the `doAction` method of the `Table2` component, and use it for the expand action ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1274-R1296))
*  Replace the `key || 'key'` expression with the `primaryField || key` expression in the `doAction` method of the `Table2` component, to use the fallback value of `primaryField` for the expandable key field ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1301-R1323))
*  Add the `selectable` and `multiple` props to the `Table2` component, and pass them to the `Table` component, to support the original CRUD attributes for row selection ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R1381-R1382), [link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R1494-R1499))
*  Add the `primaryField` prop to the `Table2` component, and pass it to the `Table` component, to use it as the key field ([link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R1393), [link](https://github.com/baidu/amis/pull/6916/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1533-R1564))
