### PR TITLE
styles: 优化combo组件删除按钮提示浮层的位置

### DIFF
--- a/packages/amis-ui/scss/components/form/_combo.scss
+++ b/packages/amis-ui/scss/components/form/_combo.scss
@@ -187,6 +187,7 @@
       white-space: nowrap;
       align-items: flex-start;
       padding-top: var(--Form-label-paddingTop);
+      height: px2rem(30px);
 
       &.is-disabled {
         pointer-events: none;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f394f6</samp>

Adjusted the height of the combo input in `form/_combo.scss` to improve form layout.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4f394f6</samp>

> _`combo input` grows_
> _matching design and form_
> _autumn of alignment_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4f394f6</samp>

*  Adjust the height of the combo input to match the design specifications and improve the alignment ([link](https://github.com/baidu/amis/pull/7144/files?diff=unified&w=0#diff-19cf1d528747f83afd11fea7dc0be10a71d0aeef38126bf1f4431617a6bf7914R190))
