### PR TITLE
fix: 修复 objectToArray 过滤器输出 key 和 value 取值颠倒的问题 Close: #6364

### DIFF
--- a/packages/amis-core/__tests__/filter.test.ts
+++ b/packages/amis-core/__tests__/filter.test.ts
@@ -232,16 +232,16 @@ test(`filter:objectToArray`, () => {
     })
   ).toMatchObject([
     {
-      value: 'a',
-      label: 1
+      label: 'a',
+      value: 1
     },
     {
-      value: 'b',
-      label: 2
+      label: 'b',
+      value: 2
     },
     {
-      value: 'done',
-      label: 'Done'
+      label: 'done',
+      value: 'Done'
     }
   ]);
 });

--- a/packages/amis-core/src/utils/filter.ts
+++ b/packages/amis-core/src/utils/filter.ts
@@ -243,8 +243,8 @@ extendsFilters({
       input,
       (result: any, v, k) => {
         (result || (result = [])).push({
-          [label]: v,
-          [value]: k
+          [label]: k,
+          [value]: v
         });
       },
       []


### PR DESCRIPTION
### What

copilot:summary

copilot:poem

### Why

Close https://github.com/baidu/amis/issues/6364

### How

copilot:walkthrough
