### PR TITLE
fix: 修复input组件font自定义样式不生效问题

### DIFF
--- a/packages/amis-core/src/utils/style-helper.ts
+++ b/packages/amis-core/src/utils/style-helper.ts
@@ -35,6 +35,7 @@ export const inheritValueMap: PlainObject = {
 
 interface extra {
   important?: boolean;
+  inner?: string;
   pre?: string;
   suf?: string;
 }
@@ -141,7 +142,8 @@ export function formatStyle(
             .replace('-label', '')
             .replace('-description', '')
             .replace('-addOn', '')
-            .replace('-icon', '') || ''
+            .replace('-icon', '')
+            .replace('-inner', '') || ''
         )
       ) {
         classNameList.push(n);
@@ -225,9 +227,10 @@ export function formatStyle(
         }
         if (styles.length > 0) {
           const cx = (weights?.pre || '') + className + (weights?.suf || '');
+          const inner = weights?.inner || '';
           res.push({
-            className: cx + status2string[status],
-            content: `.${cx + status2string[status]} {\n  ${styles.join(
+            className: cx + status2string[status] + inner,
+            content: `.${cx + status2string[status]} ${inner}{\n  ${styles.join(
               '\n  '
             )}\n}`
           });

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -1040,6 +1040,24 @@ export default class TextControl extends React.PureComponent<
     );
   }
 
+  /**
+   * 处理input的自定义样式
+   */
+  @autobind
+  formatInputThemeCss() {
+    const {themeCss, css} = this.props;
+    const inputFontThemeCss: any = {inputControlClassName: {}};
+    const inputControlClassNameObject =
+      (themeCss || css)?.inputControlClassName || {};
+    for (let key in inputControlClassNameObject) {
+      if (~key.indexOf('font')) {
+        inputFontThemeCss.inputControlClassName[key] =
+          inputControlClassNameObject[key];
+      }
+    }
+    return inputFontThemeCss;
+  }
+
   @supportStatic()
   render(): JSX.Element {
     const {
@@ -1080,6 +1098,32 @@ export default class TextControl extends React.PureComponent<
           }}
           env={env}
         />
+        <CustomStyle
+          config={{
+            themeCss: this.formatInputThemeCss(),
+            classNames: [
+              {
+                key: 'inputControlClassName',
+                value: inputControlClassName,
+                weights: {
+                  default: {
+                    inner: 'input'
+                  },
+                  hover: {
+                    inner: 'input'
+                  },
+                  active: {
+                    pre: `${ns}TextControl.is-focused > .${inputControlClassName}, `,
+                    inner: 'input'
+                  }
+                }
+              }
+            ],
+            id: id + '-inner'
+          }}
+          env={env}
+        />
+
         <CustomStyle
           config={{
             themeCss: themeCss || css,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 78002e3</samp>

This pull request adds a new feature to customize the styles of inner elements of a component, and applies it to the `InputText` component. It changes the `style-helper.ts` and `InputText.tsx` files to implement this feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 78002e3</samp>

> _Oh we're the coders of the sea, and we love to style our `InputText`_
> _We use the `inner` prop and the `-inner` suffix to make it look complex_
> _Heave away, me hearties, heave away_
> _We'll `formatStyle` with a smile, and we'll test our code in a while_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 78002e3</samp>

*  Add `inner` property to `extra` interface and `replace` method to support custom styles for inner elements of components ([link](https://github.com/baidu/amis/pull/6968/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdR38), [link](https://github.com/baidu/amis/pull/6968/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL144-R146))
*  Use `inner` property from `weights` object to append inner class name to result object and content string in `formatStyle` function ([link](https://github.com/baidu/amis/pull/6968/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL228-R233))
*  Create `formatInputThemeCss` method to filter out font-related properties from `themeCss` or `css` prop in `InputText` component ([link](https://github.com/baidu/amis/pull/6968/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11R1043-R1060))
*  Use `CustomStyle` components to apply custom styles to input control and inner input element in `InputText` component, using `classNames`, `inner` and `id` props ([link](https://github.com/baidu/amis/pull/6968/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11R1103-R1128))
