### PR TITLE
fix: 修复 tpl 改成异步模版后存在不更新的情况

### DIFF
--- a/packages/amis/src/renderers/Tpl.tsx
+++ b/packages/amis/src/renderers/Tpl.tsx
@@ -68,7 +68,7 @@ export class Tpl extends React.Component<TplProps, TplState> {
   constructor(props: TplProps) {
     super(props);
     this.state = {
-      content: this.getContent()
+      content: ''
     };
     this.mounted = true;
   }
@@ -92,46 +92,52 @@ export class Tpl extends React.Component<TplProps, TplState> {
   }
 
   @autobind
-  updateContent() {
-    const {tpl, html, text} = this.props;
-
-    if (html || tpl || text) {
-      this.getAsyncContent().then(content => {
-        this.mounted && this.setState({content});
-      });
-    }
+  async updateContent() {
+    const content = await this.getAsyncContent();
+    this.mounted && this.setState({content});
   }
 
+  // @autobind
+  // getContent() {
+  //   const {tpl, html, text, raw, data, placeholder} = this.props;
+  //   const value = getPropValue(this.props);
+
+  //   if (raw) {
+  //     return raw;
+  //   } else if (html) {
+  //     return filter(html, data);
+  //   } else if (tpl) {
+  //     return filter(tpl, data);
+  //   } else if (text) {
+  //     return escapeHtml(filter(text, data));
+  //   } else {
+  //     return value == null || value === ''
+  //       ? `<span class="text-muted">${placeholder}</span>`
+  //       : typeof value === 'string'
+  //       ? value
+  //       : JSON.stringify(value);
+  //   }
+  // }
+
   @autobind
-  getContent() {
-    const {tpl, html, text, raw, data, placeholder} = this.props;
+  async getAsyncContent() {
+    const {tpl, html, text, data, raw, placeholder} = this.props;
     const value = getPropValue(this.props);
 
     if (raw) {
       return raw;
     } else if (html) {
-      return filter(html, data);
+      return asyncFilter(html, data);
     } else if (tpl) {
-      return filter(tpl, data);
+      return asyncFilter(tpl, data);
     } else if (text) {
-      return escapeHtml(filter(text, data));
+      return escapeHtml(await asyncFilter(text, data));
     } else {
       return value == null || value === ''
         ? `<span class="text-muted">${placeholder}</span>`
         : typeof value === 'string'
         ? value
         : JSON.stringify(value);
-    }
-  }
-
-  @autobind
-  async getAsyncContent() {
-    const {tpl, html, text, data} = this.props;
-
-    if (html || tpl) {
-      return asyncFilter(html || tpl, data);
-    } else {
-      return escapeHtml(await asyncFilter(text, data));
     }
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 28a17f1</samp>

Refactored `Tpl` component to support async expressions in content props. Added `getAsyncContent()` method to handle promise-based rendering.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 28a17f1</samp>

> _Oh we're the coders of the sea, and we work with `Tpl`_
> _We refactor and we test, and we make it run so well_
> _We use async expressions now, in `html`, `tpl`, and `text`_
> _We heave away on the count of three, and we call `getAsyncContent()`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 28a17f1</samp>

*  Replace `getContent()` method with `getAsyncContent()` method to support asynchronous expressions in the `Tpl` component ([link](https://github.com/baidu/amis/pull/7082/files?diff=unified&w=0#diff-6aa4f8266d0cadc3587df2ab984129ea6a3747a6ddc824bc7ef9b86508898f45L71-R71), [link](https://github.com/baidu/amis/pull/7082/files?diff=unified&w=0#diff-6aa4f8266d0cadc3587df2ab984129ea6a3747a6ddc824bc7ef9b86508898f45L95-R124), [link](https://github.com/baidu/amis/pull/7082/files?diff=unified&w=0#diff-6aa4f8266d0cadc3587df2ab984129ea6a3747a6ddc824bc7ef9b86508898f45L113-R134), [link](https://github.com/baidu/amis/pull/7082/files?diff=unified&w=0#diff-6aa4f8266d0cadc3587df2ab984129ea6a3747a6ddc824bc7ef9b86508898f45L127-L137))
