### PR TITLE
feat(amis-editor;amis):时间范围组件快捷键自定义支持固定值的配置 + 设计器快捷键配置功能

### DIFF
--- a/packages/amis-editor-core/scss/_mixin.scss
+++ b/packages/amis-editor-core/scss/_mixin.scss
@@ -88,26 +88,9 @@
 }
 
 @mixin panel-sm-content {
-  --Form-fontSize: #{$Editor-right-panel-font-size};
-  --ColorPicker-fontSize: #{$Editor-right-panel-font-size};
-  --fontSizeBase: #{$Editor-right-panel-font-size};
-  --Form-item-fontSize: #{$Editor-right-panel-font-size};
-  --Button--md-fontSize: #{$Editor-right-panel-font-size};
-  --Form-input-fontSize: #{$Editor-right-panel-font-size};
-  --Button-fontSize: #{$Editor-right-panel-font-size};
+  @extend :root;
+  --fonts-size-7: #{$Editor-right-panel-font-size};
   --Form-input-lineHeight: #{$Editor-right-panel-line-height};
   --InputGroup-select-borderColor: #{$Editor-right-panel-border-color};
   --Form-input-borderColor: #{$Editor-right-panel-border-color};
-
-  --checkbox-checkbox-default-fontSize: #{$Editor-right-panel-font-size};
-  --select-base-default-fontSize: #{$Editor-right-panel-font-size};
-  --input-default-default-fontSize: #{$Editor-right-panel-font-size};
-  --button-size-default-fontSize: #{$Editor-right-panel-font-size};
-  --link-fontSize: #{$Editor-right-panel-font-size};
-  --link-onHover-fontSize: #{$Editor-right-panel-font-size};
-  --link-disabled-fontSize: #{$Editor-right-panel-font-size};
-  --link-onClick-fontSize: #{$Editor-right-panel-font-size};
-  --radio-default-default-fontSize: #{$Editor-right-panel-font-size};
-  --select-base-default-option-fontSize: #{$Editor-right-panel-font-size};
-  --DatePicker-fontSize: #{$Editor-right-panel-font-size};
 }

--- a/packages/amis-editor-core/scss/_rightPanel.scss
+++ b/packages/amis-editor-core/scss/_rightPanel.scss
@@ -18,8 +18,6 @@ $tooltip-bottom: '[data-tooltip][data-position=' bottom ']:hover:after';
   transition: width ease-in-out 0.2s;
   // transform: translateZ(0);
 
-  @include panel-sm-content();
-
   .ae-Settings-content {
     padding: var(--gap-base);
     #{$tooltip-bottom} {
@@ -245,6 +243,10 @@ $tooltip-bottom: '[data-tooltip][data-position=' bottom ']:hover:after';
 
       .editor-prop-config-tabs {
         padding-bottom: 45px;
+
+        &-links {
+          --fonts-size-7: 14px;
+        }
       }
 
       .ae-Settings-actions,
@@ -315,7 +317,8 @@ $tooltip-bottom: '[data-tooltip][data-position=' bottom ']:hover:after';
           font-family: PingFangSC-Regular;
           color: #84868c;
           width: 100%;
-          font-size: 14px;
+          --Tabs--line-active-fontSize: 14px;
+          --Tabs--line-fontSize: 14px;
           letter-spacing: 0;
           font-weight: 400;
           text-decoration: none;

--- a/packages/amis-editor-core/scss/control/_dateshortcut-control.scss
+++ b/packages/amis-editor-core/scss/control/_dateshortcut-control.scss
@@ -68,7 +68,8 @@
       @include flexBox();
       width: 100%;
       padding: #{px2rem(5px)} #{px2rem(10px)};
-      height: #{px2rem(38px)};
+      min-height: #{px2rem(38px)};
+      align-items: baseline;
 
       &:hover {
         background: #e9effd;
@@ -93,9 +94,14 @@
 
       &-content {
         display: inline-block;
-        width: 100%;
+        flex-grow: 1;
+        max-width: calc(100% - 32px);
         text-align: left;
         padding: 0 #{px2rem(5px)};
+
+        &-label {
+          line-height: var(--input-size-default-height);
+        }
       }
 
       &-close {

--- a/packages/amis-editor-core/scss/editor.scss
+++ b/packages/amis-editor-core/scss/editor.scss
@@ -1,6 +1,7 @@
 @import '../../../node_modules/amis-ui/scss/functions';
 @import '../../../node_modules/amis-ui/scss/variables';
 @import '../../../node_modules/amis-ui/scss/mixins';
+@import '../../../node_modules/amis-ui/scss/components';
 @import './mixin';
 @import './variables';
 @import './backTop';

--- a/packages/amis-editor/src/plugin/Form/InputDateRange.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputDateRange.tsx
@@ -403,7 +403,7 @@ export class DateRangeControlPlugin extends BasePlugin {
                     type: 'input-date'
                   },
                   placeholder: '请选择静态值',
-                  needDeleteProps: ['minDate'], // 避免自我限制
+                  needDeleteProps: ['minDate', 'ranges', 'shortcuts'], // 避免自我限制
                   label: tipedLabel('最小值', dateTooltip)
                 }),
                 getSchemaTpl('valueFormula', {
@@ -416,7 +416,7 @@ export class DateRangeControlPlugin extends BasePlugin {
                     type: 'input-date'
                   },
                   placeholder: '请选择静态值',
-                  needDeleteProps: ['maxDate'], // 避免自我限制
+                  needDeleteProps: ['maxDate', 'ranges', 'shortcuts'], // 避免自我限制
                   label: tipedLabel('最大值', dateTooltip)
                 }),
 
@@ -450,28 +450,29 @@ export class DateRangeControlPlugin extends BasePlugin {
                 getSchemaTpl('dateShortCutControl', {
                   name: 'shortcuts',
                   mode: 'normal',
-                  normalDropDownOption: {
-                    yesterday: '昨天',
-                    thisweek: '这个周',
-                    prevweek: '上周',
-                    thismonth: '这个月',
-                    prevmonth: '上个月',
-                    thisquarter: '这个季度',
-                    prevquarter: '上个季度',
-                    thisyear: '今年'
-                  },
-                  customDropDownOption: {
-                    daysago: '最近n天',
-                    dayslater: 'n天以内',
-                    weeksago: '最近n周',
-                    weekslater: 'n周以内',
-                    monthsago: '最近n月',
-                    monthslater: 'n月以内',
-                    quartersago: '最近n季度',
-                    quarterslater: 'n季度以内',
-                    yearsago: '最近n年',
-                    yearslater: 'n年以内'
-                  }
+                  certainOptions: [
+                    'today',
+                    'yesterday',
+                    'thisweek',
+                    'prevweek',
+                    'thismonth',
+                    'prevmonth',
+                    'thisquarter',
+                    'prevquarter',
+                    'thisyear'
+                  ],
+                  modifyOptions: [
+                    '$daysago',
+                    '$dayslater',
+                    '$weeksago',
+                    '$weekslater',
+                    '$monthsago',
+                    '$monthslater',
+                    '$quartersago',
+                    '$quarterslater',
+                    '$yearsago',
+                    '$yearslater'
+                  ]
                 }),
                 getSchemaTpl('remark'),
                 getSchemaTpl('labelRemark'),

--- a/packages/amis-ui/src/components/DateRangePicker.tsx
+++ b/packages/amis-ui/src/components/DateRangePicker.tsx
@@ -1112,11 +1112,13 @@ export class DateRangePicker extends React.Component<
                       FormulaExec['formula'](shortcutRaw.startDate, data),
                       format
                     )
+                  : typeof shortcutRaw.startDate === 'string'
+                  ? moment(shortcutRaw.startDate, format)
                   : shortcutRaw.startDate;
 
                 return startDate &&
                   moment.isMoment(startDate) &&
-                  startDate?.isValid()
+                  startDate.isValid()
                   ? startDate
                   : (item as ShortCutDateRange).startDate;
               },
@@ -1126,9 +1128,11 @@ export class DateRangePicker extends React.Component<
                       FormulaExec['formula'](shortcutRaw.endDate, data),
                       format
                     )
-                  : shortcutRaw.startDate;
+                  : typeof shortcutRaw.endDate === 'string'
+                  ? moment(shortcutRaw.endDate, format)
+                  : shortcutRaw.endDate;
 
-                return endDate && moment.isMoment(endDate) && endDate?.isValid()
+                return endDate && moment.isMoment(endDate) && endDate.isValid()
                   ? endDate
                   : (item as ShortCutDateRange).endDate;
               }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee1c6e8</samp>

This pull request improves the style and functionality of the date range picker component and the right panel in the amis-editor-core package. It fixes some bugs related to date validation and shortcut buttons, and enhances the layout, alignment, and responsiveness of the UI elements. It also reduces the code duplication and imports the common style components from the amis-ui package.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ee1c6e8</samp>

> _We're sailing on the code sea, with amis-editor-core_
> _We're fixing bugs and styling up the date range picker more_
> _We're heaving on the `panel-sm-content`, on the count of three_
> _We're importing from the amis-ui, to share the components we need_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ee1c6e8</samp>

*  Simplify the `panel-sm-content` mixin by using the `:root` selector and the `--fonts-size-7` variable ([link](https://github.com/baidu/amis/pull/7118/files?diff=unified&w=0#diff-e19fa9e095a02106d64f76df86a492a0c737849e388f9467e599d805c135e458L91-R95))
*  Remove the redundant `panel-sm-content` mixin from the `.right-panel` selector ([link](https://github.com/baidu/amis/pull/7118/files?diff=unified&w=0#diff-69d1923eb31930c821a1b40db55dc2ee5d56f27a957b81e9a080bed77905a7baL21-L22))
*  Override the `--fonts-size-7` variable for the `.right-panel-content-links` selector to set the font size to 14px ([link](https://github.com/baidu/amis/pull/7118/files?diff=unified&w=0#diff-69d1923eb31930c821a1b40db55dc2ee5d56f27a957b81e9a080bed77905a7baR246-R249))
*  Add the `--Tabs--line-active-fontSize` and `--Tabs--line-fontSize` variables to the `.right-panel-content-tabs` selector to set the font size of the tabs to 14px ([link](https://github.com/baidu/amis/pull/7118/files?diff=unified&w=0#diff-69d1923eb31930c821a1b40db55dc2ee5d56f27a957b81e9a080bed77905a7baL318-R321))
*  Import the style components from the `amis-ui` package in the `editor.scss` file ([link](https://github.com/baidu/amis/pull/7118/files?diff=unified&w=0#diff-a655efcb1bba154f0bdcbcff35544de6ac126ba2ace65f57c008e0d1eb4c1fc9R4))
*  Add the `min-height` and `align-items` properties to the `.cxd-DateRangePicker-shortcut` selector to improve the layout and alignment of the shortcut buttons ([link](https://github.com/baidu/amis/pull/7118/files?diff=unified&w=0#diff-621ff1f8584a3c3973cc44b0f2c1cc3a82607d2056f5ff91ff11e26916e0f6eaL71-R72))
*  Add the `flex-grow` and `max-width` properties to the `.cxd-DateRangePicker-shortcut-content` selector to prevent the content from overflowing or shrinking ([link](https://github.com/baidu/amis/pull/7118/files?diff=unified&w=0#diff-621ff1f8584a3c3973cc44b0f2c1cc3a82607d2056f5ff91ff11e26916e0f6eaL96-R104))
*  Add the `.cxd-DateRangePicker-shortcut-content-label` selector to set the line height of the label to the same as the input height ([link](https://github.com/baidu/amis/pull/7118/files?diff=unified&w=0#diff-621ff1f8584a3c3973cc44b0f2c1cc3a82607d2056f5ff91ff11e26916e0f6eaL96-R104))
*  Add the `ranges` and `shortcuts` properties to the `needDeleteProps` array for the `minDate` and `maxDate` fields in the `DateRangeControlPlugin` class to avoid the self-restriction of the date values ([link](https://github.com/baidu/amis/pull/7118/files?diff=unified&w=0#diff-57750c096cc98f331f2101f229a6afcb6c830bba8f0b5cdcdc0bf130286c6961L406-R406), [link](https://github.com/baidu/amis/pull/7118/files?diff=unified&w=0#diff-57750c096cc98f331f2101f229a6afcb6c830bba8f0b5cdcdc0bf130286c6961L419-R419))
*  Replace the deprecated `normalDropDownOption` and `customDropDownOption` properties with the `certainOptions` and `modifyOptions` properties for the `shortcuts` field in the `DateRangeControlPlugin` class ([link](https://github.com/baidu/amis/pull/7118/files?diff=unified&w=0#diff-57750c096cc98f331f2101f229a6afcb6c830bba8f0b5cdcdc0bf130286c6961L453-R475))
*  Add the `typeof shortcutRaw.startDate === 'string'` and `typeof shortcutRaw.endDate === 'string'` conditions to the `getStartDate` and `getEndDate` functions in the `DateRangePicker` class to check and convert the date properties of the `shortcutRaw` object ([link](https://github.com/baidu/amis/pull/7118/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1115-R1121), [link](https://github.com/baidu/amis/pull/7118/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L1129-R1135))
