### PR TITLE
feat: crud filter 支持深层数组的清除 Close: #7083

### DIFF
--- a/packages/amis-ui/src/components/ResultBox.tsx
+++ b/packages/amis-ui/src/components/ResultBox.tsx
@@ -251,6 +251,7 @@ export class ResultBox extends React.Component<ResultBoxProps> {
       maxTagCount,
       overflowTagPopover,
       showArrow,
+      popOverContainer,
       ...rest
     } = this.props;
     const isFocused = this.state.isFocused;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ff8051f</samp>

The pull request adds a new utility function `JSONValueMap` to fix a bug with empty arrays in `Form` component, and a new prop `popOverContainer` to `ResultBox` component to allow custom popover containers. The changes aim to improve the functionality and flexibility of the `Combo` and `ResultBox` components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ff8051f</samp>

> _Sing, O Muse, of the skillful code that the developers wrought_
> _To enhance the `ResultBox` with a `popOverContainer` prop_
> _That they might customize the style and position of the popover_
> _And delight the users with the splendid details they discover_

### Why

Close: #7083

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ff8051f</samp>

* Fix a bug in `qsstringify` function where empty arrays in the data object were not cleared by `qs.stringify` ([link](https://github.com/baidu/amis/pull/7202/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1313-R1318))
  * Add `JSONValueMap` function to `helper.ts` that maps each value in a JSON-like object with a custom function and recursively applies it to nested objects and arrays ([link](https://github.com/baidu/amis/pull/7202/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aR1745-R1811))
* Add `popOverContainer` prop to `ResultBox` component to allow specifying a custom container element for the popover that shows the result details ([link](https://github.com/baidu/amis/pull/7202/files?diff=unified&w=0#diff-b2b02397aef9b4b756c750f0b676d6ee9c06c43000e874cd361f0b21d3b730dbR254))
