### PR TITLE
chore: 修复DateRangePicker组件shortcuts属性兼容问题

### DIFF
--- a/packages/amis-ui/src/components/DateRangePicker.tsx
+++ b/packages/amis-ui/src/components/DateRangePicker.tsx
@@ -455,7 +455,7 @@ export class DateRangePicker extends React.Component<
     joinValues: true,
     clearable: true,
     delimiter: ',',
-    ranges: 'yesterday,7daysago,prevweek,thismonth,prevmonth,prevquarter',
+    ranges: '',
     shortcuts: 'yesterday,7daysago,prevweek,thismonth,prevmonth,prevquarter',
     resetValue: '',
     closeOnSelect: true,
@@ -1403,7 +1403,7 @@ export class DateRangePicker extends React.Component<
 
     return (
       <div className={cx(`${ns}DateRangePicker-wrap`)} ref={this.calendarRef}>
-        {this.renderShortcuts(shortcuts ?? ranges)}
+        {this.renderShortcuts(ranges || shortcuts)}
         <div className={cx(`${ns}DateRangePicker-picker-wrap`)}>
           {(!isTimeRange || (editState === 'start' && !embed)) && (
             <Calendar
@@ -1624,7 +1624,7 @@ export class DateRangePicker extends React.Component<
         close={this.close}
         confirm={this.confirm}
         onChange={this.handleMobileChange}
-        footerExtra={this.renderShortcuts(shortcuts ?? ranges)}
+        footerExtra={this.renderShortcuts(ranges || shortcuts)}
         showViewMode={
           viewMode === 'quarters' || viewMode === 'months' ? 'years' : 'months'
         }

--- a/packages/amis-ui/src/components/MonthRangePicker.tsx
+++ b/packages/amis-ui/src/components/MonthRangePicker.tsx
@@ -483,7 +483,7 @@ export class MonthRangePicker extends React.Component<
 
     return (
       <div className={`${ns}DateRangePicker-wrap`}>
-        {this.renderShortcuts(shortcuts ?? ranges)}
+        {this.renderShortcuts(ranges || shortcuts)}
         <Calendar
           className={`${ns}DateRangePicker-start`}
           value={startDate}
@@ -614,7 +614,7 @@ export class MonthRangePicker extends React.Component<
         close={this.close}
         confirm={this.confirm}
         onChange={this.handleMobileChange}
-        footerExtra={this.renderShortcuts(shortcuts ?? ranges)}
+        footerExtra={this.renderShortcuts(ranges || shortcuts)}
         showViewMode="years"
       />
     );

--- a/packages/amis/src/renderers/Form/InputMonthRange.tsx
+++ b/packages/amis/src/renderers/Form/InputMonthRange.tsx
@@ -65,7 +65,7 @@ export class MonthRangeControlRenderer extends MonthRangeControl {
     delimiter: ',',
     timeFormat: '',
     /** shortcuts的兼容配置 */
-    ranges: 'thismonth,prevmonth',
+    ranges: '',
     shortcuts: 'thismonth,prevmonth',
     animation: true
   };


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 67ccacb</samp>

The pull request enhances the `DateRangePicker` and `MonthRangePicker` components by allowing more flexibility and consistency in customizing the date range shortcuts. It also fixes a bug in the `DateRangePicker` component that ignored the `ranges` prop.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 67ccacb</samp>

> _Sing, O Muse, of the skillful coder who changed the date range picker_
> _And gave it new power to render the shortcuts as he desired_
> _He preferred the ranges prop over the shortcuts prop, as a master builder_
> _Who chooses the best materials for his work, admired by all_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 67ccacb</samp>

*  Swap the order of the `shortcuts` and `ranges` props in the `renderShortcuts` method call to prioritize the `ranges` prop over the `shortcuts` prop when rendering the date range picker shortcuts ([link](https://github.com/baidu/amis/pull/7069/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1406-R1406), [link](https://github.com/baidu/amis/pull/7069/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1627-R1627), [link](https://github.com/baidu/amis/pull/7069/files?diff=unified&w=0#diff-20fd7d34747427d50e8fb67f237bc5b6753ec2e777f1ab3c71a9aafe1c358762L486-R486), [link](https://github.com/baidu/amis/pull/7069/files?diff=unified&w=0#diff-20fd7d34747427d50e8fb67f237bc5b6753ec2e777f1ab3c71a9aafe1c358762L617-R617))
*  Apply the same change to the `DateRangePicker` and `MonthRangePicker` components, which are UI components that allow users to select a start and end date or month from a calendar or predefined shortcuts ([link](https://github.com/baidu/amis/pull/7069/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1406-R1406), [link](https://github.com/baidu/amis/pull/7069/files?diff=unified&w=0#diff-20fd7d34747427d50e8fb67f237bc5b6753ec2e777f1ab3c71a9aafe1c358762L486-R486))
*  Apply the same change to the mobile versions of the components, which use the `MobileCalendar` component to render the date range picker or month range picker on smaller screens ([link](https://github.com/baidu/amis/pull/7069/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1627-R1627), [link](https://github.com/baidu/amis/pull/7069/files?diff=unified&w=0#diff-20fd7d34747427d50e8fb67f237bc5b6753ec2e777f1ab3c71a9aafe1c358762L617-R617))
