### PR TITLE
feat: CURD2支持设置顶部&底部的外层CSS类

### DIFF
--- a/packages/amis/src/renderers/CRUD2.tsx
+++ b/packages/amis/src/renderers/CRUD2.tsx
@@ -153,9 +153,19 @@ export interface CRUD2CommonSchema extends BaseSchema, SpinnerExtraProps {
   headerToolbar?: SchemaCollection;
 
   /**
+   * 顶部区域CSS类名
+   */
+  headerToolbarClassName?: string;
+
+  /**
    * 底部区域
    */
   footerToolbar?: SchemaCollection;
+
+  /**
+   * 底部区域CSS类名
+   */
+  footerToolbarClassName?: string;
 
   /**
    * 是否将接口返回的内容自动同步到地址栏，前提是开启了同步地址栏。
@@ -235,7 +245,9 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
     'onSaved',
     'onQuery',
     'autoFillHeight',
-    'showSelection'
+    'showSelection',
+    'headerToolbarClassName',
+    'footerToolbarClassName'
   ];
   static defaultProps = {
     toolbarInline: true,
@@ -1172,6 +1184,8 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
       footerToolbar,
       // columnsTogglable 在本渲染器中渲染，不需要 table 渲染，避免重复
       columnsTogglable,
+      headerToolbarClassName,
+      footerToolbarClassName,
       ...rest
     } = this.props;
 
@@ -1184,7 +1198,7 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
       >
         <div className={cx('Crud2-filter')}>{this.renderFilter(filter)}</div>
 
-        <div className={cx('Crud2-toolbar')}>
+        <div className={cx('Crud2-toolbar', headerToolbarClassName)}>
           {this.renderToolbar('headerToolbar', headerToolbar)}
         </div>
 
@@ -1242,7 +1256,7 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
         {/* spinner可以交给孩子处理 */}
         {/* <Spinner overlay size="lg" key="info" show={store.loading} /> */}
 
-        <div className={cx('Crud2-toolbar')}>
+        <div className={cx('Crud2-toolbar', footerToolbarClassName)}>
           {this.renderToolbar('footerToolbar', footerToolbar)}
         </div>
       </div>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 439abd1</samp>

This pull request enhances the CRUD2 component with new schema properties for styling the toolbar areas. It modifies the `CRUD2.tsx` file to implement the new properties and apply them to the `div` elements.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 439abd1</samp>

> _Oh, we are the coders of the CRUD2 component_
> _We make it look fancy with a bit of CSS_
> _We pass in the schema with the class name properties_
> _And render the toolbars with the style we express_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 439abd1</samp>

*  Add new properties `headerToolbarClassName` and `footerToolbarClassName` to the `CRUD2CommonSchema` interface to allow customizing the CSS class name for the header and footer toolbar area of the CRUD2 component ([link](https://github.com/baidu/amis/pull/6929/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaR156-R160),[link](https://github.com/baidu/amis/pull/6929/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaR166-R170))
*  Pass the new properties from the `CRUD2` component to the `CRUD2Renderer` component and from there to the `renderToolbar` method in `packages/amis/src/renderers/CRUD2.tsx` ([link](https://github.com/baidu/amis/pull/6929/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL238-R250),[link](https://github.com/baidu/amis/pull/6929/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaR1187-R1188))
*  Apply the new properties to the `div` elements that wrap the header and footer toolbar area of the CRUD2 component using the `cx` function in `packages/amis/src/renderers/CRUD2.tsx` ([link](https://github.com/baidu/amis/pull/6929/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL1187-R1201),[link](https://github.com/baidu/amis/pull/6929/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL1245-R1259))
