### PR TITLE
feat: InputImages 多选图片列表支持拖拽排序 Close: #6826

### DIFF
--- a/docs/zh-CN/components/form/input-image.md
+++ b/docs/zh-CN/components/form/input-image.md
@@ -420,38 +420,67 @@ app.listen(8080, function () {});
 }
 ```
 
+## 拖拽排序
+
+可配置 `draggable` 为 `true` 启动拖拽排序。
+
+```schema: scope="body"
+{
+  "type": "form",
+  "title": "表单",
+  data: {
+    image: [
+      'http://www.sortablejs.com/assets/img/npm.png',
+      'http://www.sortablejs.com/assets/img/bower.png',
+      'http://www.sortablejs.com/assets/img/js.png'
+    ]
+  },
+  "body": [
+    'Images: <br />${image|split|join:"<br />"}',
+    {
+      type: 'input-image',
+      name: 'image',
+      multiple: true,
+      draggable: true
+    }
+  ]
+}
+```
+
 ## 属性表
 
 除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置
 
-| 属性名             | 类型                            | 默认值                 | 说明                                                                                                                                             |
-| ------------------ | ------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| receiver           | [API](../../../docs/types/api)  |                        | 上传文件接口                                                                                                                                     |
-| accept             | `string`                        | `.jpeg,.jpg,.png,.gif` | 支持的图片类型格式，请配置此属性为图片后缀，例如`.jpg,.png`                                                                                      |
-| maxSize            | `number`                        |                        | 默认没有限制，当设置后，文件大小大于此值将不允许上传。单位为`B`                                                                                  |
-| maxLength          | `number`                        |                        | 默认没有限制，当设置后，一次只允许上传指定数量文件。                                                                                             |
-| multiple           | `boolean`                       | `false`                | 是否多选。                                                                                                                                       |
-| joinValues         | `boolean`                       | `true`                 | [拼接值](./options#%E6%8B%BC%E6%8E%A5%E5%80%BC-joinvalues)                                                                                       |
-| extractValue       | `boolean`                       | `false`                | [提取值](./options#%E6%8F%90%E5%8F%96%E5%A4%9A%E9%80%89%E5%80%BC-extractvalue)                                                                   |
-| delimiter          | `string`                        | `,`                    | [拼接符](./options#%E6%8B%BC%E6%8E%A5%E7%AC%A6-delimiter)                                                                                        |
-| autoUpload         | `boolean`                       | `true`                 | 否选择完就自动开始上传                                                                                                                           |
-| hideUploadButton   | `boolean`                       | `false`                | 隐藏上传按钮                                                                                                                                     |
-| fileField          | `string`                        | `file`                 | 如果你不想自己存储，则可以忽略此属性。                                                                                                           |
-| crop               | `boolean`或`{"aspectRatio":""}` |                        | 用来设置是否支持裁剪。                                                                                                                           |
-| crop.aspectRatio   | `number`                        |                        | 裁剪比例。浮点型，默认 `1` 即 `1:1`，如果要设置 `16:9` 请设置 `1.7777777777777777` 即 `16 / 9`。。                                               |
-| crop.rotatable     | `boolean`                       | `false`                | 裁剪时是否可旋转                                                                                                                                 |
-| crop.scalable      | `boolean`                       | `false`                | 裁剪时是否可缩放                                                                                                                                 |
-| crop.viewMode      | `number`                        | `1`                    | 裁剪时的查看模式，0 是无限制                                                                                                                     |
-| cropFormat         | `string`                        | `image/png`            | 裁剪文件格式                                                                                                                                     |
-| cropQuality        | `number`                        | `1`                    | 裁剪文件格式的质量，用于 jpeg/webp，取值在 0 和 1 之间                                                                                           |
-| limit              | Limit                           |                        | 限制图片大小，超出不让上传。                                                                                                                     |
-| frameImage         | `string`                        |                        | 默认占位图地址                                                                                                                                   |
-| fixedSize          | `boolean`                       |                        | 是否开启固定尺寸,若开启，需同时设置 fixedSizeClassName                                                                                           |
-| fixedSizeClassName | `string`                        |                        | 开启固定尺寸时，根据此值控制展示尺寸。例如`h-30`,即图片框高为 h-30,AMIS 将自动缩放比率设置默认图所占位置的宽度，最终上传图片根据此尺寸对应缩放。 |
-| initAutoFill       | `boolean`                       | `false`                | 表单反显时是否执行 autoFill                                                                                                                      |
-| uploadBtnText       | `string` \| [SchemaNode](../../docs/types/schemanode)                       |                 | 上传按钮文案。支持tpl、schema形式配置。                                                                                                             |
-| dropCrop           | `boolean`                       | `true`                 | 图片上传后是否进入裁剪模式                                                                                                                       |
-| initCrop           | `boolean`                       | `false`                | 图片选择器初始化后是否立即进入裁剪模式                                                                                                           |
+| 属性名             | 类型                                                  | 默认值                 | 说明                                                                                                                                             |
+| ------------------ | ----------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| receiver           | [API](../../../docs/types/api)                        |                        | 上传文件接口                                                                                                                                     |
+| accept             | `string`                                              | `.jpeg,.jpg,.png,.gif` | 支持的图片类型格式，请配置此属性为图片后缀，例如`.jpg,.png`                                                                                      |
+| maxSize            | `number`                                              |                        | 默认没有限制，当设置后，文件大小大于此值将不允许上传。单位为`B`                                                                                  |
+| maxLength          | `number`                                              |                        | 默认没有限制，当设置后，一次只允许上传指定数量文件。                                                                                             |
+| multiple           | `boolean`                                             | `false`                | 是否多选。                                                                                                                                       |
+| joinValues         | `boolean`                                             | `true`                 | [拼接值](./options#%E6%8B%BC%E6%8E%A5%E5%80%BC-joinvalues)                                                                                       |
+| extractValue       | `boolean`                                             | `false`                | [提取值](./options#%E6%8F%90%E5%8F%96%E5%A4%9A%E9%80%89%E5%80%BC-extractvalue)                                                                   |
+| delimiter          | `string`                                              | `,`                    | [拼接符](./options#%E6%8B%BC%E6%8E%A5%E7%AC%A6-delimiter)                                                                                        |
+| autoUpload         | `boolean`                                             | `true`                 | 否选择完就自动开始上传                                                                                                                           |
+| hideUploadButton   | `boolean`                                             | `false`                | 隐藏上传按钮                                                                                                                                     |
+| fileField          | `string`                                              | `file`                 | 如果你不想自己存储，则可以忽略此属性。                                                                                                           |
+| crop               | `boolean`或`{"aspectRatio":""}`                       |                        | 用来设置是否支持裁剪。                                                                                                                           |
+| crop.aspectRatio   | `number`                                              |                        | 裁剪比例。浮点型，默认 `1` 即 `1:1`，如果要设置 `16:9` 请设置 `1.7777777777777777` 即 `16 / 9`。。                                               |
+| crop.rotatable     | `boolean`                                             | `false`                | 裁剪时是否可旋转                                                                                                                                 |
+| crop.scalable      | `boolean`                                             | `false`                | 裁剪时是否可缩放                                                                                                                                 |
+| crop.viewMode      | `number`                                              | `1`                    | 裁剪时的查看模式，0 是无限制                                                                                                                     |
+| cropFormat         | `string`                                              | `image/png`            | 裁剪文件格式                                                                                                                                     |
+| cropQuality        | `number`                                              | `1`                    | 裁剪文件格式的质量，用于 jpeg/webp，取值在 0 和 1 之间                                                                                           |
+| limit              | Limit                                                 |                        | 限制图片大小，超出不让上传。                                                                                                                     |
+| frameImage         | `string`                                              |                        | 默认占位图地址                                                                                                                                   |
+| fixedSize          | `boolean`                                             |                        | 是否开启固定尺寸,若开启，需同时设置 fixedSizeClassName                                                                                           |
+| fixedSizeClassName | `string`                                              |                        | 开启固定尺寸时，根据此值控制展示尺寸。例如`h-30`,即图片框高为 h-30,AMIS 将自动缩放比率设置默认图所占位置的宽度，最终上传图片根据此尺寸对应缩放。 |
+| initAutoFill       | `boolean`                                             | `false`                | 表单反显时是否执行 autoFill                                                                                                                      |
+| uploadBtnText      | `string` \| [SchemaNode](../../docs/types/schemanode) |                        | 上传按钮文案。支持 tpl、schema 形式配置。                                                                                                        |
+| dropCrop           | `boolean`                                             | `true`                 | 图片上传后是否进入裁剪模式                                                                                                                       |
+| initCrop           | `boolean`                                             | `false`                | 图片选择器初始化后是否立即进入裁剪模式                                                                                                           |
+| draggable          | `boolean`                                             | false                  | 开启后支持拖拽排序改变图片值顺序                                                                                                                 |
+| draggableTip       | `string`                                              | '拖拽排序'             | 拖拽提示文案                                                                                                                                     |
 
 ### Limit 属性表
 

--- a/packages/amis-ui/scss/components/form/_image.scss
+++ b/packages/amis-ui/scss/components/form/_image.scss
@@ -25,7 +25,7 @@
       var(--inputImage-base-default-bottom-left-border-radius);
     cursor: pointer;
     margin-right: var(--gap-base);
-    
+
     &-bg {
       position: absolute;
       z-index: 0;
@@ -119,11 +119,10 @@
     }
 
     &:not(:disabled):not(.is-disabled) {
-
       &.is-invalid:hover {
         border-color: var(--FileControl-danger-color);
       }
-  
+
       &:hover {
         svg {
           color: var(--inputImage-base-hover-icon-color);
@@ -198,6 +197,10 @@
     }
   }
 
+  &-itemList {
+    display: inline;
+  }
+
   &-item {
     border: var(--borderWidth) solid var(--borderColor);
     border-radius: var(--ImageControl-addBtn-borderRadius);
@@ -220,6 +223,10 @@
 
     svg.icon-refresh {
       transform: rotate(180deg);
+    }
+
+    &--dragging {
+      border: var(--borderWidth) solid var(--colors-brand-5);
     }
   }
 

--- a/packages/amis-ui/src/locale/de-DE.ts
+++ b/packages/amis-ui/src/locale/de-DE.ts
@@ -156,6 +156,7 @@ register('de-DE', {
   'Iframe.invalid': 'Ungültige Iframe-URL',
   'Iframe.invalidProtocol':
     'HTTP-URL-Iframe kann nicht in https verwendet werden',
+  'Image.dragTip': 'Zum Sortieren ziehen',
   'Image.upload': 'Bild hochladen',
   'Image.configError':
     'Es können nur eine Beschneidung oder mehrere festgelegt werden',

--- a/packages/amis-ui/src/locale/en-US.ts
+++ b/packages/amis-ui/src/locale/en-US.ts
@@ -151,6 +151,7 @@ register('en-US', {
   'Form.nestedError': 'Form cannot appear as a descendant of form',
   'Iframe.invalid': 'Invalid iframe url',
   'Iframe.invalidProtocol': 'Can not use http url iframe in https',
+  'Image.dragTip': 'Drag to sort',
   'Image.upload': 'Upload image',
   'Image.errorRetry': 'upload failed, please try again',
   'Image.configError': 'Can only set one of crop or multiple',

--- a/packages/amis-ui/src/locale/zh-CN.ts
+++ b/packages/amis-ui/src/locale/zh-CN.ts
@@ -155,6 +155,7 @@ register('zh-CN', {
   'Form.nestedError': '表单不要直接嵌套在表单下面',
   'Iframe.invalid': 'iframe 地址不合法',
   'Iframe.invalidProtocol': '无法加载 http 协议的 iframe',
+  'Image.dragTip': '拖拽排序',
   'Image.upload': '图片上传',
   'Image.errorRetry': '上传失败，请重试',
   'Image.configError': '图片多选配置和裁剪配置只能设置一个',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 01541b3</samp>

This pull request enhances the `input-image` component by adding a `draggable` option that allows users to sort the images by drag and drop. It also updates the style, documentation, and localization for this feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 01541b3</samp>

> _Sing, O Muse, of the skillful code review_
> _That brought new features to the `input-image`_
> _And made it easy for the users to move_
> _And sort their pictures with a simple drag._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 01541b3</samp>

*  Add `draggable` and `draggableTip` props to `ImageProps` interface and `ImageControl` class ([link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R288-R299), [link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1465-R1543))
*  Import `Sortable` library from `sortablejs` and create `fileKeys` weak map to store unique keys for each file value or object ([link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R43), [link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R419), [link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L552-R579))
*  Define `dragTipRef`, `initDragging`, and `destroyDragging` methods to handle drag and drop sorting logic and lifecycle ([link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R487), [link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R1467-R1516))
*  Wrap image items in `ImageControl-itemList` div and add `dragTipRef` span when `draggable` is enabled ([link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1619-R1705), [link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1838-R1942))
*  Add drag handle icon and tooltip to image item toolbar when `draggable` is available ([link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R1841-R1856))
*  Add `Image.dragTip` message to locale files and provide translations for English, Chinese, and German ([link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-7c7473c7eeac8c306a9c1dbf7f116bf87b1bcd4c31e9e0f8c619febc67faf8a5R159), [link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-fb22f243566a7ed671bc6279e3cc6f0a1eddc2fe4259d84b4cb8a7f596987e49R154), [link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-2fd35dabf975bb2b4ad936c4efcf03b6ce58a0954eba2964acffa8e557091e64R158))
*  Add documentation and schema example for `draggable` property in Chinese ([link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-df614ff2471c08c1530f00dafa191c2c351525189dad40bf7cad37dc1ef58f65L423-R483))
*  Add style rules for `ImageControl-itemList` and `ImageControl-item--dragging` classes in SCSS file ([link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aR200-R203), [link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aR227-R230))
*  Remove extra blank lines in SCSS and TSX files ([link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aL28-R28), [link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aL122-R125), [link](https://github.com/baidu/amis/pull/6923/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1823-R1930))
