### PR TITLE
feat: 新增 radio 组件可结合 combo 或者 inputTable 实现单选效果 Close: #6995

### DIFF
--- a/docs/zh-CN/components/form/radio.md
+++ b/docs/zh-CN/components/form/radio.md
@@ -1,0 +1,190 @@
+---
+title: Radio 单选框
+description:
+type: 0
+group: null
+menuName: Radio
+icon:
+order: 8
+---
+
+实现组合中的单选功能，此组件只有在 `combo` 和 `input-table` 中有意义。
+
+## combo 中使用
+
+```schema: scope="body"
+{
+    "type": "form",
+    "debug": true,
+    data: {
+        answers: [
+          {
+            isAnswer: false,
+            answer: '选项 1'
+          },
+          {
+            isAnswer: false,
+            answer: '选项 2',
+          }
+        ]
+      },
+    "body": [
+        {
+          type: 'combo',
+          label: '可选答案',
+          name: 'answers',
+          multiple: true,
+          addable: true,
+          strictMode: false,
+          items: [
+            {
+              type: 'radio',
+              name: 'isAnswer',
+              columnClassName: 'no-grow'
+            },
+            {
+              type: 'input-text',
+              name: 'answer',
+              placeholder: '答案文案'
+            }
+          ]
+        },
+    ]
+}
+```
+
+## input-table 中使用
+
+```schema: scope="body"
+{
+    "type": "form",
+    "debug": true,
+    data: {
+        answers: [
+          {
+            isAnswer: false,
+            answer: '选项 1'
+          },
+          {
+            isAnswer: false,
+            answer: '选项 2',
+            children: [
+              {
+                isAnswer: false,
+                answer: '选项 1'
+              },
+              {
+                isAnswer: false,
+                answer: '选项 2'
+              }
+            ]
+          }
+        ]
+      },
+    "body": [
+        {
+          type: 'input-table',
+          label: '可选答案',
+          name: 'answers',
+          multiple: true,
+          addable: true,
+          strictMode: false,
+          columns: [
+            {
+              label: '',
+              type: 'radio',
+              name: 'isAnswer',
+            },
+            {
+              label: '答案文案',
+              type: 'input-text',
+              name: 'answer',
+              placeholder: '答案文案'
+            }
+          ]
+        }
+    ]
+}
+```
+
+## 配置真假值
+
+默认情况：
+
+- 单选框勾选时，表单项值为：true
+- 单选框取消勾选时，表单项值为：false
+
+如果你想调整这个值，可以配置`trueValue`和`falseValue`
+
+```schema: scope="body"
+{
+    "type": "form",
+    "debug": true,
+    data: {
+        answers: [
+          {
+            isAnswer: false,
+            answer: '选项 1'
+          },
+          {
+            isAnswer: false,
+            answer: '选项 2',
+          }
+        ]
+      },
+    "body": [
+        {
+          type: 'combo',
+          label: '可选答案',
+          name: 'answers',
+          multiple: true,
+          addable: true,
+          strictMode: false,
+          items: [
+            {
+              type: 'radio',
+              name: 'isAnswer',
+              columnClassName: 'no-grow',
+              trueValue: 1,
+              falseValue: 0
+            },
+            {
+              type: 'input-text',
+              name: 'answer',
+              placeholder: '答案文案'
+            }
+          ]
+        },
+    ]
+}
+```
+
+## 属性表
+
+除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置
+
+| 属性名     | 类型                      | 默认值  | 说明     |
+| ---------- | ------------------------- | ------- | -------- |
+| option     | `string`                  |         | 选项说明 |
+| trueValue  | `string｜number｜boolean` | `true`  | 标识真值 |
+| falseValue | `string｜number｜boolean` | `false` | 标识假值 |
+
+## 事件表
+
+当前组件会对外派发以下事件，可以通过`onEvent`来监听这些事件，并通过`actions`来配置执行的动作，在`actions`中可以通过`${事件参数名}`来获取事件产生的数据（`< 2.3.2 及以下版本 为 ${event.data.[事件参数名]}`），详细请查看[事件动作](../../docs/concepts/event-action)。
+
+> `[name]`表示当前组件绑定的名称，即`name`属性，如果没有配置`name`属性，则通过`value`取值。
+
+| 事件名称 | 事件参数                   | 说明               |
+| -------- | -------------------------- | ------------------ |
+| change   | `[name]: boolean` 组件的值 | 选中状态变化时触发 |
+
+## 动作表
+
+当前组件对外暴露以下特性动作，其他组件可以通过指定`actionType: 动作名称`、`componentId: 该组件id`来触发这些动作，动作配置可以通过`args: {动作配置项名称: xxx}`来配置具体的参数，详细请查看[事件动作](../../docs/concepts/event-action#触发其他组件的动作)。
+
+| 动作名称 | 动作配置                                    | 说明                                                   |
+| -------- | ------------------------------------------- | ------------------------------------------------------ |
+| clear    | -                                           | 清空                                                   |
+| reset    | -                                           | 将值重置为`resetValue`，若没有配置`resetValue`，则清空 |
+| setValue | `value: string \|number \|boolean` 更新的值 | 更新数据                                               |

--- a/examples/components/Components.tsx
+++ b/examples/components/Components.tsx
@@ -557,6 +557,15 @@ export const components = [
           ).then(wrapDoc)
         )
       },
+
+      {
+        label: 'Radio 单选框',
+        path: '/zh-CN/components/form/radio',
+        component: React.lazy(() =>
+          import('../../docs/zh-CN/components/form/radio.md').then(wrapDoc)
+        )
+      },
+
       {
         label: 'Radios 单选框',
         path: '/zh-CN/components/form/radios',

--- a/packages/amis-core/src/utils/helper.ts
+++ b/packages/amis-core/src/utils/helper.ts
@@ -764,10 +764,17 @@ export interface TreeArray extends Array<TreeItem> {}
  */
 export function mapTree<T extends TreeItem>(
   tree: Array<T>,
-  iterator: (item: T, key: number, level: number, paths: Array<T>) => T,
+  iterator: (
+    item: T,
+    key: number,
+    level: number,
+    paths: Array<T>,
+    indexes: Array<number>
+  ) => T,
   level: number = 1,
   depthFirst: boolean = false,
-  paths: Array<T> = []
+  paths: Array<T> = [],
+  indexes: Array<number> = []
 ) {
   return tree.map((item: any, index) => {
     if (depthFirst) {
@@ -777,15 +784,20 @@ export function mapTree<T extends TreeItem>(
             iterator,
             level + 1,
             depthFirst,
-            paths.concat(item)
+            paths.concat(item),
+            indexes.concat(index)
           )
         : undefined;
       children && (item = {...item, children: children});
-      item = iterator(item, index, level, paths) || {...(item as object)};
+      item = iterator(item, index, level, paths, indexes.concat(index)) || {
+        ...(item as object)
+      };
       return item;
     }
 
-    item = iterator(item, index, level, paths) || {...(item as object)};
+    item = iterator(item, index, level, paths, indexes.concat(index)) || {
+      ...(item as object)
+    };
 
     if (item.children && item.children.splice) {
       item.children = mapTree(
@@ -793,7 +805,8 @@ export function mapTree<T extends TreeItem>(
         iterator,
         level + 1,
         depthFirst,
-        paths.concat(item)
+        paths.concat(item),
+        indexes.concat(index)
       );
     }
 

--- a/packages/amis/src/Schema.ts
+++ b/packages/amis/src/Schema.ts
@@ -132,6 +132,7 @@ import {MultilineTextSchema} from './renderers/MultilineText';
 import {DateRangeSchema} from './renderers/DateRange';
 import {PasswordSchema} from './renderers/Password';
 import {WordsSchema} from './renderers/Words';
+import {RadioControlSchema} from './renderers/Form/Radio';
 
 // 每加个类型，这补充一下。
 export type SchemaType =
@@ -313,6 +314,7 @@ export type SchemaType =
   | 'input-number'
   | 'panel'
   | 'picker'
+  | 'radio'
   | 'radios'
   | 'input-range'
   | 'input-rating'
@@ -461,6 +463,7 @@ export type SchemaObject =
   | NumberControlSchema
   | PickerControlSchema
   | RadiosControlSchema
+  | RadioControlSchema
   | RangeControlSchema
   | RatingControlSchema
   | RichTextControlSchema

--- a/packages/amis/src/index.tsx
+++ b/packages/amis/src/index.tsx
@@ -49,6 +49,7 @@ import './renderers/Form/ChartRadios';
 import './renderers/Form/InputRating';
 import './renderers/Form/Switch';
 import './renderers/Form/Radios';
+import './renderers/Form/Radio';
 import './renderers/Form/JSONSchema';
 import './renderers/Form/JSONSchemaEditor';
 import './renderers/Form/ListSelect';

--- a/packages/amis/src/renderers/Form/Combo.tsx
+++ b/packages/amis/src/renderers/Form/Combo.tsx
@@ -46,6 +46,7 @@ import {
 } from '../../Schema';
 import {ListenerAction} from 'amis-core';
 import type {SchemaTokenizeableString} from '../../Schema';
+import isPlainObject from 'lodash/isPlainObject';
 
 export type ComboCondition = {
   test: string;
@@ -381,6 +382,7 @@ export default class ComboControl extends React.Component<ComboProps> {
     super(props);
 
     this.handleChange = this.handleChange.bind(this);
+    this.handleRadioChange = this.handleRadioChange.bind(this);
     this.handleSingleFormChange = this.handleSingleFormChange.bind(this);
     this.handleSingleFormInit = this.handleSingleFormInit.bind(this);
     this.handleFormInit = this.handleFormInit.bind(this);
@@ -748,6 +750,29 @@ export default class ComboControl extends React.Component<ComboProps> {
           item => item.unique && item.syncOptions(undefined, form.data)
         )
     );
+  }
+
+  handleRadioChange(
+    ctx: any,
+    {index, name, trueValue = true, falseValue = false}: any
+  ) {
+    const {onChange, submitOnChange, multiple, disabled} = this.props;
+    if (!multiple || disabled || !name) {
+      return;
+    }
+
+    let value = this.getValueAsArray();
+    if (!Array.isArray(value) || value.length < 2 || !isPlainObject(value[0])) {
+      return;
+    }
+    value = value.map((item, i) => ({
+      ...item,
+      [name]: i === index ? trueValue : falseValue
+    }));
+
+    onChange(value, submitOnChange, true);
+
+    return false;
   }
 
   handleSingleFormChange(values: object) {
@@ -1683,6 +1708,7 @@ export default class ComboControl extends React.Component<ComboProps> {
           onChange: this.handleChange,
           onInit: this.handleFormInit,
           onAction: this.handleAction,
+          onRadioChange: this.handleRadioChange,
           ref: this.makeFormRef(index),
           canAccessSuperData,
           lazyChange: changeImmediately ? false : true,

--- a/packages/amis/src/renderers/Form/Radio.tsx
+++ b/packages/amis/src/renderers/Form/Radio.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import {
+  FormItem,
+  FormControlProps,
+  FormBaseControl,
+  resolveEventData
+} from 'amis-core';
+import cx from 'classnames';
+import {Checkbox} from 'amis-ui';
+import {withBadge, BadgeObject} from 'amis-ui';
+import {autobind, createObject} from 'amis-core';
+import {ActionObject} from 'amis-core';
+import {BaseSchema, FormBaseControlSchema} from '../../Schema';
+import {supportStatic} from './StaticHoc';
+
+/**
+ * Radio 单选框。
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/radios
+ */
+export interface RadioControlSchema extends FormBaseControlSchema {
+  /**
+   * 指定为多行文本输入框
+   */
+  type: 'radio';
+
+  /**
+   * 勾选值
+   */
+  trueValue?: boolean | string | number;
+
+  /**
+   * 未勾选值
+   */
+  falseValue?: boolean | string | number;
+
+  /**
+   * 选项说明
+   */
+  option?: string;
+
+  /**
+   * 角标
+   */
+  badge?: BadgeObject;
+  partial?: boolean;
+  optionType?: 'default' | 'button';
+}
+
+export interface RadioProps
+  extends FormControlProps,
+    Omit<
+      RadioControlSchema,
+      'type' | 'className' | 'descriptionClassName' | 'inputClassName'
+    > {
+  checked?: boolean;
+  onRadioChange?: (value: any, ctx: any) => any;
+}
+
+export default class RadioControl extends React.Component<RadioProps, any> {
+  static defaultProps: Partial<RadioProps> = {
+    trueValue: true,
+    falseValue: false
+  };
+
+  doAction(action: ActionObject, data: object, throwErrors: boolean) {
+    const {resetValue, onChange} = this.props;
+    const actionType = action?.actionType as string;
+
+    if (actionType === 'clear') {
+      onChange('');
+    } else if (actionType === 'reset') {
+      onChange(resetValue ?? '');
+    }
+  }
+
+  @autobind
+  async dispatchChangeEvent(eventData: any = {}) {
+    const {dispatchEvent, onChange, submitOnChange, onRadioChange} = this.props;
+    const ctx = resolveEventData(this.props, {value: eventData});
+
+    if (onRadioChange?.(ctx, this.props) === false) {
+      return;
+    }
+
+    const rendererEvent = await dispatchEvent('change', ctx);
+
+    if (rendererEvent?.prevented) {
+      return;
+    }
+
+    onChange && onChange(eventData, submitOnChange, true);
+  }
+
+  renderStatic() {
+    const {
+      value,
+      trueValue,
+      falseValue,
+      option,
+      render,
+      partial,
+      optionType,
+      checked,
+      labelClassName
+    } = this.props;
+
+    return (
+      <Checkbox
+        type="radio"
+        inline
+        value={value || ''}
+        trueValue={trueValue}
+        falseValue={falseValue}
+        disabled={true}
+        partial={partial}
+        optionType={optionType}
+        checked={checked}
+        labelClassName={labelClassName}
+      >
+        {option ? render('option', option) : null}
+      </Checkbox>
+    );
+  }
+
+  @supportStatic()
+  render() {
+    const {
+      className,
+      style,
+      value,
+      trueValue,
+      falseValue,
+      option,
+      onChange,
+      disabled,
+      render,
+      partial,
+      optionType,
+      checked,
+      labelClassName,
+      classPrefix: ns
+    } = this.props;
+
+    return (
+      <div className={cx(`${ns}CheckboxControl`, className)}>
+        <Checkbox
+          type="radio"
+          inline
+          value={value || ''}
+          trueValue={trueValue}
+          falseValue={falseValue}
+          disabled={disabled}
+          onChange={(value: any) => this.dispatchChangeEvent(value)}
+          partial={partial}
+          optionType={optionType}
+          checked={checked}
+          labelClassName={labelClassName}
+        >
+          {option ? render('option', option) : null}
+        </Checkbox>
+      </div>
+    );
+  }
+}
+
+// @ts-ignore
+@withBadge
+@FormItem({
+  type: 'radio',
+  sizeMutable: false
+})
+export class RadioControlRenderer extends RadioControl {}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 03fc917</samp>

This pull request adds a new radio component to the amis framework, which can be used in the combo and input-table components, and in the amis schema system. It also enhances the `mapTree` function in the `helper.ts` file by adding an `indexes` parameter. It updates the documentation, examples, and imports for the radio component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 03fc917</samp>

> _The amis framework is quite smart_
> _It lets you build forms with some art_
> _You can use a `radio`_
> _In a combo or table row_
> _And define its schema and part_

### Why

Close: #6995

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 03fc917</samp>

*  Add a new radio component to the form group ([link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-300e4f41ff51b2807c2a7be9e053b362056b1c7a37d51b0c464f20f551c3d3c8R1-R190), [link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-11a691be27b6eb52a8766bf4dd23dc9b9604abc7cb945a407d983b77e529654eL560-R569), [link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-cb3ebb556173d15828521d94fe60863af0f9174c1232fcf510e449c5f5061d5cR52), [link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-61925662bfe9e90a50dd891fe7709d5e44ea7a5cc17ba2af3a3424a26c94c99fR1-R172), [link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-1d70ef86e04744f8ab32d8c9957e4784c6b948efa3fcf7b2557766e973378f23R135), [link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-1d70ef86e04744f8ab32d8c9957e4784c6b948efa3fcf7b2557766e973378f23R317), [link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-1d70ef86e04744f8ab32d8c9957e4784c6b948efa3fcf7b2557766e973378f23R466))
*  Add a new parameter `indexes` to the `mapTree` function in `packages/amis-core/src/utils/helper.ts` ([link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL767-R777), [link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL780-R800), [link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL796-R809))
*  Add a new method `handleRadioChange` to the `ComboControl` and `InputTableControl` classes in `packages/amis/src/renderers/Form/Combo.tsx` and `packages/amis/src/renderers/Form/InputTable.tsx` ([link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829R385), [link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829R755-R777), [link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829R1711), [link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cR306), [link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cR1384-R1406), [link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cR1574))
*  Simplify the condition for checking if a column is a form item in the `renderCell` method in `packages/amis/src/renderers/Form/InputTable.tsx` ([link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1270-R1273))
*  Import the `isPlainObject` function from the lodash library to `packages/amis/src/renderers/Form/Combo.tsx` ([link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829R49))
*  Remove the `reUseRow` prop from the `renderCell` method in `packages/amis/src/renderers/Form/InputTable.tsx` ([link](https://github.com/baidu/amis/pull/7001/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1560))
