### PR TITLE
fix:移动端人员选择

### DIFF
--- a/packages/amis-ui/src/components/UserSelect.tsx
+++ b/packages/amis-ui/src/components/UserSelect.tsx
@@ -439,6 +439,16 @@ export class UserSelect extends React.Component<
       options = []
     } = this.props;
     const _selection = this.props.selection?.slice() || [];
+    if (Array.isArray(options?.[0]?.leftOptions)) {
+      eachTree(options?.[0].leftOptions, (item: Option) => {
+        const res = _selection.find(
+          (item2: Option) => item2[valueField] === item[valueField]
+        );
+        if (res) {
+          res.label = item[labelField];
+        }
+      });
+    }
 
     eachTree(options, (item: Option) => {
       const res = _selection.find(


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ddcc7bf</samp>

Fix label bug in `UserSelect` component for tree options. Update the label field of the selected options to match the label field of the options in the tree structure.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ddcc7bf</samp>

> _`UserSelect` fixed_
> _Tree labels now match options_
> _Autumn bug harvest_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ddcc7bf</samp>

* Fix label field of selected options in tree structure ([link](https://github.com/baidu/amis/pull/7138/files?diff=unified&w=0#diff-279dd4e54212ab7951c68d36628027a3db5b28064accb0cd5565aaf778f660d2R442-R451))
