### PR TITLE
fix: 修复 InputDateRange 选择开始时间不能选择将来的问题 Close: #6966

### DIFF
--- a/packages/amis-ui/scss/layout/_layout.scss
+++ b/packages/amis-ui/scss/layout/_layout.scss
@@ -271,6 +271,7 @@ body {
     }
 
     &-content {
+      display: flex;
       flex-grow: 1;
       position: relative;
       min-height: 0;

--- a/packages/amis-ui/src/components/DateRangePicker.tsx
+++ b/packages/amis-ui/src/components/DateRangePicker.tsx
@@ -1440,9 +1440,12 @@ export class DateRangePicker extends React.Component<
   ) {
     const {endDateOpenedFirst, endDate, startDate, editState} = this.state;
     const afterEndDate =
-      editState === 'start' && currentDate.isAfter(endDate!, granularity);
+      editState === 'start' &&
+      endDate &&
+      currentDate.isAfter(endDate!, granularity);
     const beforeStartDate =
       editState === 'end' &&
+      startDate &&
       !currentDate.isSameOrAfter(startDate!, granularity);
 
     if (afterEndDate || beforeStartDate) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 548349f</samp>

This pull request improves the layout and functionality of the `DateRangePicker` component. It adds `display: flex` to the `.amis-date-range-picker` selector in `_layout.scss` and null checks for `endDate` and `startDate` in `DateRangePicker.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 548349f</samp>

> _`DateRangePicker` flexes_
> _Aligns and checks for nulls_
> _Autumn bug is gone_

### Why

Close: #6966

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 548349f</samp>

*  Add `display: flex` property to `.amis-date-range-picker` selector to improve layout and responsiveness of date range picker component ([link](https://github.com/baidu/amis/pull/6978/files?diff=unified&w=0#diff-2beb3f83f0f709e5d5b6c0a772d8d394848b0ef4068a051979ff1bea74dad8a6R274))
*  Add null checks for `endDate` and `startDate` in `DateRangePicker` component to prevent errors when comparing dates with undefined values ([link](https://github.com/baidu/amis/pull/6978/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1443-R1448))
*  Fix bug that caused date range picker to crash when clearing input fields in `DateRangePicker.tsx` file ([link](https://github.com/baidu/amis/pull/6978/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1443-R1448))
