### PR TITLE
fix: 修复List多选情况下两个全选按钮的问题

### DIFF
--- a/packages/amis/src/renderers/List.tsx
+++ b/packages/amis/src/renderers/List.tsx
@@ -673,6 +673,7 @@ export default class List extends React.Component<ListProps, object> {
     actions = Array.isArray(actions) ? actions.concat() : [];
 
     if (
+      region === 'header' &&
       !~this.renderedToolbars.indexOf('check-all') &&
       (btn = this.renderCheckAll())
     ) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 08f288b</samp>

Add header toolbar customization for list renderer. Check `region` prop in `renderToolbar` function of `List.tsx` to conditionally render the header toolbar.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 08f288b</samp>

> _`region` prop checked_
> _custom header toolbar rendered_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 08f288b</samp>

*  Add a condition to render the header toolbar only if region is 'header' ([link](https://github.com/baidu/amis/pull/7203/files?diff=unified&w=0#diff-6551e087ba390220793c5f644f0d1a67ba14aa330dcd0afab19c252f6f38d37dR676)) in `List.tsx`
