### PR TITLE
feat: 补充form和crud的事件动作面板

### DIFF
--- a/packages/amis-editor/src/plugin/CRUD.tsx
+++ b/packages/amis-editor/src/plugin/CRUD.tsx
@@ -2,6 +2,7 @@ import {toast, normalizeApiResponseData} from 'amis';
 import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
 import React from 'react';
+import {getEventControlConfig} from '../renderer/event-control/helper';
 
 import {
   getI18nEnabled,
@@ -115,6 +116,178 @@ export class CRUDPlugin extends BasePlugin {
           }
         }
       ]
+    },
+    {
+      eventName: 'selectedChange',
+      eventLabel: '选择表格项',
+      description: '手动选择表格项事件',
+      dataSchema: [
+        {
+          type: 'object',
+          properties: {
+            'event.data.selectedItems': {
+              type: 'array',
+              title: '已选择行'
+            },
+            'event.data.unSelectedItems': {
+              type: 'array',
+              title: '未选择行'
+            }
+          }
+        }
+      ]
+    },
+    {
+      eventName: 'columnSort',
+      eventLabel: '列排序',
+      description: '点击列排序事件',
+      dataSchema: [
+        {
+          type: 'object',
+          properties: {
+            'event.data.orderBy': {
+              type: 'string',
+              title: '列排序列名'
+            },
+            'event.data.orderDir': {
+              type: 'string',
+              title: '列排序值'
+            }
+          }
+        }
+      ]
+    },
+    {
+      eventName: 'columnFilter',
+      eventLabel: '列筛选',
+      description: '点击列筛选事件',
+      dataSchema: [
+        {
+          type: 'object',
+          properties: {
+            'event.data.filterName': {
+              type: 'string',
+              title: '列筛选列名'
+            },
+            'event.data.filterValue': {
+              type: 'string',
+              title: '列筛选值'
+            }
+          }
+        }
+      ]
+    },
+    {
+      eventName: 'columnSearch',
+      eventLabel: '列搜索',
+      description: '点击列搜索事件',
+      dataSchema: [
+        {
+          type: 'object',
+          properties: {
+            'event.data.searchName': {
+              type: 'string',
+              title: '列搜索列名'
+            },
+            'event.data.searchValue': {
+              type: 'object',
+              title: '列搜索数据'
+            }
+          }
+        }
+      ]
+    },
+    {
+      eventName: 'orderChange',
+      eventLabel: '行排序',
+      description: '手动拖拽行排序事件',
+      dataSchema: [
+        {
+          type: 'object',
+          properties: {
+            'event.data.movedItems': {
+              type: 'array',
+              title: '已排序数据'
+            }
+          }
+        }
+      ]
+    },
+    {
+      eventName: 'columnToggled',
+      eventLabel: '列显示变化',
+      description: '点击自定义列事件',
+      dataSchema: [
+        {
+          type: 'object',
+          properties: {
+            'event.data.columns': {
+              type: 'array',
+              title: '当前显示的列配置数据'
+            }
+          }
+        }
+      ]
+    },
+    {
+      eventName: 'rowClick',
+      eventLabel: '行单击',
+      description: '点击整行事件',
+      dataSchema: [
+        {
+          type: 'object',
+          properties: {
+            'event.data.item': {
+              type: 'object',
+              title: '当前行数据'
+            },
+            'event.data.index': {
+              type: 'number',
+              title: '当前行索引'
+            }
+          }
+        }
+      ]
+    },
+    {
+      eventName: 'rowMouseEnter',
+      eventLabel: '鼠标移入行事件',
+      description: '移入整行时触发',
+      dataSchema: [
+        {
+          type: 'object',
+          properties: {
+            'event.data.item': {
+              type: 'object',
+              title: '当前行数据'
+            },
+            'event.data.index': {
+              type: 'number',
+              title: '当前行索引'
+            }
+          }
+        }
+      ]
+    },
+    {
+      eventName: 'rowMouseLeave',
+      eventLabel: '鼠标移出行事件',
+      description: '移出整行时触发',
+      dataSchema: [
+        {
+          type: 'object',
+          properties: {
+            'event.data.item': {
+              type: 'object',
+              title: '当前行数据'
+            },
+            'event.data.index': {
+              type: 'number',
+              title: '当前行索引'
+            }
+          }
+        }
+      ]
     }
   ];
 
@@ -123,6 +296,11 @@ export class CRUDPlugin extends BasePlugin {
       actionType: 'reload',
       actionLabel: '重新加载',
       description: '触发组件数据刷新并重新渲染'
+    },
+    {
+      actionLabel: '变量赋值',
+      actionType: 'setValue',
+      description: '更新列表记录'
     }
   ];
 
@@ -1499,6 +1677,17 @@ export class CRUDPlugin extends BasePlugin {
           getSchemaTpl('className', {
             name: 'bodyClassName',
             label: '内容 CSS 类名'
+          })
+        ]
+      },
+
+      {
+        title: '事件',
+        className: 'p-none',
+        body: [
+          getSchemaTpl('eventControl', {
+            name: 'onEvent',
+            ...getEventControlConfig(this.manager, context)
           })
         ]
       },

--- a/packages/amis-editor/src/plugin/Form/Form.tsx
+++ b/packages/amis-editor/src/plugin/Form/Form.tsx
@@ -399,6 +399,11 @@ export class FormPlugin extends BasePlugin {
           }
         }
       ]
+    },
+    {
+      eventName: 'asyncApiFinished',
+      eventLabel: '远程请求轮询结束',
+      description: 'asyncApi 远程请求轮询结束后触发'
     }
   ];
 
@@ -635,7 +640,7 @@ export class FormPlugin extends BasePlugin {
                   label: '异步检测接口',
                   visibleOn: 'data.asyncApi != null',
                   description:
-                    '设置此属性后，表单提交发送保存接口后，还会继续轮训请求该接口，直到返回 finished 属性为 true 才 结束'
+                    '设置此属性后，表单提交发送保存接口后，还会继续轮询请求该接口，直到返回 finished 属性为 true 才 结束'
                 }),
 
                 {
@@ -729,7 +734,7 @@ export class FormPlugin extends BasePlugin {
                   label: '异步检测接口',
                   visibleOn: 'data.initAsyncApi != null',
                   description:
-                    '设置此属性后，表单请求 initApi 后，还会继续轮训请求该接口，直到返回 finished 属性为 true 才 结束'
+                    '设置此属性后，表单请求 initApi 后，还会继续轮询请求该接口，直到返回 finished 属性为 true 才 结束'
                 }),
 
                 {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f8b197</samp>

This pull request enhances the CRUD and Form plugins of the amis-editor package by allowing users to configure event handlers for various scenarios. It adds a new `asyncApiFinished` event to the Form plugin, and a new event control component to the CRUD plugin. It also updates the schema templates and definitions for the plugins.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5f8b197</samp>

> _Oh we are the coders of the `FormPlugin` class_
> _We add new events to make it more robust_
> _We heave and we ho on the count of three_
> _And we wait for the `asyncApiFinished` to see_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5f8b197</samp>

*  Add event control feature for CRUD component ([link](https://github.com/baidu/amis/pull/7068/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aR5), [link](https://github.com/baidu/amis/pull/7068/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aR119-R290), [link](https://github.com/baidu/amis/pull/7068/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aR299-R303), [link](https://github.com/baidu/amis/pull/7068/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aR1685-R1695))
  - Import `getSchemaTpl` helper function from `../renderer/event-control/helper` to generate schema template for event control component ([link](https://github.com/baidu/amis/pull/7068/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aR5))
  - Add event definitions for CRUD events such as `columnSort`, `columnFilter`, `columnToggle`, `rowClick`, etc. to `CRUDPlugin` class ([link](https://github.com/baidu/amis/pull/7068/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aR119-R290))
  - Add action definition for `setValue` action that can update component data by assigning a value to a variable ([link](https://github.com/baidu/amis/pull/7068/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aR299-R303))
  - Add event section to `CRUDPlugin` class that renders event control component using `getSchemaTpl` and `getEventControlConfig` helper functions ([link](https://github.com/baidu/amis/pull/7068/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aR1685-R1695))
* Add `asyncApiFinished` event definition for Form component ([link](https://github.com/baidu/amis/pull/7068/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dR402-R406))
  - Add event definition for `asyncApiFinished` event that is emitted when asyncApi remote request polling is finished to `FormPlugin` class ([link](https://github.com/baidu/amis/pull/7068/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dR402-R406))
