### PR TITLE
styles: 修复button iconfont图标垂直不居中问题

### DIFF
--- a/packages/amis-ui/scss/_mixins.scss
+++ b/packages/amis-ui/scss/_mixins.scss
@@ -247,6 +247,7 @@
     font-size: $iconSize;
     width: $iconSize;
     height: $iconSize;
+    line-height: $iconSize;
   }
 
   .#{$ns}Button-icon:last-child:not(:first-child):not(.pull-left),
@@ -255,6 +256,7 @@
     margin-left: $iconMargin;
     width: $iconSize;
     height: $iconSize;
+    line-height: $iconSize;
   }
 
   .#{$ns}Button--loading:first-child:not(:last-child):not(.pull-right),
@@ -264,6 +266,7 @@
     margin-right: $iconMargin;
     width: $iconSize;
     height: $iconSize;
+    line-height: $iconSize;
   }
 
   .#{$ns}Button--loading:last-child:not(:first-child):not(.pull-left),
@@ -272,6 +275,7 @@
     margin-left: $iconMargin;
     width: $iconSize;
     height: $iconSize;
+    line-height: $iconSize;
   }
 
   &.#{$ns}Button--iconOnly {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a6b936</samp>

This pull request improves the icon styling in `amis-ui` by adjusting the line-height of icon classes to match the icon size variable in `_mixins.scss`. This enhances the visual consistency and alignment of icons in various components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3a6b936</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _the `line-height` of the icons, those shining signs_
> _that grace the web with varied shapes and hues,_
> _and matched them to the `icon-size` variable._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3a6b936</samp>

* Improve the vertical alignment of icons in different contexts by setting the line-height of the icon classes to match the icon size variable ([link](https://github.com/baidu/amis/pull/6953/files?diff=unified&w=0#diff-7e5b8022401a374798841bb3e5655feb6751e8a6c42835e0a7f438250e79132aR250), [link](https://github.com/baidu/amis/pull/6953/files?diff=unified&w=0#diff-7e5b8022401a374798841bb3e5655feb6751e8a6c42835e0a7f438250e79132aR259), [link](https://github.com/baidu/amis/pull/6953/files?diff=unified&w=0#diff-7e5b8022401a374798841bb3e5655feb6751e8a6c42835e0a7f438250e79132aR269), [link](https://github.com/baidu/amis/pull/6953/files?diff=unified&w=0#diff-7e5b8022401a374798841bb3e5655feb6751e8a6c42835e0a7f438250e79132aR278)) in `_mixins.scss`
