### PR TITLE
fix(amis-core): extendLocale增加cover参数，可用于设置非覆盖式扩展国际化语料数据

### DIFF
--- a/packages/amis-core/src/locale.tsx
+++ b/packages/amis-core/src/locale.tsx
@@ -20,11 +20,23 @@ export function register(name: string, config: LocaleConfig) {
   extendLocale(name, config);
 }
 
-export function extendLocale(name: string, config: LocaleConfig) {
-  locales[name] = {
-    ...(locales[name] || {}),
-    ...config
-  };
+export function extendLocale(
+  name: string,
+  config: LocaleConfig,
+  cover: boolean = true
+) {
+  if (cover) {
+    // 覆盖式扩展语料
+    locales[name] = {
+      ...(locales[name] || {}),
+      ...config
+    };
+  } else {
+    locales[name] = {
+      ...config,
+      ...(locales[name] || {})
+    };
+  }
 }
 
 /** 删除语料数据 */


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 96bd14c</samp>

Added a `cover` parameter to `extendLocale` function to enable merging or overwriting locale configs. This fixes issue #2499 and improves locale customization.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 96bd14c</samp>

> _`extendLocale` grows_
> _with a new parameter_
> _cover or merge - choice_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 96bd14c</samp>

* Add a `cover` parameter to `extendLocale` function to control locale merging ([link](https://github.com/baidu/amis/pull/6954/files?diff=unified&w=0#diff-023b8c9ef2dc817eaff1137c307a2995770ef92e0e39579c1efd1fc584f06bc6L23-R39))
