### PR TITLE
fix(amis-core): 修复select组件中一个未判空导致的渲染错误

### DIFF
--- a/packages/amis-core/src/utils/normalizeOptions.ts
+++ b/packages/amis-core/src/utils/normalizeOptions.ts
@@ -52,35 +52,37 @@ export function normalizeOptions(
       return option;
     });
   } else if (Array.isArray(options as Options)) {
-    return (options as Options).map(item => {
-      const value = item && item[valueField];
-      /**
-       * value 有可能为 null，但 null !== undefined，
-       * 因此从item中读取属性数据，需要判空
-       */
-      const idx =
-        value !== undefined && !item?.children
-          ? share.values.indexOf(value)
-          : -1;
+    return (options as Options)
+      .filter(item => item !== null && item !== undefined)
+      .map(item => {
+        const value = item && item[valueField];
+        const idx =
+          value !== undefined && !item.children
+            ? share.values.indexOf(value)
+            : -1;
 
-      if (~idx) {
-        return share.options[idx];
-      }
+        if (~idx) {
+          return share.options[idx];
+        }
 
-      const option = {
-        ...item,
-        [valueField]: value
-      };
+        const option = {
+          ...item,
+          [valueField]: value
+        };
 
-      if (typeof option.children !== 'undefined') {
-        option.children = normalizeOptions(option.children, share, valueField);
-      } else if (value !== undefined) {
-        share.values.push(value);
-        share.options.push(option);
-      }
+        if (typeof option.children !== 'undefined') {
+          option.children = normalizeOptions(
+            option.children,
+            share,
+            valueField
+          );
+        } else if (value !== undefined) {
+          share.values.push(value);
+          share.options.push(option);
+        }
 
-      return option;
-    });
+        return option;
+      });
   } else if (isPlainObject(options)) {
     return Object.keys(options).map(key => {
       const idx = share.values.indexOf(key);

--- a/packages/amis-core/src/utils/normalizeOptions.ts
+++ b/packages/amis-core/src/utils/normalizeOptions.ts
@@ -54,9 +54,12 @@ export function normalizeOptions(
   } else if (Array.isArray(options as Options)) {
     return (options as Options).map(item => {
       const value = item && item[valueField];
-
+      /**
+       * value 有可能为 null，但 null !== undefined，
+       * 因此从item中读取属性数据，需要判空
+       */
       const idx =
-        value !== undefined && !item.children
+        value !== undefined && !item?.children
           ? share.values.indexOf(value)
           : -1;
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 86eb7ee</samp>

Fix rendering of null options in select component. Add comment and null check in `normalizeOptions.ts` to handle null values and avoid errors.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 86eb7ee</samp>

> _`value` may be null_
> _check it before rendering_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 86eb7ee</samp>

* Fix a bug that caused some options with null values to not render correctly in the select component ([link](https://github.com/baidu/amis/pull/6937/files?diff=unified&w=0#diff-eb45b913e3f3724b5c0b3c42607798b7c6506dc80c350c38ad5ae6f6a132baa5L57-R62)). Add a comment and an optional chaining operator to handle null or undefined values in `normalizeOptions` function in `packages/amis-core/src/utils/normalizeOptions.ts`.
