### PR TITLE
fix: 修复 jssdk json-schema-editor 开启 开启高级配置 无效问题 Close: #6977

### DIFF
--- a/packages/amis-ui/src/components/PickerContainer.tsx
+++ b/packages/amis-ui/src/components/PickerContainer.tsx
@@ -32,6 +32,7 @@ export interface PickerContainerProps
   onClose?: () => void;
 
   onPickerOpen?: (props: PickerContainerProps) => any;
+  popOverContainer?: any;
 }
 
 export interface PickerContainerState {
@@ -131,7 +132,8 @@ export class PickerContainer extends React.Component<
       translate: __,
       size,
       showFooter,
-      closeOnEsc
+      closeOnEsc,
+      popOverContainer
     } = this.props;
     return (
       <>
@@ -153,6 +155,7 @@ export class PickerContainer extends React.Component<
           bodyClassName={bodyClassName}
           showFooter={showFooter}
           beforeConfirm={this.confirm}
+          popOverContainer={popOverContainer}
         >
           {() =>
             popOverRender({

--- a/packages/amis-ui/src/components/schema-editor/Array.tsx
+++ b/packages/amis-ui/src/components/schema-editor/Array.tsx
@@ -40,6 +40,7 @@ export class SchemaEditorItemArray extends SchemaEditorItemCommon {
       types,
       onTypeChange,
       enableAdvancedSetting,
+      popOverContainer,
       placeholder
     } = this.props;
     const items = value?.items || {
@@ -70,6 +71,7 @@ export class SchemaEditorItemArray extends SchemaEditorItemCommon {
           classPrefix={classPrefix}
           disabled={disabled || !!(items as any)?.$ref}
           enableAdvancedSetting={enableAdvancedSetting}
+          popOverContainer={popOverContainer}
           placeholder={placeholder}
         />
       </div>

--- a/packages/amis-ui/src/components/schema-editor/Common.tsx
+++ b/packages/amis-ui/src/components/schema-editor/Common.tsx
@@ -53,6 +53,7 @@ export interface SchemaEditorItemCommonProps extends LocaleProps, ThemeProps {
   enableAdvancedSetting?: boolean;
   /** 各属性输入控件的placeholder */
   placeholder?: SchemaEditorItemPlaceholder;
+  popOverContainer?: any;
 }
 
 export class SchemaEditorItemCommon<
@@ -97,6 +98,7 @@ export class SchemaEditorItemCommon<
       renderExtraProps,
       renderModalProps,
       enableAdvancedSetting,
+      popOverContainer,
       prefix,
       affix,
       types,
@@ -193,6 +195,7 @@ export class SchemaEditorItemCommon<
             beforeConfirm={this.handleBeforeSubmit}
             onConfirm={this.handlePropsChange}
             title={__('SubForm.editDetail')}
+            popOverContainer={popOverContainer}
           >
             {({onClick}) => (
               <Button

--- a/packages/amis-ui/src/components/schema-editor/Object.tsx
+++ b/packages/amis-ui/src/components/schema-editor/Object.tsx
@@ -198,6 +198,7 @@ export class SchemaEditorItemObject extends SchemaEditorItemCommon<
       types,
       onTypeChange,
       enableAdvancedSetting,
+      popOverContainer,
       placeholder
     } = this.props;
     const members = this.state.members;
@@ -215,6 +216,7 @@ export class SchemaEditorItemObject extends SchemaEditorItemCommon<
               types={types}
               onTypeChange={onTypeChange}
               enableAdvancedSetting={enableAdvancedSetting}
+              popOverContainer={popOverContainer}
               prefix={
                 <>
                   <InputBox

--- a/packages/amis-ui/src/components/schema-editor/index.tsx
+++ b/packages/amis-ui/src/components/schema-editor/index.tsx
@@ -66,6 +66,8 @@ export interface SchemaEditorProps extends LocaleProps, ThemeProps {
    */
   enableAdvancedSetting?: boolean;
 
+  popOverContainer?: any;
+
   /**
    * 各属性输入控件的占位提示文本
    */
@@ -168,6 +170,7 @@ export class SchemaEditor extends React.Component<SchemaEditorProps> {
       disabled,
       definitions,
       enableAdvancedSetting,
+      popOverContainer,
       placeholder
     } = this.props;
     const value: JSONSchema = this.props.value || {
@@ -226,6 +229,7 @@ export class SchemaEditor extends React.Component<SchemaEditorProps> {
           disabled={disabled}
           onTypeChange={this.handleTypeChange}
           enableAdvancedSetting={enableAdvancedSetting}
+          popOverContainer={popOverContainer}
           placeholder={placeholder}
         />
       </div>

--- a/packages/amis/src/renderers/Form/JSONSchemaEditor.tsx
+++ b/packages/amis/src/renderers/Form/JSONSchemaEditor.tsx
@@ -138,7 +138,7 @@ export default class JSONSchemaEditorControl extends React.PureComponent<JSONSch
   }
 
   render() {
-    const {enableAdvancedSetting, ...rest} = this.props;
+    const {enableAdvancedSetting, env, ...rest} = this.props;
 
     return (
       <JSONSchemaEditor
@@ -146,6 +146,7 @@ export default class JSONSchemaEditorControl extends React.PureComponent<JSONSch
         placeholder={this.normalizePlaceholder()}
         enableAdvancedSetting={enableAdvancedSetting}
         renderModalProps={this.renderModalProps}
+        popOverContainer={env?.getModalContainer}
       />
     );
   }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43cd452</samp>

This pull request adds a new prop `popOverContainer` to various components in the schema editor and the JSON schema editor to allow customizing the container element for the popovers. This improves the layout and positioning of the popovers in different contexts and scenarios. It also simplifies some code logic and uses the same container for the popovers and the modals in the JSON schema editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 43cd452</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever prop for the schema editor, `popOverContainer`,_
> _To control the placement of the popovers that display_
> _The properties of the items in the JSON array._

### Why

Close: #6977

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 43cd452</samp>

*  Add a new prop `popOverContainer` to various components that render popovers in the schema editor ([link](https://github.com/baidu/amis/pull/6982/files?diff=unified&w=0#diff-14e6744577b3c83c5a24878bc24189a129266c7c7a8c6fc4b0f4c978e7e30c1aR35), [link](https://github.com/baidu/amis/pull/6982/files?diff=unified&w=0#diff-038f9fb375b9f85f7fdebdf3251c8bb54f1a152d6e4acc55ce038e676b77984dR56), [link](https://github.com/baidu/amis/pull/6982/files?diff=unified&w=0#diff-55a05f6e8b3f9ea2d7162eb4aa987604334ca6e6bfae8880f1203d0a667a106dR69-R70))
*  Pass the `popOverContainer` prop to the `Overlay` component in the `PickerContainer` component to use the specified container element for the popovers ([link](https://github.com/baidu/amis/pull/6982/files?diff=unified&w=0#diff-14e6744577b3c83c5a24878bc24189a129266c7c7a8c6fc4b0f4c978e7e30c1aR158))
*  Pass the `popOverContainer` prop to the `PickerContainer` component in the `SchemaEditorItemArray`, `SchemaEditorItemCommon`, and `SchemaEditorItemObject` components to use the specified container element for the array item picker, the type picker, and the property picker respectively ([link](https://github.com/baidu/amis/pull/6982/files?diff=unified&w=0#diff-05b4a4567500ad678bb260fb874516d2c43569e9ea873cbc187a5e80dfca5299R74), [link](https://github.com/baidu/amis/pull/6982/files?diff=unified&w=0#diff-038f9fb375b9f85f7fdebdf3251c8bb54f1a152d6e4acc55ce038e676b77984dR198), [link](https://github.com/baidu/amis/pull/6982/files?diff=unified&w=0#diff-b6a27c8e41c8b3f6e9644af9c8c1d336af5943de3e424d7a3b81431aece65fc5R219))
*  Destructure the `popOverContainer` prop from the props of the `PickerContainer`, `SchemaEditorItemArray`, `SchemaEditorItemCommon`, `SchemaEditorItemObject`, and `SchemaEditor` components ([link](https://github.com/baidu/amis/pull/6982/files?diff=unified&w=0#diff-14e6744577b3c83c5a24878bc24189a129266c7c7a8c6fc4b0f4c978e7e30c1aL134-R136), [link](https://github.com/baidu/amis/pull/6982/files?diff=unified&w=0#diff-05b4a4567500ad678bb260fb874516d2c43569e9ea873cbc187a5e80dfca5299R43), [link](https://github.com/baidu/amis/pull/6982/files?diff=unified&w=0#diff-038f9fb375b9f85f7fdebdf3251c8bb54f1a152d6e4acc55ce038e676b77984dR101), [link](https://github.com/baidu/amis/pull/6982/files?diff=unified&w=0#diff-b6a27c8e41c8b3f6e9644af9c8c1d336af5943de3e424d7a3b81431aece65fc5R201), [link](https://github.com/baidu/amis/pull/6982/files?diff=unified&w=0#diff-55a05f6e8b3f9ea2d7162eb4aa987604334ca6e6bfae8880f1203d0a667a106dR173))
*  Pass the `popOverContainer` prop to the `SchemaEditorItemCommon` component in the `SchemaEditor` component to use the specified container element for the root schema item ([link](https://github.com/baidu/amis/pull/6982/files?diff=unified&w=0#diff-55a05f6e8b3f9ea2d7162eb4aa987604334ca6e6bfae8880f1203d0a667a106dR232))
*  Pass the `popOverContainer` prop to the `SchemaEditor` component in the `JSONSchemaEditor` component in the file `packages/amis/src/renderers/Form/JSONSchemaEditor.tsx` ([link](https://github.com/baidu/amis/pull/6982/files?diff=unified&w=0#diff-e3e1eb09695ed6073771a44c3d3a71379cf7ef71215b4a0a017e9d024cf4f13dR149))
*  Set the `popOverContainer` prop to the `getModalContainer` function from the `env` prop in the `JSONSchemaEditor` component to use the same container element for the popovers as the modals in the form renderer ([link](https://github.com/baidu/amis/pull/6982/files?diff=unified&w=0#diff-e3e1eb09695ed6073771a44c3d3a71379cf7ef71215b4a0a017e9d024cf4f13dR149))
*  Destructure the `env` prop from the props of the `JSONSchemaEditor` component ([link](https://github.com/baidu/amis/pull/6982/files?diff=unified&w=0#diff-e3e1eb09695ed6073771a44c3d3a71379cf7ef71215b4a0a017e9d024cf4f13dL141-R141))
