### PR TITLE
styles(amis-editor): FeatControl样式优化

### DIFF
--- a/packages/amis-editor-core/scss/control/_feature-control.scss
+++ b/packages/amis-editor-core/scss/control/_feature-control.scss
@@ -60,4 +60,19 @@
       text-align: center;
     }
   }
+
+  &-dragBar {
+    position: absolute;
+    display: none;
+    z-index: 2;
+    top: 50%;
+    transform: translateY(-50%);
+    left: 3px;
+    cursor: pointer;
+  }
+
+  &:hover &-dragBar {
+    display: block;
+    color: #fff;
+  }
 }

--- a/packages/amis-editor-core/scss/control/_go-config.scss
+++ b/packages/amis-editor-core/scss/control/_go-config.scss
@@ -21,8 +21,15 @@
   }
 
   &:hover {
+    border: none;
+
+    &.ae-FeatureControlItem-go {
+      color: transparent;
+    }
+
     .ae-GoConfig-trigger {
       display: block;
+      border-radius: $Editor-borderRadius;
     }
   }
 }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9f5ae1</samp>

This pull request improves the user interface of the feature control panel in the amis-editor-core package. It adds a drag bar to resize the panel and changes the style of the go config button and its modal dialog trigger.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c9f5ae1</samp>

> _`drag bar` and `button`_
> _feature panel gets a makeover_
> _winter of UI_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c9f5ae1</samp>

*  Add a drag bar to resize the feature control panel ([link](https://github.com/baidu/amis/pull/7183/files?diff=unified&w=0#diff-7d96ba24af66823b68008cfff9b0bfd7abcd69630162c2c106c1504a01392023R63-R77))
*  Remove the border and make the icon transparent for the go config button ([link](https://github.com/baidu/amis/pull/7183/files?diff=unified&w=0#diff-6beed12908d9bc11417b693030e1ea8a0f001576a9cddd58fc7eafb1c58214f3L24-R32))
*  Add a border radius to the modal dialog trigger for the go config button ([link](https://github.com/baidu/amis/pull/7183/files?diff=unified&w=0#diff-6beed12908d9bc11417b693030e1ea8a0f001576a9cddd58fc7eafb1c58214f3L24-R32))
