### PR TITLE
fix: 传图多选，joinValues为false的时候，render死循环问题修复

### DIFF
--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -503,7 +503,12 @@ export default class ImageControl extends React.Component<
   componentDidUpdate(prevProps: ImageProps) {
     const props = this.props;
 
-    if (prevProps.value !== props.value) {
+    if (
+      (props.value && !prevProps.value) ||
+      (props.value &&
+        prevProps.value &&
+        prevProps.value.length != props.value.length)
+    ) {
       const value: string | Array<string | FileValue> | FileValue = props.value;
       const multiple = props.multiple;
       const joinValues = props.joinValues;

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -503,12 +503,7 @@ export default class ImageControl extends React.Component<
   componentDidUpdate(prevProps: ImageProps) {
     const props = this.props;
 
-    if (
-      (props.value && !prevProps.value) ||
-      (props.value &&
-        prevProps.value &&
-        prevProps.value.length != props.value.length)
-    ) {
+    if (prevProps.value !== props.value) {
       const value: string | Array<string | FileValue> | FileValue = props.value;
       const multiple = props.multiple;
       const joinValues = props.joinValues;
@@ -537,7 +532,7 @@ export default class ImageControl extends React.Component<
               obj = {
                 ...org,
                 ...obj,
-                id: org.id || obj.id
+                id: org.id || obj.id || guid()
               };
             }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a146fc</samp>

Fixed a bug in `InputImage` component that prevented the image preview from updating correctly. Improved the logic for checking the value changes in `packages/amis/src/renderers/Form/InputImage.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2a146fc</samp>

> _`value` may vary_
> _preview image follows change_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2a146fc</samp>

* Fix a bug where the image preview would not update when adding or removing images ([link](https://github.com/baidu/amis/pull/7193/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L506-R511))
