### PR TITLE
styles: 优化remark组件svg icon样式

### DIFF
--- a/packages/amis/src/renderers/Remark.tsx
+++ b/packages/amis/src/renderers/Remark.tsx
@@ -130,7 +130,9 @@ class Remark extends React.Component<RemarkProps> {
         {finalLabel ? <span>{finalLabel}</span> : null}
         {finalIcon ? (
           typeof finalIcon === 'object' ? (
-            generateIcon(cx, finalIcon)
+            <span className={cx('Remark-icon', shapeClass)}>
+              {generateIcon(cx, finalIcon)}
+            </span>
           ) : hasIcon(finalIcon) ? (
             <span className={cx('Remark-icon', shapeClass)}>
               <Icon icon={finalIcon} />


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 01d0f74</samp>

Fix icon display issue in `Remark` component. Wrap icon in a span element with `icon` class in `packages/amis/src/renderers/Remark.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 01d0f74</samp>

> _`span` wraps the icon_
> _aligns with others in Remark_
> _autumn leaves fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 01d0f74</samp>

* Fix icon display issue in Remark component by:
  - Wrapping generated icon in a span element with class `icon` ([link](https://github.com/baidu/amis/pull/7003/files?diff=unified&w=0#diff-b8e71827711182bce76c92e97c6c29d8c0a5e83eb52d4d0ee300a4da7f7439d6L133-R135))
