### PR TITLE
fix: 修复自动解析文件下载里的 text 导致报错 Closes #7021

### DIFF
--- a/packages/amis-core/src/utils/api.ts
+++ b/packages/amis-core/src/utils/api.ts
@@ -343,7 +343,8 @@ export function responseAdaptor(ret: fetcherResult, api: ApiObject) {
     if (
       ret.headers &&
       contentType.startsWith('text/') &&
-      !contentType.includes('markdown')
+      !contentType.includes('markdown') &&
+      api.responseType !== 'blob'
     ) {
       try {
         data = JSON.parse(data);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5aaddf3</samp>

Fixed a bug in `api.ts` that caused binary data to be parsed as text. Excluded `blob` responses from text parsing logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5aaddf3</samp>

> _`responseType` checked_
> _No blob to text conversion_
> _Winter bug is fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5aaddf3</samp>

* Fix issue #2529 where binary data was incorrectly parsed as text by the API ([link](https://github.com/baidu/amis/pull/7024/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL346-R347))
