### PR TITLE
feat: Code 组件支持配置 maxHeight Close: #6894

### DIFF
--- a/docs/zh-CN/components/code.md
+++ b/docs/zh-CN/components/code.md
@@ -102,6 +102,22 @@ language 支持从上下文获取数据
 }
 ```
 
+## 最大高度
+
+通过配置 `maxHeight` 可以实现最大高度，超出滚动
+
+```schema
+{
+  "body": {
+    "type": "code",
+    "language": "javascript",
+    "className": "b-a",
+    "maxHeight": 200,
+    "value": "(function () {\n  let amis = amisRequire('amis/embed');\n  let amisJSON = {\n    type: 'page',\n    title: '表单页面',\n    body: {\n      type: 'form',\n      mode: 'horizontal',\n      api: '/saveForm',\n      body: [\n        {\n          label: 'Name',\n          type: 'input-text',\n          name: 'name'\n        },\n        {\n          label: 'Email',\n          type: 'input-email',\n          name: 'email'\n        }\n      ]\n    }\n  };\n  let amisScoped = amis.embed('#root', amisJSON);\n})();"
+  }
+}
+```
+
 ## 自定义语言高亮
 
 还可以通过 `customLang` 参数来自定义高亮，详情参考[示例](../../../examples/code)。
@@ -116,12 +132,13 @@ language 支持从上下文获取数据
 
 ## 属性表
 
-| 属性名      | 类型     | 默认值 | 说明                               |
-| ----------- | -------- | ------ | ---------------------------------- |
-| className   | `string` |        | 外层 CSS 类名                      |
-| value       | `string` |        | 显示的颜色值                       |
-| name        | `string` |        | 在其他组件中，时，用作变量映射     |
-| language    | `string` |        | 所使用的高亮语言，默认是 plaintext |
-| tabSize     | `number` | 4      | 默认 tab 大小                      |
-| editorTheme | `string` | 'vs'   | 主题，还有 'vs-dark'               |
-| wordWrap    | `string` | `true` | 是否折行                           |
+| 属性名      | 类型               | 默认值 | 说明                               |
+| ----------- | ------------------ | ------ | ---------------------------------- |
+| className   | `string`           |        | 外层 CSS 类名                      |
+| value       | `string`           |        | 显示的颜色值                       |
+| name        | `string`           |        | 在其他组件中，时，用作变量映射     |
+| language    | `string`           |        | 所使用的高亮语言，默认是 plaintext |
+| tabSize     | `number`           | 4      | 默认 tab 大小                      |
+| editorTheme | `string`           | 'vs'   | 主题，还有 'vs-dark'               |
+| wordWrap    | `string`           | `true` | 是否折行                           |
+| maxHeight   | `string`\|`number` |        | 最大高度                           |

--- a/packages/amis/src/renderers/Code.tsx
+++ b/packages/amis/src/renderers/Code.tsx
@@ -142,6 +142,11 @@ export interface CodeSchema extends BaseSchema {
    * 使用的标签，默认多行使用pre，单行使用code
    */
   wrapperComponent?: string;
+
+  /**
+   * 最大高度，单位为px
+   */
+  maxHeight?: number;
 }
 
 export interface CodeProps
@@ -320,7 +325,8 @@ export default class Code extends React.Component<CodeProps> {
     const sourceCode = getPropValue(this.props);
     const {
       className,
-      style,
+      maxHeight,
+      style = {},
       classnames: cx,
       editorTheme,
       customLang,
@@ -334,6 +340,11 @@ export default class Code extends React.Component<CodeProps> {
 
     if (customLang) {
       this.customLang = customLang;
+    }
+
+    if (maxHeight) {
+      style.maxHeight = style.maxHeight || maxHeight;
+      style.overflow = 'auto';
     }
 
     return (


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a4de91</samp>

This pull request adds a `maxHeight` prop to the code component, which lets users limit the height of code blocks and enable scrolling. It also updates the documentation of the code component in `docs/zh-CN/components/code.md` to include this new feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4a4de91</samp>

> _`maxHeight` prop_
> _gives code blocks a limit_
> _scroll in autumn_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4a4de91</samp>

*  Add a new `maxHeight` property for the code component that allows setting a maximum height for the code block and enabling scrolling if the content exceeds the height ([link](https://github.com/baidu/amis/pull/6920/files?diff=unified&w=0#diff-7b931acee935dedfb6eeca2fc6eb25515495c6aac8f77a2d330fd7d1095dc62dR105-R120), [link](https://github.com/baidu/amis/pull/6920/files?diff=unified&w=0#diff-7b931acee935dedfb6eeca2fc6eb25515495c6aac8f77a2d330fd7d1095dc62dL119-R144), [link](https://github.com/baidu/amis/pull/6920/files?diff=unified&w=0#diff-7f25150f14ab281ec6aa8052fe4c977282b70bb2a24a5dc0039b696cd5817c5dR145-R149), [link](https://github.com/baidu/amis/pull/6920/files?diff=unified&w=0#diff-7f25150f14ab281ec6aa8052fe4c977282b70bb2a24a5dc0039b696cd5817c5dL323-R329), [link](https://github.com/baidu/amis/pull/6920/files?diff=unified&w=0#diff-7f25150f14ab281ec6aa8052fe4c977282b70bb2a24a5dc0039b696cd5817c5dR345-R349))
* Update the documentation for the code component in `docs/zh-CN/components/code.md` to include the new property and an example of its usage ([link](https://github.com/baidu/amis/pull/6920/files?diff=unified&w=0#diff-7b931acee935dedfb6eeca2fc6eb25515495c6aac8f77a2d330fd7d1095dc62dR105-R120), [link](https://github.com/baidu/amis/pull/6920/files?diff=unified&w=0#diff-7b931acee935dedfb6eeca2fc6eb25515495c6aac8f77a2d330fd7d1095dc62dL119-R144))
