### PR TITLE
feat: input-number 支持根据精度设置展示长度

### DIFF
--- a/packages/amis/src/renderers/Form/InputNumber.tsx
+++ b/packages/amis/src/renderers/Form/InputNumber.tsx
@@ -397,6 +397,15 @@ export default class NumberControl extends React.Component<
       if (kilobitSeparator && value) {
         value = numberFormatter.format(value as number);
       }
+      const valueNum = +value;
+      if (finalPrecision && !isNaN(valueNum)) {
+        return (
+          (prefix ? prefix : '') +
+          valueNum.toFixed(finalPrecision) +
+          (suffix ? suffix : '')
+        );
+      }
+
       return (prefix ? prefix : '') + value + (suffix ? suffix : '');
     };
     // 将数字还原


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at efc8d86</samp>

Improve the input number component by adding a `finalPrecision` prop to format the value with a fixed number of decimal digits. Also preserve the existing `prefix` and `suffix` props of the component. The changes are in `InputNumber.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at efc8d86</samp>

> _`finalPrecision`_
> _cuts the decimals to fit_
> _a winter snowflake_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at efc8d86</samp>

* Format the input number value with a fixed precision if `finalPrecision` prop is specified ([link](https://github.com/baidu/amis/pull/7184/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685R400-R408))
