### PR TITLE
chore: 调整 layout 与 app 渲染器样式,支持配置成左右布局(非厂子型布局) Close: #6947

### DIFF
--- a/packages/amis-ui/scss/components/_app.scss
+++ b/packages/amis-ui/scss/components/_app.scss
@@ -29,3 +29,13 @@
   display: inline-flex;
   vertical-align: middle;
 }
+
+.#{$ns}AppContent {
+  display: flex;
+  flex-direction: column;
+}
+
+.#{$ns}AppBody {
+  flex: 1;
+  min-height: 0;
+}

--- a/packages/amis-ui/scss/layout/_layout.scss
+++ b/packages/amis-ui/scss/layout/_layout.scss
@@ -254,6 +254,21 @@ body {
       width: 100%;
     }
 
+    &-main {
+      flex-grow: 1;
+      display: flex;
+      flex-direction: row;
+      justify-content: stretch;
+      align-items: stretch;
+    }
+
+    &-content {
+      flex-grow: 1;
+      position: relative;
+      min-height: 0;
+      // height: 0;
+    }
+
     > .#{$ns}Layout-body {
       flex-grow: 1;
       position: relative;
@@ -280,15 +295,15 @@ body {
     }
 
     &--withAside {
-      flex-direction: row;
-      flex-wrap: wrap;
-      justify-content: stretch;
+      // flex-direction: row;
+      // flex-wrap: wrap;
+      // justify-content: stretch;
 
-      > .#{$ns}Layout-content {
-        flex-grow: 1;
-        width: 0;
-        position: relative;
-      }
+      // > .#{$ns}Layout-content {
+      //   flex-grow: 1;
+      //   width: 0;
+      //   position: relative;
+      // }
 
       .#{$ns}Layout-headerBar,
       .#{$ns}Layout-footer {
@@ -383,6 +398,10 @@ body {
           width: 17px;
         }
       }
+    }
+
+    &--noHeader &-asideWrap {
+      top: 0;
     }
 
     &--asideFixed.#{$ns}Layout--folded {

--- a/packages/amis-ui/src/components/Layout.tsx
+++ b/packages/amis-ui/src/components/Layout.tsx
@@ -36,6 +36,7 @@ interface LayoutProps {
   size?: 'sm' | 'base' | 'md' | 'lg';
   children?: React.ReactNode;
   bodyClassName?: string;
+  mainClassName?: string;
 }
 
 export function Layout({
@@ -54,7 +55,8 @@ export function Layout({
   size,
   boxed,
   classnames: cx,
-  bodyClassName
+  bodyClassName,
+  mainClassName
 }: LayoutProps) {
   let body = (
     <div className={cx(`Layout-body`, contentClassName)}>{children}</div>
@@ -86,22 +88,25 @@ export function Layout({
         'Layout--folded': folded,
         'Layout--offScreen': offScreen,
         [`Layout--${size}`]: size,
-        'Layout--noFooter': !footer
+        'Layout--noFooter': !footer,
+        'Layout--noHeader': !header
       })}
     >
       {header ? (
         <div className={cx('Layout-header', headerClassName)}>{header}</div>
       ) : null}
-      {aside ? (
-        <div className={cx(`Layout-aside`, asideClassName)}>
-          <div className={cx('Layout-asideWrap')}>
-            <div id="asideInner" className={cx('Layout-asideInner')}>
-              {aside}
+      <div className={cx('Layout-main', mainClassName)}>
+        {aside ? (
+          <div className={cx(`Layout-aside`, asideClassName)}>
+            <div className={cx('Layout-asideWrap')}>
+              <div id="asideInner" className={cx('Layout-asideInner')}>
+                {aside}
+              </div>
             </div>
           </div>
-        </div>
-      ) : null}
-      {body}
+        ) : null}
+        {body}
+      </div>
       {footer ? (
         <footer className={cx('Layout-footer')} role="footer">
           {footer}

--- a/packages/amis/src/renderers/App.tsx
+++ b/packages/amis/src/renderers/App.tsx
@@ -290,6 +290,10 @@ export default class App extends React.Component<AppProps, object> {
       env
     } = this.props;
 
+    if (!header && !logo && !brandName) {
+      return null;
+    }
+
     return (
       <>
         <div className={cx('Layout-brandBar')}>
@@ -438,6 +442,7 @@ export default class App extends React.Component<AppProps, object> {
         footer={this.renderFooter()}
         folded={store.folded}
         offScreen={store.offScreen}
+        contentClassName={cx('AppContent')}
       >
         {store.activePage && store.schema ? (
           <>
@@ -461,10 +466,12 @@ export default class App extends React.Component<AppProps, object> {
               </ul>
             ) : null}
 
-            {render('page', store.schema, {
-              key: `${store.activePage?.id}-${store.schemaKey}`,
-              data: store.pageData
-            })}
+            <div className={cx('AppBody')}>
+              {render('page', store.schema, {
+                key: `${store.activePage?.id}-${store.schemaKey}`,
+                data: store.pageData
+              })}
+            </div>
           </>
         ) : store.pages && !store.activePage ? (
           <NotFound>

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -2547,7 +2547,10 @@ export default class Table extends React.Component<TableProps, object> {
       <ColumnToggler
         {...rest}
         {...(isObject(config) ? config : {})}
-        tooltip={config?.tooltip || __('Table.columnsVisibility')}
+        tooltip={{
+          content: config?.tooltip || __('Table.columnsVisibility'),
+          placement: 'bottom'
+        }}
         tooltipContainer={
           env && env.getModalContainer ? env.getModalContainer : undefined
         }
@@ -2658,7 +2661,7 @@ export default class Table extends React.Component<TableProps, object> {
         disabled={!!store.modified}
         classPrefix={ns}
         key="dragging-toggle"
-        tooltip={__('Table.startSort')}
+        tooltip={{content: __('Table.startSort'), placement: 'bottom'}}
         tooltipContainer={
           env && env.getModalContainer ? env.getModalContainer : undefined
         }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b536ce8</samp>

This pull request enhances the layout components and their styling in `amis-ui` and `amis`. It adds more flexibility and customization options for the layout elements, fixes some layout issues, and improves the tooltip placement for the table buttons.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b536ce8</samp>

> _We're heaving on the ropes, me hearties, on the count of three_
> _We're making our app layout more flexible and pretty_
> _We're adding props and classes, fixing bugs and styles_
> _We're rendering `AppContent` and `AppBody` with a smile_

### Why

Close: #6947

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b536ce8</samp>

*  Add mainClassName prop to Layout component to customize the class name of the Layout-main element ([link](https://github.com/baidu/amis/pull/6950/files?diff=unified&w=0#diff-570943f3b300764dd29cdd4e273a995f26c32b04c91b693afac3ba1e45fa573bR39), [link](https://github.com/baidu/amis/pull/6950/files?diff=unified&w=0#diff-570943f3b300764dd29cdd4e273a995f26c32b04c91b693afac3ba1e45fa573bL57-R59), [link](https://github.com/baidu/amis/pull/6950/files?diff=unified&w=0#diff-570943f3b300764dd29cdd4e273a995f26c32b04c91b693afac3ba1e45fa573bL95-R109))
*  Wrap the content and aside elements of the Layout component in a new div element with the class name of Layout-main and the mainClassName prop, and move the aside element inside the Layout-main element ([link](https://github.com/baidu/amis/pull/6950/files?diff=unified&w=0#diff-570943f3b300764dd29cdd4e273a995f26c32b04c91b693afac3ba1e45fa573bL95-R109))
*  Add 'Layout--noHeader' conditional class name to Layout component to style the layout differently when there is no header element ([link](https://github.com/baidu/amis/pull/6950/files?diff=unified&w=0#diff-570943f3b300764dd29cdd4e273a995f26c32b04c91b693afac3ba1e45fa573bL89-R92), [link](https://github.com/baidu/amis/pull/6950/files?diff=unified&w=0#diff-2beb3f83f0f709e5d5b6c0a772d8d394848b0ef4068a051979ff1bea74dad8a6R403-R406))
*  Add contentClassName prop to Layout component to customize the class name of the Layout-content element, and set it to 'AppContent' in the App component ([link](https://github.com/baidu/amis/pull/6950/files?diff=unified&w=0#diff-570943f3b300764dd29cdd4e273a995f26c32b04c91b693afac3ba1e45fa573bL95-R109), [link](https://github.com/baidu/amis/pull/6950/files?diff=unified&w=0#diff-b3a4d413575f4fe07501c750c75d47f53100ca6a9536c98886c7b67d63542d39R445))
*  Wrap the page element of the App component in a new div element with the class name of AppBody ([link](https://github.com/baidu/amis/pull/6950/files?diff=unified&w=0#diff-b3a4d413575f4fe07501c750c75d47f53100ca6a9536c98886c7b67d63542d39L464-R474))
*  Add CSS rules for the AppContent and AppBody classes in the `_app.scss` file to style the main content area of the app layout ([link](https://github.com/baidu/amis/pull/6950/files?diff=unified&w=0#diff-18d82548b6d0b69475dfaa585b80f7ef62f9d794c83c7ede7a918e332538feecR32-R41))
*  Add CSS rules for the Layout-main and Layout-content classes in the `_layout.scss` file to style the main area of the layout component ([link](https://github.com/baidu/amis/pull/6950/files?diff=unified&w=0#diff-2beb3f83f0f709e5d5b6c0a772d8d394848b0ef4068a051979ff1bea74dad8a6R257-R271))
*  Comment out CSS rules for the Layout--withAside modifier class and its child selector for the Layout-content class in the `_layout.scss` file, as they are no longer needed ([link](https://github.com/baidu/amis/pull/6950/files?diff=unified&w=0#diff-2beb3f83f0f709e5d5b6c0a772d8d394848b0ef4068a051979ff1bea74dad8a6L283-R306))
*  Return null in the renderHeader function of the App component when the header, logo, and brandName props are all falsy, to avoid rendering an empty header element ([link](https://github.com/baidu/amis/pull/6950/files?diff=unified&w=0#diff-b3a4d413575f4fe07501c750c75d47f53100ca6a9536c98886c7b67d63542d39R293-R296))
*  Change the tooltip prop of the Button component from a string to an object in the Table component, to specify the content and placement of the tooltip, and set the placement to 'bottom' ([link](https://github.com/baidu/amis/pull/6950/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2550-R2553), [link](https://github.com/baidu/amis/pull/6950/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2661-R2664))
