### PR TITLE
feat: input-number 支持根据精度设置展示长度

### DIFF
--- a/packages/amis/__tests__/renderers/Form/number.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/number.test.tsx
@@ -264,7 +264,7 @@ test('Renderer:number with big value', async () => {
   fireEvent.change(input, {target: {value: '9999999999999999.999'}}); // 整数部分 17 位，会四舍五入
   fireEvent.blur(input);
   await wait(300);
-  expect(input.value).toEqual('10000000000000000');
+  expect(input.value).toEqual('10000000000000000.00');
 
   fireEvent.change(input, {target: {value: '999999999999999999.99'}}); // 整数部分 18 大于最大值
   fireEvent.blur(input);

--- a/packages/amis/src/renderers/Form/InputNumber.tsx
+++ b/packages/amis/src/renderers/Form/InputNumber.tsx
@@ -392,13 +392,17 @@ export default class NumberControl extends React.Component<
     const finalPrecision = this.filterNum(precision);
     const unit = this.state?.unit;
     // 数据格式化
-    const formatter = (value: string | number) => {
-      // 增加千分分隔
-      if (kilobitSeparator && value) {
-        value = numberFormatter.format(value as number);
-      }
-      return (prefix ? prefix : '') + value + (suffix ? suffix : '');
-    };
+    const formatter =
+      kilobitSeparator || prefix || suffix
+        ? (value: string | number) => {
+            // 增加千分分隔
+            if (kilobitSeparator && value) {
+              value = numberFormatter.format(value as number);
+            }
+
+            return (prefix ? prefix : '') + value + (suffix ? suffix : '');
+          }
+        : undefined;
     // 将数字还原
     const parser = (value: string) => {
       if (value) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 547df2b</samp>

Optimize the `formatter` function of the `InputNumber` component in `Form/InputNumber.tsx`. Avoid creating functions when not needed and use the default formatter instead.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 547df2b</samp>

> _`formatter` function_
> _only if needed, else `undefined`_
> _autumn leaves fall fast_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 547df2b</samp>

* Optimize the `formatter` function of the `InputNumber` component by only defining it when `kilobitSeparator`, `prefix` or `suffix` are truthy, otherwise use the default formatter ([link](https://github.com/baidu/amis/pull/7186/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685L395-R405)). This improves the rendering speed and memory usage of the component.
