### PR TITLE
fix: GET请求中api.data未追加到query中问题

### DIFF
--- a/packages/amis-core/src/utils/api.ts
+++ b/packages/amis-core/src/utils/api.ts
@@ -147,7 +147,8 @@ export function buildApi(
   /** 追加data到请求的Query中 */
   const attachDataToQuery = (
     apiObject: ApiObject,
-    ctx: Record<string, any>
+    ctx: Record<string, any>,
+    merge: boolean
   ) => {
     const idx = apiObject.url.indexOf('?');
     if (~idx) {
@@ -160,7 +161,7 @@ export function buildApi(
         apiObject.url.substring(0, idx) + '?' + queryStringify(params);
     } else {
       apiObject.query = {...apiObject.query, ...ctx};
-      const query = queryStringify(ctx);
+      const query = queryStringify(merge ? apiObject.query : ctx);
       if (query) {
         apiObject.url = `${apiObject.url}?${query}`;
       }
@@ -242,11 +243,11 @@ export function buildApi(
       api.data &&
       ((!~raw.indexOf('$') && autoAppend) || api.forceAppendDataToQuery)
     ) {
-      api = attachDataToQuery(api, data);
+      api = attachDataToQuery(api, data, false);
     }
 
     if (api.data && api.attachDataToQuery !== false) {
-      api = attachDataToQuery(api, data);
+      api = attachDataToQuery(api, api.data, true);
       delete api.data;
     }
   }
@@ -302,7 +303,7 @@ export function buildApi(
 
     /** JSONQL所有method需要追加data中的变量到query中 */
     if (api.forceAppendDataToQuery) {
-      api = attachDataToQuery(api, data);
+      api = attachDataToQuery(api, data, true);
     }
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b654ca</samp>

This pull request enhances the `api` object and its related functions to support more flexible query string manipulation. It allows the user to specify how the context data should be merged with or appended to the query parameters for different API methods.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7b654ca</samp>

> _The query of doom, you can't escape it_
> _`merge` or `forceAppend`, you must shape it_
> _The `api` object holds the key_
> _To unleash the power of `attachDataToQuery`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7b654ca</samp>

*  Add a `merge` parameter to `attachDataToQuery` function to control whether to merge or overwrite query parameters with context data ([link](https://github.com/baidu/amis/pull/7214/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL150-R151), [link](https://github.com/baidu/amis/pull/7214/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL163-R164))
*  Use `api.attachDataToQuery` to decide which data object to use as context data and whether to merge or overwrite query parameters in `buildApi` function ([link](https://github.com/baidu/amis/pull/7214/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL245-R250))
*  Use `api.forceAppendDataToQuery` to always append data object to query parameters when using JSONQL methods in `buildApi` function ([link](https://github.com/baidu/amis/pull/7214/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL305-R306))
