### PR TITLE
feat:CRUD&Table上下文校正、fix: 修复label为空时SubMenu高度为0不展示问题

### DIFF
--- a/packages/amis-ui/scss/components/_menu.scss
+++ b/packages/amis-ui/scss/components/_menu.scss
@@ -556,16 +556,11 @@
 
     &.#{$ns}Nav-Menu-expand-before {
       .#{$ns}Nav-Menu-submenu-title {
-        .#{$ns}Nav-Menu-item-wrap {
-          padding-right: 0;
-          padding-left: px2rem(16px);
-        }
-      }
+        flex-direction: row-reverse;
 
-      .#{$ns}Nav-Menu-submenu-arrow {
-        right: auto;
-        position: absolute;
-        margin: 0;
+        > .#{$ns}Nav-Menu-submenu-arrow {
+          margin: 0 px2rem(10px) 0 0;
+        }
       }
     }
 

--- a/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
@@ -4625,6 +4625,7 @@ exports[`Renderer:crud loadDataOnce 1`] = `
                           </div>
                           <span
                             class="cxd-TableCell-sortBtn"
+                            data-index="8"
                           >
                             <i
                               class="cxd-TableCell-sortBtn--down"
@@ -5533,6 +5534,7 @@ exports[`Renderer:crud loadDataOnce 1`] = `
                           </div>
                           <span
                             class="cxd-TableCell-sortBtn"
+                            data-index="8"
                           >
                             <i
                               class="cxd-TableCell-sortBtn--down"

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -760,7 +760,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
 
     const ctx = createObject(store.mergedData, {
       ...selectedItems[0],
-      currentPageData: store.mergedData.items.concat(),
+      currentPageData: (store.mergedData?.items || []).concat(),
       rows: selectedItems,
       items: selectedItems,
       selectedItems,

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -1795,7 +1795,12 @@ export default class CRUD extends React.Component<CRUDProps, any> {
 
     const extraProps: Pick<
       PaginationProps,
-      'showPageInput' | 'maxButtons' | 'layout' | 'popOverContainerSelector'
+      | 'showPageInput'
+      | 'maxButtons'
+      | 'layout'
+      | 'popOverContainerSelector'
+      | 'total'
+      | 'perPageAvailable'
     > = {};
 
     /** 优先级：showPageInput显性配置 > (lastPage > 9) */
@@ -1809,6 +1814,11 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       extraProps.popOverContainerSelector = (
         toolbar as Schema
       ).popOverContainerSelector;
+      extraProps.perPageAvailable = (toolbar as Schema).perPageAvailable;
+      extraProps.total = resolveVariableAndFilter(
+        (toolbar as Schema).total,
+        store.data
+      );
     } else {
       extraProps.showPageInput = lastPage > 9;
     }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0218848</samp>

This pull request enhances the CRUD renderer with better pagination and bulk actions. It fixes a bug, adds more props, and enables pagination customization with `toolbar` schema.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0218848</samp>

> _`CRUD` renderer_
> _enhances pagination, bulk_
> _autumn of errors_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0218848</samp>

*  Add nullish coalescing operator to avoid error when `store.mergedData.items` is undefined or null ([link](https://github.com/baidu/amis/pull/7002/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L763-R763))
*  Pass pagination props to `PaginationWrapper` component ([link](https://github.com/baidu/amis/pull/7002/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1798-R1803), [link](https://github.com/baidu/amis/pull/7002/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R1817-R1821))
