### PR TITLE
chore: mapping 远程字段支持 data 直接返回数组情况

### DIFF
--- a/docs/zh-CN/components/mapping.md
+++ b/docs/zh-CN/components/mapping.md
@@ -47,7 +47,8 @@ order: 57
 
 ## 渲染其它组件
 
-映射的值也可以是 amis schema，渲染其它组件  
+映射的值也可以是 amis schema，渲染其它组件
+
 > 配置了`itemSchema`后，映射值不会再作为`schema`渲染
 
 ```schema
@@ -81,6 +82,7 @@ order: 57
 当映射值是`非object`时，可使用`${item}`获取映射值；
 
 ### html 或字符串模板
+
 使用`${item}` 获取映射值
 
 ```schema
@@ -100,7 +102,8 @@ order: 57
 }
 ```
 
-### SchemaNode模板
+### SchemaNode 模板
+
 ```schema
 {
     "type": "page",
@@ -189,14 +192,14 @@ order: 57
 
 ```json
 {
-    "type": "mapping",
-    "value": "1",
-    "map": {
-        "1": "第一",
-        "2": "第二",
-        "3": "第三",
-        "*": "其他"
-    }
+  "type": "mapping",
+  "value": "1",
+  "map": {
+    "1": "第一",
+    "2": "第二",
+    "3": "第三",
+    "*": "其他"
+  }
 }
 ```
 
@@ -208,45 +211,37 @@ order: 57
 
 ```json
 {
-    "type": "mapping",
-    "value": "1",
-    "map": [
-        {"1": "第一"},
-        {"2": "第二"},
-        {"3": "第三"},
-        {"*": "其他"}
-    ]
+  "type": "mapping",
+  "value": "1",
+  "map": [{"1": "第一"}, {"2": "第二"}, {"3": "第三"}, {"*": "其他"}]
 }
 ```
 
-#### 多key对象数组
+#### 多 key 对象数组
 
-当映射值有多个key时，需要使用`valueField`指定字段作为`mapping`的`key`, 也就是用来匹配`value`的值  
+当映射值有多个 key 时，需要使用`valueField`指定字段作为`mapping`的`key`, 也就是用来匹配`value`的值  
 可使用`labelField`指定展示字段，不配置时，默认为`label`  
 **注意：**配置`labelField`后，映射值无法再作为`schema`渲染
 
 ```json
 {
-    "type": "mapping",
-    "value": "happy",
-    "valueField": "name",
-    "map": [
-        {
-            "name": "happy",
-            "label": "开心",
-            "color": "red"
-        },
-        {
-            "name": "sad",
-            "label": "悲伤",
-            "color": "blue"
-        },
-        {
-            "name": "*",
-            "label": "其他",
-            "color": "gray"
-        }
-    ]
+  "type": "mapping",
+  "value": "happy",
+  "valueField": "name",
+  "map": [
+    {
+      "name": "happy",
+      "label": "开心"
+    },
+    {
+      "name": "sad",
+      "label": "悲伤"
+    },
+    {
+      "name": "*",
+      "label": "其他"
+    }
+  ]
 }
 ```
 
@@ -473,12 +468,12 @@ List 的内容、Card 卡片的内容配置同上
 
 ## 属性表
 
-| 属性名      | 类型              | 默认值 | 说明                                                                              |
-| ----------- | ----------------- | ------ | --------------------------------------------------------------------------------- |
-| className   | `string`          |        | 外层 CSS 类名                                                                     |
-| placeholder | `string`          |        | 占位文本                                                                          |
-| map         | `object`或`Array<object>` |  | 映射配置                                                                          |
-| source      | `string` or `API` |        | [API](../../../docs/types/api) 或 [数据映射](../../../docs/concepts/data-mapping) |
-| valueField  | `string`          | value  | `2.5.2` map或source为`Array<object>`时，用来匹配映射的字段名                                  |
-| labelField  | `string`          | label  | `2.5.2` map或source为`Array<object>`时，用来展示的字段名<br />注：配置后映射值无法作为`schema`组件渲染 |
-| itemSchema  | `string`或[SchemaNode](../../docs/types/schemanode) | | `2.5.2` 自定义渲染模板，支持`html`或`schemaNode`；<br /> 当映射值是`非object`时，可使用`${item}`获取映射值；<br />当映射值是`object`时，可使用映射语法: `${xxx}`获取`object`的值；<br /> 也可使用数据映射语法：`${xxx}`获取数据域中变量值。|
+| 属性名      | 类型                                                | 默认值 | 说明                                                                                                                                                                                                                                        |
+| ----------- | --------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| className   | `string`                                            |        | 外层 CSS 类名                                                                                                                                                                                                                               |
+| placeholder | `string`                                            |        | 占位文本                                                                                                                                                                                                                                    |
+| map         | `object`或`Array<object>`                           |        | 映射配置                                                                                                                                                                                                                                    |
+| source      | `string` or `API`                                   |        | [API](../../../docs/types/api) 或 [数据映射](../../../docs/concepts/data-mapping)                                                                                                                                                           |
+| valueField  | `string`                                            | value  | `2.5.2` map 或 source 为`Array<object>`时，用来匹配映射的字段名                                                                                                                                                                             |
+| labelField  | `string`                                            | label  | `2.5.2` map 或 source 为`Array<object>`时，用来展示的字段名<br />注：配置后映射值无法作为`schema`组件渲染                                                                                                                                   |
+| itemSchema  | `string`或[SchemaNode](../../docs/types/schemanode) |        | `2.5.2` 自定义渲染模板，支持`html`或`schemaNode`；<br /> 当映射值是`非object`时，可使用`${item}`获取映射值；<br />当映射值是`object`时，可使用映射语法: `${xxx}`获取`object`的值；<br /> 也可使用数据映射语法：`${xxx}`获取数据域中变量值。 |

--- a/packages/amis/src/renderers/Mapping.tsx
+++ b/packages/amis/src/renderers/Mapping.tsx
@@ -87,7 +87,11 @@ export const Store = StoreNode.named('MappingStore')
             const data = normalizeApiResponseData(ret.data);
 
             (self as any).setMap(
-              Array.isArray(data.options) ? data.options : data
+              Array.isArray(data.options)
+                ? data.options
+                : Array.isArray(data.items)
+                ? data.items
+                : data
             );
           } else {
             throw new Error(ret.msg || 'fetch error');


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ddda934</samp>

This pull request improves the documentation and functionality of the mapping feature of the `SchemaNode` component. It fixes some formatting and typos in the `./docs/zh-CN/components/mapping.md` file, and adds support for data sources with an `items` property in the `./packages/amis/src/renderers/Mapping.tsx` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ddda934</samp>

> _We are the mappers of the data realm_
> _We wield the `SchemaNode` as our sword_
> _We face the doom of the source API_
> _We adapt and conquer with the `items` accord_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ddda934</samp>

*  Add support for data sources with `items` property in mapping component ([link](https://github.com/baidu/amis/pull/7061/files?diff=unified&w=0#diff-10379299d052dbab104341158ad896620138178f442cb844be1ab2ff745aa489L90-R94))
*  Format and simplify JSON code blocks in `mapping.md` ([link](https://github.com/baidu/amis/pull/7061/files?diff=unified&w=0#diff-892dc2908ee78957e6cf61b79ec74e22eaf02e371f33f3f52bc602aab9a60758L192-R202), [link](https://github.com/baidu/amis/pull/7061/files?diff=unified&w=0#diff-892dc2908ee78957e6cf61b79ec74e22eaf02e371f33f3f52bc602aab9a60758L211-R222), [link](https://github.com/baidu/amis/pull/7061/files?diff=unified&w=0#diff-892dc2908ee78957e6cf61b79ec74e22eaf02e371f33f3f52bc602aab9a60758L230-R244))
*  Fix typographical errors and spacing issues in `mapping.md` ([link](https://github.com/baidu/amis/pull/7061/files?diff=unified&w=0#diff-892dc2908ee78957e6cf61b79ec74e22eaf02e371f33f3f52bc602aab9a60758L50-R51), [link](https://github.com/baidu/amis/pull/7061/files?diff=unified&w=0#diff-892dc2908ee78957e6cf61b79ec74e22eaf02e371f33f3f52bc602aab9a60758R85), [link](https://github.com/baidu/amis/pull/7061/files?diff=unified&w=0#diff-892dc2908ee78957e6cf61b79ec74e22eaf02e371f33f3f52bc602aab9a60758L103-R106), [link](https://github.com/baidu/amis/pull/7061/files?diff=unified&w=0#diff-892dc2908ee78957e6cf61b79ec74e22eaf02e371f33f3f52bc602aab9a60758L476-R479))
