### PR TITLE
chore(amis-editor): 编辑器插件Plugin增加ID静态属性, 支持注册时基于ID去重

### DIFF
--- a/packages/amis-editor-core/src/manager.ts
+++ b/packages/amis-editor-core/src/manager.ts
@@ -2,8 +2,12 @@
  * @file 把一些功能性的东西放在了这个里面，辅助 compoennt/Editor.tsx 组件的。
  * 编辑器非 UI 相关的东西应该放在这。
  */
-
-import uniqBy from 'lodash/uniqBy';
+import {reaction} from 'mobx';
+import {parse, stringify} from 'json-ast-comments';
+import debounce from 'lodash/debounce';
+import findIndex from 'lodash/findIndex';
+import omit from 'lodash/omit';
+import {openContextMenus, toast, alert, DataScope, DataSchema} from 'amis';
 import {getRenderers, RenderOptions, mapTree} from 'amis-core';
 import {
   PluginInterface,
@@ -31,14 +35,14 @@ import {
   DeleteEventContext,
   RendererPluginEvent,
   PluginEvents,
-  PluginActions
+  PluginActions,
+  BasePlugin
 } from './plugin';
 import {
   EditorStoreType,
   PopOverFormContext,
   SubEditorContext
 } from './store/editor';
-
 import {
   autobind,
   camelize,
@@ -49,29 +53,18 @@ import {
   isString,
   isObject,
   isLayoutPlugin,
-  JSONPipeOut,
-  generateNodeId,
-  JSONTraverse
+  JSONPipeOut
 } from './util';
-import {reaction} from 'mobx';
 import {hackIn, makeSchemaFormRender, makeWrapper} from './component/factory';
 import {env} from './env';
-import debounce from 'lodash/debounce';
-import sortBy from 'lodash/sortBy';
-import reverse from 'lodash/reverse';
-import cloneDeep from 'lodash/cloneDeep';
-import {openContextMenus, toast, alert, DataScope, DataSchema} from 'amis';
-import {parse, stringify} from 'json-ast-comments';
 import {EditorNodeType} from './store/node';
 import {EditorProps} from './component/Editor';
-import findIndex from 'lodash/findIndex';
 import {EditorDNDManager} from './dnd';
 import {VariableManager} from './variable';
-import {IScopedContext} from 'amis';
+
+import type {IScopedContext} from 'amis';
 import type {SchemaObject, SchemaCollection} from 'amis';
 import type {RendererConfig} from 'amis-core';
-import isPlainObject from 'lodash/isPlainObject';
-import {omit} from 'lodash';
 
 export interface EditorManagerConfig
   extends Omit<EditorProps, 'value' | 'onChange'> {}
@@ -79,6 +72,8 @@ export interface EditorManagerConfig
 export interface PluginClass {
   new (manager: EditorManager, options?: any): PluginInterface;
   id?: string;
+  /** 优先级，值为整数，当存在两个ID相同的Plugin时，数字更大的优先级更高 */
+  priority?: number;
   scene?: Array<string>;
 }
 
@@ -111,22 +106,58 @@ export function registerEditorPlugin(klass: PluginClass) {
   // 处理插件身上的场景信息
   const scene = Array.from(new Set(['global'].concat(klass.scene || 'global')));
   klass.scene = scene;
-  let isExitPlugin: any = null;
+
+  let exsitedPluginIdx: any = null;
   if (klass.prototype && klass.prototype.isNpmCustomWidget) {
-    isExitPlugin = builtInPlugins.find(item =>
+    exsitedPluginIdx = builtInPlugins.findIndex(item =>
       Array.isArray(item)
         ? item[0].prototype.name === klass.prototype.name
         : item.prototype.name === klass.prototype.name
     );
   } else {
     // 待进一步优化
-    isExitPlugin = builtInPlugins.find(item => item === klass);
+    exsitedPluginIdx = builtInPlugins.findIndex(item => item === klass);
   }
-  if (!isExitPlugin) {
+
+  /** 先给新加入的plugin加一个ID */
+  if (!~exsitedPluginIdx) {
     klass.id = klass.id || klass.name || guid();
-    builtInPlugins.push(klass);
+  }
+
+  /** 因为class的继承关系，未设置ID的子class会和父class共用ID, 只有设置了priority的时候才会执行同ID去重 */
+  if (klass.priority == null || !Number.isInteger(klass.priority)) {
+    if (!~exsitedPluginIdx) {
+      builtInPlugins.push(klass);
+    } else {
+      console.warn(`注册插件「${klass.id}」异常，已存在同名插件：`, klass);
+    }
   } else {
-    console.warn(`注册插件异常，已存在同名插件：`, klass);
+    exsitedPluginIdx = ~exsitedPluginIdx
+      ? exsitedPluginIdx
+      : builtInPlugins.findIndex(
+          item =>
+            !Array.isArray(item) &&
+            item.id === klass.id &&
+            item?.prototype instanceof BasePlugin
+        );
+
+    if (!~exsitedPluginIdx) {
+      builtInPlugins.push(klass);
+    } else {
+      const current = builtInPlugins[exsitedPluginIdx] as PluginClass;
+
+      /** 同ID的插件根据优先级决定是否update */
+      const currentPriority =
+        current.priority && Number.isInteger(current.priority)
+          ? current.priority
+          : 0;
+
+      if (klass.priority > currentPriority) {
+        builtInPlugins.splice(exsitedPluginIdx, 1, klass);
+      } else {
+        console.warn(`注册插件「${klass.id}」异常，已存在同名插件：`, klass);
+      }
+    }
   }
 }
 
@@ -199,7 +230,39 @@ export class EditorManager {
     this.hackIn = parent?.hackIn || hackIn;
     // 自动加载预先注册的自定义组件
     autoPreRegisterEditorCustomPlugins();
-    const scene = config.scene || 'global';
+    /** 在顶层对外部注册的Plugin和builtInPlugins合并去重 */
+    if (!parent?.plugins) {
+      (config?.plugins || []).forEach(external => {
+        if (
+          Array.isArray(external) ||
+          !external.priority ||
+          !Number.isInteger(external.priority)
+        ) {
+          return;
+        }
+
+        const idx = builtInPlugins.findIndex(
+          builtIn =>
+            !Array.isArray(builtIn) &&
+            !Array.isArray(external) &&
+            builtIn.id === external.id &&
+            builtIn?.prototype instanceof BasePlugin
+        );
+
+        if (~idx) {
+          const current = builtInPlugins[idx] as PluginClass;
+          const currentPriority =
+            current.priority && Number.isInteger(current.priority)
+              ? current.priority
+              : 0;
+          /** 同ID Plugin根据优先级决定是否替换掉Builtin中的Plugin */
+          if (external.priority > currentPriority) {
+            builtInPlugins.splice(idx, 1);
+          }
+        }
+      });
+    }
+
     this.plugins =
       parent?.plugins ||
       (config.disableBultinPlugin ? [] : builtInPlugins) // 页面设计器注册的插件列表

--- a/packages/amis-editor/src/plugin/Alert.tsx
+++ b/packages/amis-editor/src/plugin/Alert.tsx
@@ -5,6 +5,7 @@ import {getSchemaTpl} from 'amis-editor-core';
 import type {SchemaObject} from 'amis';
 
 export class AlertPlugin extends BasePlugin {
+  static id = 'AlertPlugin';
   static scene = ['layout'];
 
   // 关联渲染器名字

--- a/packages/amis-editor/src/plugin/AnchorNav.tsx
+++ b/packages/amis-editor/src/plugin/AnchorNav.tsx
@@ -11,6 +11,7 @@ import {registerFilter} from 'amis-formula';
 registerFilter('appTranslate', (input: any) => translateSchema(input));
 
 export class AnchorNavPlugin extends BasePlugin {
+  static id = 'AnchorNavPlugin';
   // 关联渲染器名字
   rendererName = 'anchor-nav';
   $schema = '/schemas/AnchorNavSchema.json';

--- a/packages/amis-editor/src/plugin/Audio.tsx
+++ b/packages/amis-editor/src/plugin/Audio.tsx
@@ -3,6 +3,7 @@ import {BaseEventContext, BasePlugin} from 'amis-editor-core';
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 
 export class AudioPlugin extends BasePlugin {
+  static id = 'AudioPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'audio';

--- a/packages/amis-editor/src/plugin/Avatar.tsx
+++ b/packages/amis-editor/src/plugin/Avatar.tsx
@@ -13,6 +13,7 @@ const widthOrheightPipeIn = (curValue: string, rest: any) =>
   curValue ? curValue : rest.data?.size ?? DefaultSize;
 
 export class AvatarPlugin extends BasePlugin {
+  static id = 'AvatarPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'avatar';

--- a/packages/amis-editor/src/plugin/Breadcrumb.tsx
+++ b/packages/amis-editor/src/plugin/Breadcrumb.tsx
@@ -6,6 +6,7 @@ import {BaseEventContext, BasePlugin} from 'amis-editor-core';
 import {getSchemaTpl} from 'amis-editor-core';
 
 export class BreadcrumbPlugin extends BasePlugin {
+  static id = 'BreadcrumbPlugin';
   // 关联渲染器名字
   rendererName = 'breadcrumb';
   $schema = '/schemas/BreadcrumbSchema.json';

--- a/packages/amis-editor/src/plugin/Button.tsx
+++ b/packages/amis-editor/src/plugin/Button.tsx
@@ -15,6 +15,7 @@ import type {SchemaObject} from 'amis';
 import {getOldActionSchema} from '../renderer/event-control/helper';
 
 export class ButtonPlugin extends BasePlugin {
+  static id = 'ButtonPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'button';

--- a/packages/amis-editor/src/plugin/ButtonGroup.tsx
+++ b/packages/amis-editor/src/plugin/ButtonGroup.tsx
@@ -11,6 +11,7 @@ import {
 import {BUTTON_DEFAULT_ACTION} from '../component/BaseControl';
 
 export class ButtonGroupPlugin extends BasePlugin {
+  static id = 'ButtonGroupPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'button-group';

--- a/packages/amis-editor/src/plugin/CRUD.tsx
+++ b/packages/amis-editor/src/plugin/CRUD.tsx
@@ -56,6 +56,7 @@ const viewTypeToEditType = (type: string) => {
 };
 
 export class CRUDPlugin extends BasePlugin {
+  static id = 'CRUDPlugin';
   // 关联渲染器名字
   rendererName = 'crud';
   $schema = '/schemas/CRUDSchema.json';

--- a/packages/amis-editor/src/plugin/CRUD2.tsx
+++ b/packages/amis-editor/src/plugin/CRUD2.tsx
@@ -477,6 +477,7 @@ const DataOperators: Array<FeatOption> = [
 ];
 
 export class CRUDPlugin extends BasePlugin {
+  static id = 'CRUD2Plugin';
   constructor(manager: EditorManager) {
     super(manager);
     this.dsBuilderMgr = new DSBuilderManager('crud2', 'api');

--- a/packages/amis-editor/src/plugin/Card.tsx
+++ b/packages/amis-editor/src/plugin/Card.tsx
@@ -18,6 +18,7 @@ import flatten from 'lodash/flatten';
 import {VRenderer} from 'amis-editor-core';
 
 export class CardPlugin extends BasePlugin {
+  static id = 'CardPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'card';

--- a/packages/amis-editor/src/plugin/Card2.tsx
+++ b/packages/amis-editor/src/plugin/Card2.tsx
@@ -9,6 +9,7 @@ import {
 } from 'amis-editor-core';
 
 export class Card2Plugin extends BasePlugin {
+  static id = 'Card2Plugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'card2';

--- a/packages/amis-editor/src/plugin/Cards.tsx
+++ b/packages/amis-editor/src/plugin/Cards.tsx
@@ -19,6 +19,7 @@ import {diff, JSONPipeOut, repeatArray} from 'amis-editor-core';
 import {resolveArrayDatasource} from '../util';
 
 export class CardsPlugin extends BasePlugin {
+  static id = 'CardsPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'cards';

--- a/packages/amis-editor/src/plugin/Carousel.tsx
+++ b/packages/amis-editor/src/plugin/Carousel.tsx
@@ -4,6 +4,7 @@ import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {mockValue} from 'amis-editor-core';
 
 export class CarouselPlugin extends BasePlugin {
+  static id = 'CarouselPlugin';
   // 关联渲染器名字
   rendererName = 'carousel';
   $schema = '/schemas/CarouselSchema.json';

--- a/packages/amis-editor/src/plugin/Chart.tsx
+++ b/packages/amis-editor/src/plugin/Chart.tsx
@@ -70,6 +70,7 @@ const DEFAULT_EVENT_PARAMS = [
 ];
 
 export class ChartPlugin extends BasePlugin {
+  static id = 'ChartPlugin';
   // 关联渲染器名字
   rendererName = 'chart';
   $schema = '/schemas/ChartSchema.json';

--- a/packages/amis-editor/src/plugin/CodeView.tsx
+++ b/packages/amis-editor/src/plugin/CodeView.tsx
@@ -6,6 +6,7 @@ import {BaseEventContext, BasePlugin} from 'amis-editor-core';
 import {getSchemaTpl} from 'amis-editor-core';
 
 export class CodeViewPlugin extends BasePlugin {
+  static id = 'CodeViewPlugin';
   // 关联渲染器名字
   rendererName = 'code';
   $schema = '/schemas/CodeSchema.json';

--- a/packages/amis-editor/src/plugin/Collapse.tsx
+++ b/packages/amis-editor/src/plugin/Collapse.tsx
@@ -3,6 +3,7 @@ import {BasePlugin, RegionConfig, BaseEventContext} from 'amis-editor-core';
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 
 export class CollapsePlugin extends BasePlugin {
+  static id = 'CollapsePlugin';
   // 关联渲染器名字
   rendererName = 'collapse';
   $schema = '/schemas/CollapseSchema.json';

--- a/packages/amis-editor/src/plugin/CollapseGroup.tsx
+++ b/packages/amis-editor/src/plugin/CollapseGroup.tsx
@@ -6,6 +6,7 @@ import {tipedLabel} from 'amis-editor-core';
 import {isObject} from 'amis-editor-core';
 
 export class CollapseGroupPlugin extends BasePlugin {
+  static id = 'CollapseGroupPlugin';
   // 关联渲染器名字
   rendererName = 'collapse-group';
   $schema = '/schemas/CollapseGroupSchema.json';

--- a/packages/amis-editor/src/plugin/ColumnToggler.tsx
+++ b/packages/amis-editor/src/plugin/ColumnToggler.tsx
@@ -9,6 +9,7 @@ import {
 } from 'amis-editor-core';
 
 export class ColumnToggler extends BasePlugin {
+  static id = 'ColumnToggler';
   // 关联渲染器名字
   rendererName = 'column-toggler';
   $schema = '/schemas/ColumnToggler.json';

--- a/packages/amis-editor/src/plugin/Container.tsx
+++ b/packages/amis-editor/src/plugin/Container.tsx
@@ -11,6 +11,7 @@ import {
 } from 'amis-editor-core';
 
 export class ContainerPlugin extends LayoutBasePlugin {
+  static id = 'ContainerPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'container';

--- a/packages/amis-editor/src/plugin/Custom.tsx
+++ b/packages/amis-editor/src/plugin/Custom.tsx
@@ -12,6 +12,7 @@ import {
 import {getSchemaTpl} from 'amis-editor-core';
 
 export class CustomPlugin extends BasePlugin {
+  static id = 'CustomPlugin';
   // 关联渲染器名字
   rendererName = 'custom';
   $schema = '/schemas/CustomSchema.json';

--- a/packages/amis-editor/src/plugin/CustomRegion.tsx
+++ b/packages/amis-editor/src/plugin/CustomRegion.tsx
@@ -15,6 +15,7 @@ import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import isArray from 'lodash/isArray';
 
 export class CustomPlugin extends BasePlugin {
+  static id = 'CustomRegionPlugin';
   // 关联渲染器名字
   rendererName = 'custom';
   $schema = '/schemas/CustomSchema.json';

--- a/packages/amis-editor/src/plugin/Date.tsx
+++ b/packages/amis-editor/src/plugin/Date.tsx
@@ -31,6 +31,7 @@ const valueDateFormatOptions = [
   }
 ];
 export class DatePlugin extends BasePlugin {
+  static id = 'DatePlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'date';

--- a/packages/amis-editor/src/plugin/Datetime.tsx
+++ b/packages/amis-editor/src/plugin/Datetime.tsx
@@ -32,6 +32,7 @@ const valueDateFormatOptions = [
   }
 ];
 export class DatetimePlugin extends DatePlugin {
+  static id = 'DatetimePlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'datetime';

--- a/packages/amis-editor/src/plugin/Dialog.tsx
+++ b/packages/amis-editor/src/plugin/Dialog.tsx
@@ -13,6 +13,7 @@ import {
 import {getEventControlConfig} from '../renderer/event-control/helper';
 
 export class DialogPlugin extends BasePlugin {
+  static id = 'DialogPlugin';
   // 关联渲染器名字
   rendererName = 'dialog';
   $schema = '/schemas/DialogSchema.json';

--- a/packages/amis-editor/src/plugin/Divider.tsx
+++ b/packages/amis-editor/src/plugin/Divider.tsx
@@ -3,6 +3,7 @@ import {BasePlugin} from 'amis-editor-core';
 import {getSchemaTpl} from 'amis-editor-core';
 
 export class DividerPlugin extends BasePlugin {
+  static id = 'DividerPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'divider';

--- a/packages/amis-editor/src/plugin/Drawer.tsx
+++ b/packages/amis-editor/src/plugin/Drawer.tsx
@@ -13,6 +13,7 @@ import {InlineModal} from './Dialog';
 import {tipedLabel} from 'amis-editor-core';
 
 export class DrawerPlugin extends BasePlugin {
+  static id = 'DrawerPlugin';
   // 关联渲染器名字
   rendererName = 'drawer';
   $schema = '/schemas/DrawerSchema.json';

--- a/packages/amis-editor/src/plugin/DropDownButton.tsx
+++ b/packages/amis-editor/src/plugin/DropDownButton.tsx
@@ -14,6 +14,7 @@ import {
 } from 'amis-editor-core';
 import {BUTTON_DEFAULT_ACTION} from '../component/BaseControl';
 export class DropDownButtonPlugin extends BasePlugin {
+  static id = 'DropDownButtonPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'dropdown-button';

--- a/packages/amis-editor/src/plugin/Each.tsx
+++ b/packages/amis-editor/src/plugin/Each.tsx
@@ -12,6 +12,7 @@ import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {diff, JSONPipeOut} from 'amis-editor-core';
 
 export class EachPlugin extends BasePlugin {
+  static id = 'EachPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'each';

--- a/packages/amis-editor/src/plugin/Flex.tsx
+++ b/packages/amis-editor/src/plugin/Flex.tsx
@@ -5,6 +5,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {FlexPluginBase} from './Layout/FlexPluginBase';
 
 export class FlexPlugin extends FlexPluginBase {
+  static id = 'FlexPlugin';
   static scene = ['layout'];
   name = 'Flex 布局';
   pluginIcon = 'flex-container-plugin';

--- a/packages/amis-editor/src/plugin/Form/ButtonGroupSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/ButtonGroupSelect.tsx
@@ -10,6 +10,7 @@ import {getSchemaTpl, defaultValue} from 'amis-editor-core';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 
 export class ButtonGroupControlPlugin extends BasePlugin {
+  static id = 'ButtonGroupControlPlugin';
   // 关联渲染器名字
   rendererName = 'button-group-select';
   $schema = '/schemas/ButtonGroupControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/ButtonToolbar.tsx
+++ b/packages/amis-editor/src/plugin/Form/ButtonToolbar.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../component/BaseControl';
 
 export class ButtonToolbarControlPlugin extends BasePlugin {
+  static id = 'ButtonToolbarControlPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'button-toolbar';

--- a/packages/amis-editor/src/plugin/Form/ChainedSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/ChainedSelect.tsx
@@ -15,6 +15,7 @@ import {ValidatorTag} from '../../validator';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 
 export class ChainedSelectControlPlugin extends BasePlugin {
+  static id = 'ChainedSelectControlPlugin';
   // 关联渲染器名字
   rendererName = 'chained-select';
   $schema = '/schemas/ChainedSelectControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/Checkbox.tsx
+++ b/packages/amis-editor/src/plugin/Form/Checkbox.tsx
@@ -23,6 +23,7 @@ setSchemaTpl('option', {
   label: tipedLabel('说明', '选项说明')
 });
 export class CheckboxControlPlugin extends BasePlugin {
+  static id = 'CheckboxControlPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'checkbox';

--- a/packages/amis-editor/src/plugin/Form/Checkboxes.tsx
+++ b/packages/amis-editor/src/plugin/Form/Checkboxes.tsx
@@ -18,6 +18,7 @@ import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 
 export class CheckboxesControlPlugin extends BasePlugin {
+  static id = 'CheckboxesControlPlugin';
   // 关联渲染器名字
   rendererName = 'checkboxes';
   $schema = '/schemas/CheckboxesControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/CodeEditor.tsx
+++ b/packages/amis-editor/src/plugin/Form/CodeEditor.tsx
@@ -9,6 +9,7 @@ import {RendererPluginEvent, RendererPluginAction} from 'amis-editor-core';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 
 export class CodeEditorControlPlugin extends BasePlugin {
+  static id = 'CodeEditorControlPlugin';
   // 关联渲染器名字
   rendererName = 'editor';
   $schema = '/schemas/EditorControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/Combo.tsx
+++ b/packages/amis-editor/src/plugin/Form/Combo.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../renderer/event-control/helper';
 
 export class ComboControlPlugin extends BasePlugin {
+  static id = 'ComboControlPlugin';
   // 关联渲染器名字
   rendererName = 'combo';
   $schema = '/schemas/ComboControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/ConditionBuilder.tsx
+++ b/packages/amis-editor/src/plugin/Form/ConditionBuilder.tsx
@@ -16,6 +16,7 @@ import defaultConfig, {
 } from 'amis-ui/lib/components/condition-builder/config';
 
 export class ConditionBilderPlugin extends BasePlugin {
+  static id = 'ConditionBilderPlugin';
   // 关联渲染器名字
   rendererName = 'condition-builder';
   $schema = '/schemas/ConditionBuilderControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/Control.tsx
+++ b/packages/amis-editor/src/plugin/Form/Control.tsx
@@ -6,6 +6,7 @@ import {BasePlugin, RegionConfig, BaseEventContext} from 'amis-editor-core';
 import {formItemControl} from '../../component/BaseControl';
 
 export class ControlPlugin extends BasePlugin {
+  static id = 'ControlPlugin';
   // 关联渲染器名字
   rendererName = 'control';
   $schema = '/schemas/FormControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/DiffEditor.tsx
+++ b/packages/amis-editor/src/plugin/Form/DiffEditor.tsx
@@ -14,6 +14,7 @@ import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {RendererPluginEvent, RendererPluginAction} from 'amis-editor-core';
 
 export class DiffEditorControlPlugin extends BasePlugin {
+  static id = 'DiffEditorControlPlugin';
   // 关联渲染器名字
   rendererName = 'diff-editor';
   $schema = '/schemas/DiffEditorControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/FieldSet.tsx
+++ b/packages/amis-editor/src/plugin/Form/FieldSet.tsx
@@ -5,6 +5,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {BaseEventContext, BasePlugin, RegionConfig} from 'amis-editor-core';
 
 export class FieldSetControlPlugin extends BasePlugin {
+  static id = 'FieldSetControlPlugin';
   // 关联渲染器名字
   rendererName = 'fieldset';
   $schema = '/schemas/FieldSetControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/Form.tsx
+++ b/packages/amis-editor/src/plugin/Form/Form.tsx
@@ -124,6 +124,7 @@ const autoAddOptions = (values: any) => {
 };
 
 export class FormPlugin extends BasePlugin {
+  static id = 'FormPlugin';
   // 关联渲染器名字
   rendererName = 'form';
   $schema = '/schemas/FormSchema.json';

--- a/packages/amis-editor/src/plugin/Form/Formula.tsx
+++ b/packages/amis-editor/src/plugin/Form/Formula.tsx
@@ -3,6 +3,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {BasePlugin} from 'amis-editor-core';
 
 export class FormulaControlPlugin extends BasePlugin {
+  static id = 'FormulaControlPlugin';
   // 关联渲染器名字
   rendererName = 'formula';
   $schema = '/schemas/FormulaControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/Group.tsx
+++ b/packages/amis-editor/src/plugin/Form/Group.tsx
@@ -11,6 +11,7 @@ import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {JSONPipeIn, JSONUpdate, makeHorizontalDeeper} from 'amis-editor-core';
 
 export class GroupControlPlugin extends BasePlugin {
+  static id = 'GroupControlPlugin';
   // 关联渲染器名字
   rendererName = 'group';
   $schema = '/schemas/GroupControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/Hidden.tsx
+++ b/packages/amis-editor/src/plugin/Form/Hidden.tsx
@@ -3,6 +3,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {BasePlugin, getSchemaTpl} from 'amis-editor-core';
 
 export class HiddenControlPlugin extends BasePlugin {
+  static id = 'HiddenControlPlugin';
   // 关联渲染器名字
   rendererName = 'hidden';
   $schema = '/schemas/HiddenControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputArray.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputArray.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 import {diff, JSONPipeOut} from 'amis-editor-core';
 
 export class ArrayControlPlugin extends BasePlugin {
+  static id = 'ArrayControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-array';
   $schema = '/schemas/ArrayControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputCity.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputCity.tsx
@@ -15,6 +15,7 @@ import {ValidatorTag} from '../../validator';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 
 export class CityControlPlugin extends BasePlugin {
+  static id = 'CityControlPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'input-city';

--- a/packages/amis-editor/src/plugin/Form/InputColor.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputColor.tsx
@@ -55,6 +55,7 @@ const presetColorsByFormat = colorFormat.reduce<{
   return res;
 }, {});
 export class ColorControlPlugin extends BasePlugin {
+  static id = 'ColorControlPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'input-color';

--- a/packages/amis-editor/src/plugin/Form/InputDate.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputDate.tsx
@@ -140,6 +140,7 @@ const dateTooltip =
   '支持例如: <code>now、+3days、-2weeks、+1hour、+2years</code> 等（minute|min|hour|day|week|month|year|weekday|second|millisecond）这种相对值用法';
 
 export class DateControlPlugin extends BasePlugin {
+  static id = 'DateControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-date';
   $schema = '/schemas/DateControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputDateRange.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputDateRange.tsx
@@ -180,6 +180,7 @@ const sizeImmutableComponents = Object.values(DateType)
   .filter(a => a);
 
 export class DateRangeControlPlugin extends BasePlugin {
+  static id = 'DateRangeControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-date-range';
   $schema = '/schemas/DateRangeControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputDateTime.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputDateTime.tsx
@@ -3,6 +3,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {DateControlPlugin} from './InputDate';
 
 export class DateTimeControlPlugin extends DateControlPlugin {
+  static id = 'DateTimeControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-datetime';
   $schema = '/schemas/DateTimeControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputDateTimeRange.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputDateTimeRange.tsx
@@ -3,6 +3,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {DateRangeControlPlugin} from './InputDateRange';
 
 export class DateTimeRangeControlPlugin extends DateRangeControlPlugin {
+  static id = 'DateTimeRangeControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-datetime-range';
   $schema = '/schemas/DateTimeRangeControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputEmail.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputEmail.tsx
@@ -2,6 +2,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {TextControlPlugin} from './InputText';
 
 export class EmailControlPlugin extends TextControlPlugin {
+  static id = 'EmailControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-email';
   $schema = '/schemas/TextControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputExcel.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputExcel.tsx
@@ -14,6 +14,7 @@ import {formItemControl} from '../../component/BaseControl';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 
 export class ExcelControlPlugin extends BasePlugin {
+  static id = 'ExcelControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-excel';
   $schema = '/schemas/ExcelControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputFile.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputFile.tsx
@@ -6,6 +6,7 @@ import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 
 export class FileControlPlugin extends BasePlugin {
+  static id = 'FileControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-file';
   $schema = '/schemas/FileControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputGroup.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputGroup.tsx
@@ -10,6 +10,7 @@ import {
 import {ValidatorTag} from '../../validator';
 
 export class InputGroupControlPlugin extends BasePlugin {
+  static id = 'InputGroupControlPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'input-group';

--- a/packages/amis-editor/src/plugin/Form/InputImage.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputImage.tsx
@@ -48,6 +48,7 @@ const inputStateFunc = (visibleOn: string, state: string) => {
 };
 
 export class ImageControlPlugin extends BasePlugin {
+  static id = 'ImageControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-image';
   $schema = '/schemas/ImageControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputKV.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputKV.tsx
@@ -12,6 +12,7 @@ import {
 } from 'amis-editor-core';
 
 export class KVControlPlugin extends BasePlugin {
+  static id = 'KVControlPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'input-kv';

--- a/packages/amis-editor/src/plugin/Form/InputMonth.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputMonth.tsx
@@ -3,6 +3,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {DateControlPlugin} from './InputDate';
 
 export class MonthControlPlugin extends DateControlPlugin {
+  static id = 'MonthControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-month';
   $schema = '/schemas/MonthControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputMonthRange.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputMonthRange.tsx
@@ -3,6 +3,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {DateRangeControlPlugin} from './InputDateRange';
 
 export class MonthRangeControlPlugin extends DateRangeControlPlugin {
+  static id = 'MonthRangeControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-month-range';
   $schema = '/schemas/MonthRangeControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputNumber.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputNumber.tsx
@@ -20,6 +20,7 @@ import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {inputStateTpl} from '../../renderer/style-control/helper';
 
 export class NumberControlPlugin extends BasePlugin {
+  static id = 'NumberControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-number';
   $schema = '/schemas/NumberControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputPassword.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputPassword.tsx
@@ -2,6 +2,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {TextControlPlugin} from './InputText';
 
 export class PasswordControlPlugin extends TextControlPlugin {
+  static id = 'PasswordControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-password';
   $schema = '/schemas/TextControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputQuarter.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputQuarter.tsx
@@ -3,6 +3,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {DateControlPlugin} from './InputDate';
 
 export class InputQuarterPlugin extends DateControlPlugin {
+  static id = 'InputQuarterPlugin';
   // 关联渲染器名字
   rendererName = 'input-quarter';
   $schema = '/schemas/QuarterControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputQuarterRange.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputQuarterRange.tsx
@@ -3,6 +3,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {DateRangeControlPlugin} from './InputDateRange';
 
 export class QuarterRangePlugin extends DateRangeControlPlugin {
+  static id = 'QuarterRangePlugin';
   // 关联渲染器名字
   rendererName = 'input-quarter-range';
   $schema = '/schemas/MonthRangeControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputRange.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputRange.tsx
@@ -6,6 +6,7 @@ import {ValidatorTag} from '../../validator';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 
 export class RangeControlPlugin extends BasePlugin {
+  static id = 'RangeControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-range';
   $schema = '/schemas/RangeControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputRating.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputRating.tsx
@@ -12,6 +12,7 @@ import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 
 export class RateControlPlugin extends BasePlugin {
+  static id = 'RateControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-rating';
   $schema = '/schemas/RatingControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputRepeat.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputRepeat.tsx
@@ -3,6 +3,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {BasePlugin} from 'amis-editor-core';
 
 export class RepeatControlPlugin extends BasePlugin {
+  static id = 'RepeatControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-repeat';
   $schema = '/schemas/RepeatControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputRichText.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputRichText.tsx
@@ -150,6 +150,7 @@ const froalaOptionsPipeOut = (arr: Array<string>) => {
 };
 
 export class RichTextControlPlugin extends BasePlugin {
+  static id = 'RichTextControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-rich-text';
   $schema = '/schemas/RichTextControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputSubForm.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputSubForm.tsx
@@ -14,6 +14,7 @@ import {
 } from 'amis-editor-core';
 
 export class SubFormControlPlugin extends BasePlugin {
+  static id = 'SubFormControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-sub-form';
   $schema = '/schemas/SubFormControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputTable.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTable.tsx
@@ -28,6 +28,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import {resolveArrayDatasource} from '../../util';
 
 export class TableControlPlugin extends BasePlugin {
+  static id = 'TableControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-table';
   $schema = '/schemas/TableControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputTag.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTag.tsx
@@ -12,6 +12,7 @@ import {formItemControl} from '../../component/BaseControl';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 
 export class TagControlPlugin extends BasePlugin {
+  static id = 'TagControlPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'input-tag';

--- a/packages/amis-editor/src/plugin/Form/InputText.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputText.tsx
@@ -20,6 +20,7 @@ function isTextShow(value: string, name: boolean): boolean {
 }
 
 export class TextControlPlugin extends BasePlugin {
+  static id = 'TextControlPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'input-text';

--- a/packages/amis-editor/src/plugin/Form/InputTime.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTime.tsx
@@ -2,6 +2,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {DateControlPlugin} from './InputDate';
 
 export class TimeControlPlugin extends DateControlPlugin {
+  static id = 'TimeControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-time';
   $schema = '/schemas/TimeControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputTimeRange.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTimeRange.tsx
@@ -3,6 +3,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {DateRangeControlPlugin} from './InputDateRange';
 
 export class TimeRangeControlPlugin extends DateRangeControlPlugin {
+  static id = 'TimeRangeControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-time-range';
   $schema = '/schemas/DateRangeControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputTree.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTree.tsx
@@ -16,6 +16,7 @@ import {tipedLabel} from 'amis-editor-core';
 import {ValidatorTag} from '../../validator';
 
 export class TreeControlPlugin extends BasePlugin {
+  static id = 'TreeControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-tree';
   $schema = '/schemas/TreeControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputURL.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputURL.tsx
@@ -2,6 +2,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {TextControlPlugin} from './InputText';
 
 export class URLControlPlugin extends TextControlPlugin {
+  static id = 'URLControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-url';
   $schema = '/schemas/TextControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputYear.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputYear.tsx
@@ -3,6 +3,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {DateControlPlugin} from './InputDate';
 
 export class YearControlPlugin extends DateControlPlugin {
+  static id = 'YearControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-year';
   $schema = '/schemas/YearControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/InputYearRange.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputYearRange.tsx
@@ -3,6 +3,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {DateRangeControlPlugin} from './InputDateRange';
 
 export class YearRangeControlPlugin extends DateRangeControlPlugin {
+  static id = 'YearRangeControlPlugin';
   // 关联渲染器名字
   rendererName = 'input-year-range';
   $schema = '/schemas/DateRangeControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/Item.tsx
+++ b/packages/amis-editor/src/plugin/Form/Item.tsx
@@ -18,6 +18,7 @@ import {JSONDelete, JSONPipeIn, JSONUpdate} from 'amis-editor-core';
 import {SUPPORT_STATIC_FORMITEM_CMPTS} from '../../renderer/event-control/helper';
 
 export class ItemPlugin extends BasePlugin {
+  static id = 'ItemPlugin';
   // panelTitle = '表单项通配';
   panelTitle = '表单项';
   order = -990;

--- a/packages/amis-editor/src/plugin/Form/ListSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/ListSelect.tsx
@@ -6,6 +6,7 @@ import {formItemControl} from '../../component/BaseControl';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 
 export class ListControlPlugin extends BasePlugin {
+  static id = 'ListControlPlugin';
   // 关联渲染器名字
   rendererName = 'list-select';
   $schema = '/schemas/ListControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/LocationPicker.tsx
+++ b/packages/amis-editor/src/plugin/Form/LocationPicker.tsx
@@ -4,6 +4,7 @@ import {BasePlugin, BaseEventContext} from 'amis-editor-core';
 import {ValidatorTag} from '../../validator';
 
 export class LocationControlPlugin extends BasePlugin {
+  static id = 'LocationControlPlugin';
   // 关联渲染器名字
   rendererName = 'location-picker';
   $schema = '/schemas/LocationControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/MatrixCheckboxes.tsx
+++ b/packages/amis-editor/src/plugin/Form/MatrixCheckboxes.tsx
@@ -13,6 +13,7 @@ import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 
 export class MatrixControlPlugin extends BasePlugin {
+  static id = 'MatrixControlPlugin';
   // 关联渲染器名字
   rendererName = 'matrix-checkboxes';
   $schema = '/schemas/MatrixControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/NestedSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/NestedSelect.tsx
@@ -6,6 +6,7 @@ import {ValidatorTag} from '../../validator';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 
 export class NestedSelectControlPlugin extends BasePlugin {
+  static id = 'NestedSelectControlPlugin';
   // 关联渲染器名字
   rendererName = 'nested-select';
   $schema = '/schemas/NestedSelectControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/Picker.tsx
+++ b/packages/amis-editor/src/plugin/Form/Picker.tsx
@@ -18,6 +18,7 @@ import {diff} from 'amis-editor-core';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 
 export class PickerControlPlugin extends BasePlugin {
+  static id = 'PickerControlPlugin';
   // 关联渲染器名字
   rendererName = 'picker';
   $schema = '/schemas/PickerControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/Radios.tsx
+++ b/packages/amis-editor/src/plugin/Form/Radios.tsx
@@ -7,6 +7,7 @@ import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 
 export class RadiosControlPlugin extends BasePlugin {
+  static id = 'RadiosControlPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'radios';

--- a/packages/amis-editor/src/plugin/Form/Select.tsx
+++ b/packages/amis-editor/src/plugin/Form/Select.tsx
@@ -8,6 +8,7 @@ import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 
 export class SelectControlPlugin extends BasePlugin {
+  static id = 'SelectControlPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'select';

--- a/packages/amis-editor/src/plugin/Form/Static.tsx
+++ b/packages/amis-editor/src/plugin/Form/Static.tsx
@@ -254,6 +254,7 @@ setSchemaTpl('copyable', {
 });
 
 export class StaticControlPlugin extends BasePlugin {
+  static id = 'StaticControlPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'static';

--- a/packages/amis-editor/src/plugin/Form/Switch.tsx
+++ b/packages/amis-editor/src/plugin/Form/Switch.tsx
@@ -6,6 +6,7 @@ import {getEventControlConfig} from '../../renderer/event-control/helper';
 import type {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 
 export class SwitchControlPlugin extends BasePlugin {
+  static id = 'SwitchControlPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'switch';

--- a/packages/amis-editor/src/plugin/Form/TabsTransfer.tsx
+++ b/packages/amis-editor/src/plugin/Form/TabsTransfer.tsx
@@ -7,6 +7,7 @@ import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 
 export class TabsTransferPlugin extends BasePlugin {
+  static id = 'TabsTransferPlugin';
   // 关联渲染器名字
   rendererName = 'tabs-transfer';
   $schema = '/schemas/TransferControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/Textarea.tsx
+++ b/packages/amis-editor/src/plugin/Form/Textarea.tsx
@@ -8,6 +8,7 @@ import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 
 export class TextareaControlPlugin extends BasePlugin {
+  static id = 'TextareaControlPlugin';
   // 关联渲染器名字
   rendererName = 'textarea';
   $schema = '/schemas/TextareaControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/Transfer.tsx
+++ b/packages/amis-editor/src/plugin/Form/Transfer.tsx
@@ -8,6 +8,7 @@ import {ValidatorTag} from '../../validator';
 import {tipedLabel} from 'amis-editor-core';
 
 export class TransferPlugin extends BasePlugin {
+  static id = 'TransferPlugin';
   // 关联渲染器名字
   rendererName = 'transfer';
   $schema = '/schemas/TransferControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/TreeSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/TreeSelect.tsx
@@ -12,6 +12,7 @@ import {ValidatorTag} from '../../validator';
 import {tipedLabel} from 'amis-editor-core';
 
 export class TreeSelectControlPlugin extends BasePlugin {
+  static id = 'TreeSelectControlPlugin';
   // 关联渲染器名字
   rendererName = 'tree-select';
   $schema = '/schemas/TreeSelectControlSchema.json';

--- a/packages/amis-editor/src/plugin/Form/UUID.tsx
+++ b/packages/amis-editor/src/plugin/Form/UUID.tsx
@@ -8,6 +8,7 @@ import {
 } from 'amis-editor-core';
 
 export class UUIDControlPlugin extends BasePlugin {
+  static id = 'UUIDControlPlugin';
   // 关联渲染器名字
   rendererName = 'uuid';
   $schema = '/schemas/UUIDControlSchema.json';

--- a/packages/amis-editor/src/plugin/Grid.tsx
+++ b/packages/amis-editor/src/plugin/Grid.tsx
@@ -20,6 +20,7 @@ import {Icon} from 'amis-editor-core';
 import {JSONChangeInArray, JSONPipeIn, repeatArray} from 'amis-editor-core';
 
 export class GridPlugin extends BasePlugin {
+  static id = 'GridPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'grid';

--- a/packages/amis-editor/src/plugin/HBox.tsx
+++ b/packages/amis-editor/src/plugin/HBox.tsx
@@ -20,6 +20,7 @@ import {JSONChangeInArray, JSONPipeIn, repeatArray} from 'amis-editor-core';
 import {Icon} from 'amis-editor-core';
 
 export class HBoxPlugin extends BasePlugin {
+  static id = 'HBoxPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'hbox';

--- a/packages/amis-editor/src/plugin/IFrame.tsx
+++ b/packages/amis-editor/src/plugin/IFrame.tsx
@@ -9,6 +9,7 @@ import {
 import {defaultValue, getSchemaTpl, valuePipeOut} from 'amis-editor-core';
 
 export class IFramePlugin extends BasePlugin {
+  static id = 'IFramePlugin';
   // 关联渲染器名字
   rendererName = 'iframe';
   $schema = '/schemas/IFrameSchema.json';

--- a/packages/amis-editor/src/plugin/Icon.tsx
+++ b/packages/amis-editor/src/plugin/Icon.tsx
@@ -4,6 +4,7 @@ import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {getEventControlConfig} from '../renderer/event-control';
 
 export class IconPlugin extends BasePlugin {
+  static id = 'IconPlugin';
   // 关联渲染器名字
   rendererName = 'icon';
   $schema = '/schemas/Icon.json';

--- a/packages/amis-editor/src/plugin/Image.tsx
+++ b/packages/amis-editor/src/plugin/Image.tsx
@@ -10,6 +10,7 @@ import {defaultValue, getSchemaTpl, tipedLabel} from 'amis-editor-core';
 import {mockValue} from 'amis-editor-core';
 
 export class ImagePlugin extends BasePlugin {
+  static id = 'ImagePlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'image';

--- a/packages/amis-editor/src/plugin/Images.tsx
+++ b/packages/amis-editor/src/plugin/Images.tsx
@@ -4,6 +4,7 @@ import {defaultValue, getSchemaTpl, tipedLabel} from 'amis-editor-core';
 import {mockValue} from 'amis-editor-core';
 
 export class ImagesPlugin extends BasePlugin {
+  static id = 'ImagesPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'images';

--- a/packages/amis-editor/src/plugin/Json.tsx
+++ b/packages/amis-editor/src/plugin/Json.tsx
@@ -3,6 +3,7 @@ import {BaseEventContext, BasePlugin} from 'amis-editor-core';
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import flatten from 'lodash/flatten';
 export class JsonPlugin extends BasePlugin {
+  static id = 'JsonPlugin';
   // 关联渲染器名字
   rendererName = 'json';
   $schema = '/schemas/JsonSchema.json';

--- a/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
+++ b/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
@@ -45,6 +45,7 @@ const defaultFlexContainerSchema = {
 };
 
 export class FlexPluginBase extends LayoutBasePlugin {
+  static id = 'FlexPluginBase';
   rendererName = 'flex';
   $schema = '/schemas/FlexSchema.json';
   disabledRendererPlugin = false;

--- a/packages/amis-editor/src/plugin/Layout/Layout1_2_v4.tsx
+++ b/packages/amis-editor/src/plugin/Layout/Layout1_2_v4.tsx
@@ -2,6 +2,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {FlexPluginBase} from './FlexPluginBase';
 
 export default class Layout1_2_v4 extends FlexPluginBase {
+  static id = 'Layout1_2_v4';
   static scene = ['layout'];
 
   name = '经典布局';

--- a/packages/amis-editor/src/plugin/Layout/Layout_fixed.tsx
+++ b/packages/amis-editor/src/plugin/Layout/Layout_fixed.tsx
@@ -2,6 +2,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {FlexPluginBase} from './FlexPluginBase';
 
 export default class Layout_fixed extends FlexPluginBase {
+  static id = 'Layout_fixed';
   static scene = ['layout'];
 
   name = '悬浮容器';

--- a/packages/amis-editor/src/plugin/Layout/Layout_free_container.tsx
+++ b/packages/amis-editor/src/plugin/Layout/Layout_free_container.tsx
@@ -3,6 +3,7 @@ import {registerEditorPlugin, getSchemaTpl} from 'amis-editor-core';
 import {ContainerPlugin} from '../Container';
 
 export default class Layout_free_container extends ContainerPlugin {
+  static id = 'Layout_free_container';
   name = '自由容器';
   isBaseComponent = true;
   pluginIcon = 'layout-free-container';

--- a/packages/amis-editor/src/plugin/Layout/Layout_sorption_container.tsx
+++ b/packages/amis-editor/src/plugin/Layout/Layout_sorption_container.tsx
@@ -2,6 +2,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {FlexPluginBase, defaultFlexColumnSchema} from './FlexPluginBase';
 
 export default class Layout_fixed_top extends FlexPluginBase {
+  static id = 'Layout_fixed_top';
   static scene = ['layout'];
 
   name = '吸附容器';

--- a/packages/amis-editor/src/plugin/Link.tsx
+++ b/packages/amis-editor/src/plugin/Link.tsx
@@ -4,6 +4,7 @@ import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {tipedLabel} from 'amis-editor-core';
 
 export class LinkPlugin extends BasePlugin {
+  static id = 'LinkPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'link';

--- a/packages/amis-editor/src/plugin/List.tsx
+++ b/packages/amis-editor/src/plugin/List.tsx
@@ -20,6 +20,7 @@ import {
 } from '../util';
 
 export class ListPlugin extends BasePlugin {
+  static id = 'ListPlugin';
   // 关联渲染器名字
   rendererName = 'list';
   $schema = '/schemas/ListSchema.json';

--- a/packages/amis-editor/src/plugin/ListItem.tsx
+++ b/packages/amis-editor/src/plugin/ListItem.tsx
@@ -15,6 +15,7 @@ import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {VRenderer} from 'amis-editor-core';
 
 export class ListItemPlugin extends BasePlugin {
+  static id = 'ListItemPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'list-item';

--- a/packages/amis-editor/src/plugin/Log.tsx
+++ b/packages/amis-editor/src/plugin/Log.tsx
@@ -6,6 +6,7 @@ import {BaseEventContext, BasePlugin} from 'amis-editor-core';
 import {getSchemaTpl, tipedLabel} from 'amis-editor-core';
 
 export class LogPlugin extends BasePlugin {
+  static id = 'LogPlugin';
   // 关联渲染器名字
   rendererName = 'log';
   $schema = '/schemas/LogSchema.json';

--- a/packages/amis-editor/src/plugin/Mapping.tsx
+++ b/packages/amis-editor/src/plugin/Mapping.tsx
@@ -13,6 +13,7 @@ import {
 import {schemaArrayFormat, schemaToArray} from '../util';
 
 export class MappingPlugin extends BasePlugin {
+  static id = 'MappingPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'mapping';

--- a/packages/amis-editor/src/plugin/Markdown.tsx
+++ b/packages/amis-editor/src/plugin/Markdown.tsx
@@ -3,6 +3,7 @@ import {BaseEventContext, BasePlugin} from 'amis-editor-core';
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 
 export class MarkdownPlugin extends BasePlugin {
+  static id = 'MarkdownPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'markdown';

--- a/packages/amis-editor/src/plugin/Nav.tsx
+++ b/packages/amis-editor/src/plugin/Nav.tsx
@@ -12,6 +12,7 @@ import {
 } from 'amis-editor-core';
 import {getEventControlConfig} from '../renderer/event-control/helper';
 export class NavPlugin extends BasePlugin {
+  static id = 'NavPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'nav';

--- a/packages/amis-editor/src/plugin/OfficeViewer.tsx
+++ b/packages/amis-editor/src/plugin/OfficeViewer.tsx
@@ -3,6 +3,7 @@ import {BaseEventContext, BasePlugin} from 'amis-editor-core';
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 
 export class OfficeViewerPlugin extends BasePlugin {
+  static id = 'OfficeViewerPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'office-viewer';

--- a/packages/amis-editor/src/plugin/Operation.tsx
+++ b/packages/amis-editor/src/plugin/Operation.tsx
@@ -12,6 +12,7 @@ import {
 import {getSchemaTpl} from 'amis-editor-core';
 
 export class OperationPlugin extends BasePlugin {
+  static id = 'OperationPlugin';
   // 关联渲染器名字
   rendererName = 'operation';
   $schema = '/schemas/OperationSchema.json';

--- a/packages/amis-editor/src/plugin/Others/Action.tsx
+++ b/packages/amis-editor/src/plugin/Others/Action.tsx
@@ -13,6 +13,7 @@ import {diff} from 'amis-editor-core';
 import type {SchemaCollection} from 'amis';
 
 export class ActionPlugin extends BasePlugin {
+  static id = 'ActionPlugin';
   panelTitle = '按钮';
   rendererName = 'action';
   name = '行为按钮';

--- a/packages/amis-editor/src/plugin/Others/TableCell.tsx
+++ b/packages/amis-editor/src/plugin/Others/TableCell.tsx
@@ -13,6 +13,7 @@ import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {getVariable} from 'amis-core';
 
 export class TableCellPlugin extends BasePlugin {
+  static id = 'TableCellPlugin';
   panelTitle = '列配置';
   panelIcon = 'fa fa-columns';
   panelBodyCreator = (context: BaseEventContext) => {

--- a/packages/amis-editor/src/plugin/Page.tsx
+++ b/packages/amis-editor/src/plugin/Page.tsx
@@ -13,6 +13,7 @@ import {tipedLabel} from 'amis-editor-core';
 import {jsonToJsonSchema, EditorNodeType} from 'amis-editor-core';
 
 export class PagePlugin extends BasePlugin {
+  static id = 'PagePlugin';
   // 关联渲染器名字
   rendererName = 'page';
   $schema = '/schemas/PageSchema.json';

--- a/packages/amis-editor/src/plugin/Pagination.tsx
+++ b/packages/amis-editor/src/plugin/Pagination.tsx
@@ -12,6 +12,7 @@ import {RendererPluginEvent} from 'amis-editor-core';
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 
 export class PaginationPlugin extends BasePlugin {
+  static id = 'PaginationPlugin';
   // 关联渲染器名字
   rendererName = 'pagination';
   $schema = '/schemas/PaginationSchema.json';

--- a/packages/amis-editor/src/plugin/Panel.tsx
+++ b/packages/amis-editor/src/plugin/Panel.tsx
@@ -14,6 +14,7 @@ import {
 } from 'amis-editor-core';
 
 export class PanelPlugin extends BasePlugin {
+  static id = 'PanelPlugin';
   // 关联渲染器名字
   rendererName = 'panel';
   $schema = '/schemas/panelSchema.json';

--- a/packages/amis-editor/src/plugin/Plain.tsx
+++ b/packages/amis-editor/src/plugin/Plain.tsx
@@ -8,6 +8,7 @@ import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {getEventControlConfig} from '../renderer/event-control/helper';
 
 export class PlainPlugin extends BasePlugin {
+  static id = 'PlainPlugin';
   // 关联渲染器名字
   rendererName = 'plain';
   $schema = '/schemas/PlainSchema.json';

--- a/packages/amis-editor/src/plugin/Progress.tsx
+++ b/packages/amis-editor/src/plugin/Progress.tsx
@@ -6,6 +6,7 @@ import {ValidatorTag} from '../validator';
 import {getEventControlConfig} from '../renderer/event-control/helper';
 
 export class ProgressPlugin extends BasePlugin {
+  static id = 'ProgressPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'progress';

--- a/packages/amis-editor/src/plugin/Property.tsx
+++ b/packages/amis-editor/src/plugin/Property.tsx
@@ -6,6 +6,7 @@ import {BaseEventContext, BasePlugin} from 'amis-editor-core';
 import {getSchemaTpl} from 'amis-editor-core';
 
 export class PropertyPlugin extends BasePlugin {
+  static id = 'PropertyPlugin';
   // 关联渲染器名字
   rendererName = 'property';
   $schema = '/schemas/PropertySchema.json';

--- a/packages/amis-editor/src/plugin/QRCode.tsx
+++ b/packages/amis-editor/src/plugin/QRCode.tsx
@@ -3,6 +3,7 @@ import {BasePlugin} from 'amis-editor-core';
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 
 export class QRCodePlugin extends BasePlugin {
+  static id = 'QRCodePlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'qrcode';

--- a/packages/amis-editor/src/plugin/Reset.tsx
+++ b/packages/amis-editor/src/plugin/Reset.tsx
@@ -2,6 +2,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {ButtonPlugin} from './Button';
 
 export class ResetPlugin extends ButtonPlugin {
+  static id = 'ResetPlugin';
   // 关联渲染器名字
   rendererName = 'reset';
   disabledRendererPlugin = true; // 组件面板不显示

--- a/packages/amis-editor/src/plugin/SearchBox.tsx
+++ b/packages/amis-editor/src/plugin/SearchBox.tsx
@@ -11,6 +11,7 @@ import {getEventControlConfig} from '../renderer/event-control/helper';
 import type {Schema} from 'amis-core';
 
 export class SearchBoxPlugin extends BasePlugin {
+  static id = 'SearchBoxPlugin';
   // 关联渲染器名字
   rendererName = 'search-box';
   $schema = '/schemas/SearchBoxSchema.json';

--- a/packages/amis-editor/src/plugin/Service.tsx
+++ b/packages/amis-editor/src/plugin/Service.tsx
@@ -12,6 +12,7 @@ import {getEventControlConfig} from '../renderer/event-control/helper';
 import type {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 
 export class ServicePlugin extends BasePlugin {
+  static id = 'ServicePlugin';
   // 关联渲染器名字
   rendererName = 'service';
   $schema = '/schemas/ServiceSchema.json';

--- a/packages/amis-editor/src/plugin/Sparkline.tsx
+++ b/packages/amis-editor/src/plugin/Sparkline.tsx
@@ -7,6 +7,7 @@ import {BasePlugin} from 'amis-editor-core';
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 
 export class SparklinePlugin extends BasePlugin {
+  static id = 'SparklinePlugin';
   // 关联渲染器名字
   rendererName = 'sparkline';
   $schema = '/schemas/SparklineSchema.json';

--- a/packages/amis-editor/src/plugin/Status.tsx
+++ b/packages/amis-editor/src/plugin/Status.tsx
@@ -9,6 +9,7 @@ import pick from 'lodash/pick';
 import {getI18nEnabled} from 'amis-editor-core';
 
 export class StatusPlugin extends BasePlugin {
+  static id = 'StatusPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'status';

--- a/packages/amis-editor/src/plugin/Steps.tsx
+++ b/packages/amis-editor/src/plugin/Steps.tsx
@@ -6,6 +6,7 @@ import {BasePlugin} from 'amis-editor-core';
 import {getSchemaTpl} from 'amis-editor-core';
 
 export class StepsPlugin extends BasePlugin {
+  static id = 'StepsPlugin';
   // 关联渲染器名字
   rendererName = 'steps';
   $schema = '/schemas/StepsSchema.json';

--- a/packages/amis-editor/src/plugin/Submit.tsx
+++ b/packages/amis-editor/src/plugin/Submit.tsx
@@ -2,6 +2,7 @@ import {registerEditorPlugin} from 'amis-editor-core';
 import {ButtonPlugin} from './Button';
 
 export class SubmitPlugin extends ButtonPlugin {
+  static id = 'SubmitPlugin';
   // 关联渲染器名字
   rendererName = 'submit';
   disabledRendererPlugin = true; // 组件面板不显示

--- a/packages/amis-editor/src/plugin/Table.tsx
+++ b/packages/amis-editor/src/plugin/Table.tsx
@@ -34,6 +34,7 @@ import {
 } from '../util';
 
 export class TablePlugin extends BasePlugin {
+  static id = 'TablePlugin';
   // 关联渲染器名字
   rendererName = 'table';
   $schema = '/schemas/TableSchema.json';

--- a/packages/amis-editor/src/plugin/Table2.tsx
+++ b/packages/amis-editor/src/plugin/Table2.tsx
@@ -27,6 +27,7 @@ import type {SchemaObject} from 'amis';
 import {resolveArrayDatasource} from '../util';
 
 export class Table2Plugin extends BasePlugin {
+  static id = 'Table2Plugin';
   // 关联渲染器名字
   rendererName = 'table2';
   $schema = '/schemas/TableSchema.json';

--- a/packages/amis-editor/src/plugin/TableCell2.tsx
+++ b/packages/amis-editor/src/plugin/TableCell2.tsx
@@ -21,6 +21,7 @@ import type {SchemaObject} from 'amis';
 import {remarkTpl} from '../component/BaseControl';
 
 export class TableCell2Plugin extends BasePlugin {
+  static id = 'TableCell2Plugin';
   panelTitle = '列配置';
   panelIcon = 'fa fa-columns';
 

--- a/packages/amis-editor/src/plugin/TableView.tsx
+++ b/packages/amis-editor/src/plugin/TableView.tsx
@@ -85,6 +85,7 @@ function getCellRealPosition(table: TableViewSchema) {
 }
 
 export class TableViewPlugin extends BasePlugin {
+  static id = 'TableViewPlugin';
   // 关联渲染器名字
   rendererName = 'table-view';
   $schema = '/schemas/TableViewSchema.json';

--- a/packages/amis-editor/src/plugin/Tabs.tsx
+++ b/packages/amis-editor/src/plugin/Tabs.tsx
@@ -24,6 +24,7 @@ import {
 } from '../renderer/event-control/helper';
 
 export class TabsPlugin extends BasePlugin {
+  static id = 'TabsPlugin';
   // 关联渲染器名字
   rendererName = 'tabs';
   $schema = '/schemas/TabsSchema.json';

--- a/packages/amis-editor/src/plugin/Tag.tsx
+++ b/packages/amis-editor/src/plugin/Tag.tsx
@@ -19,6 +19,7 @@ const presetColors = [
 ];
 
 export class TagPlugin extends BasePlugin {
+  static id = 'TagPlugin';
   // 关联渲染器名字
   rendererName = 'tag';
   $schema = '/schemas/TagSchema.json';

--- a/packages/amis-editor/src/plugin/Tasks.tsx
+++ b/packages/amis-editor/src/plugin/Tasks.tsx
@@ -7,6 +7,7 @@ import {BasePlugin} from 'amis-editor-core';
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 
 export class TasksPlugin extends BasePlugin {
+  static id = 'TasksPlugin';
   // 关联渲染器名字
   rendererName = 'tasks';
   $schema = '/schemas/TasksSchema.json';

--- a/packages/amis-editor/src/plugin/Time.tsx
+++ b/packages/amis-editor/src/plugin/Time.tsx
@@ -33,6 +33,7 @@ const dateFormatOptions = [
   }
 ];
 export class TimePlugin extends DatePlugin {
+  static id = 'TimePlugin';
   // 关联渲染器名字
   rendererName = 'time';
   name = '时间展示';

--- a/packages/amis-editor/src/plugin/Timeline.tsx
+++ b/packages/amis-editor/src/plugin/Timeline.tsx
@@ -5,6 +5,7 @@ import {registerEditorPlugin, getSchemaTpl} from 'amis-editor-core';
 import {BasePlugin, BaseEventContext} from 'amis-editor-core';
 
 export class TimelinePlugin extends BasePlugin {
+  static id = 'TimelinePlugin';
   rendererName = 'timeline';
   $schema = '/schemas/TimelineSchema.json';
   label: '时间轴';

--- a/packages/amis-editor/src/plugin/TooltipWrapper.tsx
+++ b/packages/amis-editor/src/plugin/TooltipWrapper.tsx
@@ -8,6 +8,7 @@ import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {tipedLabel} from 'amis-editor-core';
 
 export class TooltipWrapperPlugin extends BasePlugin {
+  static id = 'TooltipWrapperPlugin';
   static scene = ['layout'];
   rendererName = 'tooltip-wrapper';
   $schema = '/schemas/TooltipWrapperSchema.json';

--- a/packages/amis-editor/src/plugin/Tpl.tsx
+++ b/packages/amis-editor/src/plugin/Tpl.tsx
@@ -105,6 +105,7 @@ setSchemaTpl('tpl:wrapperComponent', {
 });
 
 export class TplPlugin extends BasePlugin {
+  static id = 'TplPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'tpl';

--- a/packages/amis-editor/src/plugin/Video.tsx
+++ b/packages/amis-editor/src/plugin/Video.tsx
@@ -5,6 +5,7 @@ import {JSONPipeOut} from 'amis-editor-core';
 import {mockValue} from 'amis-editor-core';
 
 export class VideoPlugin extends BasePlugin {
+  static id = 'VideoPlugin';
   // 关联渲染器名字
   rendererName = 'video';
   $schema = '/schemas/VideoSchema.json';

--- a/packages/amis-editor/src/plugin/WebComponent.tsx
+++ b/packages/amis-editor/src/plugin/WebComponent.tsx
@@ -21,6 +21,7 @@ try {
 }
 
 export class WebComponentPlugin extends BasePlugin {
+  static id = 'WebComponentPlugin';
   // 关联渲染器名字
   rendererName = 'web-component';
   $schema = '/schemas/WebComponentSchema.json';

--- a/packages/amis-editor/src/plugin/Wizard.tsx
+++ b/packages/amis-editor/src/plugin/Wizard.tsx
@@ -24,6 +24,7 @@ import {
 } from '../renderer/event-control/helper';
 
 export class WizardPlugin extends BasePlugin {
+  static id = 'WizardPlugin';
   // 关联渲染器名字
   rendererName = 'wizard';
   $schema = '/schemas/WizardSchema.json';

--- a/packages/amis-editor/src/plugin/Wrapper.tsx
+++ b/packages/amis-editor/src/plugin/Wrapper.tsx
@@ -7,6 +7,7 @@ import {
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 
 export class WrapperPlugin extends LayoutBasePlugin {
+  static id = 'WrapperPlugin';
   static scene = ['layout'];
   // 关联渲染器名字
   rendererName = 'wrapper';


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b54e64</samp>

This pull request adds a `priority` property to the plugin system of the `EditorManager` class and assigns a unique `id` property to each plugin class. This allows the editor to filter out lower-priority plugins and avoid conflicts. It also fixes some typos and reorders some imports in the `manager.ts` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6b54e64</samp>

> _Sing, O Muse, of the skillful EditorManager_
> _Who devised a cunning system for his plugins_
> _Each one endowed with a unique id and a priority_
> _To compete for glory and honor in the rendering of content_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6b54e64</samp>

*  Add a `priority` property to the plugin classes and the `PluginClass` interface to allow overriding built-in plugins with external plugins with the same id and higher priority ([link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fR75-R76), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-9e800e2e2ff573616dd84d6b5882a989df97448c47e12fc452ff99603382602bR8), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-d1f97c0365bc7a697fc80a9342eb61af3902015cb90f955196782218d389d095R14), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-ff8e197301de6b531c03595ddb05b8b55f26fc6cbd8e4944798a19a1e4995c34R6), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-3293c0a03bcf642d329f5d9c6932643038015236aaf3c48a2689c2a8f255a9ddR16), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-7e7736325393045332f8a98d5e20e74e1228cd8ad9308b6b606cfc9d423b8a43R9), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-da2ca6c6a8ac5b6fcef2f72eb2ab705288b464dc1ddda4122cffd5f2cecf022bR18), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-0fa33553973012822424d6d86a2c6b3e36190f9e892bcdb741cfa239850d7c46R14), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aR59), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-f162c189df375d2178fe291db3819b5020ed44dd8ecf188faf5655cd4687e5b1R480), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-2598ee4f39e11dd487affc85bc26fa0b6a2ddf0a19bc3ffa37b50e48a278d50aR21), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-10e238d33064583da0938c85bdeac9e3ab37df255d77d36b362342d38da4fe4aR12), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-6fcd0de29255b9fa752de9b00697c1212b9edfba358ce635621be27559a030b0R22), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-db2199816e5d1d4f1050533ef5714a1b6ed8c525d8bbb40f65f1ab1a9fb8ebb8R7), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0R73), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-2486cd2f6bc1188d1aec9f002681d15ca53d0c8f86a568fdb4c7eddca3e83fd7R9), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-d12a28691f71413cd3f77032ea5dfdd1a804c5575471d832b0897bf99792e5acR6), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-33cf8f47f6167ca85dcfc70353f5c54cf9b8214d182806a5ae5315524864b4c6R9), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-d6fd425339c04cdb81a8bdbbd9f156de128ef9794df75fcf0b7ea4d96896911aR12), [link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-a8bde19ea54cb5b89af40437705c677c4ed3ed7d653c8821c63841a1a96fd18cR14))
* Modify the `registerEditorPlugin` function in `manager.ts` to handle the priority property and update the `builtInPlugins` array accordingly, adding warnings for failed or conflicting registrations ([link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fL121-R160))
* Filter out the built-in plugins that have lower priority than the external plugins in the constructor of the `EditorManager` class in `manager.ts` ([link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fL200-R264))
* Import some modules from `mobx`, `json-ast-comments`, `lodash` and `amis` in `manager.ts` to use in the `EditorManager` class, grouping the imports by source ([link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fR5-R10))
* Import the `BasePlugin` type from `./plugin` module in `manager.ts` to use as a type annotation for the plugin classes ([link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fL32-R39))
* Rename the variable `isExitPlugin` to `exsitedPluginIdx` in `manager.ts` to fix a typo and make it more descriptive ([link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fL112-R112))
* Reorder and remove some imports from `./util`, `amis`, `json-ast-comments` and `lodash` modules in `manager.ts` to reduce duplication and unused imports, grouping them by type and source ([link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fL50-R67))
* Remove an empty line in `manager.ts` to improve code style and consistency ([link](https://github.com/baidu/amis/pull/7101/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fL39))
