### PR TITLE
fix: 修复Editor-Tag 配置面板状态变更时schema中icon未清除的问题

### DIFF
--- a/packages/amis-editor/src/plugin/Tag.tsx
+++ b/packages/amis-editor/src/plugin/Tag.tsx
@@ -208,7 +208,14 @@ export class TagPlugin extends BasePlugin {
                     label: '状态',
                     value: 'status'
                   }
-                ]
+                ],
+                onChange: (value: any, origin: any, item: any, form: any) => {
+                  if (value !== 'status') {
+                    form.setValues({
+                      icon: undefined
+                    });
+                  }
+                }
               },
               getSchemaTpl('icon', {
                 visibleOn: 'data.displayMode === "status"',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 417a5fa</samp>

Fix icon field bug for Tag component in amis-editor. Clear `icon` value when `type` is not `status` in `Tag.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 417a5fa</samp>

> _`type` changes, then_
> _`icon` field disappears_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 417a5fa</samp>

* Add an `onChange` handler to clear the `icon` field when the `type` is not `status` for the `Tag` component schema ([link](https://github.com/baidu/amis/pull/7228/files?diff=unified&w=0#diff-1a3e387bfdfe239568e46164ba3a620903cec02b7a0fd2390cea0a6ba131ce14L211-R218))
