### PR TITLE
feat: action 支持 confirmTitle 来设置 confirmText 的弹窗标题 Close: #7200

### DIFF
--- a/docs/zh-CN/components/action.md
+++ b/docs/zh-CN/components/action.md
@@ -174,7 +174,7 @@ icon 也可以是 url 地址，比如
 
 ## 操作前确认
 
-可以通过配置`confirmText`，实现在任意操作前，弹出提示框确认是否进行该操作。
+可以通过配置`confirmText`，实现在任意操作前，弹出提示框确认是否进行该操作。同时可以通过配置 `confirmTitle` 来设置弹窗标题
 
 ```schema: scope="body"
 {
@@ -182,6 +182,7 @@ icon 也可以是 url 地址，比如
     "type": "button",
     "actionType": "ajax",
     "confirmText": "确认要发出这个请求？",
+    "confirmTitle": "炸弹",
     "api": "/api/mock2/form/saveForm"
 }
 ```
@@ -1029,6 +1030,7 @@ action 还可以使用 `body` 来渲染其他组件，让那些不支持行为�
 | activeClassName    | `string`                             | `is-active` | 给按钮高亮添加类名。                                                                                                                                                        |
 | block              | `boolean`                            | -           | 用`display:"block"`来显示按钮。                                                                                                                                             |
 | confirmText        | [模板](../../docs/concepts/template) | -           | 当设置后，操作在开始前会询问用户。可用 `${xxx}` 取值。                                                                                                                      |
+| confirmTitle       | [模板](../../docs/concepts/template) | -           | 确认框标题，前提是 confirmText 有内容，支持模版语法                                                                                                                         |
 | reload             | `string`                             | -           | 指定此次操作完后，需要刷新的目标组件名字（组件的`name`值，自己配置的），多个请用 `,` 号隔开。                                                                               |
 | tooltip            | `string`                             | -           | 鼠标停留时弹出该段文字，也可以配置对象类型：字段为`title`和`content`。可用 `${xxx}` 取值。                                                                                  |
 | disabledTip        | `'string' \| 'TooltipObject'`        | -           | 被禁用后鼠标停留时弹出该段文字，也可以配置对象类型：字段为`title`和`content`。可用 `${xxx}` 取值。                                                                          |

--- a/packages/amis/src/renderers/Action.tsx
+++ b/packages/amis/src/renderers/Action.tsx
@@ -388,6 +388,7 @@ const ActionProps = [
   'url',
   'link',
   'confirmText',
+  'confirmTitle',
   'tooltip',
   'disabledTip',
   'className',
@@ -1003,7 +1004,10 @@ export class ActionRenderer extends React.Component<ActionRendererProps> {
       env.confirm &&
       (confirmText = filter(action.confirmText, mergedData))
     ) {
-      let confirmed = await env.confirm(confirmText);
+      let confirmed = await env.confirm(
+        confirmText,
+        filter(action.confirmTitle, mergedData) || undefined
+      );
       if (confirmed) {
         // 触发渲染器事件
         const rendererEvent = await dispatchEvent(

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -845,7 +845,9 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       env.confirm &&
       (confirmText = filter(action.confirmText, ctx))
     ) {
-      env.confirm(confirmText).then((confirmed: boolean) => confirmed && fn());
+      env
+        .confirm(confirmText, filter(action.confirmTitle, ctx) || undefined)
+        .then((confirmed: boolean) => confirmed && fn());
     } else {
       fn();
     }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c7cd15</samp>

This pull request adds the `confirmTitle` property to the `action` and `crud` components, which enables customizing the confirmation dialog title when performing actions. It also updates the documentation and the type definition of the `action` component accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3c7cd15</samp>

> _If you want to confirm an action_
> _You can use a new `confirmTitle` fraction_
> _It will change the dialog's name_
> _To match your schema's aim_
> _Just pass it to the `crud` for satisfaction_

### Why

Close: #7200

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c7cd15</samp>

*  Add `confirmTitle` property to `action` component to allow customizing the title of the confirmation dialog ([link](https://github.com/baidu/amis/pull/7204/files?diff=unified&w=0#diff-14efa61b55a270c37a101b885c2bcc5bc2525fe5dcefe9c65ff9f36cc0b4b4edL177-R177), [link](https://github.com/baidu/amis/pull/7204/files?diff=unified&w=0#diff-14efa61b55a270c37a101b885c2bcc5bc2525fe5dcefe9c65ff9f36cc0b4b4edR185), [link](https://github.com/baidu/amis/pull/7204/files?diff=unified&w=0#diff-14efa61b55a270c37a101b885c2bcc5bc2525fe5dcefe9c65ff9f36cc0b4b4edR1033), [link](https://github.com/baidu/amis/pull/7204/files?diff=unified&w=0#diff-4d89203911a9d3ef38c82118f074ad24c49244699f1f2cbb6072134908f60098R391), [link](https://github.com/baidu/amis/pull/7204/files?diff=unified&w=0#diff-4d89203911a9d3ef38c82118f074ad24c49244699f1f2cbb6072134908f60098L1006-R1010))
*  Pass `confirmTitle` property to `env.confirm` method in `crud` component to show custom title for bulk actions confirmation dialog ([link](https://github.com/baidu/amis/pull/7204/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L848-R850))
