### PR TITLE
fix: 修复schemaApi直接返回表单项 label 不展示问题 Close: #2668

### DIFF
--- a/packages/amis-core/src/store/service.ts
+++ b/packages/amis-core/src/store/service.ts
@@ -437,11 +437,15 @@ export const ServiceStore = iRendererStore
 
             self.schema = Array.isArray(json.data)
               ? json.data
-              : {
-                  type: 'wrapper',
-                  wrap: false,
-                  ...normalizeApiResponseData(json.data)
-                };
+              : Object.assign(
+                  json.data?.type
+                    ? {}
+                    : {
+                        type: 'wrapper',
+                        wrap: false
+                      },
+                  normalizeApiResponseData(json.data)
+                );
             self.schemaKey = '' + Date.now();
             isObject(json.data.data) &&
               self.updateData(


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ced25ed</samp>

Fix schema type overwriting bug in `ServiceStore`. Use `Object.assign` to merge normalized data with default wrapper object.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ced25ed</samp>

> _`ServiceStore` bug_
> _Object.assign preserves_
> _schema in winter_

### Why

 Close: #2668

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ced25ed</samp>

* Fix a bug where the schema property of the ServiceStore would be overwritten by the normalizeApiResponseData function ([link](https://github.com/baidu/amis/pull/7091/files?diff=unified&w=0#diff-191662131d9c1b3897df9477357be99371cbafd0eb7370f884d3f75c102653faL440-R448))
* Use Object.assign to merge the default wrapper object with the normalized data object, and only add the wrapper object if the json.data object does not have a type property ([link](https://github.com/baidu/amis/pull/7091/files?diff=unified&w=0#diff-191662131d9c1b3897df9477357be99371cbafd0eb7370f884d3f75c102653faL440-R448))
* Preserve the original schema type and other properties that might be defined in the json.data object ([link](https://github.com/baidu/amis/pull/7091/files?diff=unified&w=0#diff-191662131d9c1b3897df9477357be99371cbafd0eb7370f884d3f75c102653faL440-R448))
* Improve the compatibility and stability of the Service component ([link](https://github.com/baidu/amis/pull/7091/files?diff=unified&w=0#diff-191662131d9c1b3897df9477357be99371cbafd0eb7370f884d3f75c102653faL440-R448))
