### PR TITLE
feat(amis-editor;amis):时间范围组件快捷键自定义支持固定值的配置 + 设计器快捷键配置功能

### DIFF
--- a/packages/amis-editor-core/scss/_mixin.scss
+++ b/packages/amis-editor-core/scss/_mixin.scss
@@ -88,28 +88,9 @@
 }
 
 @mixin panel-sm-content {
-  --Form-fontSize: #{$Editor-right-panel-font-size};
-  --ColorPicker-fontSize: #{$Editor-right-panel-font-size};
-  --fontSizeBase: #{$Editor-right-panel-font-size};
-  --Form-item-fontSize: #{$Editor-right-panel-font-size};
-  --Button--md-fontSize: #{$Editor-right-panel-font-size};
-  --Form-input-fontSize: #{$Editor-right-panel-font-size};
-  --Button-fontSize: #{$Editor-right-panel-font-size};
+  @extend :root;
+  --fonts-size-7: #{$Editor-right-panel-font-size};
   --Form-input-lineHeight: #{$Editor-right-panel-line-height};
   --InputGroup-select-borderColor: #{$Editor-right-panel-border-color};
   --Form-input-borderColor: #{$Editor-right-panel-border-color};
-
-  --checkbox-checkbox-default-fontSize: #{$Editor-right-panel-font-size};
-  --select-base-default-fontSize: #{$Editor-right-panel-font-size};
-  --input-default-default-fontSize: #{$Editor-right-panel-font-size};
-  --button-size-default-fontSize: #{$Editor-right-panel-font-size};
-  --link-fontSize: #{$Editor-right-panel-font-size};
-  --link-onHover-fontSize: #{$Editor-right-panel-font-size};
-  --link-disabled-fontSize: #{$Editor-right-panel-font-size};
-  --link-onClick-fontSize: #{$Editor-right-panel-font-size};
-  --radio-default-default-fontSize: #{$Editor-right-panel-font-size};
-  --select-base-default-option-fontSize: #{$Editor-right-panel-font-size};
-  --Tabs--line-fontSize: #{$Editor-right-panel-font-size};
-  --Tabs--line-active-fontSize: #{$Editor-right-panel-font-size};
-  --Tabs--line-hover-fontSize: #{$Editor-right-panel-font-size};
 }

--- a/packages/amis-editor-core/scss/_rightPanel.scss
+++ b/packages/amis-editor-core/scss/_rightPanel.scss
@@ -20,8 +20,6 @@ $tooltip-bottom: '[data-tooltip][data-position=' bottom ']:hover:after';
   transition: width ease-in-out 0.2s;
   // transform: translateZ(0);
 
-  @include panel-sm-content();
-
   .ae-Settings-content {
     padding: var(--gap-base);
     #{$tooltip-bottom} {
@@ -247,6 +245,10 @@ $tooltip-bottom: '[data-tooltip][data-position=' bottom ']:hover:after';
 
       .editor-prop-config-tabs {
         padding-bottom: 45px;
+
+        &-links {
+          --fonts-size-7: 14px;
+        }
       }
 
       .ae-Settings-actions,
@@ -317,7 +319,8 @@ $tooltip-bottom: '[data-tooltip][data-position=' bottom ']:hover:after';
           font-family: PingFangSC-Regular;
           color: #84868c;
           width: 100%;
-          font-size: 14px;
+          --Tabs--line-active-fontSize: 14px;
+          --Tabs--line-fontSize: 14px;
           letter-spacing: 0;
           font-weight: 400;
           text-decoration: none;

--- a/packages/amis-editor-core/scss/control/_dateshortcut-control.scss
+++ b/packages/amis-editor-core/scss/control/_dateshortcut-control.scss
@@ -68,7 +68,8 @@
       @include flexBox();
       width: 100%;
       padding: #{px2rem(5px)} #{px2rem(10px)};
-      height: #{px2rem(38px)};
+      min-height: #{px2rem(38px)};
+      align-items: baseline;
 
       &:hover {
         background: #e9effd;
@@ -93,9 +94,14 @@
 
       &-content {
         display: inline-block;
-        width: 100%;
+        flex-grow: 1;
+        max-width: calc(100% - 32px);
         text-align: left;
         padding: 0 #{px2rem(5px)};
+
+        &-label {
+          line-height: var(--input-size-default-height);
+        }
       }
 
       &-close {

--- a/packages/amis-editor-core/scss/editor.scss
+++ b/packages/amis-editor-core/scss/editor.scss
@@ -1,6 +1,7 @@
 @import '../../../node_modules/amis-ui/scss/functions';
 @import '../../../node_modules/amis-ui/scss/variables';
 @import '../../../node_modules/amis-ui/scss/mixins';
+@import '../../../node_modules/amis-ui/scss/components';
 @import './mixin';
 @import './variables';
 @import './backTop';

--- a/packages/amis-editor/src/plugin/Form/InputDateRange.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputDateRange.tsx
@@ -445,28 +445,29 @@ export class DateRangeControlPlugin extends BasePlugin {
                 }),
                 getSchemaTpl('dateShortCutControl', {
                   mode: 'normal',
-                  normalDropDownOption: {
-                    yesterday: '昨天',
-                    thisweek: '这个周',
-                    prevweek: '上周',
-                    thismonth: '这个月',
-                    prevmonth: '上个月',
-                    thisquarter: '这个季度',
-                    prevquarter: '上个季度',
-                    thisyear: '今年'
-                  },
-                  customDropDownOption: {
-                    daysago: '最近n天',
-                    dayslater: 'n天以内',
-                    weeksago: '最近n周',
-                    weekslater: 'n周以内',
-                    monthsago: '最近n月',
-                    monthslater: 'n月以内',
-                    quartersago: '最近n季度',
-                    quarterslater: 'n季度以内',
-                    yearsago: '最近n年',
-                    yearslater: 'n年以内'
-                  }
+                  certainOptions: [
+                    'today',
+                    'yesterday',
+                    'thisweek',
+                    'prevweek',
+                    'thismonth',
+                    'prevmonth',
+                    'thisquarter',
+                    'prevquarter',
+                    'thisyear'
+                  ],
+                  modifyOptions: [
+                    '$daysago',
+                    '$dayslater',
+                    '$weeksago',
+                    '$weekslater',
+                    '$monthsago',
+                    '$monthslater',
+                    '$quartersago',
+                    '$quarterslater',
+                    '$yearsago',
+                    '$yearslater'
+                  ]
                 }),
                 getSchemaTpl('remark'),
                 getSchemaTpl('labelRemark'),

--- a/packages/amis-editor/src/renderer/DateShortCutControl.tsx
+++ b/packages/amis-editor/src/renderer/DateShortCutControl.tsx
@@ -7,20 +7,45 @@ import Sortable from 'sortablejs';
 import {findDOMNode} from 'react-dom';
 import {FormItem, Icon} from 'amis';
 
-import type {FormControlProps} from 'amis-core';
-import type {BaseEventContext} from 'amis-editor-core';
-import type {Option} from 'amis';
+import {FormControlProps, Option, optionValueCompare} from 'amis-core';
+import {BaseEventContext, getSchemaTpl} from 'amis-editor-core';
 
 import {autobind} from 'amis-editor-core';
+import {FormulaDateType} from './FormulaControl';
 
-type $Object = {
-  [key: string]: string;
+const DefaultValue = [
+  'yesterday',
+  '7daysago',
+  'prevweek',
+  'thismonth',
+  'prevmonth',
+  'prevquarter'
+];
+
+const CertainPresetShorcut = {
+  today: '今天',
+  yesterday: '昨天',
+  thisweek: '这个周',
+  prevweek: '上周',
+  thismonth: '这个月',
+  prevmonth: '上个月',
+  thisquarter: '这个季度',
+  prevquarter: '上个季度',
+  thisyear: '今年'
 };
 
-enum RangeType {
-  Normal = 'Normal',
-  Custom = 'Custom'
-}
+const ModifyPresetShorcut = {
+  $daysago: '最近n天',
+  $dayslater: 'n天以内',
+  $weeksago: '最近n周',
+  $weekslater: 'n周以内',
+  $monthsago: '最近n月',
+  $monthslater: 'n月以内',
+  $quartersago: '最近n季度',
+  $quarterslater: 'n季度以内',
+  $yearsago: '最近n年',
+  $yearslater: 'n年以内'
+};
 
 export interface DateShortCutControlProps extends FormControlProps {
   className?: string;
@@ -28,25 +53,38 @@ export interface DateShortCutControlProps extends FormControlProps {
    * 编辑器上下文数据，用于获取字段所在Form的其他字段
    */
   context: BaseEventContext;
-  normalDropDownOption: $Object;
-  customDropDownOption: $Object;
+  certainOptions: Array<keyof typeof CertainPresetShorcut>;
+  modifyOptions: Array<keyof typeof ModifyPresetShorcut>;
 }
 
-interface OptionsType {
-  label?: string;
+type PresetShorCutType = string;
+
+// 完全自定义label与时间计算方式的快捷键数据格式
+type CustomShortCutType = {
+  label: string;
+  startDate: string;
+  endDate: string;
+};
+
+// 可修改数字的预置快捷键数据值格式
+type ModifyOptionType = {
+  key: keyof typeof ModifyPresetShorcut;
   value: string;
-  type: RangeType;
-  inputType?: string;
+};
+
+enum OptionType {
+  Custom = 1,
+  Certain = 2,
+  Modify = 3
+}
+
+interface OptionDataType {
+  data: PresetShorCutType | CustomShortCutType | ModifyOptionType;
+  type?: OptionType; // 自定义的、某个特定的、可修改数字的特定描述区域
 }
 
 interface DateShortCutControlState {
-  options: Array<OptionsType>;
-}
-
-interface InputOption {
-  type: 'middle' | 'suffix';
-  prefix?: string;
-  suffix: string;
+  options: Array<OptionDataType>;
 }
 
 const ShortCutItemWrap = (props: {
@@ -79,8 +117,8 @@ export class DateShortCutControl extends React.PureComponent<
   sortable?: Sortable;
   drag?: HTMLElement | null;
   target: HTMLElement | null;
-  normalDropDownOptionArr: Array<Option>;
-  customDropDownOptionArr: Array<Option>;
+  certainDropDownOptions: Array<Option>;
+  modifyDropDownOptions: Array<Option>;
 
   static defaultProps: Partial<DateShortCutControlProps> = {
     label: '快捷键'
@@ -88,45 +126,61 @@ export class DateShortCutControl extends React.PureComponent<
 
   constructor(props: DateShortCutControlProps) {
     super(props);
-    const {normalDropDownOption, customDropDownOption, data} = props;
-    this.normalDropDownOptionArr = Object.keys(normalDropDownOption).map(
-      key => ({
-        label: normalDropDownOption[key],
-        value: key
-      })
-    );
-    this.customDropDownOptionArr = Object.keys(customDropDownOption).map(
-      key => ({
-        label: customDropDownOption[key],
-        value: key
-      })
-    );
-    const defaultRanges = [
-      'yesterday',
-      '7daysago',
-      'prevweek',
-      'thismonth',
-      'prevmonth',
-      'prevquarter'
-    ];
+
+    // 初始化下拉选项
+    const {certainOptions, modifyOptions, data} = props;
+    this.certainDropDownOptions = certainOptions.map(key => ({
+      label: CertainPresetShorcut[key],
+      value: key
+    }));
+    this.modifyDropDownOptions = modifyOptions.map(key => ({
+      label: ModifyPresetShorcut[key],
+      value: key
+    }));
+
+    // 初始化原始组件配置的快捷键
+    let initData = data?.ranges ?? DefaultValue;
+    initData = Array.isArray(initData) ? initData : initData.split(',');
+
     this.state = {
-      options: (data?.ranges ?? defaultRanges).map(
-        (item: string, index: number) => {
-          const arr = item.match(/^(\d+)[a-zA-Z]+/);
-          if (arr) {
+      options: initData
+        .map((item: PresetShorCutType | CustomShortCutType) => {
+          if (!item) {
+            return null;
+          }
+
+          // 完全自定义的快捷键
+          if (
+            typeof item != 'string' &&
+            item.label &&
+            item.startDate &&
+            item.endDate
+          ) {
             return {
-              value: arr[1],
-              type: RangeType.Custom,
-              inputType: item.match(/[a-zA-Z]+/)?.[0]
+              type: OptionType.Custom,
+              data: item
             };
           }
+
+          // amis中提供的可灵活配置数字的自定义快捷键
+          const arr = (item as string).match(/^([a-zA-Z]*)(\d+)([a-zA-Z]*)$/);
+          if (arr) {
+            return {
+              data: {
+                value: arr[2],
+                key: `${arr[1]}$${arr[3]}`
+              },
+              type: OptionType.Modify
+            };
+          }
+
+          // 固定值的快捷键
           return {
-            label: normalDropDownOption[item],
-            value: item,
-            type: RangeType.Normal
+            data: item,
+            type: OptionType.Certain
           };
-        }
-      )
+        })
+        .filter(Boolean)
     };
   }
 
@@ -203,19 +257,118 @@ export class DateShortCutControl extends React.PureComponent<
   }
 
   /**
+   * 生成快捷键项的配置
+   */
+  renderOption(option: OptionDataType, index: number) {
+    const {render, data: schema} = this.props;
+
+    if (option.type === OptionType.Certain) {
+      return (
+        <span className={klass + 'Item-content-label'}>
+          {
+            CertainPresetShorcut[
+              option.data as keyof typeof CertainPresetShorcut
+            ]
+          }
+        </span>
+      );
+    }
+
+    if (option.type === OptionType.Custom) {
+      const data = option?.data as CustomShortCutType;
+      return render(
+        'inner',
+        {
+          type: 'form',
+          wrapWithPanel: false,
+          body: [
+            {
+              type: 'input-text',
+              mode: 'normal',
+              placeholder: '快捷键名称',
+              name: 'label'
+            },
+            getSchemaTpl('valueFormula', {
+              name: 'startDate',
+              header: '表达式或相对值',
+              DateTimeType: FormulaDateType.IsDate,
+              rendererSchema: {
+                ...schema,
+                type: 'input-date'
+              },
+              placeholder: '开始时间',
+              needDeleteProps: ['ranges', 'maxDate', 'id', 'minDuration'],
+              label: false
+            }),
+            getSchemaTpl('valueFormula', {
+              name: 'endDate',
+              header: '表达式或相对值',
+              DateTimeType: FormulaDateType.IsDate,
+              rendererSchema: {
+                ...schema,
+                type: 'input-date'
+              },
+              placeholder: '结束时间',
+              needDeleteProps: ['ranges', 'maxDate', 'id', 'minDuration'],
+              label: false
+            })
+          ],
+          onChange: (value: CustomShortCutType) => {
+            this.handleOptionChange(value, index);
+          }
+        },
+        {
+          data
+        }
+      );
+    }
+
+    const key = (option.data as ModifyOptionType)
+      .key as keyof typeof ModifyPresetShorcut;
+    const label = ModifyPresetShorcut[key].split('n');
+
+    return render(
+      'inner',
+      {
+        type: 'form',
+        wrapWithPanel: false,
+        body: [
+          {
+            name: 'value',
+            type: 'input-text',
+            prefix: label[0] || undefined,
+            suffix: label[1] || undefined,
+            mode: 'normal',
+            placeholder: 'n'
+          }
+        ],
+        onChange: (value: ModifyOptionType) =>
+          this.handleOptionChange(value, index)
+      },
+      {
+        data: option.data
+      }
+    );
+  }
+
+  /**
    * 生成内容体
    */
   renderContent() {
     const {options} = this.state;
+
     return (
       <div className={klass + '-wrapper'}>
         {options && options.length ? (
           <ul className={klass + '-content'} ref={this.dragRef}>
             {options.map((option, index) => (
               <li className={klass + 'Item'} key={index}>
-                {option.type === RangeType.Normal
-                  ? this.renderNormalOption(option, index)
-                  : this.renderCustomOption(option, index)}
+                <ShortCutItemWrap
+                  index={index}
+                  handleDelete={this.handleDelete}
+                >
+                  {this.renderOption(option, index)}
+                </ShortCutItemWrap>
               </li>
             ))}
           </ul>
@@ -227,90 +380,32 @@ export class DateShortCutControl extends React.PureComponent<
   }
 
   /**
-   * 生成固定跨度选项
-   */
-  renderNormalOption(option: OptionsType, index: number) {
-    return (
-      <ShortCutItemWrap index={index} handleDelete={this.handleDelete}>
-        <span>{option.label}</span>
-      </ShortCutItemWrap>
-    );
-  }
-
-  /**
-   * 生成自定义跨度选项
-   */
-  renderCustomOption(option: OptionsType, index: number) {
-    const {render} = this.props;
-
-    const renderInput = (option: InputOption & {value: string}) => {
-      if (option.type === 'middle') {
-        return render('inner', {
-          type: 'input-text',
-          prefix: option?.prefix,
-          suffix: option.suffix,
-          mode: 'normal',
-          placeholder: 'n',
-          value: option?.value,
-          onChange: (value: string) => this.handleCustomItemChange(value, index)
-        });
-      }
-      return render('inner', {
-        type: 'input-text',
-        placeholder: 'n',
-        mode: 'normal',
-        suffix: option.suffix,
-        value: option?.value,
-        onChange: (value: string) => this.handleCustomItemChange(value, index)
-      });
-    };
-
-    const dateMap: {[key: string]: InputOption} = {
-      daysago: {prefix: '最近', suffix: '天', type: 'middle'},
-      dayslater: {suffix: '天以内', type: 'suffix'},
-      weeksago: {prefix: '最近', suffix: '周', type: 'middle'},
-      weekslater: {suffix: '周以内', type: 'suffix'},
-      monthsago: {prefix: '最近', suffix: '月', type: 'middle'},
-      monthslater: {suffix: '月以内', type: 'suffix'},
-      quartersago: {prefix: '最近', suffix: '季度', type: 'middle'},
-      quarterslater: {suffix: '季度以内', type: 'suffix'},
-      yearsago: {prefix: '最近', suffix: '年', type: 'middle'},
-      yearslater: {suffix: '年以内', type: 'suffix'}
-    };
-
-    return (
-      <ShortCutItemWrap index={index} handleDelete={this.handleDelete}>
-        {option.inputType
-          ? renderInput({...dateMap[option.inputType], value: option.value})
-          : null}
-      </ShortCutItemWrap>
-    );
-  }
-
-  /**
    * 自定义跨度变化
    */
-  handleCustomItemChange(value: string, index: number) {
+  handleOptionChange(
+    data: string | CustomShortCutType | ModifyOptionType,
+    index: number
+  ) {
     const options = [...this.state.options];
-    options[index].value = value;
+    options[index].data = data;
     this.setState({options}, () => this.onChangeOptions());
   }
 
   /**
    * option添加
    */
-  addItem(item: Option, type: RangeType) {
+  addItem(item: Option, type: OptionType) {
     this.setState(
       {
-        options: [
-          ...this.state.options,
-          {
-            label: item?.label ?? '',
-            type,
-            value: type === RangeType.Normal ? item.value : '',
-            ...(type === RangeType.Normal ? {} : {inputType: item.value})
-          }
-        ]
+        options: this.state.options.concat({
+          type,
+          data:
+            type === OptionType.Certain
+              ? item.value
+              : type === OptionType.Modify
+              ? {key: item.value, value: undefined}
+              : {label: undefined, startDate: undefined, endDate: undefined}
+        })
       },
       () => {
         this.onChangeOptions();
@@ -335,16 +430,29 @@ export class DateShortCutControl extends React.PureComponent<
   onChangeOptions() {
     const {options} = this.state;
     const {onBulkChange} = this.props;
-    const newOptions: Array<string> = [];
-    options.forEach((item, index) => {
-      if (item.type === RangeType.Normal) {
-        newOptions[index] = item.value;
+    const newRanges: Array<string | CustomShortCutType> = [];
+
+    options.forEach(item => {
+      if (item.type === OptionType.Certain) {
+        newRanges.push(item.data as string);
       }
-      if (item.type === RangeType.Custom && item.value) {
-        newOptions[index] = `${item.value}${item.inputType}`;
+
+      if (item.type === OptionType.Modify) {
+        let data = item.data as ModifyOptionType;
+        let value = data.value;
+        /^\d+$/.test(value) && newRanges.push(data.key.replace('$', value));
+      }
+
+      if (item.type === OptionType.Custom) {
+        let data = item.data as CustomShortCutType;
+        data.label &&
+          data.startDate &&
+          data.endDate &&
+          newRanges.push({...data});
       }
     });
-    onBulkChange && onBulkChange({ranges: newOptions});
+
+    onBulkChange && onBulkChange({ranges: newRanges});
   }
 
   render() {
@@ -365,11 +473,11 @@ export class DateShortCutControl extends React.PureComponent<
                 closeOnClick: true,
                 closeOnOutside: true,
                 level: 'enhance',
-                buttons: this.normalDropDownOptionArr.map((item: any) => ({
+                buttons: this.certainDropDownOptions.map((item: any) => ({
                   ...item,
                   type: 'button',
                   onAction: (e: React.MouseEvent, action: any) =>
-                    this.addItem(item, RangeType.Normal)
+                    this.addItem(item, OptionType.Certain)
                 }))
               },
               {
@@ -385,12 +493,30 @@ export class DateShortCutControl extends React.PureComponent<
                 label: '自定义跨度',
                 closeOnClick: true,
                 closeOnOutside: true,
-                buttons: this.customDropDownOptionArr.map((item: any) => ({
-                  ...item,
-                  type: 'button',
-                  onAction: (e: React.MouseEvent, action: any) =>
-                    this.addItem(item, RangeType.Custom)
-                }))
+                buttons: this.modifyDropDownOptions
+                  .map((item: any) => ({
+                    ...item,
+                    type: 'button',
+                    onAction: (e: React.MouseEvent, action: any) =>
+                      this.addItem(item, OptionType.Modify)
+                  }))
+                  .concat([
+                    {
+                      type: 'button',
+                      label: '其他',
+                      onAction: (e: React.MouseEvent, action: any) =>
+                        this.addItem(
+                          {
+                            value: {
+                              label: undefined,
+                              startDate: undefined,
+                              endData: undefined
+                            }
+                          },
+                          OptionType.Custom
+                        )
+                    }
+                  ])
               },
               {
                 popOverContainer: null

--- a/packages/amis-ui/src/components/DateRangePicker.tsx
+++ b/packages/amis-ui/src/components/DateRangePicker.tsx
@@ -1096,11 +1096,13 @@ export class DateRangePicker extends React.Component<
                       FormulaExec['formula'](rangeRaw.startDate, data),
                       format
                     )
+                  : typeof rangeRaw.startDate === 'string'
+                  ? moment(rangeRaw.startDate, format)
                   : rangeRaw.startDate;
 
                 return startDate &&
                   moment.isMoment(startDate) &&
-                  startDate?.isValid()
+                  startDate.isValid()
                   ? startDate
                   : (item as ShortCutDateRange).startDate;
               },
@@ -1110,9 +1112,11 @@ export class DateRangePicker extends React.Component<
                       FormulaExec['formula'](rangeRaw.endDate, data),
                       format
                     )
-                  : rangeRaw.startDate;
+                  : typeof rangeRaw.endDate === 'string'
+                  ? moment(rangeRaw.endDate, format)
+                  : rangeRaw.endDate;
 
-                return endDate && moment.isMoment(endDate) && endDate?.isValid()
+                return endDate && moment.isMoment(endDate) && endDate.isValid()
                   ? endDate
                   : (item as ShortCutDateRange).endDate;
               }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1eb44f4</samp>

This pull request updates the style and functionality of the date range control component and its related plugins in the AMIS editor. It fixes a bug that shows the wrong date, improves the layout and appearance of the component, and aligns the schema template with the new props. It also simplifies and reuses some SCSS code by importing the amis-ui package and using CSS variables.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1eb44f4</samp>

> _We are the masters of the editor_
> _We wield the power of SCSS_
> _We simplify and customize the styles_
> _We fix the bugs of the date range picker_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1eb44f4</samp>

*  Simplify the `panel-sm-content` mixin by inheriting global CSS variables and using a generic font size variable ([link](https://github.com/baidu/amis/pull/7010/files?diff=unified&w=0#diff-e19fa9e095a02106d64f76df86a492a0c737849e388f9467e599d805c135e458L91-R95))
* Remove redundant inclusion of the `panel-sm-content` mixin in the `.right-panel` class ([link](https://github.com/baidu/amis/pull/7010/files?diff=unified&w=0#diff-69d1923eb31930c821a1b40db55dc2ee5d56f27a957b81e9a080bed77905a7baL23-L24))
* Add custom font size for the links in the right panel that open external pages or documents ([link](https://github.com/baidu/amis/pull/7010/files?diff=unified&w=0#diff-69d1923eb31930c821a1b40db55dc2ee5d56f27a957b81e9a080bed77905a7baR248-R251))
* Replace hard-coded font size for the tabs in the right panel with CSS variables ([link](https://github.com/baidu/amis/pull/7010/files?diff=unified&w=0#diff-69d1923eb31930c821a1b40db55dc2ee5d56f27a957b81e9a080bed77905a7baL320-R323))
* Modify the style of the date shortcut control to avoid cutting off and overflowing the content ([link](https://github.com/baidu/amis/pull/7010/files?diff=unified&w=0#diff-621ff1f8584a3c3973cc44b0f2c1cc3a82607d2056f5ff91ff11e26916e0f6eaL71-R72), [link](https://github.com/baidu/amis/pull/7010/files?diff=unified&w=0#diff-621ff1f8584a3c3973cc44b0f2c1cc3a82607d2056f5ff91ff11e26916e0f6eaL96-R104))
* Import the SCSS components from the `amis-ui` package to reuse and customize the basic styles and variables for the amis components ([link](https://github.com/baidu/amis/pull/7010/files?diff=unified&w=0#diff-a655efcb1bba154f0bdcbcff35544de6ac126ba2ace65f57c008e0d1eb4c1fc9R4))
* Update the schema template for the date range control plugin to match the new props of the date range control component and use dynamic values for the options ([link](https://github.com/baidu/amis/pull/7010/files?diff=unified&w=0#diff-57750c096cc98f331f2101f229a6afcb6c830bba8f0b5cdcdc0bf130286c6961L448-R470))
* Fix a bug in the date range picker component that causes the wrong date to show when switching between relative and absolute date options by parsing the strings with the moment library and the format prop ([link](https://github.com/baidu/amis/pull/7010/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1099-R1105), [link](https://github.com/baidu/amis/pull/7010/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1113-R1119))
