### PR TITLE
fix: 修复nestSelect下拉弹框宽度相关的问题

### DIFF
--- a/packages/amis-core/src/utils/helper.ts
+++ b/packages/amis-core/src/utils/helper.ts
@@ -1139,9 +1139,12 @@ export function spliceTree<T extends TreeItem>(
  * @param tree
  */
 export function getTreeDepth<T extends TreeItem>(tree: Array<T>): number {
+  if (Array.isArray(tree) && tree.length === 0) {
+    return 0;
+  }
   return Math.max(
     ...tree.map(item => {
-      if (Array.isArray(item.children) && item.children.length >= 1) {
+      if (Array.isArray(item.children)) {
         return 1 + getTreeDepth(item.children);
       }
 

--- a/packages/amis-core/src/utils/helper.ts
+++ b/packages/amis-core/src/utils/helper.ts
@@ -1141,7 +1141,7 @@ export function spliceTree<T extends TreeItem>(
 export function getTreeDepth<T extends TreeItem>(tree: Array<T>): number {
   return Math.max(
     ...tree.map(item => {
-      if (Array.isArray(item.children)) {
+      if (Array.isArray(item.children) && item.children.length >= 1) {
         return 1 + getTreeDepth(item.children);
       }
 

--- a/packages/amis-ui/scss/components/form/_nested-select.scss
+++ b/packages/amis-ui/scss/components/form/_nested-select.scss
@@ -2,7 +2,6 @@
   position: relative;
 
   .#{$ns}NestedSelect-menu {
-    min-width: px2rem(100px);
     padding-top: px2rem(4px);
     padding-bottom: px2rem(4px);
     box-shadow: 0 px2rem(2px) px2rem(8px) 0 rgba(7, 12, 20, 0.12);
@@ -46,6 +45,7 @@
 
   &-menu {
     width: px2rem(160px);
+    min-width: px2rem(100px);
     min-height: px2rem(32px);
     max-height: px2rem(175px);
     background: var(--Form-select-menu-bg);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b377a57</samp>

This pull request improves the nested select component's style and fixes a bug in the `getTreeDepth` function. It removes a redundant style rule from `_nested-select.scss` and adds a minimum width for the dropdown menu. It also checks for empty child arrays in `helper.ts` to avoid errors.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b377a57</samp>

> _We fix the bugs that haunt our code_
> _We make the UI look good_
> _We face the errors and the crashes_
> _We are the masters of the node_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b377a57</samp>

* Fix bug in `getTreeDepth` function that caused error on empty child arrays ([link](https://github.com/baidu/amis/pull/7027/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1144-R1144))
