### PR TITLE
fix: 修复 inputFormula 组件在 sdk 模式下弹窗样式问题 Close: #5755

### DIFF
--- a/packages/amis-ui/src/components/formula/Picker.tsx
+++ b/packages/amis-ui/src/components/formula/Picker.tsx
@@ -121,6 +121,8 @@ export interface FormulaPickerProps extends FormulaEditorProps {
   onConfirm?: (value?: any) => void;
 
   onRef?: (node: any) => void;
+
+  popOverContainer?: any;
 }
 
 export interface FormulaPickerState {
@@ -330,6 +332,7 @@ export class FormulaPicker extends React.Component<
       variableMode,
       mixedMode,
       evalMode,
+      popOverContainer,
       ...rest
     } = this.props;
     const {isOpened, value, editorValue, isError} = this.state;
@@ -466,6 +469,7 @@ export class FormulaPicker extends React.Component<
           closeOnEsc
           show={this.state.isOpened}
           onHide={this.close}
+          container={popOverContainer}
         >
           <Modal.Header onClose={this.close} className="font-bold">
             {__(title || 'FormulaEditor.title')}

--- a/packages/amis/src/renderers/Form/InputFormula.tsx
+++ b/packages/amis/src/renderers/Form/InputFormula.tsx
@@ -196,7 +196,8 @@ export class InputFormulaRenderer extends React.Component<InputFormulaProps> {
       functionClassName,
       data,
       onPickerOpen,
-      selfVariableName
+      selfVariableName,
+      env
     } = this.props;
     let {variables, functions} = this.props;
 
@@ -212,6 +213,7 @@ export class InputFormulaRenderer extends React.Component<InputFormulaProps> {
 
     return (
       <FormulaPicker
+        popOverContainer={env.getModalContainer}
         ref={this.formulaRef}
         className={className}
         value={value}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8f5cd2c</samp>

This pull request enhances the formula picker and input components by allowing custom popover containers. This fixes the layout issues when using these components in modal dialogs or other complex scenarios.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8f5cd2c</samp>

> _Oh we are the coders of the `FormulaPicker`_
> _We make it pop over any container_
> _We heave and we ho and we tweak the `env` prop_
> _To make it work better in a modal_

### Why

Close: #5755

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8f5cd2c</samp>

*  Add `popOverContainer` prop to `FormulaPickerProps` interface and `FormulaPicker` class to specify the container element for the popover component ([link](https://github.com/baidu/amis/pull/7034/files?diff=unified&w=0#diff-a91de98202f6b9b02dd68acc182e85cefc52df9fc5002c2c6ac80593972a4611R124-R125), [link](https://github.com/baidu/amis/pull/7034/files?diff=unified&w=0#diff-a91de98202f6b9b02dd68acc182e85cefc52df9fc5002c2c6ac80593972a4611R335))
*  Pass `popOverContainer` state to `Overlay` component to set the container option for the popover positioning and sizing ([link](https://github.com/baidu/amis/pull/7034/files?diff=unified&w=0#diff-a91de98202f6b9b02dd68acc182e85cefc52df9fc5002c2c6ac80593972a4611R472))
*  Add `env` prop to `InputFormulaRenderer` class to access the environment object and its utility methods ([link](https://github.com/baidu/amis/pull/7034/files?diff=unified&w=0#diff-913fb8d07888e592949feed6847e6997721160c1df681059970998dbe0f0bb45L199-R200))
*  Pass `env.getModalContainer` method as `popOverContainer` prop to `FormulaPicker` component to set the popover container to the modal container element in `InputFormula.tsx` ([link](https://github.com/baidu/amis/pull/7034/files?diff=unified&w=0#diff-913fb8d07888e592949feed6847e6997721160c1df681059970998dbe0f0bb45R216))
