### PR TITLE
fix(amis-editor): icon-button-group支持icon字体

### DIFF
--- a/packages/amis-editor-core/scss/control/_icon-button-group-control.scss
+++ b/packages/amis-editor-core/scss/control/_icon-button-group-control.scss
@@ -11,11 +11,16 @@
       margin: 0 !important;
       padding: 0 !important;
       width: 20px;
+      min-height: 20px;
     }
 
     &.is-active {
       svg {
         fill: $Editor-theme-color;
+        color: $Editor-theme-color;
+      }
+      i {
+        color: $Editor-theme-color;
       }
     }
   }

--- a/packages/amis-editor/src/renderer/ButtonGroupControl.tsx
+++ b/packages/amis-editor/src/renderer/ButtonGroupControl.tsx
@@ -2,12 +2,13 @@
  * @file icon按钮组
  */
 import React from 'react';
-import {FormItem, Button, Icon, FormControlProps} from 'amis';
+import {FormItem, Button, Icon, hasIcon, FormControlProps} from 'amis';
 import cx from 'classnames';
 
 export interface ButtonGroupControlProps extends FormControlProps {
   options?: Array<{
     label: string;
+    iconFont?: string;
     icon: string;
     value: string;
     iconClassName?: string;
@@ -35,11 +36,13 @@ export default class ButtonGroupControl extends React.Component<ButtonGroupContr
               tooltip={item.label}
               active={value === item.value}
             >
-              {item.icon ? (
+              {hasIcon(item.icon) ? (
                 <Icon
                   icon={item.icon}
                   className={cx('icon', item.iconClassName)}
                 />
+              ) : item.icon ? (
+                <i className={item.icon}></i>
               ) : (
                 item.label
               )}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 57ab642</samp>

This pull request enhances the button group control in the editor by allowing custom icon fonts and improving the style. It modifies the `ButtonGroupControl` component and the `_icon-button-group-control.scss` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 57ab642</samp>

> _Button group control_
> _Custom `iconFont` prop added_
> _Icons shine like snow_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 57ab642</samp>

* Add a new prop iconFont to the ButtonGroupControl component to allow custom icon fonts for each button ([link](https://github.com/baidu/amis/pull/7026/files?diff=unified&w=0#diff-ae647830d4654b35558a5fcfd50afa5ae637827aa0bdfc8326d236e2e01be38fR11),[link](https://github.com/baidu/amis/pull/7026/files?diff=unified&w=0#diff-ae647830d4654b35558a5fcfd50afa5ae637827aa0bdfc8326d236e2e01be38fL38-R41))
* Set a minimum height and a theme color for the button group control in the scss file `packages/amis-editor-core/scss/control/_icon-button-group-control.scss` ([link](https://github.com/baidu/amis/pull/7026/files?diff=unified&w=0#diff-354a9020874e84d01c091d4602286194a7c582999a32e44dfdcb683d625fc09cR14),[link](https://github.com/baidu/amis/pull/7026/files?diff=unified&w=0#diff-354a9020874e84d01c091d4602286194a7c582999a32e44dfdcb683d625fc09cL19-R24))
