### PR TITLE
chore:事件动作增加循环调用检查

### DIFF
--- a/packages/amis-core/src/factory.tsx
+++ b/packages/amis-core/src/factory.tsx
@@ -87,6 +87,7 @@ export interface RendererProps
 
 export type RendererComponent = React.ComponentType<RendererProps> & {
   propsList?: Array<any>;
+  circularEventAction?: {[eventName: string]: string};
 };
 
 export interface RendererConfig extends RendererBasicConfig {

--- a/packages/amis-core/src/utils/renderer-event.ts
+++ b/packages/amis-core/src/utils/renderer-event.ts
@@ -275,4 +275,18 @@ export const resolveEventData = (
   );
 };
 
+export const checkCircular = (
+  eventName: string,
+  actionType: string,
+  props: any
+) => {
+  const isCircular = props?.onEvent?.[eventName]?.actions?.some(
+    (item: any) =>
+      item.actionType === actionType &&
+      (item.componentId === props?.id || item.componentName === props?.name)
+  );
+
+  return !isCircular;
+};
+
 export default {};

--- a/packages/amis/src/renderers/Page.tsx
+++ b/packages/amis/src/renderers/Page.tsx
@@ -1,16 +1,7 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {Renderer, RendererProps, filterTarget} from 'amis-core';
-import {observer} from 'mobx-react';
 import {ServiceStore, IServiceStore} from 'amis-core';
-import {
-  Api,
-  SchemaNode,
-  ActionObject,
-  Location,
-  ApiObject,
-  FunctionPropertyNames
-} from 'amis-core';
+import {Api, ActionObject, Location} from 'amis-core';
 import {filter, evalExpression} from 'amis-core';
 import {
   isVisible,
@@ -34,9 +25,6 @@ import {
   SchemaMessage
 } from '../Schema';
 import {SchemaRemark} from './Remark';
-import {onAction} from 'mobx-state-tree';
-import mapValues from 'lodash/mapValues';
-import {resolveVariable} from 'amis-core';
 import {buildStyle} from 'amis-core';
 import {PullRefresh} from 'amis-ui';
 import {scrollPosition, isMobile} from 'amis-core';
@@ -270,6 +258,10 @@ export default class Page extends React.Component<PageProps> {
     'style',
     'showErrorMsg'
   ];
+
+  static circularEventAction: {[eventName: string]: string} = {
+    inited: 'reload'
+  };
 
   constructor(props: PageProps) {
     super(props);
@@ -698,7 +690,8 @@ export default class Page extends React.Component<PageProps> {
         responseStatus:
           value?.status === undefined ? (store?.error ? 1 : 0) : value?.status,
         responseMsg: value?.msg || store?.msg
-      })
+      }),
+      this
     );
 
     interval &&

--- a/packages/amis/src/renderers/Service.tsx
+++ b/packages/amis/src/renderers/Service.tsx
@@ -174,6 +174,11 @@ export default class Service extends React.Component<ServiceProps> {
 
   static propsList: Array<string> = [];
 
+  static circularEventAction: {[eventName: string]: string} = {
+    fetchInited: 'reload',
+    fetchSchemaInited: 'reload'
+  };
+
   constructor(props: ServiceProps) {
     super(props);
 
@@ -524,7 +529,8 @@ export default class Service extends React.Component<ServiceProps> {
         responseStatus:
           result?.status === undefined ? (store.error ? 1 : 0) : result?.status,
         responseMsg: store.msg
-      })
+      }),
+      this
     );
 
     if (!isEmpty(data) && onBulkChange) {
@@ -537,14 +543,18 @@ export default class Service extends React.Component<ServiceProps> {
   afterSchemaFetch(schema: any) {
     const {onBulkChange, formStore, dispatchEvent, store} = this.props;
 
-    dispatchEvent?.('fetchSchemaInited', {
-      ...schema,
-      __response: {msg: store.msg, error: store.error}, // 保留，兼容历史
-      responseData: schema,
-      responseStatus:
-        schema?.status === undefined ? (store.error ? 1 : 0) : schema?.status,
-      responseMsg: store.msg
-    });
+    dispatchEvent?.(
+      'fetchSchemaInited',
+      {
+        ...schema,
+        __response: {msg: store.msg, error: store.error}, // 保留，兼容历史
+        responseData: schema,
+        responseStatus:
+          schema?.status === undefined ? (store.error ? 1 : 0) : schema?.status,
+        responseMsg: store.msg
+      },
+      this
+    );
 
     if (formStore && schema?.data && onBulkChange) {
       onBulkChange && onBulkChange(schema.data);

--- a/packages/amis/src/renderers/Wizard.tsx
+++ b/packages/amis/src/renderers/Wizard.tsx
@@ -237,6 +237,10 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
     'startStep'
   ];
 
+  static circularEventAction: {[eventName: string]: string} = {
+    inited: 'reload'
+  };
+
   dom: any;
   form: any;
   asyncCancel: () => void;
@@ -382,7 +386,8 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
 
     const rendererEvent = await dispatchEvent(
       action,
-      value ? createObject(data, value) : data
+      value ? createObject(data, value) : data,
+      this
     );
 
     return rendererEvent?.prevented ?? false;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 60e8169</samp>

This pull request adds a new feature to the `amis` framework to support circular events and actions for various components, such as `Form`, `Page`, `Service`, and `Wizard`. It also improves the event dispatching mechanism to include the source component information and prevent infinite loops. It modifies several files in the `amis-core` and `amis` packages, such as `Form.tsx`, `SchemaRenderer.tsx`, `factory.tsx`, and `renderer-event.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 60e8169</samp>

> _Sing, O Muse, of the cunning RendererComponent_
> _That with circularEventAction checked the loops of fate_
> _And saved the Form and Service from endless turmoil_
> _When they dispatched events with their own context and state_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 60e8169</samp>

*  Add a `circularEventAction` property to the `RendererComponent` type and various components to declare the event names and action types for circular detection ([link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-f32fad412c5300ebd34ca8f39d2d60e882c3db418757ced49c3a79af4f22f2ebR90), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3R458-R466), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0R262-R265), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852R177-R181), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-8c1e1e55c146ca688906b7443643b4a9c53472e61bd55b64d534e92d1b247e3bR240-R243))
*  Add a logic to check for circular event action configurations in the `dispatchEvent` method of the `SchemaRenderer` class using the `checkCircular` function from `amis-core` utils ([link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-337f9a56707dbfa5917084f1e2048555a5ade95f13df3f685076114867426347R8), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-337f9a56707dbfa5917084f1e2048555a5ade95f13df3f685076114867426347L20-R26), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-337f9a56707dbfa5917084f1e2048555a5ade95f13df3f685076114867426347L224-R241), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6R278-R291))
*  Pass the `this` argument to the `dispatchEvent` function to identify the source component of various events in the `Form`, `Page`, `Service`, and `Wizard` components ([link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L675-R685), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L835-R847), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L869-R879), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1085-R1096), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1108-R1119), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1126-R1145), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1153-R1169), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1171-R1187), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1181-R1198), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1208-R1229), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L701-R694), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852L527-R533), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852L540-R557), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-8c1e1e55c146ca688906b7443643b4a9c53472e61bd55b64d534e92d1b247e3bL385-R390))
*  Remove unused imports from `Page` component ([link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L2-R4), [link](https://github.com/baidu/amis/pull/7074/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L37-L39))
