### PR TITLE
fix:修复动作配置面板切换动作选中失效问题

### DIFF
--- a/packages/amis-core/src/store/form.ts
+++ b/packages/amis-core/src/store/form.ts
@@ -188,8 +188,8 @@ export const FormStore = ServiceStore.named('FormStore')
 
       // 如果数据域中有数据变化，就都reset一下，去掉之前残留的验证消息
       self.items.forEach(item => {
-        const value = item.value;
-        if (typeof value !== 'undefined' && value !== item.tmpValue) {
+        const value = getVariable(values, item.name);
+        if (value !== undefined && value !== item.tmpValue) {
           item.changeTmpValue(value);
         }
         item.reset();


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f016ab5</samp>

Fix action config dialog bug and add debug option in AMIS editor. The bug prevented the form data from reflecting the action type change in `action-config-dialog.tsx`. The debug option allows inspecting the form state and schema in the console.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f016ab5</samp>

> _Sing, O Muse, of the cunning fix that the coder wrought_
> _To mend the action config dialog of the AMIS editor,_
> _Where the form data failed to match the action type that was sought,_
> _And caused confusion and dismay to the user and the mentor._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f016ab5</samp>

* Workaround the issue of `form.setValues` not updating the form data when the action type is changed by using multiple `form.setValueByName` calls instead ([link](https://github.com/baidu/amis/pull/7148/files?diff=unified&w=0#diff-3d7b0c5e5c5515b4c22895cf1ee4f3be874c4fd89fa5b5445bfcf8e55523e919L132-R162))
