### PR TITLE
chore(amis-editor): 脚手架pipeOut支持异步; styles(amis-editor): 操作列配置面板按钮样式

### DIFF
--- a/packages/amis-editor-core/src/component/ScaffoldModal.tsx
+++ b/packages/amis-editor-core/src/component/ScaffoldModal.tsx
@@ -14,16 +14,18 @@ export interface SubEditorProps {
 @observer
 export class ScaffoldModal extends React.Component<SubEditorProps> {
   @autobind
-  handleConfirm([values]: any) {
+  async handleConfirm([values]: any) {
     const store = this.props.store;
+    const pipeOutFunc = store.scaffoldForm?.pipeOut;
 
     values = {
       ...store.scaffoldForm?.value,
       ...values
     };
 
-    if (store.scaffoldForm?.pipeOut) {
-      const mapped = store.scaffoldForm.pipeOut(values);
+    if (pipeOutFunc && typeof pipeOutFunc === 'function') {
+      const mapped = await pipeOutFunc(values);
+
       values = {
         ...mapped
       };

--- a/packages/amis-editor/src/plugin/Operation.tsx
+++ b/packages/amis-editor/src/plugin/Operation.tsx
@@ -57,10 +57,9 @@ export class OperationPlugin extends BasePlugin {
       {
         children: (
           <Button
-            level="info"
             size="sm"
-            className="m-b-sm"
             block
+            className="m-b-sm ae-Button--enhance"
             onClick={() => {
               // this.manager.showInsertPanel('buttons', context.id, '按钮');
               this.manager.showRendererPanel(


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 35054c5</samp>

This pull request enhances the amis-editor by adding support for async `pipeOut` functions in the scaffold modal and by fixing a style issue with the operation button. The changes affect the files `ScaffoldModal.tsx` and `Operation.tsx` in the amis-editor-core and amis-editor packages respectively.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 35054c5</samp>

> _To fix a style issue they found_
> _They changed the `Button` component around_
> _They removed the `level` prop_
> _And added a custom class on top_
> _Now the button looks better in the toolbar's bound_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 35054c5</samp>

*  Support async `pipeOut` functions for scaffold form output ([link](https://github.com/baidu/amis/pull/6928/files?diff=unified&w=0#diff-85faab9f8c432f5b71f49bdb3e107d8f36edae4199b8cc13dd9b6a2b391b613dL17-R19), [link](https://github.com/baidu/amis/pull/6928/files?diff=unified&w=0#diff-85faab9f8c432f5b71f49bdb3e107d8f36edae4199b8cc13dd9b6a2b391b613dL25-R33))
* Improve button style in editor toolbar ([link](https://github.com/baidu/amis/pull/6928/files?diff=unified&w=0#diff-af7f2960905447bb89941a83aa87d377d72c10d609e651b733bf49a600f40f25L60-R62))
