### PR TITLE
feat: tabs source支持动态hash key 配置

### DIFF
--- a/docs/zh-CN/components/tabs.md
+++ b/docs/zh-CN/components/tabs.md
@@ -530,6 +530,46 @@ order: 68
 }
 ```
 
+内容来源于 source
+
+```schema: scope="body"
+{
+    "type": "page",
+    "data": {
+        "arr": [
+            {
+                "a": "收入",
+                "b": 199,
+                "key": "a"
+            },
+
+            {
+                "a": "支出",
+                "b": 299,
+                "key": "b"
+            }
+        ]
+    },
+    "body": [
+        {
+            "type": "tabs",
+            "activeKey": "b",
+            "source": "${arr}",
+            "tabs": [
+                {
+                    "title": "${a}",
+                    "hash": "${key}",
+                    "body": {
+                        "type": "tpl",
+                        "tpl": "金额：${b|number}元"
+                    }
+                }
+            ]
+        }
+    ]
+}
+```
+
 #### 配置索引值
 
 单个`tab`上不要配置`hash`属性，配置需要展示的`tab`索引值，`0`代表第一个。支持变量，如`"${id}"`

--- a/packages/amis/src/renderers/Tabs.tsx
+++ b/packages/amis/src/renderers/Tabs.tsx
@@ -228,7 +228,7 @@ export interface TabsProps
 }
 
 interface TabSource extends TabSchema {
-  ctx?: any;
+  data?: any;
 }
 
 export interface TabsState {
@@ -312,13 +312,8 @@ export default class Tabs extends React.Component<TabsProps, TabsState> {
     tabs = Array.isArray(tabs) ? tabs : [tabs];
 
     const sourceTabs: Array<TabSource> = [];
-    arr.forEach((value, index) => {
-      const ctx = createObject(
-        data,
-        isObject(value) ? {index, ...value} : {item: value, index}
-      );
-
-      sourceTabs.push(...tabs.map((tab: TabSource) => ({...tab, ctx})));
+    arr.forEach(value => {
+      sourceTabs.push(...tabs.map((tab: TabSource) => ({...tab, data: value})));
     });
 
     return [sourceTabs, true];
@@ -772,14 +767,18 @@ export default class Tabs extends React.Component<TabsProps, TabsState> {
 
     // 是否从 source 数据中生成
     if (isFromSource) {
-      children = tabs.map((tab: TabSource, index: number) =>
-        isVisible(tab, tab.ctx) ? (
+      children = tabs.map((tab: TabSource, index: number) => {
+        const ctx = createObject(
+          data,
+          isObject(tab.data) ? {index, ...tab.data} : {item: tab.data, index}
+        );
+        return isVisible(tab, ctx) ? (
           <Tab
             {...(tab as any)}
-            title={filter(tab.title, tab.ctx)}
-            disabled={disabled || isDisabled(tab, tab.ctx)}
+            title={filter(tab.title, ctx)}
+            disabled={disabled || isDisabled(tab, ctx)}
             key={index}
-            eventKey={index}
+            eventKey={filter(tab.hash, ctx) || index}
             prevKey={index > 0 ? tabs[index - 1]?.hash || index - 1 : 0}
             nextKey={
               index < tabs.length - 1
@@ -803,15 +802,15 @@ export default class Tabs extends React.Component<TabsProps, TabsState> {
               (tab as any)?.type ? (tab as any) : tab.tab || tab.body,
               {
                 disabled: disabled,
-                data: tab.ctx,
+                data: ctx,
                 formMode: tab.mode || subFormMode || formMode,
                 formHorizontal:
                   tab.horizontal || subFormHorizontal || formHorizontal
               }
             )}
           </Tab>
-        ) : null
-      );
+        ) : null;
+      });
     } else {
       children = tabs.map((tab, index) =>
         isVisible(tab, data) ? (


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0ab66d7</samp>

This pull request enhances the `Tabs` component to support dynamic tabs and URL hash navigation. It also updates the documentation with an example of how to use the `hash` property.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0ab66d7</samp>

> _`Tabs` component grows_
> _Dynamic `title` and `hash`_
> _Autumn leaves change color_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0ab66d7</samp>

*  Add an example schema for the `hash` property of the `tabs` component in the documentation ([link](https://github.com/baidu/amis/pull/7129/files?diff=unified&w=0#diff-a3d5076043d377b678e8d6ca12805c7b8e4f0ab3daea536a4c2976c88c7e98b9R533-R572))
*  Enable dynamic generation of `title` and `hash` properties for each tab from the data source using the `filter` function from the `tpl` module in `Tabs.tsx` ([link](https://github.com/baidu/amis/pull/7129/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL321-R327))
*  Use the `hash` property as the `eventKey` prop for the `Tab` component instead of the index to support browser history navigation and consistent identifiers in `Tabs.tsx` ([link](https://github.com/baidu/amis/pull/7129/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL779-R788))
