### PR TITLE
fix: inputDateRange 快捷键选择上周时，配置面板报错

### DIFF
--- a/packages/amis-editor/src/plugin/Form/InputDateRange.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputDateRange.tsx
@@ -7,6 +7,7 @@ import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {FormulaDateType} from '../../renderer/FormulaControl';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 import {getRendererByName} from 'amis-core';
+import omit from 'lodash/omit';
 
 const formatX = [
   {
@@ -398,7 +399,7 @@ export class DateRangeControlPlugin extends BasePlugin {
                   header: '表达式或相对值',
                   DateTimeType: FormulaDateType.IsDate,
                   rendererSchema: {
-                    ...context?.schema,
+                    ...omit(context?.schema, ['shortcuts']),
                     value: context?.schema.minDate,
                     type: 'input-date'
                   },
@@ -411,7 +412,7 @@ export class DateRangeControlPlugin extends BasePlugin {
                   header: '表达式或相对值',
                   DateTimeType: FormulaDateType.IsDate,
                   rendererSchema: {
-                    ...context?.schema,
+                    ...omit(context?.schema, ['shortcuts']),
                     value: context?.schema.maxDate,
                     type: 'input-date'
                   },


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e203ed</samp>

Removed `shortcuts` option from date pickers in `InputDateRange` component. This makes the form editor more user-friendly and reliable.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2e203ed</samp>

> _The `InputDateRange` component_
> _Had a `shortcuts` option that meant_
> _You could pick some dates_
> _But sometimes make mistakes_
> _So the pull request got rid of it_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e203ed</samp>

* Import `omit` function from `lodash` to exclude `shortcuts` property from date picker schemas ([link](https://github.com/baidu/amis/pull/7128/files?diff=unified&w=0#diff-57750c096cc98f331f2101f229a6afcb6c830bba8f0b5cdcdc0bf130286c6961R10))
* Modify `rendererSchema` property of `Formula` components for `minDate` and `maxDate` fields to omit `shortcuts` from `context?.schema` ([link](https://github.com/baidu/amis/pull/7128/files?diff=unified&w=0#diff-57750c096cc98f331f2101f229a6afcb6c830bba8f0b5cdcdc0bf130286c6961L401-R402), [link](https://github.com/baidu/amis/pull/7128/files?diff=unified&w=0#diff-57750c096cc98f331f2101f229a6afcb6c830bba8f0b5cdcdc0bf130286c6961L414-R415))
