### PR TITLE
fix: 编辑态下子编辑器不能展示正确数据

### DIFF
--- a/packages/amis-editor-core/src/store/editor.ts
+++ b/packages/amis-editor-core/src/store/editor.ts
@@ -1600,13 +1600,16 @@ export const MainStore = types
         self.subEditorContext = {
           ...context,
           hostNode: self.getNodeById(activeId),
-          data: extendObject(context.data, {
-            __curCmptTreeWrap: {
-              label: context.title,
-              disabled: true
-            },
-            __superCmptTreeSource: self.getComponentTreeSource()
-          })
+          data: createObject(
+            self.ctx,
+            extendObject(context.data, {
+              __curCmptTreeWrap: {
+                label: context.title,
+                disabled: true
+              },
+              __superCmptTreeSource: self.getComponentTreeSource()
+            })
+          )
         };
       },
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f347184</samp>

Fix dialog data reactivity bug by creating observable objects in `openDialog` action. Modify `packages/amis-editor-core/src/store/editor.ts` to use `createObject` function from mobx.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f347184</samp>

> _`openDialog` calls_
> _`createObject` to fix_
> _bug with reactivity_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f347184</samp>

* Fix a bug where dialog data is not reactive to parent component changes by wrapping it with `createObject` function ([link](https://github.com/baidu/amis/pull/7222/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8L1603-R1612))
