### PR TITLE
feat(amis): 日期选择器支持用表达式自定义快捷键

### DIFF
--- a/docs/zh-CN/components/form/input-date-range.md
+++ b/docs/zh-CN/components/form/input-date-range.md
@@ -107,7 +107,7 @@ order: 15
 
 ## 快捷键
 
-`ranges`属性支持自定义快捷选择日期范围快捷键
+`shortcuts`属性支持自定义快捷选择日期范围快捷键
 
 ```schema: scope="body"
 {
@@ -118,7 +118,7 @@ order: 15
             "type": "input-date-range",
             "name": "select",
             "label": "日期范围",
-              "ranges": [
+              "shortcuts": [
                 "7daysago",
                 "15dayslater",
                 "2weeksago",
@@ -156,6 +156,42 @@ order: 15
 - `{n}yearsago`: 最近 n 年
 - `{n}yearslater`: n 年以内
 
+快捷键也支持使用表达式的写法，可以使用这种方式自定义快捷键
+
+> 3.1.0 及以上版本
+
+```schema: scope="body"
+{
+    "type": "form",
+    "debug": true,
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+        {
+            "type": "input-date-range",
+            "name": "select",
+            "label": "日期范围",
+              "shortcuts": [
+                {
+                    "label": "1天前",
+                    "startDate": "${DATEMODIFY(NOW(), -1, 'day')}",
+                    "endDate": "${NOW()}"
+                },
+                {
+                    "label": "1个月前",
+                    "startDate": "${DATEMODIFY(NOW(), -1, 'months')}",
+                    "endDate": "${NOW()}"
+                },
+                {
+                    "label": "本季度",
+                    "startDate": "${STARTOF(NOW(), 'quarter')}",
+                    "endDate": "${ENDOF(NOW(), 'quarter')}"
+                }
+            ]
+        }
+    ]
+}
+```
+
 ## 内嵌模式
 
 ```schema: scope="body"
@@ -178,20 +214,20 @@ order: 15
 
 除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置
 
-| 属性名      | 类型                      | 默认值                                                          | 说明                                                                         | 版本    |
-| ----------- | ------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------- |
-| format      | `string`                  | `X`                                                             | [日期选择器值格式](./date#%E5%80%BC%E6%A0%BC%E5%BC%8F)                       |
-| inputFormat | `string`                  | `YYYY-MM-DD`                                                    | [日期选择器显示格式](./date#%E6%98%BE%E7%A4%BA%E6%A0%BC%E5%BC%8F)            |
-| placeholder | `string`                  | `"请选择日期范围"`                                              | 占位文本                                                                     |
-| ranges      | `Array<string> 或 string` | `"yesterday,7daysago,prevweek,thismonth,prevmonth,prevquarter"` | 日期范围快捷键                                                               |
-| minDate     | `string`                  |                                                                 | 限制最小日期，用法同 [限制范围](./date#%E9%99%90%E5%88%B6%E8%8C%83%E5%9B%B4) |
-| maxDate     | `string`                  |                                                                 | 限制最大日期，用法同 [限制范围](./date#%E9%99%90%E5%88%B6%E8%8C%83%E5%9B%B4) |
-| minDuration | `string`                  |                                                                 | 限制最小跨度，如： 2days                                                     |
-| maxDuration | `string`                  |                                                                 | 限制最大跨度，如：1year                                                      |
-| utc         | `boolean`                 | `false`                                                         | [保存 UTC 值](./date#utc)                                                    |
-| clearable   | `boolean`                 | `true`                                                          | 是否可清除                                                                   |
-| embed       | `boolean`                 | `false`                                                         | 是否内联模式                                                                 |
-| animation   | `boolean`                 | `true`                                                          | 是否启用游标动画                                                             | `2.2.0` |
+| 属性名      | 类型                                                                               | 默认值                                                          | 说明                                                                         | 版本                    |
+| ----------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------- | ----------------------- |
+| format      | `string`                                                                           | `X`                                                             | [日期选择器值格式](./date#%E5%80%BC%E6%A0%BC%E5%BC%8F)                       |
+| inputFormat | `string`                                                                           | `YYYY-MM-DD`                                                    | [日期选择器显示格式](./date#%E6%98%BE%E7%A4%BA%E6%A0%BC%E5%BC%8F)            |
+| placeholder | `string`                                                                           | `"请选择日期范围"`                                              | 占位文本                                                                     |
+| shortcuts   | `string \| string[] \| Array<{label: string; startDate: string; endDate: string}>` | `"yesterday,7daysago,prevweek,thismonth,prevmonth,prevquarter"` | 日期范围快捷键                                                               | `3.1.0`版本后支持表达式 |
+| minDate     | `string`                                                                           |                                                                 | 限制最小日期，用法同 [限制范围](./date#%E9%99%90%E5%88%B6%E8%8C%83%E5%9B%B4) |
+| maxDate     | `string`                                                                           |                                                                 | 限制最大日期，用法同 [限制范围](./date#%E9%99%90%E5%88%B6%E8%8C%83%E5%9B%B4) |
+| minDuration | `string`                                                                           |                                                                 | 限制最小跨度，如： 2days                                                     |
+| maxDuration | `string`                                                                           |                                                                 | 限制最大跨度，如：1year                                                      |
+| utc         | `boolean`                                                                          | `false`                                                         | [保存 UTC 值](./date#utc)                                                    |
+| clearable   | `boolean`                                                                          | `true`                                                          | 是否可清除                                                                   |
+| embed       | `boolean`                                                                          | `false`                                                         | 是否内联模式                                                                 |
+| animation   | `boolean`                                                                          | `true`                                                          | 是否启用游标动画                                                             | `2.2.0`                 |
 
 ## 事件表
 

--- a/docs/zh-CN/components/form/input-date.md
+++ b/docs/zh-CN/components/form/input-date.md
@@ -247,7 +247,8 @@ order: 13
 ## 快捷键
 
 你也可以配置`shortcuts`属性支持快捷选择日期
-注：移动端 picker 的形式不支持快捷键
+
+> 注：移动端 picker 的形式不支持快捷键
 
 ```schema: scope="body"
 {
@@ -259,7 +260,7 @@ order: 13
             "type": "input-date",
             "name": "date",
             "label": "日期",
-            "shortcuts": ["yesterday" ,"today", "tomorrow"]
+            "shortcuts": ["yesterday", "today", "tomorrow"]
         }
     ]
 }
@@ -288,6 +289,33 @@ order: 13
 - `{n}monthslater`: n 月后
 - `{n}quartersago`: n 季度前
 - `{n}quarterslater`: n 季度后
+
+快捷键也支持使用表达式的写法，可以使用这种方式自定义快捷键
+
+> 3.1.0 及以上版本
+
+```schema: scope="body"
+{
+    "type": "form",
+    "debug": true,
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+        {
+            "type": "input-date",
+            "name": "date",
+            "label": "日期",
+            "shortcuts": [
+                {
+                    "label": "前天",
+                    "date": "${STARTOF(DATEMODIFY(NOW(), -2, 'day'))}"
+                },
+                "yesterday",
+                "today"
+            ]
+        }
+    ]
+}
+```
 
 ## UTC
 
@@ -358,19 +386,19 @@ order: 13
 
 除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置
 
-| 属性名        | 类型      | 默认值         | 说明                                                                                                        |
-| ------------- | --------- | -------------- | ----------------------------------------------------------------------------------------------------------- |
-| value         | `string`  |                | [默认值](./date#%E9%BB%98%E8%AE%A4%E5%80%BC)                                                                |
-| format        | `string`  | `X`            | 日期选择器值格式，更多格式类型请参考 [文档](https://momentjs.com/docs/#/displaying/format/)                 |
-| inputFormat   | `string`  | `YYYY-MM-DD`   | 日期选择器显示格式，即时间戳格式，更多格式类型请参考 [文档](https://momentjs.com/docs/#/displaying/format/) |
-| closeOnSelect | `boolean` | `false`        | 点选日期后，是否马上关闭选择框                                                                              |
-| placeholder   | `string`  | `"请选择日期"` | 占位文本                                                                                                    |
-| shortcuts     | `string`  |                | 日期快捷键                                                                                                  |
-| minDate       | `string`  |                | 限制最小日期                                                                                                |
-| maxDate       | `string`  |                | 限制最大日期                                                                                                |
-| utc           | `boolean` | `false`        | 保存 utc 值                                                                                                 |
-| clearable     | `boolean` | `true`         | 是否可清除                                                                                                  |
-| embed         | `boolean` | `false`        | 是否内联模式                                                                                                |
+| 属性名        | 类型                                                           | 默认值         | 说明                                                                                                        | 版本                    |
+| ------------- | -------------------------------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------- |
+| value         | `string`                                                       |                | [默认值](./date#%E9%BB%98%E8%AE%A4%E5%80%BC)                                                                |
+| format        | `string`                                                       | `X`            | 日期选择器值格式，更多格式类型请参考 [文档](https://momentjs.com/docs/#/displaying/format/)                 |
+| inputFormat   | `string`                                                       | `YYYY-MM-DD`   | 日期选择器显示格式，即时间戳格式，更多格式类型请参考 [文档](https://momentjs.com/docs/#/displaying/format/) |
+| closeOnSelect | `boolean`                                                      | `false`        | 点选日期后，是否马上关闭选择框                                                                              |
+| placeholder   | `string`                                                       | `"请选择日期"` | 占位文本                                                                                                    |
+| shortcuts     | `string \| string[] \| Array<{"label": string; date: string}>` |                | 日期快捷键，字符串格式为预设值，对象格式支持写表达式                                                        | `3.1.0`版本后支持表达式 |
+| minDate       | `string`                                                       |                | 限制最小日期                                                                                                |
+| maxDate       | `string`                                                       |                | 限制最大日期                                                                                                |
+| utc           | `boolean`                                                      | `false`        | 保存 utc 值                                                                                                 |
+| clearable     | `boolean`                                                      | `true`         | 是否可清除                                                                                                  |
+| embed         | `boolean`                                                      | `false`        | 是否内联模式                                                                                                |
 
 ## 事件表
 

--- a/docs/zh-CN/components/form/input-datetime-range.md
+++ b/docs/zh-CN/components/form/input-datetime-range.md
@@ -46,7 +46,7 @@ order: 16
 
 ## 快捷键
 
-`ranges`属性支持自定义日期时间范围快捷键
+`shortcuts`属性支持自定义日期时间范围快捷键
 
 ```schema: scope="body"
 {
@@ -57,7 +57,46 @@ order: 16
             "type": "input-datetime-range",
             "name": "select",
             "label": "日期范围",
-            "ranges": "today,yesterday,1dayago,7daysago"
+            "shortcuts": "today,yesterday,1dayago,7daysago"
+        }
+    ]
+}
+```
+
+快捷键也支持使用表达式的写法，可以使用这种方式自定义快捷键
+
+> 3.1.0 及以上版本
+
+```schema: scope="body"
+{
+    "type": "form",
+    "debug": true,
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+        {
+            "type": "input-datetime-range",
+            "name": "select",
+            "label": "日期范围",
+            "inputFormat": "YYYY-MM-DD HH:mm:ss",
+            "timeFormat": "HH:mm:ss",
+            "format": "x",
+            "shortcuts": [
+                {
+                    "label": "1天前",
+                    "startDate": "${DATEMODIFY(NOW(), -1, 'day')}",
+                    "endDate": "${NOW()}"
+                },
+                {
+                    "label": "1个月前",
+                    "startDate": "${DATEMODIFY(NOW(), -1, 'months')}",
+                    "endDate": "${NOW()}"
+                },
+                {
+                    "label": "本季度",
+                    "startDate": "${STARTOF(NOW(), 'quarter')}",
+                    "endDate": "${ENDOF(NOW(), 'quarter')}"
+                }
+            ]
         }
     ]
 }
@@ -67,17 +106,17 @@ order: 16
 
 除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置
 
-| 属性名      | 类型                      | 默认值                                                          | 说明                                                                                       | 版本    |
-| ----------- | ------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------- |
-| format      | `string`                  | `X`                                                             | [日期时间选择器值格式](./input-datetime#%E5%80%BC%E6%A0%BC%E5%BC%8F)                       |
-| inputFormat | `string`                  | `YYYY-MM-DD`                                                    | [日期时间选择器显示格式](./input-datetime#%E6%98%BE%E7%A4%BA%E6%A0%BC%E5%BC%8F)            |
-| placeholder | `string`                  | `"请选择日期范围"`                                              | 占位文本                                                                                   |
-| ranges      | `Array<string> 或 string` | `"yesterday,7daysago,prevweek,thismonth,prevmonth,prevquarter"` | 日期范围快捷键                                                                             |
-| minDate     | `string`                  |                                                                 | 限制最小日期时间，用法同 [限制范围](./input-datetime#%E9%99%90%E5%88%B6%E8%8C%83%E5%9B%B4) |
-| maxDate     | `string`                  |                                                                 | 限制最大日期时间，用法同 [限制范围](./input-datetime#%E9%99%90%E5%88%B6%E8%8C%83%E5%9B%B4) |
-| utc         | `boolean`                 | `false`                                                         | [保存 UTC 值](./input-datetime#utc)                                                        |
-| clearable   | `boolean`                 | `true`                                                          | 是否可清除                                                                                 |
-| animation   | `boolean`                 | `true`                                                          | 是否启用游标动画                                                                           | `2.2.0` |
+| 属性名      | 类型                                                                               | 默认值                                                          | 说明                                                                                       | 版本                    |
+| ----------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ----------------------- |
+| format      | `string`                                                                           | `X`                                                             | [日期时间选择器值格式](./input-datetime#%E5%80%BC%E6%A0%BC%E5%BC%8F)                       |
+| inputFormat | `string`                                                                           | `YYYY-MM-DD`                                                    | [日期时间选择器显示格式](./input-datetime#%E6%98%BE%E7%A4%BA%E6%A0%BC%E5%BC%8F)            |
+| placeholder | `string`                                                                           | `"请选择日期范围"`                                              | 占位文本                                                                                   |
+| shortcuts   | `string \| string[] \| Array<{label: string; startDate: string; endDate: string}>` | `"yesterday,7daysago,prevweek,thismonth,prevmonth,prevquarter"` | 日期范围快捷键，详情参考[快捷键](./input-date-range#快捷键)                                | `3.1.0`版本后支持表达式 |
+| minDate     | `string`                                                                           |                                                                 | 限制最小日期时间，用法同 [限制范围](./input-datetime#%E9%99%90%E5%88%B6%E8%8C%83%E5%9B%B4) |
+| maxDate     | `string`                                                                           |                                                                 | 限制最大日期时间，用法同 [限制范围](./input-datetime#%E9%99%90%E5%88%B6%E8%8C%83%E5%9B%B4) |
+| utc         | `boolean`                                                                          | `false`                                                         | [保存 UTC 值](./input-datetime#utc)                                                        |
+| clearable   | `boolean`                                                                          | `true`                                                          | 是否可清除                                                                                 |
+| animation   | `boolean`                                                                          | `true`                                                          | 是否启用游标动画                                                                           | `2.2.0`                 |
 
 ## 事件表
 

--- a/docs/zh-CN/components/form/input-datetime.md
+++ b/docs/zh-CN/components/form/input-datetime.md
@@ -278,6 +278,33 @@ order: 14
 - `{n}hoursago` : n 小时前，例如：`2hoursago`，下面用法相同
 - `{n}hourslater` : n 小时后，例如：`2hourslater`，下面用法相同
 
+快捷键也支持使用表达式的写法，可以使用这种方式自定义快捷键
+
+> 3.1.0 及以上版本
+
+```schema: scope="body"
+{
+    "type": "form",
+    "debug": true,
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+        {
+            "type": "input-datetime",
+            "name": "datetime",
+            "label": "日期",
+            "shortcuts": [
+                {
+                    "label": "前天",
+                    "date": "${STARTOF(DATEMODIFY(NOW(), -2, 'day'))}"
+                },
+                "yesterday",
+                "today"
+            ]
+        }
+    ]
+}
+```
+
 ## UTC
 
 ```schema: scope="body"
@@ -330,19 +357,19 @@ order: 14
 
 除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置
 
-| 属性名          | 类型      | 默认值                 | 说明                                                                                                            |
-| --------------- | --------- | ---------------------- | --------------------------------------------------------------------------------------------------------------- |
-| value           | `string`  |                        | [默认值](./datetime#%E9%BB%98%E8%AE%A4%E5%80%BC)                                                                |
-| format          | `string`  | `X`                    | 日期时间选择器值格式，更多格式类型请参考 [文档](https://momentjs.com/docs/#/displaying/format/)                 |
-| inputFormat     | `string`  | `YYYY-MM-DD HH:mm:ss`  | 日期时间选择器显示格式，即时间戳格式，更多格式类型请参考 [文档](https://momentjs.com/docs/#/displaying/format/) |
-| placeholder     | `string`  | `"请选择日期以及时间"` | 占位文本                                                                                                        |
-| shortcuts       | `string`  |                        | 日期时间快捷键                                                                                                  |
-| minDate         | `string`  |                        | 限制最小日期时间                                                                                                |
-| maxDate         | `string`  |                        | 限制最大日期时间                                                                                                |
-| utc             | `boolean` | `false`                | 保存 utc 值                                                                                                     |
-| clearable       | `boolean` | `true`                 | 是否可清除                                                                                                      |
-| embed           | `boolean` | `false`                | 是否内联                                                                                                        |
-| timeConstraints | `object`  | `true`                 | 请参考 [input-time](./input-time#控制输入范围) 里的说明                                                         |
+| 属性名          | 类型                                                           | 默认值                 | 说明                                                                                                            | 版本                    |
+| --------------- | -------------------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| value           | `string`                                                       |                        | [默认值](./datetime#%E9%BB%98%E8%AE%A4%E5%80%BC)                                                                |
+| format          | `string`                                                       | `X`                    | 日期时间选择器值格式，更多格式类型请参考 [文档](https://momentjs.com/docs/#/displaying/format/)                 |
+| inputFormat     | `string`                                                       | `YYYY-MM-DD HH:mm:ss`  | 日期时间选择器显示格式，即时间戳格式，更多格式类型请参考 [文档](https://momentjs.com/docs/#/displaying/format/) |
+| placeholder     | `string`                                                       | `"请选择日期以及时间"` | 占位文本                                                                                                        |
+| shortcuts       | `string \| string[] \| Array<{"label": string; date: string}>` |                        | 日期时间快捷键                                                                                                  | `3.1.0`版本后支持表达式 |
+| minDate         | `string`                                                       |                        | 限制最小日期时间                                                                                                |
+| maxDate         | `string`                                                       |                        | 限制最大日期时间                                                                                                |
+| utc             | `boolean`                                                      | `false`                | 保存 utc 值                                                                                                     |
+| clearable       | `boolean`                                                      | `true`                 | 是否可清除                                                                                                      |
+| embed           | `boolean`                                                      | `false`                | 是否内联                                                                                                        |
+| timeConstraints | `object`                                                       | `true`                 | 请参考 [input-time](./input-time#控制输入范围) 里的说明                                                         |
 
 ## 事件表
 

--- a/packages/amis-editor/src/plugin/Form/InputDateRange.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputDateRange.tsx
@@ -22,7 +22,9 @@ const DateType: {
   [key: string]: {
     format: string;
     placeholder: string;
-    ranges: string[];
+    shortcuts: string[];
+    /** shortcuts的兼容配置, 不需要配置了 */
+    ranges?: string[];
     sizeMutable?: boolean;
     type?: string;
     timeFormat?: string;
@@ -33,7 +35,7 @@ const DateType: {
     ...getRendererByName('input-date-range'),
     format: 'YYYY-MM-DD',
     placeholder: '请选择日期范围',
-    ranges: [
+    shortcuts: [
       'yesterday',
       '7daysago',
       'prevweek',
@@ -62,7 +64,7 @@ const DateType: {
     format: 'YYYY-MM-DD HH:mm:ss',
     timeFormat: 'HH:mm:ss',
     placeholder: '请选择日期时间范围',
-    ranges: [
+    shortcuts: [
       'yesterday',
       '7daysago',
       'prevweek',
@@ -91,7 +93,7 @@ const DateType: {
     format: 'HH:mm',
     timeFormat: 'HH:mm:ss',
     placeholder: '请选择时间范围',
-    ranges: [],
+    shortcuts: [],
     formatOptions: [
       {
         label: 'HH:mm',
@@ -119,7 +121,7 @@ const DateType: {
     ...getRendererByName('input-month-range'),
     format: 'YYYY-MM',
     placeholder: '请选择月份范围',
-    ranges: [],
+    shortcuts: [],
     formatOptions: [
       ...formatX,
       {
@@ -140,7 +142,7 @@ const DateType: {
     ...getRendererByName('input-quarter-range'),
     format: 'YYYY [Q]Q',
     placeholder: '请选择季度范围',
-    ranges: ['thisquarter', 'prevquarter'],
+    shortcuts: ['thisquarter', 'prevquarter'],
     formatOptions: [
       ...formatX,
       {
@@ -157,7 +159,7 @@ const DateType: {
     ...getRendererByName('input-year-range'),
     format: 'YYYY',
     placeholder: '请选择年范围',
-    ranges: ['thisyear', 'lastYear'],
+    shortcuts: ['thisyear', 'lastYear'],
     formatOptions: [
       ...formatX,
       {
@@ -321,7 +323,9 @@ export class DateRangeControlPlugin extends BasePlugin {
                       minDate: '',
                       maxDate: '',
                       value: '',
-                      ranges: DateType[type]?.ranges,
+                      shortcuts: DateType[type]?.shortcuts,
+                      /** amis 3.1.0之后ranges属性废弃 */
+                      ranges: undefined,
                       // size immutable 组件去除 size 字段
                       size: sizeImmutableComponents.includes(value)
                         ? undefined
@@ -444,6 +448,7 @@ export class DateRangeControlPlugin extends BasePlugin {
                   label: tipedLabel('最大跨度', rangTooltip)
                 }),
                 getSchemaTpl('dateShortCutControl', {
+                  name: 'shortcuts',
                   mode: 'normal',
                   normalDropDownOption: {
                     yesterday: '昨天',

--- a/packages/amis-editor/src/renderer/DateShortCutControl.tsx
+++ b/packages/amis-editor/src/renderer/DateShortCutControl.tsx
@@ -101,7 +101,7 @@ export class DateShortCutControl extends React.PureComponent<
         value: key
       })
     );
-    const defaultRanges = [
+    const defaultShortcuts = [
       'yesterday',
       '7daysago',
       'prevweek',
@@ -110,7 +110,8 @@ export class DateShortCutControl extends React.PureComponent<
       'prevquarter'
     ];
     this.state = {
-      options: (data?.ranges ?? defaultRanges).map(
+      /** amis 3.1.0之后ranges属性废弃，此处兼容 */
+      options: (data?.ranges ?? data?.shortcuts ?? defaultShortcuts).map(
         (item: string, index: number) => {
           const arr = item.match(/^(\d+)[a-zA-Z]+/);
           if (arr) {
@@ -334,7 +335,7 @@ export class DateShortCutControl extends React.PureComponent<
    */
   onChangeOptions() {
     const {options} = this.state;
-    const {onBulkChange} = this.props;
+    const {onBulkChange, name} = this.props;
     const newOptions: Array<string> = [];
     options.forEach((item, index) => {
       if (item.type === RangeType.Normal) {
@@ -344,7 +345,9 @@ export class DateShortCutControl extends React.PureComponent<
         newOptions[index] = `${item.value}${item.inputType}`;
       }
     });
-    onBulkChange && onBulkChange({ranges: newOptions});
+    /** amis 3.1.0之后ranges属性废弃 */
+    onBulkChange &&
+      onBulkChange({[name ?? 'shortcuts']: newOptions, ranges: undefined});
   }
 
   render() {

--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -1166,6 +1166,7 @@ setSchemaTpl('nav-default-active', {
 setSchemaTpl('dateShortCutControl', (schema: object = {}) => {
   return {
     type: 'ae-DateShortCutControl',
+    name: 'shortcuts',
     ...schema
   };
 });

--- a/packages/amis-ui/src/components/DateRangePicker.tsx
+++ b/packages/amis-ui/src/components/DateRangePicker.tsx
@@ -5,23 +5,32 @@
  */
 
 import React from 'react';
+import {findDOMNode} from 'react-dom';
 import moment, {unitOfTime} from 'moment';
 import omit from 'lodash/omit';
 import kebabCase from 'lodash/kebabCase';
-import {findDOMNode} from 'react-dom';
+import {
+  PopOver,
+  Overlay,
+  isExpression,
+  FormulaExec,
+  filterDate,
+  themeable,
+  getComputedStyle,
+  isMobile,
+  noop,
+  ucFirst,
+  localeable
+} from 'amis-core';
 import {Icon} from './icons';
-import {Overlay} from 'amis-core';
 import {ShortCuts, ShortCutDateRange} from './DatePicker';
 import Calendar from './calendar/Calendar';
-import {PopOver} from 'amis-core';
 import PopUp from './PopUp';
-import {ClassNamesFn, themeable, ThemeProps, getComputedStyle} from 'amis-core';
-import type {PlainObject} from 'amis-core';
-import {isMobile, noop, ucFirst} from 'amis-core';
-import {LocaleProps, localeable} from 'amis-core';
 import CalendarMobile from './CalendarMobile';
 import Input from './Input';
 import Button from './Button';
+
+import type {PlainObject, ThemeProps, LocaleProps} from 'amis-core';
 
 export interface DateRangePickerProps extends ThemeProps, LocaleProps {
   className?: string;
@@ -32,10 +41,16 @@ export interface DateRangePickerProps extends ThemeProps, LocaleProps {
   format: string;
   utc?: boolean;
   inputFormat?: string;
+  /**
+   * @deprecated 3.1.0后废弃，用shortcuts替代
+   */
   ranges?: string | Array<ShortCuts>;
+  shortcuts?: string | Array<ShortCuts>;
   clearable?: boolean;
   minDate?: moment.Moment;
   maxDate?: moment.Moment;
+  minDateRaw?: string;
+  maxDateRaw?: string;
   minDuration?: moment.Duration;
   maxDuration?: moment.Duration;
   joinValues: boolean;
@@ -83,7 +98,7 @@ export interface DateRangePickerState {
   endDateOpenedFirst: boolean;
 }
 
-export const availableRanges: {[propName: string]: any} = {
+export const availableShortcuts: {[propName: string]: any} = {
   'today': {
     label: 'Date.today',
     startDate: (now: moment.Moment) => {
@@ -441,6 +456,7 @@ export class DateRangePicker extends React.Component<
     clearable: true,
     delimiter: ',',
     ranges: 'yesterday,7daysago,prevweek,thismonth,prevmonth,prevquarter',
+    shortcuts: 'yesterday,7daysago,prevweek,thismonth,prevmonth,prevquarter',
     resetValue: '',
     closeOnSelect: true,
     overlayPlacement: 'auto',
@@ -1018,56 +1034,65 @@ export class DateRangePicker extends React.Component<
     );
   }
 
-  selectRannge(range: PlainObject) {
-    const {closeOnSelect, minDate, maxDate} = this.props;
+  selectShortcut(shortcut: PlainObject) {
+    const {closeOnSelect, minDateRaw, maxDateRaw, format, data} = this.props;
     const now = moment();
+    /** minDate和maxDate要实时计算，因为用户可能设置为${NOW()}，暂时不考虑毫秒级的时间差 */
+    const minDate = minDateRaw
+      ? filterDate(minDateRaw, data, format)
+      : undefined;
+    const maxDate = maxDateRaw
+      ? filterDate(maxDateRaw, data, format)
+      : undefined;
+    const startDate = shortcut.startDate(now.clone());
+    const endDate = shortcut.endDate(now.clone());
+
     this.setState(
       {
         startDate:
-          minDate && minDate.isValid()
-            ? moment.max(range.startDate(now.clone()), minDate)
-            : range.startDate(now.clone()),
+          minDate && minDate?.isValid()
+            ? moment.max(startDate, minDate)
+            : startDate,
         endDate:
-          maxDate && maxDate.isValid()
-            ? moment.min(maxDate, range.endDate(now.clone()))
-            : range.endDate(now.clone())
+          maxDate && maxDate?.isValid() ? moment.min(maxDate, endDate) : endDate
       },
       closeOnSelect ? this.confirm : noop
     );
   }
 
-  renderRanges(ranges: string | Array<ShortCuts> | undefined) {
-    if (!ranges) {
+  renderShortcuts(shortcuts: string | Array<ShortCuts> | undefined) {
+    if (!shortcuts) {
       return null;
     }
-    const {classPrefix: ns} = this.props;
-    let rangeArr: Array<string | ShortCuts>;
-    if (typeof ranges === 'string') {
-      rangeArr = ranges.split(',');
+    const {classPrefix: ns, format, data} = this.props;
+    let shortcutArr: Array<string | ShortCuts>;
+    if (typeof shortcuts === 'string') {
+      shortcutArr = shortcuts.split(',');
     } else {
-      rangeArr = ranges;
+      shortcutArr = shortcuts;
     }
     const __ = this.props.translate;
 
     return (
       <ul className={`${ns}DateRangePicker-rangers`}>
-        {rangeArr.map(item => {
+        {shortcutArr.map((item, index) => {
           if (!item) {
             return null;
           }
-          let range: PlainObject = {};
+
+          let shortcut: PlainObject = {};
           if (typeof item === 'string') {
-            if (availableRanges[item]) {
-              range = availableRanges[item];
-              range.key = item;
+            if (availableShortcuts[item]) {
+              shortcut = availableShortcuts[item];
+              shortcut.key = item;
             } else {
               // 通过正则尝试匹配
               for (let i = 0, len = advancedRanges.length; i < len; i++) {
                 let value = advancedRanges[i];
                 const m = value.regexp.exec(item);
                 if (m) {
-                  range = value.resolve.apply(item, [__, ...m]);
-                  range.key = item;
+                  shortcut = value.resolve.apply(item, [__, ...m]);
+                  shortcut.key = item;
                 }
               }
             }
@@ -1075,20 +1100,46 @@ export class DateRangePicker extends React.Component<
             (item as ShortCutDateRange).startDate &&
             (item as ShortCutDateRange).endDate
           ) {
-            range = {
+            const shortcutRaw = {...item} as ShortCutDateRange;
+
+            shortcut = {
               ...item,
-              startDate: () => (item as ShortCutDateRange).startDate,
-              endDate: () => (item as ShortCutDateRange).endDate
+              startDate: () => {
+                const startDate = isExpression(shortcutRaw.startDate)
+                  ? moment(
+                      FormulaExec['formula'](shortcutRaw.startDate, data),
+                      format
+                    )
+                  : shortcutRaw.startDate;
+
+                return startDate &&
+                  moment.isMoment(startDate) &&
+                  startDate?.isValid()
+                  ? startDate
+                  : (item as ShortCutDateRange).startDate;
+              },
+              endDate: () => {
+                const endDate = isExpression(shortcutRaw.endDate)
+                  ? moment(
+                      FormulaExec['formula'](shortcutRaw.endDate, data),
+                      format
+                    )
+                  : shortcutRaw.startDate;
+
+                return endDate && moment.isMoment(endDate) && endDate?.isValid()
+                  ? endDate
+                  : (item as ShortCutDateRange).endDate;
+              }
             };
           }
-          if (Object.keys(range).length) {
+          if (Object.keys(shortcut).length) {
             return (
               <li
                 className={`${ns}DateRangePicker-ranger`}
-                onClick={() => this.selectRannge(range)}
-                key={range.key || range.label}
+                onClick={() => this.selectShortcut(shortcut)}
+                key={index}
               >
-                <a>{__(range.label)}</a>
+                <a>{__(shortcut.label)}</a>
               </li>
             );
           } else {
@@ -1327,6 +1378,7 @@ export class DateRangePicker extends React.Component<
       timeFormat,
       inputFormat,
       ranges,
+      shortcuts,
       locale,
       embed,
       type,
@@ -1351,7 +1403,7 @@ export class DateRangePicker extends React.Component<
 
     return (
       <div className={cx(`${ns}DateRangePicker-wrap`)} ref={this.calendarRef}>
-        {this.renderRanges(ranges)}
+        {this.renderShortcuts(shortcuts ?? ranges)}
         <div className={cx(`${ns}DateRangePicker-picker-wrap`)}>
           {(!isTimeRange || (editState === 'start' && !embed)) && (
             <Calendar
@@ -1545,6 +1597,7 @@ export class DateRangePicker extends React.Component<
       dateFormat,
       viewMode = 'days',
       ranges,
+      shortcuts,
       label,
       animation
     } = this.props;
@@ -1571,7 +1624,7 @@ export class DateRangePicker extends React.Component<
         close={this.close}
         confirm={this.confirm}
         onChange={this.handleMobileChange}
-        footerExtra={this.renderRanges(ranges)}
+        footerExtra={this.renderShortcuts(shortcuts ?? ranges)}
         showViewMode={
           viewMode === 'quarters' || viewMode === 'months' ? 'years' : 'months'
         }

--- a/packages/amis-ui/src/components/MonthRangePicker.tsx
+++ b/packages/amis-ui/src/components/MonthRangePicker.tsx
@@ -20,7 +20,7 @@ import {LocaleProps, localeable} from 'amis-core';
 import {DateRangePicker} from './DateRangePicker';
 import capitalize from 'lodash/capitalize';
 import {ShortCuts, ShortCutDateRange} from './DatePicker';
-import {availableRanges} from './DateRangePicker';
+import {availableShortcuts} from './DateRangePicker';
 import CalendarMobile from './CalendarMobile';
 import type {PlainObject} from 'amis-core';
 
@@ -33,7 +33,11 @@ export interface MonthRangePickerProps extends ThemeProps, LocaleProps {
   utc?: boolean;
   inputFormat?: string;
   timeFormat?: string;
+  /**
+   * @deprecated 3.1.0后废弃，用shortcuts替代
+   */
   ranges?: string | Array<ShortCuts>;
+  shortcuts?: string | Array<ShortCuts>;
   clearable?: boolean;
   minDate?: moment.Moment;
   maxDate?: moment.Moment;
@@ -300,49 +304,49 @@ export class MonthRangePicker extends React.Component<
     );
   }
 
-  selectRannge(range: PlainObject) {
+  selectShortcut(shortcut: PlainObject) {
     const {closeOnSelect, minDate, maxDate} = this.props;
     this.setState(
       {
         startDate: minDate
-          ? moment.max(range.startDate(moment()), minDate)
-          : range.startDate(moment()),
+          ? moment.max(shortcut.startDate(moment()), minDate)
+          : shortcut.startDate(moment()),
         endDate: maxDate
-          ? moment.min(maxDate, range.endDate(moment()))
-          : range.endDate(moment())
+          ? moment.min(maxDate, shortcut.endDate(moment()))
+          : shortcut.endDate(moment())
       },
       closeOnSelect ? this.confirm : noop
     );
   }
 
-  renderRanges(ranges: string | Array<ShortCuts> | undefined) {
-    if (!ranges) {
+  renderShortcuts(shortcuts: string | Array<ShortCuts> | undefined) {
+    if (!shortcuts) {
       return null;
     }
     const {classPrefix: ns} = this.props;
-    let rangeArr: Array<string | ShortCuts>;
-    if (typeof ranges === 'string') {
-      rangeArr = ranges.split(',');
+    let shortcutArr: Array<string | ShortCuts>;
+    if (typeof shortcuts === 'string') {
+      shortcutArr = shortcuts.split(',');
     } else {
-      rangeArr = ranges;
+      shortcutArr = shortcuts;
     }
     const __ = this.props.translate;
 
     return (
       <ul className={`${ns}DateRangePicker-rangers`}>
-        {rangeArr.map(item => {
+        {shortcutArr.map((item, index) => {
           if (!item) {
             return null;
           }
-          let range: PlainObject = {};
+          let shortcut: PlainObject = {};
           if (typeof item === 'string') {
-            range = availableRanges[item];
-            range.key = item;
+            shortcut = availableShortcuts[item];
+            shortcut.key = item;
           } else if (
             (item as ShortCutDateRange).startDate &&
             (item as ShortCutDateRange).endDate
           ) {
-            range = {
+            shortcut = {
               ...item,
               startDate: () => (item as ShortCutDateRange).startDate,
               endDate: () => (item as ShortCutDateRange).endDate
@@ -351,10 +355,10 @@ export class MonthRangePicker extends React.Component<
           return (
             <li
               className={`${ns}DateRangePicker-ranger`}
-              onClick={() => this.selectRannge(range)}
-              key={range.key || range.label}
+              onClick={() => this.selectShortcut(shortcut)}
+              key={index}
             >
-              <a>{__(range.label)}</a>
+              <a>{__(shortcut.label)}</a>
             </li>
           );
         })}
@@ -468,6 +472,7 @@ export class MonthRangePicker extends React.Component<
       locale,
       embed,
       ranges,
+      shortcuts,
       inputFormat,
       timeFormat
     } = this.props;
@@ -478,7 +483,7 @@ export class MonthRangePicker extends React.Component<
 
     return (
       <div className={`${ns}DateRangePicker-wrap`}>
-        {this.renderRanges(ranges)}
+        {this.renderShortcuts(shortcuts ?? ranges)}
         <Calendar
           className={`${ns}DateRangePicker-start`}
           value={startDate}
@@ -571,12 +576,12 @@ export class MonthRangePicker extends React.Component<
       minDuration,
       maxDuration,
       ranges,
-      label
+      shortcuts,
+      label,
+      translate: __
     } = this.props;
     const mobileUI = isMobile() && useMobileUI;
-
     const {isOpened, isFocused, startDate, endDate} = this.state;
-
     const selectedDate = DateRangePicker.unFormatValue(
       value,
       format,
@@ -590,9 +595,9 @@ export class MonthRangePicker extends React.Component<
       ? selectedDate.endDate.format(inputFormat)
       : '';
     const arr = [];
+
     startViewValue && arr.push(startViewValue);
     endViewValue && arr.push(endViewValue);
-    const __ = this.props.translate;
 
     const calendarMobile = (
       <CalendarMobile
@@ -609,7 +614,7 @@ export class MonthRangePicker extends React.Component<
         close={this.close}
         confirm={this.confirm}
         onChange={this.handleMobileChange}
-        footerExtra={this.renderRanges(ranges)}
+        footerExtra={this.renderShortcuts(shortcuts ?? ranges)}
         showViewMode="years"
       />
     );

--- a/packages/amis/__tests__/renderers/Form/dateRange.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/dateRange.test.tsx
@@ -116,13 +116,13 @@ test('Renderer:dateRange with relative default', async () => {
 });
 
 // 3. 快捷键
-test('Renderer:dateRange with ranges', async () => {
+test('Renderer:dateRange with shortcuts', async () => {
   const {container, start, end, getByText}: any = await setup([
     {
       type: 'input-date-range',
       name: 'a',
       label: 'date-range',
-      ranges: [
+      shortcuts: [
         '7daysago',
         '15dayslater',
         '2weeksago',

--- a/packages/amis/__tests__/renderers/Form/datetimeRange.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/datetimeRange.test.tsx
@@ -1,8 +1,8 @@
 /**
  * 组件名称：InputDatetimeRange 日期时间范围
- * 
+ *
  * 备注：InputDatetimeRange 与 dateRange 等日期范围使用的是同一个组件，所以只测试不同的地方即可
- * 
+ *
  * 单测内容：
  1. 默认值
  2. timeFormat 控制可以选择秒
@@ -132,13 +132,13 @@ test('Renderer:datetimeRange with timeFormat', async () => {
 });
 
 // 4. 快捷键
-test('Renderer:datetimeRange with ranges', async () => {
+test('Renderer:datetimeRange with shortcuts', async () => {
   const {container, start, end, getByText}: any = await setup([
     {
       type: 'input-datetime-range',
       name: 'a',
       label: '日期时间范围',
-      ranges: ['1hoursago', '2hourslater']
+      shortcuts: ['1hoursago', '2hourslater']
     }
   ]);
 

--- a/packages/amis/src/renderers/Form/InputDate.tsx
+++ b/packages/amis/src/renderers/Form/InputDate.tsx
@@ -14,6 +14,8 @@ import {createObject, anyChanged, isMobile, autobind} from 'amis-core';
 import {ActionObject} from 'amis-core';
 import {supportStatic} from './StaticHoc';
 
+import type {ShortCuts} from 'amis-ui/lib/components/DatePicker';
+
 export interface InputDateBaseControlSchema extends FormBaseControlSchema {
   /**
    * 指定为日期选择控件
@@ -55,6 +57,11 @@ export interface InputDateBaseControlSchema extends FormBaseControlSchema {
    * 边框模式，全边框，还是半边框，或者没边框。
    */
   borderMode?: 'full' | 'half' | 'none';
+
+  /**
+   * 日期快捷键
+   */
+  shortcuts?: string | ShortCuts[];
 }
 
 /**
@@ -513,6 +520,8 @@ export default class DateControl extends React.PureComponent<
           timeFormat={timeFormat}
           format={valueFormat || format}
           {...this.state}
+          minDateRaw={this.props.minDate}
+          maxDateRaw={this.props.maxDate}
           classnames={cx}
           onRef={this.getRef}
           schedules={this.state.schedules}

--- a/packages/amis/src/renderers/Form/InputDateRange.tsx
+++ b/packages/amis/src/renderers/Form/InputDateRange.tsx
@@ -82,12 +82,20 @@ export interface DateRangeControlSchema extends FormBaseControlSchema {
 
   /**
    * 日期范围快捷键
+   * @deprecated 3.1.0及以后版本废弃，建议用 shortcuts 属性。
    */
   ranges?: string | Array<ShortCuts>;
+
+  /**
+   * 日期范围快捷键
+   */
+  shortcuts?: string | Array<ShortCuts>;
+
   /**
    * 日期范围开始时间-占位符
    */
   startPlaceholder?: string;
+
   /**
    * 日期范围结束时间-占位符
    */
@@ -280,6 +288,8 @@ export default class DateRangeControl extends React.Component<DateRangeProps> {
           format={format}
           minDate={minDate ? filterDate(minDate, data, format) : undefined}
           maxDate={maxDate ? filterDate(maxDate, data, format) : undefined}
+          minDateRaw={minDate}
+          maxDateRaw={maxDate}
           minDuration={minDuration ? parseDuration(minDuration) : undefined}
           maxDuration={maxDuration ? parseDuration(maxDuration) : undefined}
           onChange={this.handleChange}
@@ -324,6 +334,8 @@ export class TimeRangeControlRenderer extends DateRangeControl {
     timeFormat: 'HH:mm',
     inputFormat: 'HH:mm',
     viewMode: 'time',
-    ranges: ''
+    /** shortcuts的兼容配置 */
+    ranges: '',
+    shortcuts: ''
   };
 }

--- a/packages/amis/src/renderers/Form/InputMonthRange.tsx
+++ b/packages/amis/src/renderers/Form/InputMonthRange.tsx
@@ -64,7 +64,9 @@ export class MonthRangeControlRenderer extends MonthRangeControl {
     joinValues: true,
     delimiter: ',',
     timeFormat: '',
+    /** shortcuts的兼容配置 */
     ranges: 'thismonth,prevmonth',
+    shortcuts: 'thismonth,prevmonth',
     animation: true
   };
 }

--- a/packages/amis/src/renderers/Form/InputQuarterRange.tsx
+++ b/packages/amis/src/renderers/Form/InputQuarterRange.tsx
@@ -62,7 +62,9 @@ export class QuarterRangeControlRenderer extends QuarterRangeControl {
     joinValues: true,
     delimiter: ',',
     timeFormat: '',
+    /** shortcuts的兼容配置 */
     ranges: 'thisquarter,prevquarter',
+    shortcuts: 'thisquarter,prevquarter',
     animation: true
   };
 }

--- a/packages/amis/src/renderers/Form/InputYearRange.tsx
+++ b/packages/amis/src/renderers/Form/InputYearRange.tsx
@@ -63,7 +63,9 @@ export class YearRangeControlRenderer extends YearRangeControl {
     joinValues: true,
     delimiter: ',',
     timeFormat: '',
+    /** shortcuts的兼容配置 */
     ranges: 'thisyear,prevyear',
+    shortcuts: 'thisyear,prevyear',
     animation: true
   };
 }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ddc5e5d</samp>

This pull request adds support for expressions in various date-related components, such as `input-date`, `input-date-range`, `input-datetime` and `input-datetime-range`. Expressions can be used to define custom shortcuts and dynamic date ranges based on the data and format props. The pull request also updates the documentation, the type definitions and fixes some typos in the code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ddc5e5d</samp>

> _Oh, we're the crew of the `input-date-range`_
> _And we work with expressions all day_
> _We can set the min and max with a phrase_
> _Or use shortcuts to pick a date_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ddc5e5d</samp>

*  Add support for using expressions to define custom shortcuts and ranges for input-date, input-date-range, input-datetime and input-datetime-range components ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-05f312d2f6d17f335f4b7942ab35adb09e492cec2fb9cbb7d34e2d2bd13a84beR159-R194), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-05f312d2f6d17f335f4b7942ab35adb09e492cec2fb9cbb7d34e2d2bd13a84beL181-R230), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-d984ad08db80ac1f6694b5454e00ee0f791a16337effc29a77fd977c7ebff295L250-R252), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-d984ad08db80ac1f6694b5454e00ee0f791a16337effc29a77fd977c7ebff295L262-R263), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-d984ad08db80ac1f6694b5454e00ee0f791a16337effc29a77fd977c7ebff295R293-R319), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-d984ad08db80ac1f6694b5454e00ee0f791a16337effc29a77fd977c7ebff295L361-R401), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-f0f649fb48286ca1a3355b21d5a6843d70d796c50137d19ef1741049c8e7a577L66-R119), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-1df5e88733871e92d86ce0af46616a0c2d8e894285da4e8726c0db67081cfbbcR281-R307), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-1df5e88733871e92d86ce0af46616a0c2d8e894285da4e8726c0db67081cfbbcL333-R372), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL10-R16), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL221-R234), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cR257-R258), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cR310), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL337-R347), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL550-R580), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL605-R639), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL613-R674), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL633-R681), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L13-R13), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348R39-R40), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1021-R1043), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1043-R1053), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1054-R1068), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1078-R1118), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1088-R1126), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-56835df54b63fc25653bc9cb41f895a4e75843bbbf719028fbcc740ae394a94fR17-R18), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-56835df54b63fc25653bc9cb41f895a4e75843bbbf719028fbcc740ae394a94fR60-R64), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-56835df54b63fc25653bc9cb41f895a4e75843bbbf719028fbcc740ae394a94fR523-R524), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-6a9d63c3962b312f04344a4c28956690724f3f476fe6b8f2802501fc10b28ce2R283-R284))
  * Import `isExpression`, `FormulaExec` and `filterDate` functions from `amis-core` in `DatePicker`, `DateRangePicker` and `MonthRangePicker` components to evaluate expressions and filter dates based on the `data` and `format` props ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL10-R16), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L13-R13))
  * Modify the type of the `date` field in the `ShortCutDate` type and the `shortcuts` prop in the `InputDateProps` interface to allow using expressions or objects with `label` and `date` fields ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL221-R234), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-56835df54b63fc25653bc9cb41f895a4e75843bbbf719028fbcc740ae394a94fR17-R18), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-56835df54b63fc25653bc9cb41f895a4e75843bbbf719028fbcc740ae394a94fR60-R64))
  * Modify the type of the `ranges` prop in the `input-date-range` component to allow using expressions or objects with `label`, `startDate` and `endDate` fields ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-05f312d2f6d17f335f4b7942ab35adb09e492cec2fb9cbb7d34e2d2bd13a84beL181-R230))
  * Add the `minDateRaw` and `maxDateRaw` props to the `DateProps`, `DateRangePickerProps` and `MonthRangePickerProps` interfaces to pass the original `minDate` and `maxDate` values from the input components, which may contain expressions ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cR257-R258), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348R39-R40), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-6a9d63c3962b312f04344a4c28956690724f3f476fe6b8f2802501fc10b28ce2R283-R284))
  * Add the `data` prop to the `DateProps` interface to pass the data context for evaluating expressions in the `shortcuts` prop ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cR310))
  * Rename the `selectRannge` method to `selectShortcut` in the `DatePicker` component to avoid confusion with the `selectRange` method in the `DateRangePicker` component and to reflect the actual functionality of selecting a shortcut date ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL337-R347))
  * Modify the `selectShortcut` method in the `DatePicker` component to handle expressions in the `shortcuts` prop by using the `filterDate` and `FormulaExec` functions to calculate the `minDate` and `maxDate` and to evaluate the expression in the shortcut date ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL550-R580))
  * Add the `format` and `data` props to the `renderShortCuts` method in the `DatePicker` component to pass the format and data context for evaluating expressions in the `shortcuts` prop ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL605-R639))
  * Modify the `renderShortCuts` method in the `DatePicker` component to handle expressions in the `shortcuts` prop by using the `isExpression` and `FormulaExec` functions to check and evaluate the expression in the shortcut date and to check if the result is a valid moment object ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL613-R674))
  * Modify the `renderShortCuts` method in the `DatePicker` component to use the index as the key for the shortcut list items to avoid potential duplicate keys if the `label` or `key` fields are not unique ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL633-R681))
  * Modify the `selectRange` method in the `DateRangePicker` component to handle expressions in the `ranges` prop by using the `filterDate` function to calculate the `minDate` and `maxDate` and to compare them with the `startDate` and `endDate` from the range ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1021-R1043))
  * Add the `format` and `data` props to the `renderRanges` method in the `DateRangePicker` component to pass the format and data context for evaluating expressions in the `ranges` prop ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1043-R1053))
  * Modify the `renderRanges` method in the `DateRangePicker` component to use the index as the key for the range list items to avoid potential duplicate keys if the `label` or `key` fields are not unique ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1054-R1068))
  * Modify the `renderRanges` method in the `DateRangePicker` component to handle expressions in the `ranges` prop by using the `isExpression` and `FormulaExec` functions to check and evaluate the expressions in the `startDate` and `endDate` fields and to check if the results are valid moment objects ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1078-R1118))
  * Modify the `renderRanges` method in the `DateRangePicker` component to use the `selectRange` method instead of the `selectRannge` method to fix a typo and to reflect the actual functionality of selecting a range ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1088-R1126))
  * Fix a typo in the `selectRannge` method name in the `MonthRangePicker` component and modify the `renderRanges` method to use the `selectRange` method instead ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-20fd7d34747427d50e8fb67f237bc5b6753ec2e777f1ab3c71a9aafe1c358762L303-R303), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-20fd7d34747427d50e8fb67f237bc5b6753ec2e777f1ab3c71a9aafe1c358762L354-R354))
  * Add the `minDateRaw` and `maxDateRaw` props to the `DatePicker` component in the `InputDate` component to pass the original `minDate` and `maxDate` values, which may contain expressions, to the `DatePicker` component ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-56835df54b63fc25653bc9cb41f895a4e75843bbbf719028fbcc740ae394a94fR523-R524))
* Add documentation for using expressions to define custom shortcuts and ranges for input-date, input-date-range, input-datetime and input-datetime-range components in `docs/zh-CN/components/form` ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-05f312d2f6d17f335f4b7942ab35adb09e492cec2fb9cbb7d34e2d2bd13a84beR159-R194), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-05f312d2f6d17f335f4b7942ab35adb09e492cec2fb9cbb7d34e2d2bd13a84beL181-R230), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-d984ad08db80ac1f6694b5454e00ee0f791a16337effc29a77fd977c7ebff295L250-R252), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-d984ad08db80ac1f6694b5454e00ee0f791a16337effc29a77fd977c7ebff295L262-R263), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-d984ad08db80ac1f6694b5454e00ee0f791a16337effc29a77fd977c7ebff295R293-R319), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-d984ad08db80ac1f6694b5454e00ee0f791a16337effc29a77fd977c7ebff295L361-R401), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-f0f649fb48286ca1a3355b21d5a6843d70d796c50137d19ef1741049c8e7a577L66-R119), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-1df5e88733871e92d86ce0af46616a0c2d8e894285da4e8726c0db67081cfbbcR281-R307), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-1df5e88733871e92d86ce0af46616a0c2d8e894285da4e8726c0db67081cfbbcL333-R372))
  * Add examples of using expressions to define custom shortcuts and ranges for each component by using the `DATEMODIFY` and `STARTOF/ENDOF` functions to create dynamic dates based on the current date and time ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-05f312d2f6d17f335f4b7942ab35adb09e492cec2fb9cbb7d34e2d2bd13a84beR159-R194), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-d984ad08db80ac1f6694b5454e00ee0f791a16337effc29a77fd977c7ebff295R293-R319), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-f0f649fb48286ca1a3355b21d5a6843d70d796c50137d19ef1741049c8e7a577L66-R119), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-1df5e88733871e92d86ce0af46616a0c2d8e894285da4e8726c0db67081cfbbcR281-R307))
  * Add version notes that expressions are supported from 3.1.0 and above for each component ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-05f312d2f6d17f335f4b7942ab35adb09e492cec2fb9cbb7d34e2d2bd13a84beL181-R230), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-d984ad08db80ac1f6694b5454e00ee0f791a16337effc29a77fd977c7ebff295L361-R401), [link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-1df5e88733871e92d86ce0af46616a0c2d8e894285da4e8726c0db67081cfbbcL333-R372))
  * Fix a typo in the schema example for the input-date component by adding a comma after "yesterday" ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-d984ad08db80ac1f6694b5454e00ee0f791a16337effc29a77fd977c7ebff295L262-R263))
  * Add a note that the mobile picker mode does not support shortcuts for the input-date component ([link](https://github.com/baidu/amis/pull/6963/files?diff=unified&w=0#diff-d984ad08db80ac1f6694b5454e00ee0f791a16337effc29a77fd977c7ebff295L250-R252))
