### PR TITLE
fix: 修复 minLength maxLength 关联上下文变量的及时性问题 Close: #2864

### DIFF
--- a/packages/amis/src/renderers/Form/Combo.tsx
+++ b/packages/amis/src/renderers/Form/Combo.tsx
@@ -412,7 +412,13 @@ export default class ComboControl extends React.Component<ComboProps> {
   componentDidUpdate(prevProps: ComboProps) {
     const props = this.props;
 
-    if (anyChanged(['minLength', 'maxLength', 'value'], prevProps, props)) {
+    if (
+      anyChanged(['minLength', 'maxLength', 'value'], prevProps, props) ||
+      this.resolveVariableProps(prevProps, 'minLength') !==
+        this.resolveVariableProps(props, 'minLength') ||
+      this.resolveVariableProps(prevProps, 'maxLength') !==
+        this.resolveVariableProps(props, 'maxLength')
+    ) {
       const {store, multiple} = props;
       const values = this.getValueAsArray(props);
 
@@ -1768,7 +1774,14 @@ export default class ComboControl extends React.Component<ComboProps> {
 @FormItem({
   type: 'combo',
   storeType: ComboStore.name,
-  extendsData: false
+  extendsData: false,
+  shouldComponentUpdate: (props: any, prevProps: any) =>
+    (isPureVariable(props.maxLength) &&
+      resolveVariableAndFilter(prevProps.maxLength, prevProps.data) !==
+        resolveVariableAndFilter(props.maxLength, props.data)) ||
+    (isPureVariable(props.minLength) &&
+      resolveVariableAndFilter(prevProps.minLength, prevProps.data) !==
+        resolveVariableAndFilter(props.minLength, props.data))
 })
 export class ComboControlRenderer extends ComboControl {
   // 支持更新指定索引的值


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a3a97e9</samp>

This pull request enhances the `Combo` component in `Form` renderers by optimizing its state and rendering logic based on the `minLength` and `maxLength` props. This fixes a bug and improves the performance of the component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a3a97e9</samp>

> _There once was a component called `Combo`_
> _That rendered too much and was slow_
> _But with a clever fix_
> _It checked `minLength` and `maxLength`_
> _And now it updates only when they grow_

### Why

Close: #2864

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a3a97e9</samp>

* Fix a bug where the combo box component would not update its state when the `minLength` or `maxLength` props change due to data changes ([link](https://github.com/baidu/amis/pull/7106/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L415-R421),[link](https://github.com/baidu/amis/pull/7106/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1771-R1784))
