### PR TITLE
feat: tabs 配置面板优化

### DIFF
--- a/packages/amis-editor/src/plugin/Tabs.tsx
+++ b/packages/amis-editor/src/plugin/Tabs.tsx
@@ -176,11 +176,24 @@ export class TabsPlugin extends BasePlugin {
 
               {
                 label: tipedLabel(
-                  '默认选项卡',
-                  '默认显示某个选项卡，选项卡配置hash时使用hash，否则使用索引值，支持获取变量，如：<code>tab\\${id}</code>、<code>\\${id}</code>'
+                  '初始选项卡',
+                  '组件初始化时激活的选项卡，优先级高于激活的选项卡，不可响应上下文数据，选项卡配置hash时使用hash，否则使用索引值，支持获取变量，如：<code>tab\\${id}</code>、<code>\\${id}</code>'
+                ),
+                type: 'input-text',
+                name: 'defaultKey',
+                placeholder: '初始默认激活的选项卡',
+                pipeOut: (data: string) =>
+                  data === '' || isNaN(Number(data)) ? data : Number(data)
+              },
+
+              {
+                label: tipedLabel(
+                  '激活的选项卡',
+                  '默认显示某个选项卡，可响应上下文数据，选项卡配置hash时使用hash，否则使用索引值，支持获取变量，如：<code>tab\\${id}</code>、<code>\\${id}</code>'
                 ),
                 type: 'input-text',
                 name: 'activeKey',
+                placeholder: '默认激活的选项卡',
                 pipeOut: (data: string) =>
                   data === '' || isNaN(Number(data)) ? data : Number(data)
               }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e7c63bf</samp>

Add `defaultKey` and rename `activeKey` properties for `TabsPlugin` in `Tabs.tsx`. Improve labels and tooltips for tabs component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e7c63bf</samp>

> _Tabs component grows_
> _`defaultKey` and `激活的选项卡`_
> _Autumn of changes_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e7c63bf</samp>

* Add and rename properties for tabs component to allow specifying initial and default active tabs ([link](https://github.com/baidu/amis/pull/7194/files?diff=unified&w=0#diff-2c32e3cbde81bd6ef4d57f7f53b484aa001df0a3ac5cb64ff4bef2f6858f84a4L179-R196))
* Update labels, tooltips, and placeholders for tabs properties to make them more clear and consistent ([link](https://github.com/baidu/amis/pull/7194/files?diff=unified&w=0#diff-2c32e3cbde81bd6ef4d57f7f53b484aa001df0a3ac5cb64ff4bef2f6858f84a4L179-R196))
