### PR TITLE
fix: api使用JSONQL时无法解析上层变量; chore: 调整api中JSONQL结构

### DIFF
--- a/packages/amis-core/src/utils/api.ts
+++ b/packages/amis-core/src/utils/api.ts
@@ -11,6 +11,7 @@ import {
   qsstringify,
   cloneObject,
   createObject,
+  extendObject,
   qsparse,
   uuid,
   JSONTraverse
@@ -287,15 +288,20 @@ export function buildApi(
     api.method = 'post';
     api.jsonql = dataMapping(
       api.jsonql,
-      {
-        ...api.query,
-        ...data
-      },
+      /** 需要上层数据域的内容 */
+      extendObject(data, {...api.query, ...data}, false),
       undefined,
       false,
       true
     );
-    api.body = api.data = api.jsonql;
+    /** 同时设置了JSONQL和data时走兼容场景 */
+    api.body = api.data =
+      api.data && api.jsonql
+        ? {
+            data: api.data,
+            jsonql: api.jsonql
+          }
+        : api.jsonql;
   }
 
   return api;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0697711</samp>

Enhance JSONQL support and refactor code in `api.ts`. The changes enable more flexible data queries and simplify object merging logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0697711</samp>

> _`buildApi` is the key to unleash the power_
> _JSONQL queries can reach the higher tower_
> _No more limits on the data we can devour_
> _We extend the objects and we never cower_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0697711</samp>

* Import and use `extendObject` function to merge `data` and `api.query` objects in `buildApi` function ([link](https://github.com/baidu/amis/pull/7103/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cR14), [link](https://github.com/baidu/amis/pull/7103/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL290-R298))
* Wrap `api.jsonql` property in an object with key `jsonql` in `buildApi` function to match JSONQL API format ([link](https://github.com/baidu/amis/pull/7103/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL290-R298))
