### PR TITLE
fix: 修复图标选择组件无法渲染iconfont

### DIFF
--- a/packages/amis-ui/scss/components/form/_icon-select.scss
+++ b/packages/amis-ui/scss/components/form/_icon-select.scss
@@ -66,6 +66,9 @@
           height: 100%;
         }
       }
+      &-iconfont {
+        margin-right: var(--sizes-size-4);
+      }
     }
 
     &-wrapper {

--- a/packages/amis-ui/src/components/icons.tsx
+++ b/packages/amis-ui/src/components/icons.tsx
@@ -278,6 +278,9 @@ export function Icon({
 
   const Component = getIcon(icon);
   const isURLIcon = typeof icon === 'string' && icon?.indexOf('.') !== -1;
+  const isIconfont =
+    typeof icon === 'string' &&
+    (~icon?.indexOf('iconfont') || ~icon?.indexOf('fa'));
 
   return Component ? (
     <>
@@ -293,6 +296,8 @@ export function Icon({
     </>
   ) : isURLIcon ? (
     <img className={cx(`${classPrefix}Icon`, className)} src={icon} />
+  ) : isIconfont ? (
+    <i className={cx(icon, className)} />
   ) : (
     <span className="text-danger">没有 icon {icon}</span>
   );

--- a/packages/amis/src/renderers/Form/IconSelect.tsx
+++ b/packages/amis/src/renderers/Form/IconSelect.tsx
@@ -147,7 +147,13 @@ export default class IconSelectControl extends React.PureComponent<
               dangerouslySetInnerHTML={{__html: SvgStr[0].replace(/\\"/g, '"')}}
             ></div>
           ) : (
-            <Icon icon={valueTemp} className="icon" />
+            <Icon
+              icon={valueTemp}
+              className={cx(
+                `${ns}IconSelectControl-input-area-iconfont`,
+                'icon'
+              )}
+            />
           )
         ) : null}
         <span className={cx(`${ns}IconSelectControl-input-icon-id`)}>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c70bb4d</samp>

This pull request adds support for iconfont icons in the `Icon` and `IconSelect` components. It also adjusts the style and layout of the iconfont icons in the `IconSelect` input area.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c70bb4d</samp>

> _To make icon-select look nice_
> _We added some margin and spice_
> _We passed a `className`_
> _To the `Icon` component_
> _And used `<i>` for iconfont slice_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c70bb4d</samp>

* Add a margin-right style to the iconfont icons in the icon-select input area ([link](https://github.com/baidu/amis/pull/6974/files?diff=unified&w=0#diff-cd02c5ef4e88381be525a4a2a153c1afb69bb4642350cc36eb9a6409315c25aaR69-R71), [link](https://github.com/baidu/amis/pull/6974/files?diff=unified&w=0#diff-49d6f3f00021b4f9590babc577f72384ca28f30e459dd1aec1e677b790500c06L150-R156))
* Modify the `Icon` component to render iconfont icons using an `<i>` element with the icon and className props ([link](https://github.com/baidu/amis/pull/6974/files?diff=unified&w=0#diff-1db9a23d0ea625849dbe5c523e7ccab192bfa73c87891759c8a7de36e2d874efR281-R283), [link](https://github.com/baidu/amis/pull/6974/files?diff=unified&w=0#diff-1db9a23d0ea625849dbe5c523e7ccab192bfa73c87891759c8a7de36e2d874efR299-R300))
* Update the `IconSelect` component to pass a custom className prop to the `Icon` component when rendering iconfont icons ([link](https://github.com/baidu/amis/pull/6974/files?diff=unified&w=0#diff-49d6f3f00021b4f9590babc577f72384ca28f30e459dd1aec1e677b790500c06L150-R156))
