### PR TITLE
chore(amis-editor): 调整 api 适配器 tip 写法,换成内部渲染器的 render 渲染配置 Close: #6971

### DIFF
--- a/packages/amis-editor/src/renderer/APIAdaptorControl.tsx
+++ b/packages/amis-editor/src/renderer/APIAdaptorControl.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import cx from 'classnames';
 import {autobind, getSchemaTpl, setSchemaTpl} from 'amis-editor-core';
 import {tipedLabel} from 'amis-editor-core';
-import {FormControlProps, render} from 'amis-core';
+import {FormControlProps} from 'amis-core';
 import {FormItem, Icon, TooltipWrapper} from 'amis';
 import {TooltipObject} from 'amis-ui/lib/components/TooltipWrapper';
 interface AdaptorFuncParam {
@@ -71,6 +71,7 @@ export default class APIAdaptorControl extends React.Component<
 
   // 生成tooltip 的参数
   genTooltipProps(content: any, othersProps?: TooltipObject) {
+    const {render} = this.props;
     return {
       tooltipTheme: 'light',
       trigger: 'hover',
@@ -81,7 +82,10 @@ export default class APIAdaptorControl extends React.Component<
         ? {content}
         : {
             content: ' ', // amis缺陷，必须有这个字段，否则显示不出来
-            children: () => content
+            children: () =>
+              React.isValidElement(content)
+                ? content
+                : render('content', content)
           }),
       ...(this.props.tooltipProps || {}),
       ...(othersProps || {})
@@ -253,9 +257,10 @@ export const adaptorApiStruct = `{
   ...
 }`;
 
-export const adaptorApiStructTooltip = render(
-  genCodeSchema(adaptorApiStruct, ['350px', '128px'])
-);
+export const adaptorApiStructTooltip = genCodeSchema(adaptorApiStruct, [
+  '350px',
+  '128px'
+]);
 
 // 适配器 response 参数说明
 export const adaptorResponseStruct = `{
@@ -267,8 +272,9 @@ export const adaptorResponseStruct = `{
   ...
 }`;
 
-export const adaptorResponseStructTooltip = render(
-  genCodeSchema(adaptorResponseStruct, ['345px', '144px'])
+export const adaptorResponseStructTooltip = genCodeSchema(
+  adaptorResponseStruct,
+  ['345px', '144px']
 );
 
 // 接收适配器 示例代码
@@ -433,11 +439,11 @@ setSchemaTpl('apiAdaptor', {
     }
   ],
   editorPlaceholder: adaptorDefaultCode,
-  switchTip: render(adaptorEditorDescSchema)
+  switchTip: adaptorEditorDescSchema
 });
 
 setSchemaTpl('validateApiAdaptor', {
   ...getSchemaTpl('apiAdaptor'),
   editorPlaceholder: validateApiAdaptorDefaultCode,
-  switchTip: render(validateApiAdaptorEditorDescSchema)
+  switchTip: validateApiAdaptorEditorDescSchema
 });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a7b694</samp>

Refactored and improved tooltip rendering in `APIAdaptorControl.tsx`. Used amis schemas instead of React elements for tooltip content.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2a7b694</samp>

> _Oh we're the coders of the sea, and we work with `amis`_
> _We simplify the logic and we fix the rendering glitches_
> _We heave away the `render` import, it's unnecessary_
> _And we let the `TooltipWrapper` handle the work for we_

### Why

Close: #6971

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2a7b694</samp>

* Remove unused `render` import from `amis-core` in `APIAdaptorControl.tsx` ([link](https://github.com/baidu/amis/pull/7039/files?diff=unified&w=0#diff-02be4670a1c90d1a68dcd49df72b9908d9c65a69e263db17ab38bbbd4b8e42a0L9-R9))
* Destructure `render` prop from `props` object in `APIAdaptorControl.tsx` ([link](https://github.com/baidu/amis/pull/7039/files?diff=unified&w=0#diff-02be4670a1c90d1a68dcd49df72b9908d9c65a69e263db17ab38bbbd4b8e42a0R74))
* Modify `content` prop of `TooltipWrapper` component in `APIAdaptorControl.tsx` to accept either a React element or an amis schema, and use `render` function to render the schema if needed ([link](https://github.com/baidu/amis/pull/7039/files?diff=unified&w=0#diff-02be4670a1c90d1a68dcd49df72b9908d9c65a69e263db17ab38bbbd4b8e42a0L84-R88))
* Change `adaptorApiStructTooltip`, `adaptorResponseStructTooltip`, `switchTip` props of various components in `APIAdaptorControl.tsx` from rendered React elements to plain amis schema objects, to leverage the modified `TooltipWrapper` component ([link](https://github.com/baidu/amis/pull/7039/files?diff=unified&w=0#diff-02be4670a1c90d1a68dcd49df72b9908d9c65a69e263db17ab38bbbd4b8e42a0L256-R263), [link](https://github.com/baidu/amis/pull/7039/files?diff=unified&w=0#diff-02be4670a1c90d1a68dcd49df72b9908d9c65a69e263db17ab38bbbd4b8e42a0L270-R277), [link](https://github.com/baidu/amis/pull/7039/files?diff=unified&w=0#diff-02be4670a1c90d1a68dcd49df72b9908d9c65a69e263db17ab38bbbd4b8e42a0L436-R442), [link](https://github.com/baidu/amis/pull/7039/files?diff=unified&w=0#diff-02be4670a1c90d1a68dcd49df72b9908d9c65a69e263db17ab38bbbd4b8e42a0L442-R448))
