### PR TITLE
fix: 修复 inputTable 编辑点取消删除行问题 Close: #6980

### DIFF
--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -802,8 +802,12 @@ export default class FormTable extends React.Component<TableProps, TableState> {
   }
 
   cancelEdit() {
-    let items = this.state.items.concat();
-    items.splice(this.state.editIndex, 1);
+    const items = this.state.items.concat();
+    let item = {
+      ...items[this.state.editIndex]
+    };
+    const isNew = !!item.__isPlaceholder;
+    isNew && items.splice(this.state.editIndex, 1);
 
     this.setState(
       {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 68ea968</samp>

Fix a bug in `InputTable` component that deletes existing items when canceling the edit. Add `item` and `isNew` variables to handle the editing logic in `cancelEdit` method.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 68ea968</samp>

> _`cancelEdit` fixed_
> _No more deleting old items_
> _Only `isNew` spliced_

### Why

Close: #6980

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 68ea968</samp>

* Fix a bug that causes existing items to be deleted when canceling the edit in the input table ([link](https://github.com/baidu/amis/pull/6984/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL805-R810))
