### PR TITLE
fix: 修复 createObjectFromChain 导致页面编辑器 api 编辑报错问题 Close: #6943

### DIFF
--- a/packages/amis-core/src/store/form.ts
+++ b/packages/amis-core/src/store/form.ts
@@ -206,7 +206,7 @@ export const FormStore = ServiceStore.named('FormStore')
       const data = cloneObject(self.data);
 
       if (value !== origin) {
-        if (prev.__prev) {
+        if (prev.hasOwnProperty('__prev')) {
           // 基于之前的 __prev 改
           const prevData = cloneObject(prev.__prev);
           setVariable(prevData, name, origin);
@@ -255,7 +255,7 @@ export const FormStore = ServiceStore.named('FormStore')
       const prev = self.data;
       const data = cloneObject(self.data);
 
-      if (prev.__prev) {
+      if (prev.hasOwnProperty('__prev')) {
         // 基于之前的 __prev 改
         const prevData = cloneObject(prev.__prev);
         setVariable(prevData, name, getVariable(prev, name));

--- a/packages/amis-core/src/store/iRenderer.ts
+++ b/packages/amis-core/src/store/iRenderer.ts
@@ -100,7 +100,7 @@ export const iRendererStore = StoreNode.named('iRendererStore')
 
         const prev = self.data;
         const data = cloneObject(self.data);
-        if (prev.__prev) {
+        if (prev.hasOwnProperty('__prev')) {
           // 基于之前的 __prev 改
           const prevData = cloneObject(prev.__prev);
           setVariable(prevData, name, origin);

--- a/packages/amis-core/src/utils/object.ts
+++ b/packages/amis-core/src/utils/object.ts
@@ -42,18 +42,23 @@ export function extractObjectChain(value: any) {
 export function createObjectFromChain(chain: Array<object>) {
   return chain
     .filter(item => item)
-    .reduce((proto, value) =>
-      Object.assign(
-        Object.create(proto || Object.prototype, {
+    .reduce((proto, value) => {
+      proto = proto || Object.prototype;
+      if (Object.isFrozen(proto)) {
+        proto = cloneObject(proto);
+      }
+
+      return Object.assign(
+        Object.create(proto, {
           __super: {
-            value: proto || Object.prototype,
+            value: proto,
             writable: false,
             enumerable: false
           }
         }),
         value
-      )
-    );
+      );
+    });
 }
 
 export function cloneObject(target: any, persistOwnProps: boolean = true) {

--- a/packages/amis-editor/src/renderer/APIControl.tsx
+++ b/packages/amis-editor/src/renderer/APIControl.tsx
@@ -517,6 +517,7 @@ export default class APIControl extends React.Component<
         closeOnEsc: true,
         closeOnOutside: false,
         showCloseButton: true,
+        // data: {},
         body: [this.renderApiConfigTabs()]
       }
     };

--- a/packages/amis-editor/src/renderer/event-control/index.tsx
+++ b/packages/amis-editor/src/renderer/event-control/index.tsx
@@ -967,7 +967,7 @@ export class EventControl extends React.Component<
           ) : (
             <div className="ae-event-control-placeholder">
               {/* 翻译未生效，临时方案 */}
-              {_i18n('4db5110d41293fef57f5a1f364187896')}
+              {_i18n('快去添加事件，让你的产品动起来吧')}
             </div>
           )}
         </ul>

--- a/packages/amis-ui/scss/layout/_layout.scss
+++ b/packages/amis-ui/scss/layout/_layout.scss
@@ -152,13 +152,13 @@ body {
   //     }
   // }
 
-  &-body {
+  &-main {
     padding-bottom: var(--Layout-footer-height);
     width: 100%;
     height: 100%;
   }
 
-  &--noFooter &-body {
+  &--noFooter &-main {
     padding-bottom: 0;
   }
 

--- a/packages/amis-ui/scss/layout/_layout.scss
+++ b/packages/amis-ui/scss/layout/_layout.scss
@@ -262,6 +262,14 @@ body {
       align-items: stretch;
     }
 
+    &-body {
+      flex-grow: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: stretch;
+      align-items: stretch;
+    }
+
     &-content {
       flex-grow: 1;
       position: relative;

--- a/packages/amis/src/renderers/App.tsx
+++ b/packages/amis/src/renderers/App.tsx
@@ -313,7 +313,11 @@ export default class App extends React.Component<AppProps, object> {
               />
             ) : logo ? (
               <img className={cx('AppLogo')} src={logo} />
-            ) : null}
+            ) : (
+              <span className="visible-folded ">
+                {brandName?.substring(0, 1)}
+              </span>
+            )}
             <span className="hidden-folded m-l-sm">{brandName}</span>
           </div>
         </div>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e4817d9</samp>

This pull request fixes a bug in form data handling, improves some utility functions and stylesheets, and adds some user interface enhancements. It mainly affects the `amis-core` and `amis-editor` packages, and touches the `amis-ui` and `amis` packages as well. Some changes may need further clarification or testing.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e4817d9</samp>

> _We're fixing bugs and tweaking code, we're sailing on the web_
> _We're changing strings and logos too, to please the user's eye_
> _We're using `hasOwnProperty` and `_i18n` too_
> _So heave away and pull the rope, we'll make this ship go by_

### Why

Close: #6943

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e4817d9</samp>

*  Fix bug that causes error when form data has `__prev` property ([link](https://github.com/baidu/amis/pull/6975/files?diff=unified&w=0#diff-c8aefd7686b13cf0a0b440b598f20cc50e9abac39fcd9281de29dc6e9d3b358eL209-R209), [link](https://github.com/baidu/amis/pull/6975/files?diff=unified&w=0#diff-c8aefd7686b13cf0a0b440b598f20cc50e9abac39fcd9281de29dc6e9d3b358eL258-R258), [link](https://github.com/baidu/amis/pull/6975/files?diff=unified&w=0#diff-bda8cf53fd9e2519263119f3191cfc57b424d5d9307441736c080a609f6e40f8L103-R103))
* Improve performance and compatibility of `createObjectFromChain` function in `object.ts` ([link](https://github.com/baidu/amis/pull/6975/files?diff=unified&w=0#diff-59e272ba9fc180f46d655081bd34bd278fa2930abbbc286d4e8701145ab0f263L45-R54), [link](https://github.com/baidu/amis/pull/6975/files?diff=unified&w=0#diff-59e272ba9fc180f46d655081bd34bd278fa2930abbbc286d4e8701145ab0f263L55-R61))
* Replace hard-coded string with translated message in `EventControl` component ([link](https://github.com/baidu/amis/pull/6975/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754L970-R970))
* Add fallback option for displaying brand name in `App` component ([link](https://github.com/baidu/amis/pull/6975/files?diff=unified&w=0#diff-b3a4d413575f4fe07501c750c75d47f53100ca6a9536c98886c7b67d63542d39L316-R320))
* Rename `App-body` class to `App-main` in layout stylesheet ([link](https://github.com/baidu/amis/pull/6975/files?diff=unified&w=0#diff-2beb3f83f0f709e5d5b6c0a772d8d394848b0ef4068a051979ff1bea74dad8a6L155-R155), [link](https://github.com/baidu/amis/pull/6975/files?diff=unified&w=0#diff-2beb3f83f0f709e5d5b6c0a772d8d394848b0ef4068a051979ff1bea74dad8a6L161-R161))
* Comment out line that sets `data` property of `APIControl` component ([link](https://github.com/baidu/amis/pull/6975/files?diff=unified&w=0#diff-e65abd8ed33a9d63bc29309ed26eb057b2d1f780106822c5eabeeaa220f8c91fR520))
