### PR TITLE
styles: 修复input-color组件样式问题

### DIFF
--- a/packages/amis-ui/scss/components/form/_color.scss
+++ b/packages/amis-ui/scss/components/form/_color.scss
@@ -75,6 +75,9 @@
 
   &-clear {
     @include input-clear();
+    svg {
+      top: 0;
+    }
   }
 
   &-arrow {
@@ -94,11 +97,12 @@
       width: 10px;
       height: 10px;
       top: 0;
+      transform: rotate(90deg);
     }
   }
 
   &.is-opened &-arrow > svg {
-    transform: rotate(180deg);
+    transform: rotate(270deg);
   }
 }
 

--- a/packages/amis-ui/src/components/ColorPicker.tsx
+++ b/packages/amis-ui/src/components/ColorPicker.tsx
@@ -302,7 +302,11 @@ export class ColorControl extends React.PureComponent<
         ) : null}
 
         <span className={cx('ColorPicker-arrow')}>
-          <Icon icon="caret" className="icon" onClick={this.handleClick} />
+          <Icon
+            icon="right-arrow-bold"
+            className="icon"
+            onClick={this.handleClick}
+          />
         </span>
 
         {!mobileUI && isOpened ? (


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f35b83</samp>

This pull request improves the color picker UI by changing the arrow icon and adjusting its style. It affects the files `packages/amis-ui/scss/components/form/_color.scss` and `packages/amis-ui/src/components/ColorPicker.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2f35b83</samp>

> _Oh, we're the crew of the color picker_
> _And we work on the UI_
> _We've changed the `caret` to the `right-arrow-bold`_
> _And we think it looks mighty fine_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2f35b83</samp>

* Replace the caret icon with the right-arrow-bold icon in the color picker component to improve the visibility and consistency of the UI (`[link](https://github.com/baidu/amis/pull/7145/files?diff=unified&w=0#diff-5de67cb5c117252507f5b17afb10359feb9b34b0948bf6501a043001600e1923L305-R309)`)
