### PR TITLE
fix: 修复分组情况的列固顶功能 Close: #6646

### DIFF
--- a/packages/amis-ui/scss/components/_table.scss
+++ b/packages/amis-ui/scss/components/_table.scss
@@ -75,14 +75,15 @@
     z-index: -1;
     opacity: 0;
 
-    &-shadow {
+    &:after {
+      content: '';
       position: absolute;
+      width: 100%;
       box-shadow: var(--Table-fixedTop-boxShadow);
-      z-index: -1;
-      height: 10px;
-      margin-top: -10px;
+      z-index: 10;
+      height: 1px;
+      margin-top: -3px;
       background-color: transparent;
-      opacity: 0;
     }
 
     // box-sizing: content-box;
@@ -93,8 +94,7 @@
     //   box-sizing: border-box;
     // }
 
-    &.in,
-    &.in + .#{$ns}Table-fixedTop-shadow {
+    &.in {
       position: fixed;
       opacity: 1;
       z-index: $zindex-affix;

--- a/packages/amis-ui/scss/layout/_layout.scss
+++ b/packages/amis-ui/scss/layout/_layout.scss
@@ -257,6 +257,7 @@ body {
     &-main {
       flex-grow: 1;
       display: flex;
+      min-width: 0;
       flex-direction: row;
       justify-content: stretch;
       align-items: stretch;
@@ -264,6 +265,7 @@ body {
 
     &-body {
       flex-grow: 1;
+      min-width: 0;
       display: flex;
       flex-direction: column;
       justify-content: stretch;
@@ -273,6 +275,7 @@ body {
     &-content {
       display: flex;
       flex-grow: 1;
+      min-width: 0;
       position: relative;
       min-height: 0;
       // height: 0;

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
@@ -449,6 +449,7 @@ exports[`Renderer:input table add 1`] = `
                         class="cxd-Table-tr--odd cxd-Table-tr--1th"
                         data-id="1"
                         data-index="0"
+                        style="height: 0px;"
                       >
                         <td
                           class="v-middle nowrap"

--- a/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
@@ -1222,10 +1222,6 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                 </div>
               </div>
               <div
-                class="cxd-Table-fixedTop-shadow"
-                style=""
-              />
-              <div
                 class="cxd-Table-toolbar cxd-Table-footToolbar"
               >
                 <div
@@ -1986,10 +1982,6 @@ exports[`Renderer: crud sortable & orderBy & orderDir & orderField 1`] = `
                   </table>
                 </div>
               </div>
-              <div
-                class="cxd-Table-fixedTop-shadow"
-                style=""
-              />
               <div
                 class="cxd-Table-toolbar cxd-Table-footToolbar"
               >
@@ -2794,10 +2786,6 @@ exports[`Renderer:crud basic interval headerToolbar footerToolbar 1`] = `
                   </table>
                 </div>
               </div>
-              <div
-                class="cxd-Table-fixedTop-shadow"
-                style=""
-              />
               <div
                 class="cxd-Table-toolbar cxd-Table-footToolbar"
               >
@@ -4652,10 +4640,6 @@ exports[`Renderer:crud source & alwaysShowPagination 1`] = `
                   </table>
                 </div>
               </div>
-              <div
-                class="cxd-Table-fixedTop-shadow"
-                style=""
-              />
               <div
                 class="cxd-Table-toolbar cxd-Table-footToolbar"
               >

--- a/packages/amis/__tests__/renderers/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Pagination.test.tsx.snap
@@ -321,10 +321,6 @@ exports[`Renderer:Pagination 1`] = `
             </table>
           </div>
         </div>
-        <div
-          class="cxd-Table-fixedTop-shadow"
-          style=""
-        />
       </div>
     </div>
   </div>

--- a/packages/amis/__tests__/renderers/__snapshots__/Table.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Table.test.tsx.snap
@@ -434,10 +434,6 @@ exports[`Renderer:table 1`] = `
         </table>
       </div>
     </div>
-    <div
-      class="cxd-Table-fixedTop-shadow"
-      style=""
-    />
   </div>
 </div>
 `;
@@ -893,10 +889,6 @@ exports[`Renderer:table align 1`] = `
         </table>
       </div>
     </div>
-    <div
-      class="cxd-Table-fixedTop-shadow"
-      style=""
-    />
   </div>
 </div>
 `;
@@ -1664,10 +1656,6 @@ exports[`Renderer:table children 1`] = `
                   </table>
                 </div>
               </div>
-              <div
-                class="cxd-Table-fixedTop-shadow"
-                style=""
-              />
             </div>
           </div>
         </div>
@@ -2111,10 +2099,6 @@ exports[`Renderer:table classNameExpr 1`] = `
         </table>
       </div>
     </div>
-    <div
-      class="cxd-Table-fixedTop-shadow"
-      style=""
-    />
   </div>
 </div>
 `;
@@ -2173,6 +2157,7 @@ exports[`Renderer:table column head style className 1`] = `
               class="cxd-Table-tr--odd cxd-Table-tr--1th"
               data-id="1"
               data-index="0"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -2188,6 +2173,7 @@ exports[`Renderer:table column head style className 1`] = `
               class="cxd-Table-tr--even cxd-Table-tr--1th"
               data-id="2"
               data-index="1"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -2203,6 +2189,7 @@ exports[`Renderer:table column head style className 1`] = `
               class="cxd-Table-tr--odd cxd-Table-tr--1th"
               data-id="3"
               data-index="2"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -2218,6 +2205,7 @@ exports[`Renderer:table column head style className 1`] = `
               class="cxd-Table-tr--even cxd-Table-tr--1th"
               data-id="4"
               data-index="3"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -2233,6 +2221,7 @@ exports[`Renderer:table column head style className 1`] = `
               class="cxd-Table-tr--odd cxd-Table-tr--1th"
               data-id="5"
               data-index="4"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -2248,6 +2237,7 @@ exports[`Renderer:table column head style className 1`] = `
               class="cxd-Table-tr--even cxd-Table-tr--1th"
               data-id="6"
               data-index="5"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -2263,6 +2253,7 @@ exports[`Renderer:table column head style className 1`] = `
               class="cxd-Table-tr--odd cxd-Table-tr--1th"
               data-id="7"
               data-index="6"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -2278,6 +2269,7 @@ exports[`Renderer:table column head style className 1`] = `
               class="cxd-Table-tr--even cxd-Table-tr--1th"
               data-id="8"
               data-index="7"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -2293,6 +2285,7 @@ exports[`Renderer:table column head style className 1`] = `
               class="cxd-Table-tr--odd cxd-Table-tr--1th"
               data-id="9"
               data-index="8"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -2308,6 +2301,7 @@ exports[`Renderer:table column head style className 1`] = `
               class="cxd-Table-tr--even cxd-Table-tr--1th"
               data-id="10"
               data-index="9"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -2769,10 +2763,6 @@ exports[`Renderer:table column head style className 1`] = `
         </table>
       </div>
     </div>
-    <div
-      class="cxd-Table-fixedTop-shadow"
-      style=""
-    />
   </div>
 </div>
 `;
@@ -3471,10 +3461,6 @@ exports[`Renderer:table combine Renderer:table combineNum only 1`] = `
                   </table>
                 </div>
               </div>
-              <div
-                class="cxd-Table-fixedTop-shadow"
-                style=""
-              />
             </div>
           </div>
         </div>
@@ -4248,10 +4234,6 @@ exports[`Renderer:table combine Renderer:table combineNum with fromIndex 1`] = `
                   </table>
                 </div>
               </div>
-              <div
-                class="cxd-Table-fixedTop-shadow"
-                style=""
-              />
             </div>
           </div>
         </div>
@@ -5214,10 +5196,6 @@ exports[`Renderer:table groupName-default 1`] = `
                   </table>
                 </div>
               </div>
-              <div
-                class="cxd-Table-fixedTop-shadow"
-                style=""
-              />
             </div>
           </div>
         </div>
@@ -6064,32 +6042,50 @@ exports[`Renderer:table groupName-middleNoGroupName 1`] = `
                           </span>
                         </th>
                         <th
+                          class=""
                           colspan="1"
                           data-index="4"
+                          label="Grade"
                           rowspan="2"
                           style="width: 0px; height: 0px;"
                         >
-                          <span
-                            class="cxd-TplField"
+                          <div
+                            class="cxd-TableCell--title"
                           >
-                            <span>
-                              Grade
+                            <span
+                              class="cxd-TplField"
+                            >
+                              <span>
+                                Grade
+                              </span>
                             </span>
-                          </span>
+                          </div>
+                          <div
+                            class="cxd-Table-content-colDragLine"
+                          />
                         </th>
                         <th
+                          class=""
                           colspan="1"
                           data-index="5"
+                          label="Version"
                           rowspan="2"
                           style="width: 0px; height: 0px;"
                         >
-                          <span
-                            class="cxd-TplField"
+                          <div
+                            class="cxd-TableCell--title"
                           >
-                            <span>
-                              Version
+                            <span
+                              class="cxd-TplField"
+                            >
+                              <span>
+                                Version
+                              </span>
                             </span>
-                          </span>
+                          </div>
+                          <div
+                            class="cxd-Table-content-colDragLine"
+                          />
                         </th>
                         <th
                           colspan="2"
@@ -6172,10 +6168,6 @@ exports[`Renderer:table groupName-middleNoGroupName 1`] = `
                   </table>
                 </div>
               </div>
-              <div
-                class="cxd-Table-fixedTop-shadow"
-                style=""
-              />
             </div>
           </div>
         </div>
@@ -6997,46 +6989,73 @@ exports[`Renderer:table groupName-startNoGroupName 1`] = `
                     <thead>
                       <tr>
                         <th
+                          class=""
                           colspan="1"
                           data-index="3"
+                          label="Engine"
                           rowspan="2"
                           style="width: 0px; height: 0px;"
                         >
-                          <span
-                            class="cxd-TplField"
+                          <div
+                            class="cxd-TableCell--title"
                           >
-                            <span>
-                              Engine
+                            <span
+                              class="cxd-TplField"
+                            >
+                              <span>
+                                Engine
+                              </span>
                             </span>
-                          </span>
+                          </div>
+                          <div
+                            class="cxd-Table-content-colDragLine"
+                          />
                         </th>
                         <th
+                          class=""
                           colspan="1"
                           data-index="4"
+                          label="Grade"
                           rowspan="2"
                           style="width: 0px; height: 0px;"
                         >
-                          <span
-                            class="cxd-TplField"
+                          <div
+                            class="cxd-TableCell--title"
                           >
-                            <span>
-                              Grade
+                            <span
+                              class="cxd-TplField"
+                            >
+                              <span>
+                                Grade
+                              </span>
                             </span>
-                          </span>
+                          </div>
+                          <div
+                            class="cxd-Table-content-colDragLine"
+                          />
                         </th>
                         <th
+                          class=""
                           colspan="1"
                           data-index="5"
+                          label="Version"
                           rowspan="2"
                           style="width: 0px; height: 0px;"
                         >
-                          <span
-                            class="cxd-TplField"
+                          <div
+                            class="cxd-TableCell--title"
                           >
-                            <span>
-                              Version
+                            <span
+                              class="cxd-TplField"
+                            >
+                              <span>
+                                Version
+                              </span>
                             </span>
-                          </span>
+                          </div>
+                          <div
+                            class="cxd-Table-content-colDragLine"
+                          />
                         </th>
                         <th
                           colspan="2"
@@ -7099,10 +7118,6 @@ exports[`Renderer:table groupName-startNoGroupName 1`] = `
                   </table>
                 </div>
               </div>
-              <div
-                class="cxd-Table-fixedTop-shadow"
-                style=""
-              />
             </div>
           </div>
         </div>
@@ -8065,10 +8080,6 @@ exports[`Renderer:table groupName-withTpl 1`] = `
                   </table>
                 </div>
               </div>
-              <div
-                class="cxd-Table-fixedTop-shadow"
-                style=""
-              />
             </div>
           </div>
         </div>
@@ -8132,6 +8143,7 @@ exports[`Renderer:table isHead fixed 1`] = `
               class="cxd-Table-tr--odd cxd-Table-tr--1th"
               data-id="1"
               data-index="0"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -8147,6 +8159,7 @@ exports[`Renderer:table isHead fixed 1`] = `
               class="cxd-Table-tr--even cxd-Table-tr--1th"
               data-id="2"
               data-index="1"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -8162,6 +8175,7 @@ exports[`Renderer:table isHead fixed 1`] = `
               class="cxd-Table-tr--odd cxd-Table-tr--1th"
               data-id="3"
               data-index="2"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -8177,6 +8191,7 @@ exports[`Renderer:table isHead fixed 1`] = `
               class="cxd-Table-tr--even cxd-Table-tr--1th"
               data-id="4"
               data-index="3"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -8192,6 +8207,7 @@ exports[`Renderer:table isHead fixed 1`] = `
               class="cxd-Table-tr--odd cxd-Table-tr--1th"
               data-id="5"
               data-index="4"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -8207,6 +8223,7 @@ exports[`Renderer:table isHead fixed 1`] = `
               class="cxd-Table-tr--even cxd-Table-tr--1th"
               data-id="6"
               data-index="5"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -8222,6 +8239,7 @@ exports[`Renderer:table isHead fixed 1`] = `
               class="cxd-Table-tr--odd cxd-Table-tr--1th"
               data-id="7"
               data-index="6"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -8237,6 +8255,7 @@ exports[`Renderer:table isHead fixed 1`] = `
               class="cxd-Table-tr--even cxd-Table-tr--1th"
               data-id="8"
               data-index="7"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -8252,6 +8271,7 @@ exports[`Renderer:table isHead fixed 1`] = `
               class="cxd-Table-tr--odd cxd-Table-tr--1th"
               data-id="9"
               data-index="8"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -8267,6 +8287,7 @@ exports[`Renderer:table isHead fixed 1`] = `
               class="cxd-Table-tr--even cxd-Table-tr--1th"
               data-id="10"
               data-index="9"
+              style="height: 0px;"
             >
               <td
                 class=""
@@ -8728,10 +8749,6 @@ exports[`Renderer:table isHead fixed 1`] = `
         </table>
       </div>
     </div>
-    <div
-      class="cxd-Table-fixedTop-shadow"
-      style=""
-    />
   </div>
 </div>
 `;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c4874dd</samp>

This pull request enhances the table component in the `amis` UI library by simplifying the CSS for the fixed header feature, fixing the layout overflow bug, and optimizing the table rendering logic and performance. It also removes some unnecessary code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c4874dd</samp>

> _Oh we're the CSS sailors, and we work with style and grace_
> _We simplify the pseudo-elements, and we fix the overflow case_
> _We heave and ho, on the count of three_
> _We make the table render smooth and bug-free_

### Why

Close: #6646

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c4874dd</samp>

*  Simplify the CSS for the fixed table header by replacing the `&-shadow` pseudo-element with a `&:after` pseudo-element and removing the negative z-index and margin-top ([link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dL78-R86), [link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dL96-R97))
* Remove the unused references to the `&-shadow` pseudo-element from the TypeScript and JSX code ([link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1160-R1167), [link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2388))
* Fix the bug that causes the table to overflow the layout content, aside, and footer by adding a `min-width: 0` property to the corresponding selectors in `_layout.scss` ([link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-2beb3f83f0f709e5d5b6c0a772d8d394848b0ef4068a051979ff1bea74dad8a6R260), [link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-2beb3f83f0f709e5d5b6c0a772d8d394848b0ef4068a051979ff1bea74dad8a6R268), [link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-2beb3f83f0f709e5d5b6c0a772d8d394848b0ef4068a051979ff1bea74dad8a6R278))
* Improve the performance and smoothness of the table rendering by using the `requestAnimationFrame` method instead of the `Promise.resolve().then` method for updating the table information ([link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL851-R851))
* Fix the bug that causes the table header rows to have inconsistent heights when the table is rendered inside a modal with a scale animation by using the `offsetHeight` property instead of the `getBoundingClientRect` method ([link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1213-R1215))
* Improve the accuracy and consistency of the table header columns widths by using the `offsetWidth` property instead of the `getBoundingClientRect` method ([link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1231-R1222))
* Improve the performance and consistency of the table body rows heights by using the `offsetHeight` property instead of the `getComputedStyle` method ([link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1238-R1228))
* Follow the code style and avoid potential errors by adding a semicolon to the end of the `item.style.cssText` assignment and a `px` unit to the end of the `heights[index]` value ([link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1262-R1246), [link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1297-R1281))
* Clean up the unused or redundant TypeScript code by removing the `theadHeight` variable, the commented out code for setting the leading and trailing flags, and the code for syncing the height of the table header cells ([link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1327-L1329), [link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1336-L1338), [link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1344-L1350), [link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1359-L1364))
* Allow the custom label prop to override the column label prop when rendering the table header cells by adding a `props.label` prop to the `renderHeadCell` method ([link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2167-R2134))
* Fix the bug that causes the sortable icon to be missing when the table has nested columns by modifying the logic for rendering the table header cells with nested columns in the `renderHeadCell` method and the JSX template ([link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2361-R2348), [link](https://github.com/baidu/amis/pull/7037/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2431-R2426))
