### PR TITLE
fix: 修复循环each组件，配置成员渲染器，选中容器，组件侧边栏隐藏的问题

### DIFF
--- a/packages/amis-editor/src/plugin/Each.tsx
+++ b/packages/amis-editor/src/plugin/Each.tsx
@@ -10,6 +10,7 @@ import {
 } from 'amis-editor-core';
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {diff, JSONPipeOut} from 'amis-editor-core';
+import {schemaToArray} from '../util';
 
 export class EachPlugin extends BasePlugin {
   static id = 'EachPlugin';
@@ -132,7 +133,7 @@ export class EachPlugin extends BasePlugin {
       value &&
       this.manager.openSubEditor({
         title: '配置成员渲染器',
-        value: value.items,
+        value: schemaToArray(value.items),
         slot: {
           type: 'container',
           body: '$$'


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19c9556</samp>

This pull request enhances the `each` renderer sub-editor in `amis-editor` by using a common function to convert the `items` schema to an array. This improves the user experience and the compatibility with different schema formats.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 19c9556</samp>

> _`each` type renderer, unleash your power_
> _`schemaToArray`, transform the schema_
> _Sub-editor, show the items list_
> _No matter the format, you can handle this_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 19c9556</samp>

* Import the `schemaToArray` function from the `util` module to convert schema objects to arrays ([link](https://github.com/baidu/amis/pull/7209/files?diff=unified&w=0#diff-3a0279a7838f7675af297c48b02cc8e56f6db60530dc4293b6b0f1d09fb47185R13))
* Use the `schemaToArray` function on the `value.items` argument of the `openSubEditor` method in the `Each` component, which renders the `each` type schema ([link](https://github.com/baidu/amis/pull/7209/files?diff=unified&w=0#diff-3a0279a7838f7675af297c48b02cc8e56f6db60530dc4293b6b0f1d09fb47185L135-R136))
