### PR TITLE
feat: input-kv 添加 autoParseJSON 配置 Close: #7092

### DIFF
--- a/docs/zh-CN/components/form/input-kv.md
+++ b/docs/zh-CN/components/form/input-kv.md
@@ -198,14 +198,14 @@ key 只能是字符串，因此输入格式是 `input-text`，但 value 格式�
 
 ## 属性表
 
-| 属性名                | 类型      | 默认值         | 说明                         |
-| --------------------- | --------- | -------------- | ---------------------------- |
-| valueType             | `type`    | `"input-text"` | 值类型                       |
-| keyPlaceholder        | `string`  |                | key 的提示信息的             |
-| valuePlaceholder      | `string`  |                | value 的提示信息的           |
-| draggable             | `boolean` | true           | 是否可拖拽排序               |
-| defaultValue          |           | `''`           | 默认值                       |
-| autoConvertJSONString | `boolean` | `true`         | 是否自动转换 json 对象字符串 |
+| 属性名           | 类型      | 默认值         | 说明                         |
+| ---------------- | --------- | -------------- | ---------------------------- |
+| valueType        | `type`    | `"input-text"` | 值类型                       |
+| keyPlaceholder   | `string`  |                | key 的提示信息的             |
+| valuePlaceholder | `string`  |                | value 的提示信息的           |
+| draggable        | `boolean` | true           | 是否可拖拽排序               |
+| defaultValue     |           | `''`           | 默认值                       |
+| autoParseJSON    | `boolean` | `true`         | 是否自动转换 json 对象字符串 |
 
 ## 事件表
 

--- a/docs/zh-CN/components/form/input-kv.md
+++ b/docs/zh-CN/components/form/input-kv.md
@@ -198,13 +198,14 @@ key 只能是字符串，因此输入格式是 `input-text`，但 value 格式�
 
 ## 属性表
 
-| 属性名           | 类型      | 默认值         | 说明               |
-| ---------------- | --------- | -------------- | ------------------ |
-| valueType        | `type`    | `"input-text"` | 值类型             |
-| keyPlaceholder   | `string`  |                | key 的提示信息的   |
-| valuePlaceholder | `string`  |                | value 的提示信息的 |
-| draggable        | `boolean` | true           | 是否可拖拽排序     |
-| defaultValue     |           | `''`           | 默认值             |
+| 属性名                | 类型      | 默认值         | 说明                         |
+| --------------------- | --------- | -------------- | ---------------------------- |
+| valueType             | `type`    | `"input-text"` | 值类型                       |
+| keyPlaceholder        | `string`  |                | key 的提示信息的             |
+| valuePlaceholder      | `string`  |                | value 的提示信息的           |
+| draggable             | `boolean` | true           | 是否可拖拽排序               |
+| defaultValue          |           | `''`           | 默认值                       |
+| autoConvertJSONString | `boolean` | `true`         | 是否自动转换 json 对象字符串 |
 
 ## 事件表
 

--- a/packages/amis/src/schemaExtend.ts
+++ b/packages/amis/src/schemaExtend.ts
@@ -9,7 +9,7 @@ import {isObject} from 'amis-core';
 // input-kv 实际上是 combo 的一种扩展
 addSchemaFilter(function (schema: Schema, renderer, props?: any) {
   if (schema && schema.type === 'input-kv') {
-    const autoConvertJSONString = schema.autoConvertJSONString ?? true;
+    const autoParseJSON = schema.autoParseJSON ?? true;
     return {
       draggable: true,
       ...schema,
@@ -42,7 +42,7 @@ addSchemaFilter(function (schema: Schema, renderer, props?: any) {
           const key: string = item.key ?? '';
           let value: any = item.value ?? schema.defaultValue ?? '';
           if (
-            autoConvertJSONString &&
+            autoParseJSON &&
             typeof value === 'string' &&
             value.startsWith('{')
           ) {

--- a/packages/amis/src/schemaExtend.ts
+++ b/packages/amis/src/schemaExtend.ts
@@ -9,6 +9,7 @@ import {isObject} from 'amis-core';
 // input-kv 实际上是 combo 的一种扩展
 addSchemaFilter(function (schema: Schema, renderer, props?: any) {
   if (schema && schema.type === 'input-kv') {
+    const autoConvertJSONString = schema.autoConvertJSONString ?? true;
     return {
       draggable: true,
       ...schema,
@@ -40,7 +41,11 @@ addSchemaFilter(function (schema: Schema, renderer, props?: any) {
         value.forEach((item: any) => {
           const key: string = item.key ?? '';
           let value: any = item.value ?? schema.defaultValue ?? '';
-          if (typeof value === 'string' && value.startsWith('{')) {
+          if (
+            autoConvertJSONString &&
+            typeof value === 'string' &&
+            value.startsWith('{')
+          ) {
             try {
               value = JSON.parse(value);
             } catch (e) {}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at af26d4c</samp>

This pull request adds a new feature to the `input-kv` component that allows parsing JSON object strings as values. It updates the component schema in `schemaExtend.ts` and the documentation in `input-kv.md`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at af26d4c</samp>

> _`input-kv` changes_
> _JSON string or object?_
> _New option added_

### Why

Close: #7092

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at af26d4c</samp>

*  Add a new property `autoConvertJSONString` to the `input-kv` component that controls whether to automatically convert a JSON object string to an object value ([link](https://github.com/baidu/amis/pull/7094/files?diff=unified&w=0#diff-567363703fbd9e2556c1bd71411711e329d69210126c61be77f6994476db7278L201-R208))
*  Assign the `autoConvertJSONString` property from the schema to a variable in the `schemaExtend.ts` file ([link](https://github.com/baidu/amis/pull/7094/files?diff=unified&w=0#diff-8c4d1dcae8d1a050e267684d07324d2da3a74514de066caf0a0a3f858d35cbd8R12))
*  Add a condition to check the `autoConvertJSONString` variable before parsing a JSON object string in the `schemaExtend.ts` file ([link](https://github.com/baidu/amis/pull/7094/files?diff=unified&w=0#diff-8c4d1dcae8d1a050e267684d07324d2da3a74514de066caf0a0a3f858d35cbd8L43-R48))
