### PR TITLE
chore: 补充可视化编辑器里 CRUD 的 autoFillHeight 属性配置 Closes #6196

### DIFF
--- a/packages/amis-editor/src/plugin/CRUD.tsx
+++ b/packages/amis-editor/src/plugin/CRUD.tsx
@@ -1484,6 +1484,11 @@ export class CRUDPlugin extends BasePlugin {
           }),
 
           getSchemaTpl('switch', {
+            name: 'autoFillHeight',
+            label: '内容区域自适应高度'
+          }),
+
+          getSchemaTpl('switch', {
             name: 'hideCheckToggler',
             label: '隐藏选择按钮',
             visibleOn: 'data.checkOnItemClick'


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3d336c2</samp>

Added a new `autoFillHeight` option to the CRUD plugin schema in `CRUD.tsx`. This option lets the user control the height of the content area in the CRUD editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3d336c2</samp>

> _`CRUD` plugin switch_
> _Auto-fill height for content_
> _A springtime blossom_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3d336c2</samp>

* Add a new switch option `autoFillHeight` to the CRUD plugin schema ([link](https://github.com/baidu/amis/pull/7025/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aR1487-R1491))
