### PR TITLE
fix(amis-editor): 编辑器ScaffoldModal切换步骤Form数据丢失问题

### DIFF
--- a/packages/amis-editor-core/src/component/ScaffoldModal.tsx
+++ b/packages/amis-editor-core/src/component/ScaffoldModal.tsx
@@ -138,6 +138,8 @@ export class ScaffoldModal extends React.Component<SubEditorProps> {
     const form = this.amisScope?.getComponents()[0].props.store;
     const step = store.scaffoldFormStep + 1;
     form.setValueByName('__step', step);
+    /** 切换步骤导致schema重新渲染，Form数据域中的数据会丢失 */
+    store.updateScaffoldData(form?.data, true);
 
     // 控制按钮
     store.setScaffoldStep(step);
@@ -150,6 +152,7 @@ export class ScaffoldModal extends React.Component<SubEditorProps> {
     const form = this.amisScope?.getComponents()[0].props.store;
     const step = store.scaffoldFormStep - 1;
     form.setValueByName('__step', step);
+    store.updateScaffoldData(form?.data, true);
 
     // 控制按钮
     store.setScaffoldStep(step);

--- a/packages/amis-editor-core/src/store/editor.ts
+++ b/packages/amis-editor-core/src/store/editor.ts
@@ -1695,6 +1695,20 @@ export const MainStore = types
         self.scaffoldError = msg;
       },
 
+      updateScaffoldData(value: any, replace?: boolean) {
+        if (self.scaffoldForm && value) {
+          self.scaffoldForm = {
+            ...self.scaffoldForm,
+            value: replace
+              ? value
+              : {
+                  ...self.scaffoldForm.value,
+                  ...value
+                }
+          };
+        }
+      },
+
       openPopOverForm(context: PopOverFormContext) {
         self.popOverForm = context;
       },


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 309f63c</samp>

This pull request fixes a bug in the `amis-editor-core` package that caused the scaffold wizard to lose form data. It does this by adding a new method `updateScaffoldData` to the `MainStore` class and calling it from the `ScaffoldModal` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 309f63c</samp>

> _There once was a bug in the wizard_
> _That made the scaffold form data go missing_
> _To fix this issue_
> _They added a new_
> _Method called `updateScaffoldData` in the store_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 309f63c</samp>

*  Add a new method `updateScaffoldData` to the `MainStore` class to update the scaffold form data in the store ([link](https://github.com/baidu/amis/pull/7114/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8R1698-R1711))
*  Call `updateScaffoldData` in the `ScaffoldModal` component to preserve and submit the form data when switching or confirming steps in the scaffold wizard ([link](https://github.com/baidu/amis/pull/7114/files?diff=unified&w=0#diff-85faab9f8c432f5b71f49bdb3e107d8f36edae4199b8cc13dd9b6a2b391b613dR141-R142), [link](https://github.com/baidu/amis/pull/7114/files?diff=unified&w=0#diff-85faab9f8c432f5b71f49bdb3e107d8f36edae4199b8cc13dd9b6a2b391b613dR155))
