### PR TITLE
fix: input-excel 自动去掉邮箱地址里的 mailto: Closes #6889

### DIFF
--- a/packages/amis/src/renderers/Form/InputExcel.tsx
+++ b/packages/amis/src/renderers/Form/InputExcel.tsx
@@ -299,6 +299,9 @@ export default class ExcelControl extends React.PureComponent<
                 const ExcelValueType = this.ExcelJS.ValueType;
                 if (cell.type === ExcelValueType.Hyperlink) {
                   value = cell.value.hyperlink;
+                  if (value.startsWith('mailto:')) {
+                    value = value.substring(7);
+                  }
                 } else if (cell.type === ExcelValueType.Formula) {
                   value = cell.value.result;
                 } else if (cell.type === ExcelValueType.RichText) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4d443a6</samp>

Fix mailto link issue in excel input component. Strip `mailto:` prefix from cell values in `InputExcel.tsx` before triggering change event.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4d443a6</samp>

> _`mailto` removed_
> _excel cells yield email names_
> _autumn harvest time_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4d443a6</samp>

* Remove mailto prefix from cell values in excel input component ([link](https://github.com/baidu/amis/pull/6979/files?diff=unified&w=0#diff-00c90e9ef78976a7a5e149e452bb31a9c2ba2d9ed42e895cedbc4b2a5673603dR302-R304))
