### PR TITLE
feat: 自定义样式支持添加前缀;优化实现方式

### DIFF
--- a/examples/embed.tsx
+++ b/examples/embed.tsx
@@ -251,6 +251,7 @@ export function embed(
     },
     richTextToken: '',
     affixOffsetBottom: 0,
+    customStyleClassPrefix: '.amis-scope',
     ...env
   };
 

--- a/packages/amis-core/src/components/CustomStyle.tsx
+++ b/packages/amis-core/src/components/CustomStyle.tsx
@@ -1,5 +1,6 @@
-import {RendererEnv} from '../env';
-import {CustomStyleClassName, insertCustomStyle} from '../utils/style-helper';
+import type {RendererEnv} from '../env';
+import type {CustomStyleClassName} from '../utils/style-helper';
+import {insertCustomStyle} from '../utils/style-helper';
 
 interface CustomStyleProps {
   config: {

--- a/packages/amis-core/src/components/CustomStyle.tsx
+++ b/packages/amis-core/src/components/CustomStyle.tsx
@@ -1,3 +1,4 @@
+import {useEffect} from 'react';
 import type {RendererEnv} from '../env';
 import type {CustomStyleClassName} from '../utils/style-helper';
 import {insertCustomStyle} from '../utils/style-helper';
@@ -14,12 +15,15 @@ interface CustomStyleProps {
 
 export default function (props: CustomStyleProps) {
   const {themeCss, classNames, id, defaultData} = props.config;
-  insertCustomStyle(
-    themeCss,
-    classNames,
-    id,
-    defaultData,
-    props.env?.customStyleClassPrefix
-  );
+  useEffect(() => {
+    insertCustomStyle(
+      themeCss,
+      classNames,
+      id,
+      defaultData,
+      props.env?.customStyleClassPrefix
+    );
+  }, [props.config.themeCss]);
+
   return null;
 }

--- a/packages/amis-core/src/components/CustomStyle.tsx
+++ b/packages/amis-core/src/components/CustomStyle.tsx
@@ -1,0 +1,24 @@
+import {RendererEnv} from '../env';
+import {CustomStyleClassName, insertCustomStyle} from '../utils/style-helper';
+
+interface CustomStyleProps {
+  config: {
+    themeCss: any;
+    classNames: CustomStyleClassName[];
+    id?: string;
+    defaultData?: any;
+  };
+  env: RendererEnv;
+}
+
+export default function (props: CustomStyleProps) {
+  const {themeCss, classNames, id, defaultData} = props.config;
+  insertCustomStyle(
+    themeCss,
+    classNames,
+    id,
+    defaultData,
+    props.env?.customStyleClassPrefix
+  );
+  return null;
+}

--- a/packages/amis-core/src/env.tsx
+++ b/packages/amis-core/src/env.tsx
@@ -60,7 +60,11 @@ export interface RendererEnv {
   /**
    * 捕获amis执行中的错误信息
    */
-  errorCatcher: (error: any, errorInfo: any) => void;
+  errorCatcher?: (error: any, errorInfo: any) => void;
+  /**
+   * 自定义样式前缀
+   */
+  customStyleClassPrefix?: string;
   rendererResolver?: (
     path: string,
     schema: Schema,

--- a/packages/amis-core/src/index.tsx
+++ b/packages/amis-core/src/index.tsx
@@ -102,6 +102,7 @@ import type {OnEventProps} from './utils/index';
 import {valueMap as styleMap} from './utils/style-helper';
 import {RENDERER_TRANSMISSION_OMIT_PROPS} from './SchemaRenderer';
 import type {IItem} from './store/list';
+import CustomStyle from './components/CustomStyle';
 
 // @ts-ignore
 export const version = '__buildVersion';
@@ -190,7 +191,8 @@ export {
   IRow2,
   OnEventProps,
   FormSchemaBase,
-  filterTarget
+  filterTarget,
+  CustomStyle
 };
 
 export function render(

--- a/packages/amis-core/src/renderers/Item.tsx
+++ b/packages/amis-core/src/renderers/Item.tsx
@@ -33,9 +33,10 @@ import {wrapControl} from './wrapControl';
 import debounce from 'lodash/debounce';
 import {isApiOutdated, isEffectiveApi} from '../utils/api';
 import {findDOMNode} from 'react-dom';
-import {dataMapping, insertCustomStyle} from '../utils';
+import {dataMapping} from '../utils';
 import Overlay from '../components/Overlay';
 import PopOver from '../components/PopOver';
+import CustomStyle from '../components/CustomStyle';
 
 export type LabelAlign = 'right' | 'left';
 
@@ -1460,30 +1461,10 @@ export class FormItemWrap extends React.Component<FormItemProps> {
       themeCss,
       id,
       labelClassName,
-      descriptionClassName
+      descriptionClassName,
+      env
     } = this.props;
     const mode = this.props.mode || formMode;
-
-    insertCustomStyle(
-      themeCss || css,
-      [
-        {
-          key: 'labelClassName',
-          value: labelClassName
-        }
-      ],
-      id + '-label'
-    );
-    insertCustomStyle(
-      themeCss || css,
-      [
-        {
-          key: 'descriptionClassName',
-          value: descriptionClassName
-        }
-      ],
-      id + '-description'
-    );
 
     if (wrap === false || inputOnly) {
       return this.renderControl();
@@ -1513,6 +1494,32 @@ export class FormItemWrap extends React.Component<FormItemProps> {
               }
             )
           : null}
+        <CustomStyle
+          config={{
+            themeCss: themeCss || css,
+            classNames: [
+              {
+                key: 'labelClassName',
+                value: labelClassName
+              }
+            ],
+            id: id + '-label'
+          }}
+          env={env}
+        />
+        <CustomStyle
+          config={{
+            themeCss: themeCss || css,
+            classNames: [
+              {
+                key: 'descriptionClassName',
+                value: descriptionClassName
+              }
+            ],
+            id: id + '-description'
+          }}
+          env={env}
+        />
       </>
     );
   }

--- a/packages/amis-core/src/utils/style-helper.ts
+++ b/packages/amis-core/src/utils/style-helper.ts
@@ -211,12 +211,15 @@ export function formatStyle(
           } else {
             const value = style;
             if (key === 'iconSize') {
-              fn('width', value + (weights.important ? ' !important' : ''));
-              fn('height', value + (weights.important ? ' !important' : ''));
-              fn('font-size', value + (weights.important ? ' !important' : ''));
+              fn('width', value + (weights?.important ? ' !important' : ''));
+              fn('height', value + (weights?.important ? ' !important' : ''));
+              fn(
+                'font-size',
+                value + (weights?.important ? ' !important' : '')
+              );
             } else {
               value &&
-                fn(key, value + (weights.important ? ' !important' : ''));
+                fn(key, value + (weights?.important ? ' !important' : ''));
             }
           }
         }
@@ -245,27 +248,33 @@ export function formatStyle(
   };
 }
 
+export interface CustomStyleClassName {
+  key: string;
+  value?: string;
+  weights?: {
+    default?: extra;
+    hover?: extra;
+    active?: extra;
+    disabled?: extra;
+  };
+}
+
 export function insertCustomStyle(
   themeCss: any,
-  classNames: {
-    key: string;
-    value?: string;
-    weights?: {
-      default?: extra;
-      hover?: extra;
-      active?: extra;
-      disabled?: extra;
-    };
-  }[],
+  classNames: CustomStyleClassName[],
   id?: string,
-  defaultData?: any
+  defaultData?: any,
+  customStyleClassPrefix?: string
 ) {
   if (!themeCss) {
     return;
   }
 
-  const {value} = formatStyle(themeCss, classNames, id, defaultData);
+  let {value} = formatStyle(themeCss, classNames, id, defaultData);
   if (value) {
+    value = customStyleClassPrefix
+      ? `${customStyleClassPrefix} ${value}`
+      : value;
     insertStyle(value, id?.replace('u:', '') || uuid());
   }
 }

--- a/packages/amis-editor/src/plugin/Icon.tsx
+++ b/packages/amis-editor/src/plugin/Icon.tsx
@@ -111,11 +111,11 @@ export class IconPlugin extends BasePlugin {
               body: [
                 getSchemaTpl('theme:size', {
                   label: '尺寸',
-                  name: 'css.className.font.fontSize'
+                  name: 'themeCss.className.font.fontSize'
                 }),
                 getSchemaTpl('theme:colorPicker', {
                   label: '颜色',
-                  name: `css.className.font.color`,
+                  name: `themeCss.className.font.color`,
                   labelMode: 'input'
                 }),
                 getSchemaTpl('theme:paddingAndMargin', {

--- a/packages/amis/src/renderers/Action.tsx
+++ b/packages/amis/src/renderers/Action.tsx
@@ -3,7 +3,7 @@ import hotkeys from 'hotkeys-js';
 import {
   ActionObject,
   extendObject,
-  insertCustomStyle,
+  CustomStyle,
   IScopedContext,
   isObject,
   Renderer,
@@ -793,44 +793,9 @@ export class Action extends React.Component<ActionProps, ActionState> {
       loadingConfig,
       themeCss,
       css,
-      id
+      id,
+      env
     } = this.props;
-    insertCustomStyle(
-      themeCss || css,
-      [
-        {
-          key: 'className',
-          value: className,
-          weights: {
-            hover: {
-              suf: ':not(:disabled):not(.is-disabled)'
-            },
-            active: {suf: ':not(:disabled):not(.is-disabled)'}
-          }
-        }
-      ],
-      id
-    );
-    insertCustomStyle(
-      themeCss || css,
-      [
-        {
-          key: 'iconClassName',
-          value: iconClassName,
-          weights: {
-            default: {
-              important: true
-            },
-            hover: {
-              important: true,
-              suf: ':not(:disabled):not(.is-disabled)'
-            },
-            active: {important: true, suf: ':not(:disabled):not(.is-disabled)'}
-          }
-        }
-      ],
-      id
-    );
 
     if (actionType !== 'email' && body) {
       return (
@@ -882,40 +847,89 @@ export class Action extends React.Component<ActionProps, ActionState> {
     );
 
     return (
-      <Button
-        loadingConfig={loadingConfig}
-        className={cx(className, {
-          [activeClassName || 'is-active']: isActive
-        })}
-        style={style}
-        size={size}
-        level={
-          activeLevel && isActive
-            ? activeLevel
-            : level || (primary ? 'primary' : undefined)
-        }
-        loadingClassName={loadingClassName}
-        loading={loading}
-        onClick={this.handleAction}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        type={type && ~allowedType.indexOf(type) ? type : 'button'}
-        disabled={disabled}
-        componentClass={isMenuItem ? 'a' : componentClass}
-        overrideClassName={isMenuItem}
-        tooltip={filterContents(tooltip, data)}
-        disabledTip={filterContents(disabledTip, data)}
-        tooltipPlacement={tooltipPlacement}
-        tooltipContainer={tooltipContainer}
-        tooltipTrigger={tooltipTrigger}
-        tooltipRootClose={tooltipRootClose}
-        block={block}
-        iconOnly={!!(icon && !label && level !== 'link')}
-      >
-        {!loading ? iconElement : ''}
-        {label ? <span>{filter(String(label), data)}</span> : null}
-        {rightIconElement}
-      </Button>
+      <>
+        <Button
+          loadingConfig={loadingConfig}
+          className={cx(className, {
+            [activeClassName || 'is-active']: isActive
+          })}
+          style={style}
+          size={size}
+          level={
+            activeLevel && isActive
+              ? activeLevel
+              : level || (primary ? 'primary' : undefined)
+          }
+          loadingClassName={loadingClassName}
+          loading={loading}
+          onClick={this.handleAction}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+          type={type && ~allowedType.indexOf(type) ? type : 'button'}
+          disabled={disabled}
+          componentClass={isMenuItem ? 'a' : componentClass}
+          overrideClassName={isMenuItem}
+          tooltip={filterContents(tooltip, data)}
+          disabledTip={filterContents(disabledTip, data)}
+          tooltipPlacement={tooltipPlacement}
+          tooltipContainer={tooltipContainer}
+          tooltipTrigger={tooltipTrigger}
+          tooltipRootClose={tooltipRootClose}
+          block={block}
+          iconOnly={!!(icon && !label && level !== 'link')}
+        >
+          {!loading ? iconElement : ''}
+          {label ? <span>{filter(String(label), data)}</span> : null}
+          {rightIconElement}
+        </Button>
+        {/* button自定义样式 */}
+        <CustomStyle
+          config={{
+            themeCss: themeCss || css,
+            classNames: [
+              {
+                key: 'className',
+                value: className,
+                weights: {
+                  hover: {
+                    suf: ':not(:disabled):not(.is-disabled)'
+                  },
+                  active: {suf: ':not(:disabled):not(.is-disabled)'}
+                }
+              }
+            ],
+            id
+          }}
+          env={env}
+        />
+        {/* button图标自定义样式 */}
+        <CustomStyle
+          config={{
+            themeCss: themeCss || css,
+            classNames: [
+              {
+                key: 'iconClassName',
+                value: iconClassName,
+                weights: {
+                  default: {
+                    important: true
+                  },
+                  hover: {
+                    important: true,
+                    suf: ':not(:disabled):not(.is-disabled)'
+                  },
+                  active: {
+                    important: true,
+                    suf: ':not(:disabled):not(.is-disabled)'
+                  }
+                }
+              }
+            ],
+            id
+          }}
+          env={env}
+        />
+      </>
     );
   }
 }

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -5,7 +5,7 @@ import {
   FormBaseControl,
   prettyBytes,
   resolveEventData,
-  insertCustomStyle
+  CustomStyle
 } from 'amis-core';
 // import 'cropperjs/dist/cropper.css';
 const Cropper = React.lazy(() => import('react-cropper'));
@@ -1540,57 +1540,9 @@ export default class ImageControl extends React.Component<
       id,
       translate: __,
       draggable,
-      draggableTip
+      draggableTip,
+      env
     } = this.props;
-
-    insertCustomStyle(
-      themeCss,
-      [
-        {
-          key: 'inputImageControlClassName',
-          value: inputImageControlClassName
-        }
-      ],
-      id,
-      null
-    );
-
-    insertCustomStyle(
-      themeCss,
-      [
-        {
-          key: 'addBtnControlClassName',
-          value: addBtnControlClassName,
-          weights: {
-            hover: {
-              suf: ':not(:disabled):not(.is-disabled)'
-            },
-            active: {
-              suf: ':not(:disabled):not(.is-disabled)'
-            }
-          }
-        }
-      ],
-      id + '-addOn',
-      null
-    );
-
-    insertCustomStyle(
-      themeCss,
-      [
-        {
-          key: 'iconControlClassName',
-          value: iconControlClassName,
-          weights: {
-            default: {
-              suf: ' svg'
-            }
-          }
-        }
-      ],
-      id + '-icon',
-      null
-    );
 
     const {
       files,
@@ -2017,6 +1969,58 @@ export default class ImageControl extends React.Component<
             )}
           </DropZone>
         )}
+        <CustomStyle
+          config={{
+            themeCss,
+            classNames: [
+              {
+                key: 'inputImageControlClassName',
+                value: inputImageControlClassName
+              }
+            ],
+            id
+          }}
+          env={env}
+        />
+        <CustomStyle
+          config={{
+            themeCss,
+            classNames: [
+              {
+                key: 'addBtnControlClassName',
+                value: addBtnControlClassName,
+                weights: {
+                  hover: {
+                    suf: ':not(:disabled):not(.is-disabled)'
+                  },
+                  active: {
+                    suf: ':not(:disabled):not(.is-disabled)'
+                  }
+                }
+              }
+            ],
+            id: id + '-addOn'
+          }}
+          env={env}
+        />
+        <CustomStyle
+          config={{
+            themeCss,
+            classNames: [
+              {
+                key: 'iconControlClassName',
+                value: iconControlClassName,
+                weights: {
+                  default: {
+                    suf: ' svg'
+                  }
+                }
+              }
+            ],
+            id: id + '-icon'
+          }}
+          env={env}
+        />
       </div>
     );
   }

--- a/packages/amis/src/renderers/Form/InputNumber.tsx
+++ b/packages/amis/src/renderers/Form/InputNumber.tsx
@@ -5,7 +5,7 @@ import {
   FormControlProps,
   FormBaseControl,
   resolveEventData,
-  insertCustomStyle
+  CustomStyle
 } from 'amis-core';
 import cx from 'classnames';
 import {NumberInput, Select} from 'amis-ui';
@@ -386,7 +386,8 @@ export default class NumberControl extends React.Component<
       css,
       themeCss,
       inputControlClassName,
-      id
+      id,
+      env
     } = this.props;
     const finalPrecision = this.filterNum(precision);
     const unit = this.state?.unit;
@@ -412,22 +413,6 @@ export default class NumberControl extends React.Component<
       unit && value && typeof value === 'string'
         ? value.replace(unit, '')
         : value;
-
-    insertCustomStyle(
-      themeCss || css,
-      [
-        {
-          key: 'inputControlClassName',
-          value: inputControlClassName,
-          weights: {
-            active: {
-              pre: `${inputControlClassName}.focused, `
-            }
-          }
-        }
-      ],
-      id
-    );
 
     return (
       <div
@@ -486,6 +471,24 @@ export default class NumberControl extends React.Component<
             </div>
           )
         ) : null}
+        <CustomStyle
+          config={{
+            themeCss: themeCss || css,
+            classNames: [
+              {
+                key: 'inputControlClassName',
+                value: inputControlClassName,
+                weights: {
+                  active: {
+                    pre: `${inputControlClassName}.focused, `
+                  }
+                }
+              }
+            ],
+            id
+          }}
+          env={env}
+        />
       </div>
     );
   }

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -5,7 +5,7 @@ import {
   highlight,
   FormOptionsControl,
   resolveEventData,
-  insertCustomStyle,
+  CustomStyle,
   getValueByPath
 } from 'amis-core';
 import {ActionObject} from 'amis-core';
@@ -1051,6 +1051,7 @@ export default class TextControl extends React.PureComponent<
       inputControlClassName,
       id,
       addOnClassName,
+      env,
       classPrefix: ns
     } = this.props;
     let input =
@@ -1058,35 +1059,42 @@ export default class TextControl extends React.PureComponent<
         ? this.renderSugestMode()
         : this.renderNormal();
 
-    insertCustomStyle(
-      themeCss || css,
-      [
-        {
-          key: 'inputControlClassName',
-          value: inputControlClassName,
-          weights: {
-            active: {
-              pre: `${ns}TextControl.is-focused > .${inputControlClassName}, `
-            }
-          }
-        }
-      ],
-      id,
-      null
+    return (
+      <>
+        {this.renderBody(input)}
+        <CustomStyle
+          config={{
+            themeCss: themeCss || css,
+            classNames: [
+              {
+                key: 'inputControlClassName',
+                value: inputControlClassName,
+                weights: {
+                  active: {
+                    pre: `${ns}TextControl.is-focused > .${inputControlClassName}, `
+                  }
+                }
+              }
+            ],
+            id: id
+          }}
+          env={env}
+        />
+        <CustomStyle
+          config={{
+            themeCss: themeCss || css,
+            classNames: [
+              {
+                key: 'addOnClassName',
+                value: addOnClassName
+              }
+            ],
+            id: id + '-addOn'
+          }}
+          env={env}
+        />
+      </>
     );
-
-    insertCustomStyle(
-      themeCss || css,
-      [
-        {
-          key: 'addOnClassName',
-          value: addOnClassName
-        }
-      ],
-      id + '-addOn'
-    );
-
-    return this.renderBody(input);
   }
 }
 

--- a/packages/amis/src/renderers/Icon.tsx
+++ b/packages/amis/src/renderers/Icon.tsx
@@ -6,7 +6,7 @@ import {
   IconCheckedSchema,
   autobind,
   createObject,
-  insertCustomStyle
+  CustomStyle
 } from 'amis-core';
 import {BaseSchema, SchemaTpl} from '../Schema';
 import {BadgeObject, withBadge} from 'amis-ui';
@@ -83,21 +83,12 @@ export class Icon extends React.Component<IconProps, object> {
       className,
       style,
       data,
+      id,
+      themeCss,
       css,
-      id
+      env
     } = this.props;
     let icon = this.props.icon;
-
-    insertCustomStyle(
-      css,
-      [
-        {
-          key: 'className',
-          value: className
-        }
-      ],
-      id
-    );
 
     if (typeof icon !== 'string') {
       if (
@@ -153,23 +144,40 @@ export class Icon extends React.Component<IconProps, object> {
       // 如果vendor为空，则不设置前缀,这样可以支持fontawesome v5、fontawesome v6或者其他框架
       iconPrefix = `${icon}`;
     }
-    return isURLIcon ? (
-      <img
-        className={cx('Icon', className)}
-        src={icon}
-        style={style}
-        onClick={this.handleClick}
-        onMouseEnter={this.handleMouseEnter}
-        onMouseLeave={this.handleMouseLeave}
-      />
-    ) : (
-      <i
-        className={cx(iconPrefix, className)}
-        style={style}
-        onClick={this.handleClick}
-        onMouseEnter={this.handleMouseEnter}
-        onMouseLeave={this.handleMouseLeave}
-      />
+    return (
+      <>
+        {isURLIcon ? (
+          <img
+            className={cx('Icon', className)}
+            src={icon}
+            style={style}
+            onClick={this.handleClick}
+            onMouseEnter={this.handleMouseEnter}
+            onMouseLeave={this.handleMouseLeave}
+          />
+        ) : (
+          <i
+            className={cx(iconPrefix, className)}
+            style={style}
+            onClick={this.handleClick}
+            onMouseEnter={this.handleMouseEnter}
+            onMouseLeave={this.handleMouseLeave}
+          />
+        )}
+        <CustomStyle
+          config={{
+            themeCss: themeCss || css,
+            classNames: [
+              {
+                key: 'className',
+                value: className
+              }
+            ],
+            id
+          }}
+          env={env}
+        />
+      </>
     );
   }
 }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e52b705</samp>

This pull request introduces a new `CustomStyle` component in `amis-core` that can insert custom CSS styles for AMIS components based on props. It also refactors several renderers in `amis` and `amis-editor` to use this component instead of injecting styles manually. Additionally, it adds a new `customStyleClassPrefix` property to the `RendererEnv` interface that can be used to customize the prefix of the generated CSS classes for custom styles.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e52b705</samp>

> _Sing, O Muse, of the skillful work of the code smiths_
> _Who crafted the `CustomStyle` component, a wondrous tool_
> _To adorn the AMIS components with graceful themes and hues_
> _Like Hephaestus, who forged the armor of the gods and heroes_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e52b705</samp>

*  Add a new component `CustomStyle` that can insert custom CSS styles based on the `themeCss` and `classNames` props ([link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-64f487ea8bb551e6157d95133fcf65572d6990b062dd31bf6502543a77ad9fb5R1-R24))
*  Import and export the `CustomStyle` component in the `amis-core` index file ([link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-ed2759a19afd843ed555f6c368bef12e2d0dab8b1b113f0ff059a4575bad00c2R105), [link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-ed2759a19afd843ed555f6c368bef12e2d0dab8b1b113f0ff059a4575bad00c2L193-R195))
*  Add a new optional property `customStyleClassPrefix` to the `RendererEnv` interface, which can be used to customize the prefix of the generated CSS classes for custom styles ([link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-62f2e14b837dfa7b7f5f94ee2a856825f211639ddf0f85d783c666dbcd7f8d0dL63-R67))
*  Add optional chaining to the `weights` object in the `formatStyle` function, to prevent errors when the object is undefined or null ([link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL214-R222))
*  Define a new interface `CustomStyleClassName` that represents the shape of the `classNames` prop for the `CustomStyle` component, and add a new parameter `customStyleClassPrefix` to the `insertCustomStyle` function, which can be used to prepend a custom prefix to the generated CSS classes ([link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL248-R267))
*  Add a condition to prepend the `customStyleClassPrefix` to the `value` variable in the `insertCustomStyle` function, if the prefix is defined ([link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL267-R277))
*  Replace the calls to `insertCustomStyle` with the `CustomStyle` component in the `Action`, `InputImage`, `InputNumber`, `InputText`, and `Icon` renderers, and pass the `env` prop from the parent component ([link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-4d89203911a9d3ef38c82118f074ad24c49244699f1f2cbb6072134908f60098L796-R798), [link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-4d89203911a9d3ef38c82118f074ad24c49244699f1f2cbb6072134908f60098L885-R932), [link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1543-R1546), [link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R1972-R2023), [link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685L416-L431), [link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685R474-R491), [link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L1061-R1097), [link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-26fc101db139c006d317ebf50b343f3be07294c93815ad2275dd21e76babec4aL156-R180))
*  Add the `env` prop to the `InputNumber` and `InputText` components, which can be used to pass the custom style class prefix to the `CustomStyle` component ([link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685L389-R390), [link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11R1054))
*  Update the schema template names for the `IconPlugin` component, to match the new prop name for the custom style ([link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-fd3fe72052baded5f048dce2f55f2ac314c0b35abe23647f6b64e2d5dca73d5bL114-R118))
*  Remove the calls to `insertCustomStyle` for the label and description classes in the `FormItemWrap` component, and replace them with the `CustomStyle` component ([link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1463-R1468), [link](https://github.com/baidu/amis/pull/6934/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8R1497-R1522))
