### PR TITLE
feat:CRUD&Table上下文校正

### DIFF
--- a/packages/amis-core/src/store/crud.ts
+++ b/packages/amis-core/src/store/crud.ts
@@ -183,13 +183,14 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
                           })
                         ];
                       });
-                      items = items.filter((item: any) => arrItems.find(a => a === item));
+                      items = items.filter((item: any) =>
+                        arrItems.find(a => a === item)
+                      );
                     }
-                  }
-                  else {
+                  } else {
                     items = matchSorter(items, value, {
                       keys: [key]
-                    })
+                    });
                   }
                 }
               }
@@ -349,11 +350,11 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
                           })
                         ];
                       });
-                      filteredItems = filteredItems.filter(
-                        item => arrItems.find(a => a === item));
+                      filteredItems = filteredItems.filter(item =>
+                        arrItems.find(a => a === item)
+                      );
                     }
-                  }
-                  else {
+                  } else {
                     filteredItems = matchSorter(filteredItems, value, {
                       keys: [key]
                     });
@@ -539,19 +540,17 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
 
     const setSelectedItems = (items: Array<any>) => {
       self.selectedItems.replace(items);
+      // 同步data
+      self.reInitData({
+        selectedItems: items
+      });
     };
 
     const setUnSelectedItems = (items: Array<any>) => {
       self.unSelectedItems.replace(items);
-    };
-
-    const updateSelectData = (selected: Array<any>, unSelected: Array<any>) => {
-      self.selectedItems.replace(selected);
-      self.unSelectedItems.replace(unSelected);
-      // 同步到data中，使filter等部分也能拿到
+      // 同步data
       self.reInitData({
-        selectedItems: selected,
-        unSelectedItems: unSelected
+        unSelectedItems: items
       });
     };
 
@@ -646,7 +645,6 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
 
     return {
       getData,
-      updateSelectData,
       setPristineQuery,
       updateQuery,
       fetchInitData,

--- a/packages/amis-core/src/utils/DataScope.ts
+++ b/packages/amis-core/src/utils/DataScope.ts
@@ -97,28 +97,97 @@ export class DataScope {
     return false;
   }
 
+  assignSchema(target: any, schema: any): any {
+    // key相同，type也相同
+    if (target.type && target.type === schema.type) {
+      if (target.type === 'array') {
+        // 先只考虑items，不考虑contains
+        if (target.items) {
+          if (Array.isArray(target.items)) {
+            if (schema.items) {
+              if (Array.isArray(schema.items)) {
+                // 如果都是数组，就后者覆盖前者
+                return schema.items;
+              } else {
+                // 否则，追加
+                return {
+                  ...target,
+                  items: [...target.items, schema.items]
+                };
+              }
+            } else {
+              return {
+                ...target,
+                ...schema
+              };
+            }
+          } else {
+            // 非数组，则merge
+            return {
+              ...target,
+              items: this.assignSchema(target.items, schema.items)
+            };
+          }
+        } else {
+          return schema;
+        }
+      } else if (target.type === 'object' && target.properties) {
+        let properties: any = {};
+
+        // 合并属性
+        for (let key of Array.from(
+          new Set([
+            ...Object.keys(target.properties),
+            ...Object.keys(schema.properties)
+          ])
+        )) {
+          const value = target.properties[key];
+          if (value) {
+            properties[key] = schema.properties[key]
+              ? this.assignSchema(value, schema.properties[key])
+              : value;
+          } else {
+            properties[key] = schema.properties[key];
+          }
+        }
+        return {
+          ...target,
+          properties
+        };
+      } else {
+        return schema;
+      }
+    } else {
+      // key相同、type不同
+      if (Array.isArray(target.oneOf)) {
+        return {
+          ...target, // 先做个显示过度，因formula还没支持oneOf
+          oneOf: [...target.oneOf, schema]
+        };
+      } else {
+        return {
+          ...target, // 先做个显示过度，因formula还没支持oneOf
+          oneOf: [target, schema]
+        };
+      }
+    }
+  }
+
   getMergedSchema() {
     const mergedSchema: any = {
       type: 'object',
       properties: {}
     };
 
-    // todo 以后再来细化这一块，先粗略的写个大概
     this.schemas.forEach(schema => {
       const properties: any = schema.properties || {};
       Object.keys(properties).forEach(key => {
         const value = properties[key];
         if (mergedSchema.properties[key]) {
-          if (Array.isArray(mergedSchema.properties[key].oneOf)) {
-            mergedSchema.properties[key].oneOf.push();
-          } else if (
-            mergedSchema.properties[key].type &&
-            mergedSchema.properties[key].type !== value.type
-          ) {
-            mergedSchema.properties[key] = {
-              oneOf: [mergedSchema.properties[key], value]
-            };
-          }
+          mergedSchema.properties[key] = this.assignSchema(
+            mergedSchema.properties[key],
+            value
+          );
         } else {
           mergedSchema.properties[key] = value;
         }
@@ -132,19 +201,14 @@ export class DataScope {
     options: Array<any>,
     schema: JSONSchema,
     path: string = '',
-    key: string = '',
-    /** 是否数组元素，数组元素的内容将获取每个成员的对应值 */
-    isArrayItem = false,
-    /** 不是所有的都可以选择，但不影响子元素 */
-    disabled?: boolean
+    key: string = ''
   ) {
     // todo 支持 oneOf, anyOf
     const option: any = {
       label: schema.title || key,
       value: path,
       type: schema.type,
-      tag: schema.description ?? schema.type,
-      disabled
+      tag: schema.description ?? schema.type
     };
 
     options.push(option);
@@ -155,43 +219,32 @@ export class DataScope {
 
       keys.forEach(key => {
         const child: any = schema.properties![key];
-        const newPath = isArrayItem ? `ARRAYMAP(${path}, item => item.${key})` : (path + (path ? '.' : '') + key);
 
         this.buildOptions(
           option.children,
           child,
-          newPath,
-          key,
-          isArrayItem,
-          false
+          path + (path ? '.' : '') + key,
+          key
         );
       });
     } else if (schema.type === 'array' && schema.items) {
       option.children = [];
-      
-      this.buildOptions(
-        option.children,
-        {
-          title: '成员',
-          ...(schema.items as any)
-        },
-        path,
-        'items',
-        true,
-        true
-      );
 
       this.buildOptions(
         option.children,
         {
-          title: '总数',
-          type: 'number'
+          title: '成员',
+          ...(schema.items as any),
+          disabled: true
         },
-        path + (path ? '.' : '') + 'length',
-        'length',
-        true,
-        isArrayItem
+        path,
+        'items'
       );
+
+      option.children = mapTree(option.children, item => ({
+        ...item,
+        disabled: true
+      }));
     }
   }
 

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -8,7 +8,7 @@ import DeepDiff, {Diff} from 'deep-diff';
 import isPlainObject from 'lodash/isPlainObject';
 import isNumber from 'lodash/isNumber';
 import type {Schema} from 'amis';
-import type {SchemaObject} from 'amis/lib/Schema';
+import type {SchemaObject} from 'amis';
 import {assign, cloneDeep} from 'lodash';
 import {getGlobalData} from 'amis-theme-editor-helper';
 

--- a/packages/amis-editor/src/plugin/CRUD.tsx
+++ b/packages/amis-editor/src/plugin/CRUD.tsx
@@ -25,8 +25,8 @@ import {
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {isObject, JSONPipeIn} from 'amis-editor-core';
 import {setVariable, someTree} from 'amis-core';
-import {ActionSchema} from 'amis/lib/renderers/Action';
-import {CRUDCommonSchema} from 'amis/lib/renderers/CRUD';
+import {ActionSchema} from 'amis';
+import {CRUDCommonSchema} from 'amis';
 import {getEnv} from 'mobx-state-tree';
 import {EditorNodeType, RendererPluginAction} from 'amis-editor-core';
 import {normalizeApi} from 'amis-core';

--- a/packages/amis-editor/src/plugin/CRUD.tsx
+++ b/packages/amis-editor/src/plugin/CRUD.tsx
@@ -25,8 +25,8 @@ import {
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {isObject, JSONPipeIn} from 'amis-editor-core';
 import {setVariable, someTree} from 'amis-core';
-import {ActionSchema} from 'amis';
-import {CRUDCommonSchema} from 'amis';
+import type {ActionSchema} from 'amis';
+import type {CRUDCommonSchema} from 'amis';
 import {getEnv} from 'mobx-state-tree';
 import {EditorNodeType, RendererPluginAction} from 'amis-editor-core';
 import {normalizeApi} from 'amis-core';

--- a/packages/amis-editor/src/plugin/Table.tsx
+++ b/packages/amis-editor/src/plugin/Table.tsx
@@ -360,13 +360,9 @@ export class TablePlugin extends BasePlugin {
 
               isCRUDBody
                 ? null
-                : {
-                    name: 'source',
-                    type: 'input-text',
-                    label: '数据源',
-                    pipeIn: defaultValue('${items}'),
-                    description: '绑定当前环境变量'
-                  },
+                : getSchemaTpl('sourceBindControl', {
+                    label: '数据源'
+                  }),
 
               {
                 name: 'combineNum',
@@ -688,16 +684,28 @@ export class TablePlugin extends BasePlugin {
       item => item.isRegion && item.region === 'columns'
     );
 
-    for (let current of columns?.children) {
-      const schema = current.schema;
-      if (schema.name) {
-        itemsSchema.properties[schema.name] = current.info?.plugin
-          ?.buildDataSchemas
-          ? await current.info.plugin.buildDataSchemas(current, region)
-          : {
-              type: 'string',
-              title: schema.label || schema.name
-            };
+    // todo：以下的处理无效，需要cell实现才能深层细化
+    // for (let current of columns?.children) {
+    //   const schema = current.schema;
+    //   if (schema.name) {
+    //     itemsSchema.properties[schema.name] = current.info?.plugin
+    //       ?.buildDataSchemas
+    //       ? await current.info.plugin.buildDataSchemas(current, region)
+    //       : {
+    //           type: 'string',
+    //           title: schema.label || schema.name
+    //         };
+    //   }
+    // }
+
+    // 一期先简单处理，上面todo实现之后，这里可以废弃
+    // table 无法根据source确定异步数据来源，因此不能在table层做异步数据列的收集
+    for (let current of node.schema?.columns) {
+      if (current.name) {
+        itemsSchema.properties[current.name] = {
+          type: 'string',
+          title: current.label || current.name
+        };
       }
     }
 
@@ -724,6 +732,16 @@ export class TablePlugin extends BasePlugin {
           type: 'array',
           title: '数据列表',
           items: itemsSchema
+        },
+        selectedItems: {
+          type: 'array',
+          title: '已选中行'
+          // items: itemsSchema
+        },
+        unSelectedItems: {
+          type: 'array',
+          title: '未选中行'
+          // items: itemsSchema
         }
       }
     };

--- a/packages/amis-editor/src/plugin/Table.tsx
+++ b/packages/amis-editor/src/plugin/Table.tsx
@@ -22,7 +22,7 @@ import {
 import {defaultValue, getSchemaTpl, tipedLabel} from 'amis-editor-core';
 import {mockValue} from 'amis-editor-core';
 import {EditorNodeType} from 'amis-editor-core';
-import type {SchemaObject} from 'amis/lib/Schema';
+import type {SchemaObject} from 'amis';
 import {
   getEventControlConfig,
   getArgsWrapper

--- a/packages/amis/__tests__/renderers/Carousel.test.tsx
+++ b/packages/amis/__tests__/renderers/Carousel.test.tsx
@@ -147,9 +147,13 @@ test('Renderer:Carousel with name & option config', async () => {
   );
   expect(item).toHaveTextContent('这是标题');
 
-  fireEvent.click(container.querySelector('.cxd-Carousel-dot:nth-child(2')!);
+  fireEvent.click(container.querySelector('.cxd-Carousel-dot:nth-child(2)')!);
 
-  await wait(600);
+  await waitFor(() => {
+    expect(container.querySelector('.cxd-Carousel-item')!).toHaveTextContent(
+      'carousel data'
+    );
+  });
 
   expect(container.querySelector('.cxd-Carousel-item')!).toHaveTextContent(
     'carousel data'

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -1824,7 +1824,12 @@ export default class CRUD extends React.Component<CRUDProps, any> {
 
     const extraProps: Pick<
       PaginationProps,
-      'showPageInput' | 'maxButtons' | 'layout' | 'popOverContainerSelector'
+      | 'showPageInput'
+      | 'maxButtons'
+      | 'layout'
+      | 'popOverContainerSelector'
+      | 'total'
+      | 'perPageAvailable'
     > = {};
 
     /** 优先级：showPageInput显性配置 > (lastPage > 9) */
@@ -1838,6 +1843,11 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       extraProps.popOverContainerSelector = (
         toolbar as Schema
       ).popOverContainerSelector;
+      extraProps.perPageAvailable = (toolbar as Schema).perPageAvailable;
+      extraProps.total = resolveVariableAndFilter(
+        (toolbar as Schema).total,
+        store.data
+      );
     } else {
       extraProps.showPageInput = lastPage > 9;
     }

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -850,7 +850,8 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       },
       false,
       true,
-      this.props.initFetch !== false
+      this.props.initFetch !== false,
+      true
     );
 
     store.setPristineQuery();
@@ -895,7 +896,8 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     values: Record<string, any>,
     jumpToFirstPage: boolean = true,
     replaceLocation: boolean = false,
-    search: boolean = true
+    search: boolean = true,
+    isInit: boolean = false
   ) {
     const {
       store,
@@ -927,8 +929,15 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       perPageField
     );
     this.lastQuery = store.query;
+
     search &&
-      this.search(undefined, undefined, undefined, loadDataOnceFetchOnFilter);
+      this.search(
+        undefined,
+        undefined,
+        undefined,
+        loadDataOnceFetchOnFilter,
+        isInit
+      );
   }
 
   handleBulkGo(
@@ -1095,7 +1104,8 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     values?: any,
     silent?: boolean,
     clearSelection?: boolean,
-    forceReload = false
+    forceReload = false,
+    isInit: boolean = false
   ) {
     const {
       store,
@@ -1115,7 +1125,8 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       loadDataOnce,
       loadDataOnceFetchOnFilter,
       source,
-      columns
+      columns,
+      dispatchEvent
     } = this.props;
 
     // reload 需要清空用户选择。
@@ -1160,7 +1171,26 @@ export default class CRUD extends React.Component<CRUDProps, any> {
             columns: store.columns ?? columns
           })
           .then(value => {
-            const {page, lastPage} = store;
+            const {page, lastPage, data, error, msg} = store;
+
+            if (isInit) {
+              // 初始化请求完成
+              const rendererEvent = dispatchEvent?.(
+                'fetchInited',
+                createObject(this.props.data, {
+                  ...data,
+                  __response: {
+                    error,
+                    msg
+                  }
+                })
+              );
+
+              if (rendererEvent?.prevented) {
+                return;
+              }
+            }
+
             // 空列表 且 页数已经非法超出，则跳转到最后的合法页数
             if (
               !store.data.items.length &&
@@ -1686,9 +1716,8 @@ export default class CRUD extends React.Component<CRUDProps, any> {
 
     let bulkBtns: Array<ActionSchema> = [];
     let itemBtns: Array<ActionSchema> = [];
-
     const ctx = createObject(store.mergedData, {
-      currentPageData: store.mergedData.items.concat(),
+      currentPageData: store.mergedData.items?.concat(),
       rows: selectedItems.concat(),
       items: selectedItems.concat(),
       selectedItems: selectedItems.concat(),
@@ -1795,12 +1824,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
 
     const extraProps: Pick<
       PaginationProps,
-      | 'showPageInput'
-      | 'maxButtons'
-      | 'layout'
-      | 'popOverContainerSelector'
-      | 'total'
-      | 'perPageAvailable'
+      'showPageInput' | 'maxButtons' | 'layout' | 'popOverContainerSelector'
     > = {};
 
     /** 优先级：showPageInput显性配置 > (lastPage > 9) */
@@ -1814,11 +1838,6 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       extraProps.popOverContainerSelector = (
         toolbar as Schema
       ).popOverContainerSelector;
-      extraProps.perPageAvailable = (toolbar as Schema).perPageAvailable;
-      extraProps.total = resolveVariableAndFilter(
-        (toolbar as Schema).total,
-        store.data
-      );
     } else {
       extraProps.showPageInput = lastPage > 9;
     }
@@ -2398,5 +2417,14 @@ export class CRUDRenderer extends CRUD {
   closeTarget(target: string) {
     const scoped = this.context as IScopedContext;
     scoped.close(target);
+  }
+
+  setData(values: object, replace?: boolean) {
+    return this.props.store.updateData(values, undefined, replace);
+  }
+
+  getData() {
+    const {store, data} = this.props;
+    return store.getData(data);
   }
 }

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -1717,7 +1717,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     let bulkBtns: Array<ActionSchema> = [];
     let itemBtns: Array<ActionSchema> = [];
     const ctx = createObject(store.mergedData, {
-      currentPageData: store.mergedData.items?.concat(),
+      currentPageData: (store.mergedData?.items || []).concat(),
       rows: selectedItems.concat(),
       items: selectedItems.concat(),
       selectedItems: selectedItems.concat(),

--- a/packages/amis/src/renderers/CRUD2.tsx
+++ b/packages/amis/src/renderers/CRUD2.tsx
@@ -909,7 +909,8 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
         newItems.splice(0, newItems.length - 1)
       );
     }
-    store.updateSelectData(newItems, newUnSelectedItems);
+    store.setSelectedItems(newItems);
+    store.setUnSelectedItems(newUnSelectedItems);
     onSelect && onSelect(newItems);
   }
 

--- a/packages/amis/src/renderers/Service.tsx
+++ b/packages/amis/src/renderers/Service.tsx
@@ -515,10 +515,13 @@ export default class Service extends React.Component<ServiceProps> {
     const data = result?.hasOwnProperty('ok') ? result.data ?? {} : result;
     const {onBulkChange, dispatchEvent, store} = this.props;
 
-    dispatchEvent?.('fetchInited', {
-      ...data,
-      __response: {msg: store.msg, error: store.error}
-    });
+    dispatchEvent?.(
+      'fetchInited',
+      createObject(this.props.data, {
+        ...data,
+        __response: {msg: store.msg, error: store.error}
+      })
+    );
 
     if (!isEmpty(data) && onBulkChange) {
       onBulkChange(data);

--- a/packages/amis/src/renderers/Table/TableBody.tsx
+++ b/packages/amis/src/renderers/Table/TableBody.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ClassNamesFn} from 'amis-core';
+import {ClassNamesFn, RendererEvent} from 'amis-core';
 
 import {SchemaNode, ActionObject} from 'amis-core';
 import {TableRow} from './TableRow';
@@ -26,6 +26,15 @@ export interface TableBodyProps extends LocaleProps {
     props: any
   ) => React.ReactNode;
   onCheck: (item: IRow, value: boolean, shift?: boolean) => void;
+  onRowClick: (item: IRow, index: number) => Promise<RendererEvent<any> | void>;
+  onRowMouseEnter: (
+    item: IRow,
+    index: number
+  ) => Promise<RendererEvent<any> | void>;
+  onRowMouseLeave: (
+    item: IRow,
+    index: number
+  ) => Promise<RendererEvent<any> | void>;
   onQuickChange?: (
     item: IRow,
     values: object,
@@ -69,12 +78,14 @@ export class TableBody extends React.Component<TableBodyProps> {
       footable,
       ignoreFootableContent,
       footableColumns,
-      itemAction
+      itemAction,
+      onRowClick,
+      onRowMouseEnter,
+      onRowMouseLeave
     } = this.props;
 
     return rows.map((item: IRow, rowIndex: number) => {
       const itemProps = buildItemProps ? buildItemProps(item, rowIndex) : null;
-
       const doms = [
         <TableRow
           {...itemProps}
@@ -99,6 +110,9 @@ export class TableBody extends React.Component<TableBodyProps> {
           onCheck={onCheck}
           // todo 先注释 quickEditEnabled={item.depth === 1}
           onQuickChange={onQuickChange}
+          onRowClick={onRowClick}
+          onRowMouseEnter={onRowMouseEnter}
+          onRowMouseLeave={onRowMouseLeave}
           {...rowProps}
         />
       ];
@@ -124,6 +138,9 @@ export class TableBody extends React.Component<TableBodyProps> {
               render={render}
               onAction={onAction}
               onCheck={onCheck}
+              onRowClick={onRowClick}
+              onRowMouseEnter={onRowMouseEnter}
+              onRowMouseLeave={onRowMouseLeave}
               footableMode
               footableColSpan={columns.length}
               onQuickChange={onQuickChange}

--- a/packages/amis/src/renderers/Table/TableContent.tsx
+++ b/packages/amis/src/renderers/Table/TableContent.tsx
@@ -5,7 +5,8 @@ import {
   SchemaNode,
   ActionObject,
   LocaleProps,
-  OnEventProps
+  OnEventProps,
+  RendererEvent
 } from 'amis-core';
 import {TableBody} from './TableBody';
 import {observer} from 'mobx-react';
@@ -42,6 +43,15 @@ export interface TableContentProps extends LocaleProps {
     props: any
   ) => React.ReactNode;
   onCheck: (item: IRow, value: boolean, shift?: boolean) => void;
+  onRowClick: (item: IRow, index: number) => Promise<RendererEvent<any> | void>;
+  onRowMouseEnter: (
+    item: IRow,
+    index: number
+  ) => Promise<RendererEvent<any> | void>;
+  onRowMouseLeave: (
+    item: IRow,
+    index: number
+  ) => Promise<RendererEvent<any> | void>;
   onQuickChange?: (
     item: IRow,
     values: object,
@@ -128,6 +138,9 @@ export class TableContent extends React.Component<TableContentProps> {
       renderHeadCell,
       renderCell,
       onCheck,
+      onRowClick,
+      onRowMouseEnter,
+      onRowMouseLeave,
       rowClassName,
       onQuickChange,
       footable,
@@ -233,6 +246,9 @@ export class TableContent extends React.Component<TableContentProps> {
               render={render}
               renderCell={renderCell}
               onCheck={onCheck}
+              onRowClick={onRowClick}
+              onRowMouseEnter={onRowMouseEnter}
+              onRowMouseLeave={onRowMouseLeave}
               onQuickChange={onQuickChange}
               footable={footable}
               footableColumns={footableColumns}

--- a/packages/amis/src/renderers/Table/TableRow.tsx
+++ b/packages/amis/src/renderers/Table/TableRow.tsx
@@ -1,12 +1,21 @@
 import {observer} from 'mobx-react';
 import React from 'react';
-import type {IColumn, IRow} from 'amis-core';
-import {RendererProps} from 'amis-core';
+import type {IColumn, IRow} from 'amis-core/lib/store/table';
+import {RendererEvent, RendererProps} from 'amis-core';
 import {Action} from '../Action';
 import {isClickOnInput, createObject} from 'amis-core';
 
 interface TableRowProps extends Pick<RendererProps, 'render'> {
   onCheck: (item: IRow) => Promise<void>;
+  onRowClick: (item: IRow, index: number) => Promise<RendererEvent<any> | void>;
+  onRowMouseEnter: (
+    item: IRow,
+    index: number
+  ) => Promise<RendererEvent<any> | void>;
+  onRowMouseLeave: (
+    item: IRow,
+    index: number
+  ) => Promise<RendererEvent<any> | void>;
   classPrefix: string;
   renderCell: (
     region: string,
@@ -39,26 +48,13 @@ export class TableRow extends React.Component<TableRowProps> {
   }
 
   handleMouseEnter(e: React.MouseEvent<HTMLTableRowElement>) {
-    const {item, itemIndex, data, dispatchEvent} = this.props;
-
-    dispatchEvent(
-      'rowMouseEnter',
-      createObject(data, {
-        item: item?.data,
-        index: itemIndex
-      })
-    );
+    const {item, itemIndex, onRowMouseEnter} = this.props;
+    onRowMouseEnter?.(item?.data, itemIndex);
   }
 
   handleMouseLeave(e: React.MouseEvent<HTMLTableRowElement>) {
-    const {item, itemIndex, data, dispatchEvent} = this.props;
-    dispatchEvent(
-      'rowMouseLeave',
-      createObject(data, {
-        item: item?.data,
-        index: itemIndex
-      })
-    );
+    const {item, itemIndex, onRowMouseLeave} = this.props;
+    onRowMouseLeave?.(item?.data, itemIndex);
   }
 
   // 定义点击一行的行为，通过 itemAction配置
@@ -67,24 +63,13 @@ export class TableRow extends React.Component<TableRowProps> {
       return;
     }
 
-    const {
-      itemAction,
-      onAction,
-      item,
-      itemIndex,
-      data,
-      dispatchEvent,
-      onCheck
-    } = this.props;
+    e.preventDefault();
+    e.stopPropagation();
 
-    const rendererEvent = await dispatchEvent(
-      'rowClick',
-      createObject(data, {
-        rowItem: item?.data, // 保留rowItem 可能有用户已经在用 兼容之前的版本
-        item: item?.data,
-        index: itemIndex
-      })
-    );
+    const {itemAction, onAction, item, itemIndex, onCheck, onRowClick} =
+      this.props;
+
+    const rendererEvent = await onRowClick?.(item?.data, itemIndex);
 
     if (rendererEvent?.prevented) {
       return;

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import {findDOMNode} from 'react-dom';
 import isEqual from 'lodash/isEqual';
-import {ScopedContext, IScopedContext, SchemaExpression} from 'amis-core';
+import {
+  ScopedContext,
+  IScopedContext,
+  SchemaExpression,
+  extendObject
+} from 'amis-core';
 import {Renderer, RendererProps} from 'amis-core';
 import {SchemaNode, ActionObject, Schema} from 'amis-core';
 import forEach from 'lodash/forEach';
@@ -546,6 +551,9 @@ export default class Table extends React.Component<TableProps, object> {
     this.handleMouseLeave = this.handleMouseLeave.bind(this);
     this.subFormRef = this.subFormRef.bind(this);
     this.handleColumnToggle = this.handleColumnToggle.bind(this);
+    this.handleRowClick = this.handleRowClick.bind(this);
+    this.handleRowMouseEnter = this.handleRowMouseEnter.bind(this);
+    this.handleRowMouseLeave = this.handleRowMouseLeave.bind(this);
 
     this.updateAutoFillHeight = this.updateAutoFillHeight.bind(this);
 
@@ -909,16 +917,64 @@ export default class Table extends React.Component<TableProps, object> {
     this.syncSelected();
   }
 
+  handleRowClick(item: IRow, index: number) {
+    const {dispatchEvent, store, data} = this.props;
+    const items = store.rows.map((row: any) => row.data);
+    const selectedItems = store.selectedRows.map(item => item.data);
+    const unSelectedItems = store.unSelectedRows.map(item => item.data);
+    return dispatchEvent(
+      'rowClick',
+      createObject(data, {
+        rowItem: item, // 保留rowItem 可能有用户已经在用 兼容之前的版本
+        item,
+        index,
+        selectedItems,
+        unSelectedItems
+      })
+    );
+  }
+
+  handleRowMouseEnter(item: IRow, index: number) {
+    const {dispatchEvent, store, data} = this.props;
+    const selectedItems = store.selectedRows.map(item => item.data);
+    const unSelectedItems = store.unSelectedRows.map(item => item.data);
+    return dispatchEvent(
+      'rowMouseEnter',
+      createObject(data, {
+        item,
+        index,
+        selectedItems,
+        unSelectedItems
+      })
+    );
+  }
+
+  handleRowMouseLeave(item: IRow, index: number) {
+    const {dispatchEvent, store, data} = this.props;
+    const selectedItems = store.selectedRows.map(item => item.data);
+    const unSelectedItems = store.unSelectedRows.map(item => item.data);
+    return dispatchEvent(
+      'rowMouseLeave',
+      createObject(data, {
+        item,
+        index,
+        selectedItems,
+        unSelectedItems
+      })
+    );
+  }
+
   async handleCheckAll() {
     const {store, data, dispatchEvent} = this.props;
-
-    const items = store.getSelectedRows().map(item => item.data);
+    const items = store.rows.map((row: any) => row.data);
+    const selectedItems = store.getSelectedRows().map(item => item.data);
 
     const rendererEvent = await dispatchEvent(
       'selectedChange',
       createObject(data, {
-        selectedItems: store.allChecked ? [] : items,
-        unSelectedItems: store.allChecked ? items : []
+        selectedItems: store.allChecked ? [] : selectedItems,
+        unSelectedItems: store.allChecked ? selectedItems : [],
+        items
       })
     );
 
@@ -2226,7 +2282,11 @@ export default class Table extends React.Component<TableProps, object> {
       // 操作列不下发loading，否则会导致操作栏里面的所有按钮都出现loading
       loading: column.type === 'operation' ? false : props.loading,
       btnDisabled: store.dragging,
-      data: item.locals,
+      // 只有table时，也可以获取选中行
+      data: extendObject(item.locals, {
+        selectedItems: store.selectedRows.map(item => item.data),
+        unSelectedItems: store.unSelectedRows.map(item => item.data)
+      }),
       value: column.name
         ? resolveVariable(
             column.name,
@@ -2420,6 +2480,9 @@ export default class Table extends React.Component<TableProps, object> {
             render={render}
             renderCell={this.renderCell}
             onCheck={this.handleCheck}
+            onRowClick={this.handleRowClick}
+            onRowMouseEnter={this.handleRowMouseEnter}
+            onRowMouseLeave={this.handleRowMouseLeave}
             onQuickChange={store.dragging ? undefined : this.handleQuickChange}
             footable={store.footable}
             ignoreFootableContent
@@ -2793,6 +2856,7 @@ export default class Table extends React.Component<TableProps, object> {
           {
             ...this.props,
             selectedItems: store.selectedRows.map(item => item.data),
+            unSelectedItems: store.unSelectedRows.map(item => item.data),
             items: store.rows.map(item => item.data)
           },
           this.renderToolbar
@@ -2892,6 +2956,9 @@ export default class Table extends React.Component<TableProps, object> {
           renderHeadCell={this.renderHeadCell}
           renderCell={this.renderCell}
           onCheck={this.handleCheck}
+          onRowClick={this.handleRowClick}
+          onRowMouseEnter={this.handleRowMouseEnter}
+          onRowMouseLeave={this.handleRowMouseLeave}
           onQuickChange={store.dragging ? undefined : this.handleQuickChange}
           footable={store.footable}
           footableColumns={store.footableColumns}
@@ -3066,6 +3133,19 @@ export class TableRenderer extends Table {
     if (subPath) {
       return scoped.reload(subPath, ctx);
     }
+  }
+
+  setData(values: any, replace?: boolean) {
+    const data = {
+      ...values,
+      rows: values.rows ?? values.items // 做个兼容
+    };
+    return this.props.store.updateData(data, undefined, replace);
+  }
+
+  getData() {
+    const {store, data} = this.props;
+    return store.getData(data);
   }
 }
 

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -919,47 +919,34 @@ export default class Table extends React.Component<TableProps, object> {
 
   handleRowClick(item: IRow, index: number) {
     const {dispatchEvent, store, data} = this.props;
-    const items = store.rows.map((row: any) => row.data);
-    const selectedItems = store.selectedRows.map(item => item.data);
-    const unSelectedItems = store.unSelectedRows.map(item => item.data);
     return dispatchEvent(
       'rowClick',
       createObject(data, {
         rowItem: item, // 保留rowItem 可能有用户已经在用 兼容之前的版本
         item,
-        index,
-        selectedItems,
-        unSelectedItems
+        index
       })
     );
   }
 
   handleRowMouseEnter(item: IRow, index: number) {
     const {dispatchEvent, store, data} = this.props;
-    const selectedItems = store.selectedRows.map(item => item.data);
-    const unSelectedItems = store.unSelectedRows.map(item => item.data);
     return dispatchEvent(
       'rowMouseEnter',
       createObject(data, {
         item,
-        index,
-        selectedItems,
-        unSelectedItems
+        index
       })
     );
   }
 
   handleRowMouseLeave(item: IRow, index: number) {
     const {dispatchEvent, store, data} = this.props;
-    const selectedItems = store.selectedRows.map(item => item.data);
-    const unSelectedItems = store.unSelectedRows.map(item => item.data);
     return dispatchEvent(
       'rowMouseLeave',
       createObject(data, {
         item,
-        index,
-        selectedItems,
-        unSelectedItems
+        index
       })
     );
   }
@@ -2282,11 +2269,13 @@ export default class Table extends React.Component<TableProps, object> {
       // 操作列不下发loading，否则会导致操作栏里面的所有按钮都出现loading
       loading: column.type === 'operation' ? false : props.loading,
       btnDisabled: store.dragging,
-      // 只有table时，也可以获取选中行
-      data: extendObject(item.locals, {
-        selectedItems: store.selectedRows.map(item => item.data),
-        unSelectedItems: store.unSelectedRows.map(item => item.data)
-      }),
+      data: this.props.selectable
+        ? extendObject(item.locals, {
+            // 只有table时，也可以获取选中行
+            selectedItems: store.selectedRows.map(item => item.data),
+            unSelectedItems: store.unSelectedRows.map(item => item.data)
+          })
+        : item.locals,
       value: column.name
         ? resolveVariable(
             column.name,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d04de0</samp>

The pull request enhances the data handling and schema generation of the CRUD and table renderers, and improves the compatibility and usability of the editor plugin. It simplifies and cleans up the code for managing selected items in CRUD stores, and adds support for asynchronous data fetching and row events. It also refactors and fixes some imports and functions for merging JSON schemas and converting JSON data to JSON schemas. The main files affected are `packages/amis-core/src/store/crud.ts`, `packages/amis-core/src/utils/DataScope.ts`, `packages/amis-editor-core/src/util.ts`, `packages/amis-editor/src/plugin/CRUD.tsx`, `packages/amis-editor/src/plugin/Table.tsx`, `packages/amis/src/renderers/CRUD.tsx`, `packages/amis/src/renderers/Table/index.tsx`, `packages/amis/src/renderers/CRUD2.tsx`, and `packages/amis/src/renderers/Service.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1d04de0</samp>

> _Oh we are the coders of the CRUD renderer_
> _We fetch and we select and we update the data_
> _We use `setSelectedItems` and `setUnSelectedItems`_
> _And we handle the row events with promises, hooray!_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1d04de0</samp>

*  Add and use `assignSchema` function to merge JSON schemas based on their types and properties ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-7f6ffdabe1409210084f9b8d81e0168b8a472165749c0cb640fb847e8e4c2acdR100-R175),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-7f6ffdabe1409210084f9b8d81e0168b8a472165749c0cb640fb847e8e4c2acdL112-R190))
*  Remove unused `updateSelectData` function and replace it with `setSelectedItems` and `setUnSelectedItems` functions ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL649),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL912-R913))
*  Add and use `titleBuilder` parameter to `jsonToJsonSchema` function to customize the titles of schema properties ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL934-R967),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aR8))
*  Add and use `isInit` parameter to `updateLocation` and `search` functions to trigger `fetchInited` event with asynchronous data ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L853-R854),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L898-R900),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L930-R940),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1098-R1108),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1118-R1129),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1163-R1193))
*  Add and use `setData` and `getData` methods to CRUD and table renderers to update and access data, including asynchronous data ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R2431-R2439),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR3126-R3138))
*  Add and use `onRowClick`, `onRowMouseEnter`, and `onRowMouseLeave` props to table components to handle row events and dispatch them to table renderer ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efR29-R37),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL72-R88),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efR113-R115),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efR141-R143),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-91ac32323efbbdeeb403a100e73ac57bbc44aa103329f6734c33acb0bd323b25R46-R54),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-91ac32323efbbdeeb403a100e73ac57bbc44aa103329f6734c33acb0bd323b25R141-R143),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-91ac32323efbbdeeb403a100e73ac57bbc44aa103329f6734c33acb0bd323b25R249-R251),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-43b60bad2b0604663fde07452d82b7576c0d07c3fea6c0a0d6d24a1dd3b82f49R10-R18),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-43b60bad2b0604663fde07452d82b7576c0d07c3fea6c0a0d6d24a1dd3b82f49L42-R57),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-43b60bad2b0604663fde07452d82b7576c0d07c3fea6c0a0d6d24a1dd3b82f49L70-R73),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR554-R556),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR2472-R2474),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR2948-R2950))
*  Add and use `extendObject` function to extend data of table row with selected and unselected items ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL4-R9),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2229-R2278))
*  Use `rows` property of store instead of `mergedData.items` property to access the latest data after asynchronous fetching ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1689-R1720),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL912-R964))
*  Add `selectedItems` and `unSelectedItems` properties to event payload of CRUD and table renderers to update data schema based on user selection ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR2848),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-d01a7abf584cd914dc4d94abbeb0f35326953f6b5b19bbd9efbbb846b29f0194R735-R744))
*  Use `getSchemaTpl` function to generate schema template for `source` property of table renderer ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-d01a7abf584cd914dc4d94abbeb0f35326953f6b5b19bbd9efbbb846b29f0194L363-R365))
*  Use `createObject` function to extend event payload of service renderer with `data` prop ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852L518-R524))
*  Import types from `amis` instead of internal modules ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL11-R11),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aL26-R34),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-d01a7abf584cd914dc4d94abbeb0f35326953f6b5b19bbd9efbbb846b29f0194L25-R25),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL2-R2),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-91ac32323efbbdeeb403a100e73ac57bbc44aa103329f6734c33acb0bd323b25L8-R9),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-43b60bad2b0604663fde07452d82b7576c0d07c3fea6c0a0d6d24a1dd3b82f49L3-R4))
*  Comment out ineffective logic of generating data schema for table columns based on their children renderers and add simple logic based on names and labels ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-d01a7abf584cd914dc4d94abbeb0f35326953f6b5b19bbd9efbbb846b29f0194L691-R708))
*  Handle table renderer inside CRUD renderer and merge asynchronous data schema with existing schema of table items ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aL1748-R1836))
*  Format code to add semicolons and adjust indentation ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL186-R193),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL352-R357),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL542-R553))
*  Remove todo comment that was already implemented ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-7f6ffdabe1409210084f9b8d81e0168b8a472165749c0cb640fb847e8e4c2acdL106))
*  Remove unused parameters and property from `buildOptions` function and option object ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-7f6ffdabe1409210084f9b8d81e0168b8a472165749c0cb640fb847e8e4c2acdL135-R204),[link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-7f6ffdabe1409210084f9b8d81e0168b8a472165749c0cb640fb847e8e4c2acdL146-R211))
*  Simplify logic of generating options for array type schema and disable array member option and its children ([link](https://github.com/baidu/amis/pull/7017/files?diff=unified&w=0#diff-7f6ffdabe1409210084f9b8d81e0168b8a472165749c0cb640fb847e8e4c2acdL158-R247))
