### PR TITLE
fix: 处理table.column渲染mapping值是 tagSchema 不正常渲染的情况, 避免渲染tag时从 props.va…

### DIFF
--- a/packages/amis/src/renderers/Mapping.tsx
+++ b/packages/amis/src/renderers/Mapping.tsx
@@ -266,22 +266,19 @@ export const MappingField = withStore(props =>
             label = value[labelField || 'label'];
           }
         }
-        let realValue = value;
+        // 处理 table column 渲染 mapping 的值是 tagSchema 不正常渲染的情况
         if (
           isObject(label) &&
           label.type === 'tag' &&
           !isObject(label.label) &&
           label.label != null
         ) {
-          realValue = label.label;
+          return render('mapping-tag', label, {
+            // 避免渲染tag时从 props.value 取值而无法渲染 label
+            value: null
+          });
         }
-        return render('tpl', label, {
-          data: createObject(data, {
-            value: realValue,
-            label: realValue
-          }),
-          ...(label?.type === 'tag' ? {value: null} : {})
-        });
+        return render('tpl', label);
       }
       return render('mappingItemSchema', itemSchema, {
         data: createObject(data, isObject(value) ? value : {item: value}),


### PR DESCRIPTION
…lue 取值而无法渲染 label

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d6d2eb5</samp>

This pull request enhances the mapping field renderer to support tag schemas as values. It introduces a new custom renderer `mapping-tag` and adds a comment to explain the logic in `Mapping.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d6d2eb5</samp>

> _To render mapping fields with more grace_
> _This pull request makes a small change_
> _It adds a comment line_
> _And uses `mapping-tag` fine_
> _To show tag schemas in the right place_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d6d2eb5</samp>

*  Add a comment to clarify the handling of tag schema values in mapping fields ([link](https://github.com/baidu/amis/pull/7058/files?diff=unified&w=0#diff-10379299d052dbab104341158ad896620138178f442cb844be1ab2ff745aa489L269-R269))
*  Change the rendering logic of mapping field labels to use a custom renderer for tag schemas and a default renderer for other schemas ([link](https://github.com/baidu/amis/pull/7058/files?diff=unified&w=0#diff-10379299d052dbab104341158ad896620138178f442cb844be1ab2ff745aa489L276-R282))
