### PR TITLE
feat(amis): chart组件补充内置词云插件

### DIFF
--- a/fis-conf.js
+++ b/fis-conf.js
@@ -227,7 +227,7 @@ fis.match('*.html:jsx', {
 
 // 这些用了 esm
 fis.match(
-  '{echarts/extension/**.js,zrender/**.js,markdown-it-html5-media/**.js,react-hook-form/**.js,qrcode.react/**.js,axios/**.js}',
+  '{echarts/**.js,zrender/**.js,echarts-wordcloud/**.js,markdown-it-html5-media/**.js,react-hook-form/**.js,qrcode.react/**.js,axios/**.js}',
   {
     parser: fis.plugin('typescript', {
       sourceMap: false,
@@ -464,6 +464,7 @@ if (fis.project.currentMedia() === 'publish-sdk') {
         '!zrender/**',
         '!echarts/**',
         '!echarts-stat/**',
+        '!echarts-wordcloud/**',
         '!papaparse/**',
         '!exceljs/**',
         '!xlsx/**',
@@ -533,7 +534,7 @@ if (fis.project.currentMedia() === 'publish-sdk') {
 
       'barcode.js': ['src/components/BarCode.tsx', 'jsbarcode/**'],
 
-      'charts.js': ['zrender/**', 'echarts/**', 'echarts-stat/**'],
+      'charts.js': ['zrender/**', 'echarts/**', 'echarts-stat/**', 'echarts-wordcloud/**'],
 
       'ooxml-viewer.js': ['ooxml-viewer/**', 'fflate/**'],
 
@@ -548,6 +549,7 @@ if (fis.project.currentMedia() === 'publish-sdk') {
         '!amis-ui/lib/components/RichText.js',
         '!zrender/**',
         '!echarts/**',
+        '!echarts-wordcloud/**',
         '!papaparse/**',
         '!exceljs/**',
         '!xlsx/**',
@@ -760,6 +762,7 @@ if (fis.project.currentMedia() === 'publish-sdk') {
         '!zrender/**',
         '!echarts/**',
         '!echarts-stat/**',
+        '!echarts-wordcloud/**',
         '!papaparse/**',
         '!exceljs/**',
         '!xlsx/**',
@@ -835,7 +838,7 @@ if (fis.project.currentMedia() === 'publish-sdk') {
 
       'pkg/cropperjs.js': ['cropperjs/**', 'react-cropper/**'],
 
-      'pkg/charts.js': ['zrender/**', 'echarts/**', 'echarts-stat/**'],
+      'pkg/charts.js': ['zrender/**', 'echarts/**', 'echarts-stat/**', 'echarts-wordcloud/**'],
 
       'pkg/api-mock.js': ['mock/*.ts'],
 
@@ -862,6 +865,7 @@ if (fis.project.currentMedia() === 'publish-sdk') {
         '!amis-ui/lib/components/RichText.tsx',
         '!zrender/**',
         '!echarts/**',
+        '!echarts-wordcloud/**',
         '!papaparse/**',
         '!exceljs/**',
         '!xlsx/**',

--- a/packages/amis/package.json
+++ b/packages/amis/package.json
@@ -44,6 +44,7 @@
     "downshift": "6.1.12",
     "echarts": "5.4.0",
     "echarts-stat": "^1.2.0",
+    "echarts-wordcloud": "^2.1.0",
     "exceljs": "^4.3.0",
     "file-saver": "^2.0.2",
     "hls.js": "1.1.3",

--- a/packages/amis/src/renderers/Chart.tsx
+++ b/packages/amis/src/renderers/Chart.tsx
@@ -344,7 +344,9 @@ export class Chart extends React.Component<ChartProps> {
         // @ts-ignore 官方没提供 type
         import('echarts/extension/dataTool'),
         // @ts-ignore 官方没提供 type
-        import('echarts/extension/bmap/bmap')
+        import('echarts/extension/bmap/bmap'),
+        // @ts-ignore 官方没提供 type
+        import('echarts-wordcloud/dist/echarts-wordcloud')
       ]).then(async ([echarts, ecStat]) => {
         (window as any).echarts = echarts;
         (window as any).ecStat = ecStat?.default || ecStat;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c89ae25</samp>

Added support for word cloud charts in the `amis` framework by importing the `echarts-wordcloud` module as a dependency and adjusting the build and render settings. This allows users to create and display word cloud charts using the `Chart` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c89ae25</samp>

> _We're sailing on the `amis` ship, with charts of every kind_
> _We've added `echarts-wordcloud` to the modules we can find_
> _So heave away, me hearties, heave away with all your might_
> _We'll render word clouds on the screen, and make them look alright_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c89ae25</samp>

*  Add `echarts-wordcloud` module as a dependency for the `amis` package and the chart renderer component ([link](https://github.com/baidu/amis/pull/7113/files?diff=unified&w=0#diff-b49028542a3bb14de6e47e46a9f09f23ffeff3afea2a17d5ddace75726a33e12R47), [link](https://github.com/baidu/amis/pull/7113/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedL230-R230), [link](https://github.com/baidu/amis/pull/7113/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedR467), [link](https://github.com/baidu/amis/pull/7113/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedL536-R537), [link](https://github.com/baidu/amis/pull/7113/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedR552), [link](https://github.com/baidu/amis/pull/7113/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedR765), [link](https://github.com/baidu/amis/pull/7113/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedL838-R841), [link](https://github.com/baidu/amis/pull/7113/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedR868), [link](https://github.com/baidu/amis/pull/7113/files?diff=unified&w=0#diff-b835aa79eebadb985fbc93069bbd1973522b0a1d125adbbe7b2300a154647acdL347-R349))
* Import `echarts-wordcloud` dynamically in the `Chart` class in `packages/amis/src/renderers/Chart.tsx` to enable word cloud charts based on the configuration ([link](https://github.com/baidu/amis/pull/7113/files?diff=unified&w=0#diff-b835aa79eebadb985fbc93069bbd1973522b0a1d125adbbe7b2300a154647acdL347-R349))
* Exclude `echarts-wordcloud` from various plugins that transform or compress JavaScript code to avoid errors or conflicts with the esm syntax ([link](https://github.com/baidu/amis/pull/7113/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedR467), [link](https://github.com/baidu/amis/pull/7113/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedR552), [link](https://github.com/baidu/amis/pull/7113/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedR765), [link](https://github.com/baidu/amis/pull/7113/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedR868))
* Include `echarts-wordcloud` in the `charts.js` and `pkg/charts.js` packs that bundle the chart dependencies for development and production modes respectively ([link](https://github.com/baidu/amis/pull/7113/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedL536-R537), [link](https://github.com/baidu/amis/pull/7113/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedL838-R841))
