### PR TITLE
fix: 修复 inputImage 裁剪模式配置文件大小限制报错问题

### DIFF
--- a/docs/zh-CN/components/form/input-image.md
+++ b/docs/zh-CN/components/form/input-image.md
@@ -95,7 +95,7 @@ app.listen(8080, function () {});
 
 想要限制多个类型，则用逗号分隔，例如：`.jpg,.png`
 
-## 限制文件大小
+## 限制文件宽度
 
 配置 `limit`，更多属性请参考后面的属性说明。
 
@@ -112,6 +112,27 @@ app.listen(8080, function () {});
             "limit": {
               "minWidth": 1000
             },
+            "receiver": "/api/upload/file"
+        }
+    ]
+}
+```
+
+## 限制文件大小
+
+配置 `maxSize`，限制文件大小，单位为 `B`。
+
+```schema: scope="body"
+{
+    "type": "form",
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+        {
+            "type": "input-image",
+            "name": "image",
+            "label": "上传文件不能大于 1K",
+            "accept": ".jpg",
+            "maxSize": 1024,
             "receiver": "/api/upload/file"
         }
     ]

--- a/packages/amis-ui/src/locale/de-DE.ts
+++ b/packages/amis-ui/src/locale/de-DE.ts
@@ -143,6 +143,7 @@ register('de-DE', {
   'File.upload': 'Hochladen',
   'File.uploadFailed': 'Zurückgegebene Daten der Upload-API sind leer',
   'File.uploading': 'Wird hochgeladen...',
+  'File.imageAfterCrop': 'Beschnittenes Bild',
   'FormItem.autoFillLoadFailed':
     'Die Schnittstelle hat einen Fehler zurückgegeben, bitte sorgfältig prüfen',
   'FormItem.autoFillSuggest': 'Referenzdateneingabe',

--- a/packages/amis-ui/src/locale/en-US.ts
+++ b/packages/amis-ui/src/locale/en-US.ts
@@ -149,6 +149,7 @@ register('en-US', {
   'Form.unique': 'Current value is not unique',
   'Form.validateFailed': 'Form input validation failed',
   'Form.nestedError': 'Form cannot appear as a descendant of form',
+  'File.imageAfterCrop': 'Cropped image',
   'Iframe.invalid': 'Invalid iframe url',
   'Iframe.invalidProtocol': 'Can not use http url iframe in https',
   'Image.dragTip': 'Drag to sort',

--- a/packages/amis-ui/src/locale/zh-CN.ts
+++ b/packages/amis-ui/src/locale/zh-CN.ts
@@ -136,6 +136,7 @@ register('zh-CN', {
   'File.maxLength': '最多上传 {{maxLength}} 个文件',
   'File.maxSize':
     '{{filename}} 大小为 {{actualSize}} 超出了最大为 {{maxSize}} 的限制',
+  'File.imageAfterCrop': '裁剪后的图片',
   'File.pause': '暂停上传',
   'File.repick': '重新选择',
   'File.result': '已成功上传 {{uploaded}} 个文件，{{failed}} 个文件上传失败，',

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -999,6 +999,18 @@ export default class ImageControl extends React.Component<
   handleDrop(files: Array<FileX>, e?: any, event?: DropEvent) {
     const {multiple, crop, dropCrop} = this.props;
 
+    if (!files.length && Array.isArray(e)) {
+      const error = e
+        .reduce((errors: Array<string>, item) => {
+          errors = errors.concat(item.errors.map((e: any) => e.message));
+          return errors;
+        }, [])
+        .join('\n');
+
+      this.props.env.alert(error);
+      return;
+    }
+
     if (crop && !multiple && dropCrop) {
       const file = files[0] as any;
       if (!file.preview || !file.url) {
@@ -1105,7 +1117,7 @@ export default class ImageControl extends React.Component<
       if (maxSize && file.size > maxSize) {
         this.props.env.alert(
           __('File.maxSize', {
-            filename: file.name,
+            filename: file.name || __('File.imageAfterCrop'),
             actualSize: prettyBytes(file.size, 1024),
             maxSize: prettyBytes(maxSize, 1024)
           })
@@ -1617,7 +1629,7 @@ export default class ImageControl extends React.Component<
             accept={accept}
             multiple={dropMultiple}
             disabled={disabled}
-            maxSize={maxSize}
+            maxSize={crop ? undefined : maxSize}
           >
             {({
               getRootProps,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 25066c4</samp>

This pull request enhances the `input-image` component to support file size limits, cropping, and better error handling. It also updates the Chinese documentation and adds a new translation key for the cropped image label.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 25066c4</samp>

> _`input-image` is the gate to hell_
> _Drop your files and face the spell_
> _Cropped or large, valid or not_
> _You'll see the message of your lot_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 25066c4</samp>

*  Add a new translation key `File.imageAfterCrop` to the locale files for German, English, and Chinese, with the corresponding values for cropped image. ([link](https://github.com/baidu/amis/pull/7055/files?diff=unified&w=0#diff-7c7473c7eeac8c306a9c1dbf7f116bf87b1bcd4c31e9e0f8c619febc67faf8a5R146), [link](https://github.com/baidu/amis/pull/7055/files?diff=unified&w=0#diff-fb22f243566a7ed671bc6279e3cc6f0a1eddc2fe4259d84b4cb8a7f596987e49R152), [link](https://github.com/baidu/amis/pull/7055/files?diff=unified&w=0#diff-2fd35dabf975bb2b4ad936c4efcf03b6ce58a0954eba2964acffa8e557091e64R139))
*  Update the Chinese documentation of the input-image component to match the English version, by changing the section title from `限制文件大小` to `限制文件宽度`, and adding a new section `限制文件大小` with an example schema. (`docs/zh-CN/components/form/input-image.md`, [link](https://github.com/baidu/amis/pull/7055/files?diff=unified&w=0#diff-df614ff2471c08c1530f00dafa191c2c351525189dad40bf7cad37dc1ef58f65L98-R98), [link](https://github.com/baidu/amis/pull/7055/files?diff=unified&w=0#diff-df614ff2471c08c1530f00dafa191c2c351525189dad40bf7cad37dc1ef58f65R121-R141))
*  Add a new condition to the `handleDrop` method of the input-image component, to alert the user with error messages if the drop event contains an array of errors instead of files. This handles the case when the user tries to drop an invalid file type or size. (`packages/amis/src/renderers/Form/InputImage.tsx`, [link](https://github.com/baidu/amis/pull/7055/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R1002-R1013))
*  Add another condition to the `handleDrop` method of the input-image component, to use the translation key `File.imageAfterCrop` as the file name if the file name is undefined. This handles the case when the user crops an image and drops it to the input-image component, which does not have a file name by default. (`packages/amis/src/renderers/Form/InputImage.tsx`, [link](https://github.com/baidu/amis/pull/7055/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1108-R1120))
