### PR TITLE
fix: 过滤器filter解析错误

### DIFF
--- a/packages/amis-formula/src/evalutorForAsync.ts
+++ b/packages/amis-formula/src/evalutorForAsync.ts
@@ -66,7 +66,6 @@ export class AsyncEvaluator extends (Evaluator as any) {
       context.filter = filter;
 
       const argsRes = await runSequence(filter.args, async item => {
-        // await promise;
         if (item?.type === 'mixed') {
           const res = await runSequence(item.body, item =>
             typeof item === 'string' ? item : this.evalute(item)

--- a/packages/amis-formula/src/evalutorForAsync.ts
+++ b/packages/amis-formula/src/evalutorForAsync.ts
@@ -65,19 +65,21 @@ export class AsyncEvaluator extends (Evaluator as any) {
       }
       context.filter = filter;
 
-      const argsRes = await filter.args.reduce(async (promise, item) => {
-        await promise;
+      const argsRes = await runSequence(filter.args, async item => {
+        // await promise;
         if (item?.type === 'mixed') {
-          return runSequence(item.body, item =>
+          const res = await runSequence(item.body, item =>
             typeof item === 'string' ? item : this.evalute(item)
           );
+
+          return res.join('');
         } else if (item.type) {
           return this.evalute(item);
         }
         return item;
-      }, Promise.resolve([]));
+      });
 
-      return fn.apply(context, [input].concat(argsRes));
+      return await fn.apply(context, [input].concat(argsRes));
     }, Promise.resolve(input));
 
     return result;

--- a/packages/amis-formula/src/evalutorForAsync.ts
+++ b/packages/amis-formula/src/evalutorForAsync.ts
@@ -78,7 +78,7 @@ export class AsyncEvaluator extends (Evaluator as any) {
         return item;
       });
 
-      return await fn.apply(context, [input].concat(argsRes));
+      return fn.apply(context, [input].concat(argsRes));
     }, Promise.resolve(input));
 
     return result;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63662f3</samp>

Fix a bug in `AsyncEvaluator` for AMIS formulas with asynchronous filters. Use a helper function to evaluate filter arguments in order and handle `mixed` type arguments correctly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 63662f3</samp>

> _`AsyncEvaluator`_
> _Fixes filter bug with `runSequence`_
> _Autumn leaves fall gently_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 63662f3</samp>

* Fix a bug in `AsyncEvaluator` class for asynchronous filters in AMIS formulas ([link](https://github.com/baidu/amis/pull/6938/files?diff=unified&w=0#diff-79397cdbef80c51125929a2cdb1e5371ff3ff7fd2b86e695ed4d615612edb3e2L68-R82))
