### PR TITLE
fix: 修复 table selectable 没有开启缺可以点选 Close: #6944

### DIFF
--- a/packages/amis/src/renderers/Table/TableBody.tsx
+++ b/packages/amis/src/renderers/Table/TableBody.tsx
@@ -130,7 +130,7 @@ export class TableBody extends React.Component<TableBodyProps> {
               item={item}
               itemClassName={cx(
                 rowClassNameExpr
-                  ? filter(rowClassNameExpr, item.data)
+                  ? filter(rowClassNameExpr, item.locals)
                   : rowClassName
               )}
               columns={footableColumns}

--- a/packages/amis/src/renderers/Table/TableBody.tsx
+++ b/packages/amis/src/renderers/Table/TableBody.tsx
@@ -97,7 +97,7 @@ export class TableBody extends React.Component<TableBodyProps> {
           item={item}
           itemClassName={cx(
             rowClassNameExpr
-              ? filter(rowClassNameExpr, item.data)
+              ? filter(rowClassNameExpr, item.locals)
               : rowClassName,
             {
               'is-last': item.depth > 1 && rowIndex === rows.length - 1

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -888,7 +888,11 @@ export default class Table extends React.Component<TableProps, object> {
   }
 
   async handleCheck(item: IRow, value: boolean, shift?: boolean) {
-    const {store, data, dispatchEvent} = this.props;
+    const {store, data, dispatchEvent, selectable} = this.props;
+
+    if (!selectable) {
+      return;
+    }
 
     const selectedItems = value
       ? [...store.selectedRows.map(row => row.data), item.data]


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f387fe0</samp>

This pull request fixes a bug in the `Table` renderer and improves the handling of the check event. It changes the `rowClassNameExpr` evaluation context in `TableBody.tsx` and adds a condition for the selectable prop in `index.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f387fe0</samp>

> _Sing, O Muse, of the skillful coder who fixed the bug_
> _That plagued the `Table` renderer with false and faulty names_
> _And added a wise condition to the `handleCheck` event_
> _To spare the user from errors when the table was not selectable._

### Why

Close: #6944

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f387fe0</samp>

* Fix a bug where the row and cell className expressions were evaluated with the wrong data context ([link](https://github.com/baidu/amis/pull/6965/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL100-R100), [link](https://github.com/baidu/amis/pull/6965/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL133-R133))
* Add a condition to check if the table is selectable before handling the check event ([link](https://github.com/baidu/amis/pull/6965/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL891-R896))
