### PR TITLE
chore: Table2排序属性名称变更order => orderDir

### DIFF
--- a/packages/amis-ui/src/components/table/HeadCellSort.tsx
+++ b/packages/amis-ui/src/components/table/HeadCellSort.tsx
@@ -17,13 +17,13 @@ import {ColumnProps} from './index';
 
 export interface Props extends ThemeProps, LocaleProps {
   column: ColumnProps;
-  onSort?: Function;
+  onSort?: (payload: {orderBy: string; orderDir: string}) => any;
   active?: boolean;
   classnames: ClassNamesFn;
 }
 
 export interface State {
-  order: string; // 升序还是降序
+  orderDir: string; // 升序还是降序
   orderBy: string; // 一次只能按一列排序 当前列的key
 }
 
@@ -32,7 +32,7 @@ export class HeadCellSort extends React.Component<Props, State> {
     super(props);
 
     this.state = {
-      order: '',
+      orderDir: '',
       orderBy: ''
     };
   }
@@ -45,7 +45,7 @@ export class HeadCellSort extends React.Component<Props, State> {
       !props?.active &&
       props.active !== prevProps?.active
     ) {
-      this.setState({orderBy: '', order: ''});
+      this.setState({orderBy: '', orderDir: ''});
     }
   }
 
@@ -58,26 +58,27 @@ export class HeadCellSort extends React.Component<Props, State> {
         onClick={async () => {
           let sortPayload: State = {
             orderBy: '',
-            order: ''
+            orderDir: ''
           };
           if (column.name === this.state.orderBy) {
-            if (this.state.order === 'desc') {
+            if (this.state.orderDir === 'desc') {
               // 降序改为取消
-              sortPayload = {orderBy: '', order: ''};
+              sortPayload = {orderBy: '', orderDir: ''};
             } else {
               // 升序之后降序
-              sortPayload = {orderBy: column.name, order: 'desc'};
+              sortPayload = {orderBy: column.name, orderDir: 'desc'};
             }
           } else {
             // 默认先升序
-            sortPayload = {orderBy: column.name, order: 'asc'};
+            sortPayload = {orderBy: column.name, orderDir: 'asc'};
           }
 
           if (onSort) {
             const prevented = await onSort({
               orderBy: sortPayload.orderBy,
-              order: sortPayload.order
+              orderDir: sortPayload.orderDir
             });
+
             if (prevented) {
               return;
             }
@@ -89,7 +90,7 @@ export class HeadCellSort extends React.Component<Props, State> {
         <i
           className={cx(
             'TableCell-sortBtn--down',
-            active && this.state.order === 'desc' ? 'is-active' : ''
+            active && this.state.orderDir === 'desc' ? 'is-active' : ''
           )}
         >
           <Icon
@@ -101,7 +102,7 @@ export class HeadCellSort extends React.Component<Props, State> {
         <i
           className={cx(
             'TableCell-sortBtn--up',
-            active && this.state.order === 'asc' ? 'is-active' : ''
+            active && this.state.orderDir === 'asc' ? 'is-active' : ''
           )}
         >
           <Icon icon="sort-asc" className="icon" iconContent="table-sort-up" />

--- a/packages/amis-ui/src/components/table/index.tsx
+++ b/packages/amis-ui/src/components/table/index.tsx
@@ -114,7 +114,7 @@ export interface OnRowProps {
 
 export interface SortProps {
   orderBy: string;
-  order: string;
+  orderDir: string;
 }
 
 export interface TableProps extends ThemeProps, LocaleProps, SpinnerExtraProps {

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -413,7 +413,7 @@ export interface Table2Props extends RendererProps, SpinnerExtraProps {
   onSaveOrder?: Function;
   onPristineChange?: Function;
   onAction?: Function;
-  onSort?: Function;
+  onSort?: (payload: {orderBy: string; orderDir: string}) => void;
   onSearch?: Function;
   onRow?: OnRowProps;
   placeholder?: string | SchemaObject;
@@ -1157,7 +1157,7 @@ export default class Table2 extends React.Component<Table2Props, object> {
       'columnSort',
       createObject(data, {
         orderBy: payload.orderBy,
-        orderDir: payload.order
+        orderDir: payload.orderDir
       })
     );
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d209be5</samp>

This pull request refactors the sorting logic and props of the `HeadCellSort` and `Table2` components, and updates the `SortProps` interface accordingly. The main change is to use `orderDir` instead of `order` as the name for the sorting direction, and to make the `onSort` prop more consistent and type safe. This improves the clarity and maintainability of the code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d209be5</samp>

> _To sort tables with ease and precision_
> _We refactored some props and conditions_
> _We used `orderDir`_
> _And made `onSort` clearer_
> _With `orderBy` for better decisions_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d209be5</samp>

*  Rename `order` to `orderDir` in `SortProps` interface and `HeadCellSort` component state to avoid confusion with column order ([link](https://github.com/baidu/amis/pull/7188/files?diff=unified&w=0#diff-4d06f94e19c294bd033371f4ce8159e80b5ff20b39caa0fc70f64e97d6192042L26-R26), [link](https://github.com/baidu/amis/pull/7188/files?diff=unified&w=0#diff-4d06f94e19c294bd033371f4ce8159e80b5ff20b39caa0fc70f64e97d6192042L35-R35), [link](https://github.com/baidu/amis/pull/7188/files?diff=unified&w=0#diff-4d06f94e19c294bd033371f4ce8159e80b5ff20b39caa0fc70f64e97d6192042L48-R48), [link](https://github.com/baidu/amis/pull/7188/files?diff=unified&w=0#diff-4d06f94e19c294bd033371f4ce8159e80b5ff20b39caa0fc70f64e97d6192042L61-R73), [link](https://github.com/baidu/amis/pull/7188/files?diff=unified&w=0#diff-4d06f94e19c294bd033371f4ce8159e80b5ff20b39caa0fc70f64e97d6192042L79-R81), [link](https://github.com/baidu/amis/pull/7188/files?diff=unified&w=0#diff-4d06f94e19c294bd033371f4ce8159e80b5ff20b39caa0fc70f64e97d6192042L92-R93), [link](https://github.com/baidu/amis/pull/7188/files?diff=unified&w=0#diff-4d06f94e19c294bd033371f4ce8159e80b5ff20b39caa0fc70f64e97d6192042L104-R105), [link](https://github.com/baidu/amis/pull/7188/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L117-R117), [link](https://github.com/baidu/amis/pull/7188/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1160-R1160))
*  Change `onSort` prop type of `HeadCellSort` and `Table2` components to expect a payload object with `orderBy` and `orderDir` properties and return any value ([link](https://github.com/baidu/amis/pull/7188/files?diff=unified&w=0#diff-4d06f94e19c294bd033371f4ce8159e80b5ff20b39caa0fc70f64e97d6192042L20-R20), [link](https://github.com/baidu/amis/pull/7188/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L416-R416))
