### PR TITLE
fix: wizard 修复在没有配置 api 时最后一步不跳转的问题 Close: #2860

### DIFF
--- a/packages/amis/src/renderers/Wizard.tsx
+++ b/packages/amis/src/renderers/Wizard.tsx
@@ -885,8 +885,24 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
         })
         .catch(error => {});
     } else {
-      onFinished && onFinished(store.data, action);
       this.setState({completeStep: steps.length});
+
+      if (onFinished && onFinished(store.data, action) === false) {
+        return;
+      }
+
+      const finalRedirect =
+        (action.redirect || step.redirect || redirect) &&
+        filter(action.redirect || step.redirect || redirect, store.data);
+
+      if (finalRedirect) {
+        env.jumpTo(finalRedirect, action);
+      } else if (action.reload || step.reload || reload) {
+        this.reloadTarget(
+          filterTarget(action.reload || step.reload || reload!, store.data),
+          store.data
+        );
+      }
     }
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ebdb478</samp>

Fix wizard redirect or reload bug. Add logic to `Wizard.tsx` to handle the final action based on the last step settings and the `onFinished` callback.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ebdb478</samp>

> _Wizard is finished_
> _`onFinished` may return false_
> _No redirect then_

### Why

Close: #2860

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ebdb478</samp>

* Add logic to handle final redirect or reload after wizard is finished ([link](https://github.com/baidu/amis/pull/7095/files?diff=unified&w=0#diff-8c1e1e55c146ca688906b7443643b4a9c53472e61bd55b64d534e92d1b247e3bL888-R905))
* Fix bug where wizard does not respect `redirect` or `reload` settings of last step ([link](https://github.com/baidu/amis/pull/7095/files?diff=unified&w=0#diff-8c1e1e55c146ca688906b7443643b4a9c53472e61bd55b64d534e92d1b247e3bL888-R905))
