### PR TITLE
fix: 修复 Service 升级后 dataProvider 老用法兼容问题 Close: #7013

### DIFF
--- a/packages/amis/__tests__/renderers/Carousel.test.tsx
+++ b/packages/amis/__tests__/renderers/Carousel.test.tsx
@@ -147,7 +147,7 @@ test('Renderer:Carousel with name & option config', async () => {
   );
   expect(item).toHaveTextContent('这是标题');
 
-  fireEvent.click(container.querySelector('.cxd-Carousel-dot:nth-child(2')!);
+  fireEvent.click(container.querySelector('.cxd-Carousel-dot:nth-child(2)')!);
 
   await wait(600);
 

--- a/packages/amis/src/renderers/Service.tsx
+++ b/packages/amis/src/renderers/Service.tsx
@@ -35,6 +35,7 @@ import {IIRendererStore} from 'amis-core';
 
 import type {ListenerAction} from 'amis-core';
 import type {ScopedComponentType} from 'amis-core';
+import isPlainObject from 'lodash/isPlainObject';
 
 export const eventTypes = [
   /* 初始化时执行，默认 */
@@ -341,14 +342,16 @@ export default class Service extends React.Component<ServiceProps> {
    */
   @autobind
   initDataProviders(provider?: ComposedDataProvider) {
-    const dataProvider = cloneDeep(provider);
+    const dataProvider = isPlainObject(provider)
+      ? cloneDeep(provider)
+      : provider;
     let fnCollection: DataProviderCollection = {};
 
     if (dataProvider) {
-      if (typeof dataProvider === 'object' && isObject(dataProvider)) {
+      if (isPlainObject(dataProvider)) {
         Object.keys(dataProvider).forEach((event: ProviderEventType) => {
           const normalizedProvider = this.normalizeProvider(
-            dataProvider[event],
+            (dataProvider as DataProviderCollection)[event],
             event
           );
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43cd3a7</samp>

This pull request improves the validation and cloning of the `dataProvider` parameter in the `Service` renderer. It uses the `isPlainObject` function from `packages/amis/src/utils/helper.ts` to avoid errors and ensure type compatibility.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 43cd3a7</samp>

> _To avoid errors and make types more tight_
> _We import `isPlainObject` for a check that is right_
> _It validates and clones `dataProvider`_
> _In `initDataProviders` later_
> _And ensures that our code is more robust and bright_

### Why

Close: #7013

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 43cd3a7</samp>

* Import `isPlainObject` function from lodash to check for plain objects ([link](https://github.com/baidu/amis/pull/7018/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852R38))
* Use `isPlainObject` to avoid cloning non-plain objects in `dataProvider` parameter of `initDataProviders` method ([link](https://github.com/baidu/amis/pull/7018/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852L344-R354))
* Cast `dataProvider` to `DataProviderCollection` when accessing its properties for type safety ([link](https://github.com/baidu/amis/pull/7018/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852L344-R354))
