### PR TITLE
fix: nav仅点击箭头才能展开、source重置导致菜单自动关闭问题修复

### DIFF
--- a/packages/amis-ui/scss/components/_menu.scss
+++ b/packages/amis-ui/scss/components/_menu.scss
@@ -518,7 +518,7 @@
       text-transform: none;
       text-rendering: auto;
       line-height: px2rem(20px);
-      margin-left: 5px;
+      margin-left: px2rem(5px);
 
       & > svg {
         top: auto;
@@ -528,7 +528,7 @@
     &.#{$ns}Nav-Menu-rtl {
       .#{$ns}Nav-Menu-submenu-arrow {
         margin-left: 0;
-        margin-right: 5px;
+        margin-right: px2rem(5px);
       }
     }
 
@@ -542,16 +542,8 @@
   &-vertical-right,
   &-inline {
     .#{$ns}Nav-Menu-submenu-arrow {
-      display: inline-block;
       font-size: px2rem(10px);
-      vertical-align: baseline;
-      text-transform: none;
-      text-rendering: auto;
       margin: 0 0 0 px2rem(10px);
-
-      & > svg {
-        top: auto;
-      }
     }
 
     &.#{$ns}Nav-Menu-expand-before {
@@ -609,13 +601,17 @@
   &-inline,
   &-horizontal {
     .#{$ns}Nav-Menu-submenu-arrow {
-      transition: transform 0.3s;
-      transform: rotate(90deg);
+      svg {
+        transition: transform 0.3s;
+        transform: rotate(90deg);
+      }
     }
 
     & .#{$ns}Nav-Menu-submenu-open > .#{$ns}Nav-Menu-submenu-title {
       .#{$ns}Nav-Menu-submenu-arrow {
-        transform: rotate(270deg);
+        svg {
+          transform: rotate(270deg);
+        }
       }
     }
   }

--- a/packages/amis-ui/src/components/WithRemoteConfig.tsx
+++ b/packages/amis-ui/src/components/WithRemoteConfig.tsx
@@ -16,7 +16,7 @@ import {
 } from 'amis-core';
 import type {RendererEnv} from 'amis-core';
 import {isPureVariable, resolveVariableAndFilter, tokenize} from 'amis-core';
-import {reaction} from 'mobx';
+import {reaction, comparer} from 'mobx';
 import {createObject, findTreeIndex, isObject} from 'amis-core';
 import {Api, ApiObject, Payload} from 'amis-core';
 
@@ -254,7 +254,11 @@ export function withRemoteConfig<P = any>(
                             ignoreData: true
                           }).url;
                     },
-                    () => this.loadConfig()
+                    () => this.loadConfig(),
+                    // 当nav配置source: "${amisStore.app.portalNavs}"时，切换页面就会触发source更新
+                    // 因此这里增加这个配置 数据源完全不相等情况下再执行loadConfig
+                    // 否则数据源重置 保存不了展开状态 就会始终是手风琴模式了
+                    {equals: comparer.structural}
                   )
                 );
             }

--- a/packages/amis-ui/src/components/menu/index.tsx
+++ b/packages/amis-ui/src/components/menu/index.tsx
@@ -443,15 +443,7 @@ export class Menu extends React.Component<MenuProps, MenuState> {
     props: SubMenuProps;
   }) {
     const {navigations} = this.state;
-    const {
-      stacked,
-      mode,
-      collapsed,
-      accordion,
-      onToggleExpand,
-      onToggle,
-      onSelect
-    } = this.props;
+    const {stacked, mode, collapsed, accordion, onSelect} = this.props;
     const isVericalInline = stacked && mode === 'inline' && !collapsed;
 
     let openKeys = this.state.openKeys.concat();
@@ -468,10 +460,6 @@ export class Menu extends React.Component<MenuProps, MenuState> {
     }
 
     const currentItem = findTree(navigations, item => item.id === key);
-    // 因为Nav里只处理当前菜单项 因此新增一个onToggle事件
-    onToggle?.(currentItem?.link, keyPaths.length, isOpen);
-    onToggleExpand?.(uniq(openKeys));
-
     onSelect?.(currentItem?.link || currentItem, keyPaths.length);
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0ed1001</samp>

This pull request enhances the menu component and its integration with the withRemoteConfig function. It improves the menu's appearance and responsiveness, simplifies its logic and props, and adds a custom equality option for data sources. It affects the files `_menu.scss`, `index.tsx`, and `WithRemoteConfig.tsx` in the `amis-ui` package.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0ed1001</samp>

> _`withRemoteConfig` is the power we wield_
> _To customize and optimize the menu field_
> _We simplify the code and make it fast_
> _No unnecessary reloading from the past_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0ed1001</samp>

*  Remove onToggle and onToggleExpand props from Menu component and its handleOpenChange method, as they are no longer needed ([link](https://github.com/baidu/amis/pull/7049/files?diff=unified&w=0#diff-51649a538e00907694676159197c60556bbe519882d3865eecb7c21103a0679eL446-R446), [link](https://github.com/baidu/amis/pull/7049/files?diff=unified&w=0#diff-51649a538e00907694676159197c60556bbe519882d3865eecb7c21103a0679eL471-L474))
*  Modify withRemoteConfig function to accept an optional equals option, which specifies a custom equality function for comparing data sources, and use comparer.structural as the default value ([link](https://github.com/baidu/amis/pull/7049/files?diff=unified&w=0#diff-602aa42ab34a4a248db44b9b79423e2b319cf4a1b6c8de867a96b4fee67546c1L19-R19), [link](https://github.com/baidu/amis/pull/7049/files?diff=unified&w=0#diff-602aa42ab34a4a248db44b9b79423e2b319cf4a1b6c8de867a96b4fee67546c1L257-R261))
*  Use px2rem function to convert pixels to rem units for margin-left and margin-right properties of menu item text and submenu arrow, for better responsiveness and consistency ([link](https://github.com/baidu/amis/pull/7049/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL521-R521), [link](https://github.com/baidu/amis/pull/7049/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL531-R531))
*  Remove redundant or unnecessary display, vertical-align, text-transform, and text-rendering properties of submenu arrow for inline mode ([link](https://github.com/baidu/amis/pull/7049/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL545-R546))
*  Move transition and transform properties of submenu arrow to svg element inside it, to avoid affecting text alignment and spacing of menu item title ([link](https://github.com/baidu/amis/pull/7049/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL612-R614))
