### PR TITLE
fix: 修复 condition-builder 切换规则后右值丢失的问题

### DIFF
--- a/packages/amis-ui/src/components/condition-builder/Item.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Item.tsx
@@ -101,7 +101,7 @@ export class ConditionItem extends React.Component<ConditionItemProps> {
     const result = {
       ...value,
       op: op,
-      right: leftFieldSchema?.defaultValue
+      right: value.right ?? leftFieldSchema?.defaultValue
     };
 
     onChange(result, index);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5fc6505</samp>

Preserve right value of condition item when changing operator in `condition-builder/Item.tsx`. This fixes a bug that caused the right value to be reset to the default value of the left field schema.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5fc6505</samp>

> _`operator` changes_
> _keep the right value intact_
> _a gentle spring breeze_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5fc6505</samp>

* Preserve the right value of condition items when changing the operator ([link](https://github.com/baidu/amis/pull/7004/files?diff=unified&w=0#diff-bd3cef1dd1adf5cbac8db6825eccda213b5450966cc365712f22a32093048fc6L104-R104))
