### PR TITLE
fix:sdk中popup失效

### DIFF
--- a/packages/amis-ui/scss/components/form/_form.scss
+++ b/packages/amis-ui/scss/components/form/_form.scss
@@ -625,7 +625,6 @@
       flex: 1;
       flex-wrap: wrap;
       font-size: var(--fontSizeLg);
-      overflow-x: hidden;
 
       .#{$ns}ColorPicker {
         height: 100%;

--- a/packages/amis-ui/src/components/ConfirmBox.tsx
+++ b/packages/amis-ui/src/components/ConfirmBox.tsx
@@ -106,6 +106,7 @@ export function ConfirmBox({
         showConfirm
         onConfirm={handleConfirm}
         onHide={onCancel}
+        container={popOverContainer}
       >
         {typeof children === 'function'
           ? children({

--- a/packages/amis-ui/src/components/PickerContainer.tsx
+++ b/packages/amis-ui/src/components/PickerContainer.tsx
@@ -167,7 +167,8 @@ export class PickerContainer extends React.Component<
               setState: this.updateState,
               onClose: this.close,
               onChange: this.handleChange,
-              onConfirm: this.confirm
+              onConfirm: this.confirm,
+              popOverContainer
             })!
           }
         </ConfirmBox>

--- a/packages/amis-ui/src/components/TabsTransferPicker.tsx
+++ b/packages/amis-ui/src/components/TabsTransferPicker.tsx
@@ -15,6 +15,7 @@ export interface TabsTransferPickerProps
   onFocus?: () => void;
   onBlur?: () => void;
   useMobileUI?: boolean;
+  popOverContainer?: any;
 }
 
 export class TransferPicker extends React.Component<TabsTransferPickerProps> {
@@ -47,6 +48,7 @@ export class TransferPicker extends React.Component<TabsTransferPickerProps> {
       size,
       labelField = 'label',
       useMobileUI,
+      popOverContainer,
       ...rest
     } = this.props;
     const mobileUI = useMobileUI && isMobile();
@@ -55,6 +57,7 @@ export class TransferPicker extends React.Component<TabsTransferPickerProps> {
       <PickerContainer
         title={__('Select.placeholder')}
         useMobileUI={useMobileUI}
+        popOverContainer={popOverContainer}
         onFocus={this.onFoucs}
         onClose={this.onBlur}
         bodyRender={({onClose, value, onChange, setState, ...states}) => {

--- a/packages/amis-ui/src/components/TransferPicker.tsx
+++ b/packages/amis-ui/src/components/TransferPicker.tsx
@@ -21,6 +21,7 @@ export interface TransferPickerProps extends Omit<TransferProps, 'itemRender'> {
 
   onBlur?: () => void;
   useMobileUI?: boolean;
+  popOverContainer?: any;
 }
 
 export class TransferPicker extends React.Component<TransferPickerProps> {
@@ -53,6 +54,7 @@ export class TransferPicker extends React.Component<TransferPickerProps> {
       borderMode,
       labelField = 'label',
       useMobileUI,
+      popOverContainer,
       ...rest
     } = this.props;
     const mobileUI = useMobileUI && isMobile();
@@ -63,6 +65,7 @@ export class TransferPicker extends React.Component<TransferPickerProps> {
         onFocus={this.onFoucs}
         onClose={this.onBlur}
         useMobileUI={useMobileUI}
+        popOverContainer={popOverContainer}
         bodyRender={({onClose, value, onChange, setState, ...states}) => {
           return (
             <Transfer

--- a/packages/amis-ui/src/components/formula/Picker.tsx
+++ b/packages/amis-ui/src/components/formula/Picker.tsx
@@ -479,6 +479,7 @@ export class FormulaPicker extends React.Component<
             showConfirm
             onHide={this.close}
             onConfirm={this.handleEditorConfirm}
+            container={popOverContainer}
           >
             <div className={cx('FormulaPicker-popup-inner')}>
               <Editor

--- a/packages/amis-ui/src/components/schema-editor/Common.tsx
+++ b/packages/amis-ui/src/components/schema-editor/Common.tsx
@@ -121,6 +121,7 @@ export class SchemaEditorItemCommon<
             disabled={disabled || typeMutable === false}
             simpleValue
             useMobileUI={useMobileUI}
+            popOverContainer={popOverContainer}
           />
         ) : null}
 

--- a/packages/amis/src/renderers/Form/InputMonthRange.tsx
+++ b/packages/amis/src/renderers/Form/InputMonthRange.tsx
@@ -5,6 +5,7 @@ import {filterDate, parseDuration} from 'amis-core';
 import InputDateRange, {DateRangeControlSchema} from './InputDateRange';
 import {DateRangePicker} from 'amis-ui';
 import {supportStatic} from './StaticHoc';
+import {isMobile} from 'amis-core';
 
 /**
  * MonthRange 月范围控件
@@ -29,16 +30,26 @@ export default class MonthRangeControl extends InputDateRange {
       maxDuration,
       data,
       format,
+      useMobileUI,
       env,
       ...rest
     } = this.props;
+    const mobileUI = useMobileUI && isMobile();
 
     return (
       <div className={cx(`${ns}DateRangeControl`, className)}>
         <DateRangePicker
           viewMode="months"
+          useMobileUI={useMobileUI}
           format={format}
           classPrefix={ns}
+          popOverContainer={
+            mobileUI && env && env.getModalContainer
+              ? env.getModalContainer
+              : mobileUI
+              ? undefined
+              : rest.popOverContainer
+          }
           data={data}
           {...rest}
           minDate={minDate ? filterDate(minDate, data, format) : undefined}

--- a/packages/amis/src/renderers/Form/InputQuarterRange.tsx
+++ b/packages/amis/src/renderers/Form/InputQuarterRange.tsx
@@ -5,6 +5,7 @@ import {filterDate, parseDuration} from 'amis-core';
 import InputDateRange, {DateRangeControlSchema} from './InputDateRange';
 import {DateRangePicker} from 'amis-ui';
 import {supportStatic} from './StaticHoc';
+import {isMobile} from 'amis-core';
 /**
  * QuarterRange 季度范围控件
  * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/input-quarter-range
@@ -28,15 +29,25 @@ export default class QuarterRangeControl extends InputDateRange {
       data,
       format,
       env,
+      useMobileUI,
       ...rest
     } = this.props;
+    const mobileUI = useMobileUI && isMobile();
 
     return (
       <div className={cx(`${ns}DateRangeControl`, className)}>
         <DateRangePicker
           viewMode="quarters"
           format={format}
+          useMobileUI={useMobileUI}
           classPrefix={ns}
+          popOverContainer={
+            mobileUI && env && env.getModalContainer
+              ? env.getModalContainer
+              : mobileUI
+              ? undefined
+              : rest.popOverContainer
+          }
           data={data}
           {...rest}
           minDate={minDate ? filterDate(minDate, data, format) : undefined}

--- a/packages/amis/src/renderers/Form/InputRepeat.tsx
+++ b/packages/amis/src/renderers/Form/InputRepeat.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import cx from 'classnames';
+import {isMobile} from 'amis-core';
 import {FormItem, FormControlProps, FormBaseControl} from 'amis-core';
 
 /**
@@ -75,8 +76,12 @@ export default class RepeatControl extends React.Component<RepeatProps, any> {
       disabled,
       classPrefix: ns,
       useMobileUI,
+      popOverContainer,
+      env,
       translate: __
     } = this.props;
+
+    const mobileUI = useMobileUI && isMobile();
 
     let optionsArray: Array<Option> = [];
 
@@ -218,6 +223,13 @@ export default class RepeatControl extends React.Component<RepeatProps, any> {
             disabled={disabled}
             joinValues={false}
             useMobileUI={useMobileUI}
+            popOverContainer={
+              mobileUI && env && env.getModalContainer
+                ? env.getModalContainer
+                : mobileUI
+                ? undefined
+                : popOverContainer || env.getModalContainer
+            }
           />
         </div>
       </div>

--- a/packages/amis/src/renderers/Form/InputSubForm.tsx
+++ b/packages/amis/src/renderers/Form/InputSubForm.tsx
@@ -565,7 +565,9 @@ export default class SubFormControl extends React.PureComponent<
       className,
       style,
       render,
-      useMobileUI
+      useMobileUI,
+      env,
+      popOverContainer
     } = this.props;
     const dialogData = this.state.dialogData;
     const dialogCtx = this.state.dialogCtx;
@@ -588,6 +590,13 @@ export default class SubFormControl extends React.PureComponent<
             showConfirm
             onConfirm={this.handlePopupConfirm}
             onHide={this.close}
+            container={
+              mobileUI && env && env.getModalContainer
+                ? env.getModalContainer
+                : mobileUI
+                ? undefined
+                : popOverContainer
+            }
           >
             <div className="flex-1 pl-10 pr-10">
               {render('form', this.buildFormSchema(), {

--- a/packages/amis/src/renderers/Form/InputTag.tsx
+++ b/packages/amis/src/renderers/Form/InputTag.tsx
@@ -636,7 +636,13 @@ export default class TagControl extends React.PureComponent<
                 mobileUI ? (
                   <PopUp
                     className={cx(`Tag-popup`)}
-                    container={popOverContainer}
+                    container={
+                      mobileUI && env && env.getModalContainer
+                        ? env.getModalContainer
+                        : mobileUI
+                        ? undefined
+                        : popOverContainer
+                    }
                     isShow={isOpen && !!finnalOptions.length}
                     showConfirm={true}
                     onConfirm={this.onConfirm}

--- a/packages/amis/src/renderers/Form/InputYearRange.tsx
+++ b/packages/amis/src/renderers/Form/InputYearRange.tsx
@@ -5,6 +5,7 @@ import {filterDate, parseDuration} from 'amis-core';
 import InputDateRange, {DateRangeControlSchema} from './InputDateRange';
 import {DateRangePicker} from 'amis-ui';
 import {supportStatic} from './StaticHoc';
+import {isMobile} from 'amis-core';
 
 /**
  * YearRange 年份范围控件
@@ -28,16 +29,26 @@ export default class YearRangeControl extends InputDateRange {
       maxDuration,
       data,
       format,
+      useMobileUI,
       env,
       ...rest
     } = this.props;
+    const mobileUI = useMobileUI && isMobile();
 
     return (
       <div className={cx(`${ns}DateRangeControl`, className)}>
         <DateRangePicker
           viewMode="years"
           format={format}
+          useMobileUI={useMobileUI}
           classPrefix={ns}
+          popOverContainer={
+            mobileUI && env && env.getModalContainer
+              ? env.getModalContainer
+              : mobileUI
+              ? undefined
+              : rest.popOverContainer
+          }
           data={data}
           {...rest}
           minDate={minDate ? filterDate(minDate, data, format) : undefined}

--- a/packages/amis/src/renderers/Form/JSONSchemaEditor.tsx
+++ b/packages/amis/src/renderers/Form/JSONSchemaEditor.tsx
@@ -7,6 +7,7 @@ import {FormBaseControlSchema} from '../../Schema';
 
 import {schemaEditorItemPlaceholder} from 'amis-ui';
 import type {SchemaEditorItemPlaceholder} from 'amis-ui';
+import {isMobile} from 'amis-core';
 
 /**
  * JSON Schema Editor
@@ -139,6 +140,7 @@ export default class JSONSchemaEditorControl extends React.PureComponent<JSONSch
 
   render() {
     const {enableAdvancedSetting, useMobileUI, env, ...rest} = this.props;
+    const mobileUI = useMobileUI && isMobile();
 
     return (
       <JSONSchemaEditor
@@ -147,7 +149,13 @@ export default class JSONSchemaEditorControl extends React.PureComponent<JSONSch
         placeholder={this.normalizePlaceholder()}
         enableAdvancedSetting={enableAdvancedSetting}
         renderModalProps={this.renderModalProps}
-        popOverContainer={env?.getModalContainer}
+        popOverContainer={
+          mobileUI && env && env.getModalContainer
+            ? env.getModalContainer
+            : mobileUI
+            ? undefined
+            : rest.popOverContainer
+        }
       />
     );
   }

--- a/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
@@ -9,6 +9,7 @@ import {Selection as BaseSelection} from 'amis-ui';
 import {ActionObject, toNumber} from 'amis-core';
 import type {ItemRenderStates} from 'amis-ui/lib/components/Selection';
 import {supportStatic} from './StaticHoc';
+import {isMobile} from 'amis-core';
 
 /**
  * TabsTransferPicker 穿梭器的弹框形态
@@ -107,8 +108,11 @@ export class TabsTransferPickerRenderer extends BaseTabsTransferRenderer<TabsTra
       loadingConfig,
       labelField = 'label',
       valueField = 'value',
-      useMobileUI
+      useMobileUI,
+      env,
+      popOverContainer
     } = this.props;
+    const mobileUI = useMobileUI && isMobile();
 
     return (
       <div className={cx('TabsTransferControl', className)}>
@@ -141,6 +145,13 @@ export class TabsTransferPickerRenderer extends BaseTabsTransferRenderer<TabsTra
           labelField={labelField}
           valueField={valueField}
           useMobileUI={useMobileUI}
+          popOverContainer={
+            mobileUI && env && env.getModalContainer
+              ? env.getModalContainer
+              : mobileUI
+              ? undefined
+              : popOverContainer
+          }
         />
 
         <Spinner

--- a/packages/amis/src/renderers/Form/TransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TransferPicker.tsx
@@ -6,6 +6,7 @@ import {TransferPicker} from 'amis-ui';
 import {autobind, createObject} from 'amis-core';
 import {ActionObject, toNumber} from 'amis-core';
 import {supportStatic} from './StaticHoc';
+import {isMobile} from 'amis-core';
 
 /**
  * TransferPicker 穿梭器的弹框形态
@@ -86,8 +87,11 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
       loadingConfig,
       labelField = 'label',
       valueField = 'value',
-      useMobileUI
+      useMobileUI,
+      env,
+      popOverContainer
     } = this.props;
+    const mobileUI = useMobileUI && isMobile();
 
     // 目前 LeftOptions 没有接口可以动态加载
     // 为了方便可以快速实现动态化，让选项的第一个成员携带
@@ -137,6 +141,13 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
           }
           virtualThreshold={virtualThreshold}
           useMobileUI={useMobileUI}
+          popOverContainer={
+            mobileUI && env && env.getModalContainer
+              ? env.getModalContainer
+              : mobileUI
+              ? undefined
+              : popOverContainer || env.getModalContainer
+          }
         />
 
         <Spinner


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d25b11</samp>

This pull request adds the `popOverContainer` prop to various components that use pop-up or dialog elements, such as pickers, editors, and confirm boxes. This prop allows users to customize the element where the pop-up or dialog is rendered, which improves the user experience and compatibility on different devices. This pull request also adds mobile UI support to some components that use date range inputs, and fixes a bug that causes the date range picker to be cut off in some cases. The changes affect the files in the `packages/amis-ui` and `packages/amis` directories.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6d25b11</samp>

> _To render the pickers and pop-ups with ease_
> _We added the `popOverContainer` prop, please_
> _It lets users decide_
> _Where the components reside_
> _And also supports mobile UIs_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6d25b11</samp>

*  Remove the `overflow-x: hidden` style from the `.form-control` class to fix a bug that causes the date range picker to be cut off ([link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-f325489c306f0106cb368664288efa079f007a051f746e29ad32d88cde2abb4dL628))
*  Add the `popOverContainer` prop to various components that render pop-up or dialog components, such as the `ConfirmBox`, the `FormulaPicker`, the `TransferPicker`, the `InputRepeat`, the `InputSubForm`, the `InputTag`, and the `JSONSchemaEditor`, to control where the pop-up or dialog components are rendered ([link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-89c28c278d394e9838591859315788e0d256c58af10e6ac9ed2843aac62ebc78R109), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-a91de98202f6b9b02dd68acc182e85cefc52df9fc5002c2c6ac80593972a4611R482), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-14e6744577b3c83c5a24878bc24189a129266c7c7a8c6fc4b0f4c978e7e30c1aL170-R171), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-a87b5fefcecf03bc281f87d2402169d06880c1a19e4da76de947087a889b7688R18), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-a87b5fefcecf03bc281f87d2402169d06880c1a19e4da76de947087a889b7688R51), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-a87b5fefcecf03bc281f87d2402169d06880c1a19e4da76de947087a889b7688R60), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-a9a06490081b771f1ebb55275e4e4b031629faf71a6626f516c4db2701c2ff36R24), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-a9a06490081b771f1ebb55275e4e4b031629faf71a6626f516c4db2701c2ff36R57), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-a9a06490081b771f1ebb55275e4e4b031629faf71a6626f516c4db2701c2ff36R68), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-c4fb88ff2533dbf3290a81f94e9c2d9fb2416a161668ed31344de88cb9c27ae6L78-R85), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-c4fb88ff2533dbf3290a81f94e9c2d9fb2416a161668ed31344de88cb9c27ae6R226-R232), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-2c4ae5b25ab00009bb38d0723797124a995223ee12f048e29e9724ab2173527aL568-R570), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-2c4ae5b25ab00009bb38d0723797124a995223ee12f048e29e9724ab2173527aR593-R599), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-4103a995836e1ba992d9983ff105ac554d14cd82653af751b39057246d3f5fb7L639-R645), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-e3e1eb09695ed6073771a44c3d3a71379cf7ef71215b4a0a017e9d024cf4f13dL150-R158))
*  Add the `useMobileUI` prop and the `isMobile` import to various components that render date or month range inputs, such as the `InputMonthRange`, the `InputQuarterRange`, and the `InputYearRange`, to detect if the user is using a mobile device and use the mobile UI accordingly ([link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-1a33091eb500b518cc27540c2165d49fe4691c0cfde475e967828db0fad04edeR8), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-1a33091eb500b518cc27540c2165d49fe4691c0cfde475e967828db0fad04edeL32-R37), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-1a33091eb500b518cc27540c2165d49fe4691c0cfde475e967828db0fad04edeL40-R52), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-9760a8be4d8d4152c575c266a8d18f774c8229cebfed1a55ec6f2108c076db77R8), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-9760a8be4d8d4152c575c266a8d18f774c8229cebfed1a55ec6f2108c076db77L31-R35), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-9760a8be4d8d4152c575c266a8d18f774c8229cebfed1a55ec6f2108c076db77L39-R50), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-a292ec2baf39156d0c4d2ef049817db586adf0f933bab9989df0f1dcbab5b349R8), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-a292ec2baf39156d0c4d2ef049817db586adf0f933bab9989df0f1dcbab5b349L31-R36), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-a292ec2baf39156d0c4d2ef049817db586adf0f933bab9989df0f1dcbab5b349L40-R51))
*  Add the `mobileUI` constant to the `JSONSchemaEditor` component to determine if the mobile UI should be used ([link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-e3e1eb09695ed6073771a44c3d3a71379cf7ef71215b4a0a017e9d024cf4f13dR143))
*  Add the `env` prop to various components that render pop-up or dialog components, such as the `InputRepeat`, the `InputSubForm`, the `TabsTransferPicker`, and the `TransferPicker`, to provide the elements or functions to render the pop-up or dialog components ([link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-c4fb88ff2533dbf3290a81f94e9c2d9fb2416a161668ed31344de88cb9c27ae6L78-R85), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-2c4ae5b25ab00009bb38d0723797124a995223ee12f048e29e9724ab2173527aL568-R570), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-b3d9a4cde668e595a9e905f6d4ce38b014991a0a41b16a89c9297934d9ea5334L110-R115), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-b5e07e34c62b71ba2aa268d6e62e8c9c6db92b4f3d71609f840bf806f3a41c15L89-R94))
*  Add the `container` prop to the `renderDialog` function in the `ConfirmBox` component and the `render` function in the `InputSubForm` component to pass the `popOverContainer` prop to the dialog component ([link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-89c28c278d394e9838591859315788e0d256c58af10e6ac9ed2843aac62ebc78R109), [link](https://github.com/baidu/amis/pull/7155/files?diff=unified&w=0#diff-2c4ae5b25ab00009bb38d0723797124a995223ee12f048e29e9724ab2173527aR593-R599))
