### PR TITLE
fix: 参照录入的悬浮窗的取消点击后无法关闭弹窗

### DIFF
--- a/packages/amis-core/src/renderers/Item.tsx
+++ b/packages/amis-core/src/renderers/Item.tsx
@@ -22,6 +22,7 @@ import {
 import {observer} from 'mobx-react';
 import {FormHorizontal, FormSchemaBase} from './Form';
 import {
+  ActionObject,
   BaseApiObject,
   BaseSchemaWithoutType,
   ClassName,
@@ -794,11 +795,12 @@ export class FormItemWrap extends React.Component<FormItemProps> {
               minWidth: this.target ? this.target.offsetWidth : undefined
             }}
             offset={offset}
-            onHide={this.hanldeClose}
+            onHide={this.handleClose}
             overlay
           >
             {render('popOver-auto-fill-form', form, {
-              onSubmit: this.hanldeSubmit
+              onAction: this.handleAction,
+              onSubmit: this.handleSubmit
             })}
           </PopOver>
         </Overlay>
@@ -810,19 +812,25 @@ export class FormItemWrap extends React.Component<FormItemProps> {
 
   // 参照录入popOver提交
   @autobind
-  hanldeSubmit(values: any) {
+  handleSubmit(values: any) {
     const {onBulkChange, autoFill} = this.props;
     if (!autoFill || (autoFill && !autoFill?.hasOwnProperty('api'))) {
       return;
     }
 
     this.updateAutoFillData(values.selectedItems);
-
-    this.hanldeClose();
+    this.handleClose();
   }
 
   @autobind
-  hanldeClose() {
+  handleAction(e: React.UIEvent<any>, action: ActionObject, data: object) {
+    if (action.actionType === 'cancel') {
+      this.handleClose();
+    }
+  }
+
+  @autobind
+  handleClose() {
     this.setState({
       isOpened: false
     });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0bb6590</samp>

Improved the usability of the reference input component by fixing a typo and allowing users to cancel the auto-fill form. Modified `FormItemWrap` in `Item.tsx` to handle the cancel action.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0bb6590</samp>

> _`PopOver` form shows_
> _auto-fill for reference_
> _`handleAction` closes_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0bb6590</samp>

*  Import `ActionObject` type and add `handleAction` method to `FormItemWrap` class to handle cancel action of auto-fill form ([link](https://github.com/baidu/amis/pull/7127/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8R25), [link](https://github.com/baidu/amis/pull/7127/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L820-R833))
*  Rename `hanldeSubmit` method to `handleSubmit` and call `handleClose` method from it to close `PopOver` component after submitting auto-fill form ([link](https://github.com/baidu/amis/pull/7127/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L813-R815), [link](https://github.com/baidu/amis/pull/7127/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L797-R803))
*  Pass `handleAction` method as a prop to form renderer in `PopOver` component and use `handleSubmit` method instead of misspelled `hanldeSubmit` method ([link](https://github.com/baidu/amis/pull/7127/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L797-R803))
