### PR TITLE
feat:CRUD&Table上下文校正

### DIFF
--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -8,7 +8,7 @@ import DeepDiff, {Diff} from 'deep-diff';
 import isPlainObject from 'lodash/isPlainObject';
 import isNumber from 'lodash/isNumber';
 import type {Schema} from 'amis';
-import type {SchemaObject} from 'amis/lib/Schema';
+import type {SchemaObject} from 'amis';
 import {assign, cloneDeep} from 'lodash';
 import {getGlobalData} from 'amis-theme-editor-helper';
 

--- a/packages/amis-editor/src/plugin/CRUD.tsx
+++ b/packages/amis-editor/src/plugin/CRUD.tsx
@@ -24,8 +24,8 @@ import {
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {isObject, JSONPipeIn} from 'amis-editor-core';
 import {setVariable} from 'amis-core';
-import {ActionSchema} from 'amis';
-import {CRUDCommonSchema} from 'amis';
+import type {ActionSchema} from 'amis';
+import type {CRUDCommonSchema} from 'amis';
 import {getEnv} from 'mobx-state-tree';
 import {EditorNodeType, RendererPluginAction} from 'amis-editor-core';
 import {normalizeApi} from 'amis-core';

--- a/packages/amis-editor/src/plugin/CRUD.tsx
+++ b/packages/amis-editor/src/plugin/CRUD.tsx
@@ -24,8 +24,8 @@ import {
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {isObject, JSONPipeIn} from 'amis-editor-core';
 import {setVariable} from 'amis-core';
-import {ActionSchema} from 'amis/lib/renderers/Action';
-import {CRUDCommonSchema} from 'amis/lib/renderers/CRUD';
+import {ActionSchema} from 'amis';
+import {CRUDCommonSchema} from 'amis';
 import {getEnv} from 'mobx-state-tree';
 import {EditorNodeType, RendererPluginAction} from 'amis-editor-core';
 import {normalizeApi} from 'amis-core';

--- a/packages/amis-editor/src/plugin/Table.tsx
+++ b/packages/amis-editor/src/plugin/Table.tsx
@@ -22,7 +22,7 @@ import {
 import {defaultValue, getSchemaTpl, tipedLabel} from 'amis-editor-core';
 import {mockValue} from 'amis-editor-core';
 import {EditorNodeType} from 'amis-editor-core';
-import type {SchemaObject} from 'amis/lib/Schema';
+import type {SchemaObject} from 'amis';
 import {
   getEventControlConfig,
   getArgsWrapper

--- a/packages/amis/__tests__/renderers/Carousel.test.tsx
+++ b/packages/amis/__tests__/renderers/Carousel.test.tsx
@@ -147,13 +147,13 @@ test('Renderer:Carousel with name & option config', async () => {
   );
   expect(item).toHaveTextContent('这是标题');
 
-  fireEvent.click(container.querySelector('.cxd-Carousel-dot:nth-child(2')!);
+  fireEvent.click(container.querySelector('.cxd-Carousel-dot:nth-child(2)')!);
 
-  await wait(600);
-
-  expect(container.querySelector('.cxd-Carousel-item')!).toHaveTextContent(
-    'carousel data'
-  );
+  await waitFor(() => {
+    expect(container.querySelector('.cxd-Carousel-item')!).toHaveTextContent(
+      'carousel data'
+    );
+  });
 });
 
 test('Renderer:Carousel with controls & controlsTheme & thumbMode', async () => {

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -1688,7 +1688,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     let itemBtns: Array<ActionSchema> = [];
 
     const ctx = createObject(store.mergedData, {
-      currentPageData: store.mergedData.items.concat(),
+      currentPageData: (store.mergedData?.items || []).concat(),
       rows: selectedItems.concat(),
       items: selectedItems.concat(),
       selectedItems: selectedItems.concat(),


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2601391</samp>

This pull request fixes a bug in `CRUD.tsx` that caused errors when the data store was empty, and refactors some imports in the editor plugins to use the main `amis` package instead of internal modules.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2601391</samp>

> _`amis` exports types_
> _avoid internal imports_
> _winter bug is fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2601391</samp>

*  Change imports of `SchemaObject`, `ActionSchema`, and `CRUDCommonSchema` from internal modules to main `amis` package to avoid dependency issues ([link](https://github.com/baidu/amis/pull/7051/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL11-R11), [link](https://github.com/baidu/amis/pull/7051/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aL27-R28), [link](https://github.com/baidu/amis/pull/7051/files?diff=unified&w=0#diff-d01a7abf584cd914dc4d94abbeb0f35326953f6b5b19bbd9efbbb846b29f0194L25-R25))
*  Use optional chaining and fallback to prevent errors when accessing `store.mergedData.items` in `CRUD.tsx` to fix bug #2639 ([link](https://github.com/baidu/amis/pull/7051/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1691-R1691))
