### PR TITLE
chore: 日期选择器快捷键最近/以内范围调整，包含当天

### DIFF
--- a/docs/zh-CN/components/form/input-date-range.md
+++ b/docs/zh-CN/components/form/input-date-range.md
@@ -156,6 +156,8 @@ order: 15
 - `{n}yearsago`: 最近 n 年
 - `{n}yearslater`: n 年以内
 
+> {n}{_}later 和 {n}{_}ago 均包含当天
+
 ## 内嵌模式
 
 ```schema: scope="body"

--- a/packages/amis-ui/src/components/DateRangePicker.tsx
+++ b/packages/amis-ui/src/components/DateRangePicker.tsx
@@ -138,50 +138,54 @@ export const availableRanges: {[propName: string]: any} = {
   '7daysago': {
     label: 'DateRange.7daysago',
     startDate: (now: moment.Moment) => {
-      return now.add(-7, 'days').startOf('day');
+      return now.add(-7, 'days');
     },
     endDate: (now: moment.Moment) => {
-      return now.add(-1, 'days').endOf('day');
+      return now;
     }
   },
 
   '30daysago': {
     label: 'DateRange.30daysago',
     startDate: (now: moment.Moment) => {
-      return now.add(-30, 'days').startOf('day');
+      return now.add(-30, 'days');
     },
     endDate: (now: moment.Moment) => {
-      return now.add(-1, 'days').endOf('day');
+      return now;
     }
   },
 
   '90daysago': {
     label: 'DateRange.90daysago',
     startDate: (now: moment.Moment) => {
-      return now.add(-90, 'days').startOf('day');
+      return now.add(-90, 'days');
     },
     endDate: (now: moment.Moment) => {
-      return now.add(-1, 'days').endOf('day');
+      return now;
     }
   },
 
   'prevweek': {
     label: 'DateRange.lastWeek',
-    startDate: (now: moment.Moment) => {
-      return now.startOf('week').add(-1, 'weeks');
+    /** 默认开启iso，每周从周一起始，ios为false时从周日起始 */
+    startDate: (now: moment.Moment, iso: boolean = true) => {
+      return now.startOf(iso ? 'isoWeek' : 'week').add(-1, 'weeks');
     },
-    endDate: (now: moment.Moment) => {
-      return now.startOf('week').add(-1, 'days').endOf('day');
+    endDate: (now: moment.Moment, iso: boolean = true) => {
+      return now
+        .startOf(iso ? 'isoWeek' : 'week')
+        .add(-1, 'days')
+        .endOf('day');
     }
   },
 
   'thisweek': {
     label: 'DateRange.thisWeek',
-    startDate: (now: moment.Moment) => {
-      return now.startOf('week');
+    startDate: (now: moment.Moment, iso: boolean = true) => {
+      return now.startOf(iso ? 'isoWeek' : 'week');
     },
-    endDate: (now: moment.Moment) => {
-      return now.endOf('week');
+    endDate: (now: moment.Moment, iso: boolean = true) => {
+      return now.endOf(iso ? 'isoWeek' : 'week');
     }
   },
 
@@ -264,10 +268,10 @@ export const advancedRanges = [
       return {
         label: __('DateRange.hoursago', {hours}),
         startDate: (now: moment.Moment) => {
-          return now.add(-hours, 'hours').startOf('hour');
+          return now.add(-hours, 'hours');
         },
         endDate: (now: moment.Moment) => {
-          return now.add(-1, 'hours').endOf('hours');
+          return now;
         }
       };
     }
@@ -278,10 +282,10 @@ export const advancedRanges = [
       return {
         label: __('DateRange.hourslater', {hours}),
         startDate: (now: moment.Moment) => {
-          return now.startOf('hour');
+          return now;
         },
         endDate: (now: moment.Moment) => {
-          return now.add(hours, 'hours').endOf('hour');
+          return now.add(hours, 'hours');
         }
       };
     }
@@ -292,10 +296,10 @@ export const advancedRanges = [
       return {
         label: __('DateRange.daysago', {days}),
         startDate: (now: moment.Moment) => {
-          return now.add(-days, 'days').startOf('day');
+          return now.add(-days, 'days');
         },
         endDate: (now: moment.Moment) => {
-          return now.add(-1, 'days').endOf('day');
+          return now;
         }
       };
     }
@@ -306,10 +310,10 @@ export const advancedRanges = [
       return {
         label: __('DateRange.dayslater', {days}),
         startDate: (now: moment.Moment) => {
-          return now.startOf('day');
+          return now;
         },
         endDate: (now: moment.Moment) => {
-          return now.add(days, 'days').endOf('day');
+          return now.add(days, 'days');
         }
       };
     }
@@ -320,10 +324,10 @@ export const advancedRanges = [
       return {
         label: __('DateRange.weeksago', {weeks}),
         startDate: (now: moment.Moment) => {
-          return now.startOf('week').add(-weeks, 'weeks');
+          return now.add(-weeks, 'weeks');
         },
         endDate: (now: moment.Moment) => {
-          return now.startOf('week').add(-1, 'days').endOf('day');
+          return now;
         }
       };
     }
@@ -334,10 +338,10 @@ export const advancedRanges = [
       return {
         label: __('DateRange.weekslater', {weeks}),
         startDate: (now: moment.Moment) => {
-          return now.startOf('week');
+          return now;
         },
         endDate: (now: moment.Moment) => {
-          return now.startOf('week').add(weeks, 'weeks').endOf('day');
+          return now.add(weeks, 'weeks');
         }
       };
     }
@@ -348,10 +352,10 @@ export const advancedRanges = [
       return {
         label: __('DateRange.monthsago', {months}),
         startDate: (now: moment.Moment) => {
-          return now.startOf('months').add(-months, 'months');
+          return now.add(-months, 'months');
         },
         endDate: (now: moment.Moment) => {
-          return now.startOf('month').add(-1, 'days').endOf('day');
+          return now;
         }
       };
     }
@@ -362,10 +366,10 @@ export const advancedRanges = [
       return {
         label: __('DateRange.monthslater', {months}),
         startDate: (now: moment.Moment) => {
-          return now.startOf('month');
+          return now;
         },
         endDate: (now: moment.Moment) => {
-          return now.startOf('month').add(months, 'months').endOf('day');
+          return now.add(months, 'months');
         }
       };
     }
@@ -376,10 +380,10 @@ export const advancedRanges = [
       return {
         label: __('DateRange.quartersago', {quarters}),
         startDate: (now: moment.Moment) => {
-          return now.startOf('quarters').add(-quarters, 'quarters');
+          return now.add(-quarters, 'quarters');
         },
         endDate: (now: moment.Moment) => {
-          return now.startOf('quarter').add(-1, 'days').endOf('day');
+          return now;
         }
       };
     }
@@ -390,10 +394,10 @@ export const advancedRanges = [
       return {
         label: __('DateRange.quarterslater', {quarters}),
         startDate: (now: moment.Moment) => {
-          return now.startOf('quarter');
+          return now;
         },
         endDate: (now: moment.Moment) => {
-          return now.startOf('quarter').add(quarters, 'quarters').endOf('day');
+          return now.add(quarters, 'quarters');
         }
       };
     }
@@ -404,10 +408,10 @@ export const advancedRanges = [
       return {
         label: __('DateRange.yearsago', {years}),
         startDate: (now: moment.Moment) => {
-          return now.startOf('years').add(-years, 'years');
+          return now.add(-years, 'years');
         },
         endDate: (now: moment.Moment) => {
-          return now.startOf('year').add(-1, 'days').endOf('day');
+          return now;
         }
       };
     }
@@ -418,10 +422,10 @@ export const advancedRanges = [
       return {
         label: __('DateRange.yearslater', {years}),
         startDate: (now: moment.Moment) => {
-          return now.startOf('year');
+          return now;
         },
         endDate: (now: moment.Moment) => {
-          return now.startOf('year').add(years, 'years').endOf('day');
+          return now.add(years, 'years');
         }
       };
     }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 91266de</samp>

This pull request fixes some issues with the `DateRangePicker` component and its documentation. It removes the unnecessary rounding of the moment objects in the shortcuts, and adds an option to adjust the week start for different locales. It also updates the input-date-range documentation to explain the shortcut logic more clearly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 91266de</samp>

> _Sing, O Muse, of the wise and skillful coder_
> _Who clarified the range of dates for the component_
> _And made the shortcuts match the true duration_
> _Of days and weeks and months in every region_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 91266de</samp>

*  Clarify the documentation of the input-date-range component to note that later and ago shortcuts include the current day ([link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-05f312d2f6d17f335f4b7942ab35adb09e492cec2fb9cbb7d34e2d2bd13a84beR159-R160))
*  Remove the startOf and endOf methods from the moment objects in the DateRangePicker component to make the shortcuts consistent with the documentation and other shortcuts ([link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L141-R144), [link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L151-R154), [link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L161-R164), [link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L267-R274), [link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L281-R288), [link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L295-R302), [link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L309-R316), [link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L323-R330), [link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L337-R344), [link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L351-R358), [link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L365-R372), [link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L379-R386), [link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L393-R400), [link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L407-R414), [link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L421-R428))
*  Add a parameter iso to the prevweek and thisweek shortcuts in the DateRangePicker component to support different week start settings for different locales ([link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L170-R178), [link](https://github.com/baidu/amis/pull/6935/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L180-R188))
