### PR TITLE
feat: crud 导出csv支持自定义文件名

### DIFF
--- a/docs/zh-CN/components/crud.md
+++ b/docs/zh-CN/components/crud.md
@@ -1881,7 +1881,7 @@ crud 组件支持通过配置`headerToolbar`和`footerToolbar`属性，实现在
 }
 ```
 
-### 通过 api 导出 CSV
+#### 通过 api 导出 CSV
 
 > 1.4.0 及以上版本
 
@@ -1897,6 +1897,61 @@ crud 组件支持通过配置`headerToolbar`和`footerToolbar`属性，实现在
             "type": "export-csv",
             "label": "全量导出 CSV",
             "api": "/api/mock2/sample"
+        }
+    ],
+    "columns": [
+        {
+            "name": "id",
+            "label": "ID"
+        },
+        {
+            "name": "engine",
+            "label": "Rendering engine"
+        },
+        {
+            "name": "browser",
+            "label": "Browser"
+        },
+        {
+            "name": "platform",
+            "label": "Platform(s)"
+        },
+        {
+            "name": "version",
+            "label": "Engine version"
+        },
+        {
+            "name": "grade",
+            "label": "CSS grade",
+            "type": "mapping",
+            "map": {
+                "*": "<span class=\"label label-info\">${grade}</span>"
+            }
+        }
+    ]
+}
+```
+
+#### 自定义导出 CSV 的文件名
+
+> 1.4.0 及以上版本
+
+`export-csv` 可以单独配置 `api` 实现导出全量功能，这个 api 的返回结果和 CRUD 类似
+
+```schema: scope="body"
+{
+    "type": "crud",
+    "syncLocation": false,
+    "api": "/api/mock2/sample",
+    "data": {
+        "name": "123"
+    },
+    "headerToolbar": [
+        {
+            "type": "export-csv",
+            "label": "自定义导出 CSV",
+            "api": "/api/mock2/sample",
+            "filename": "自定义文件名${name}"
         }
     ],
     "columns": [

--- a/packages/amis-core/src/store/crud.ts
+++ b/packages/amis-core/src/store/crud.ts
@@ -1,4 +1,5 @@
 import {saveAs} from 'file-saver';
+import {filter} from 'amis-core';
 import {types, flow, getEnv, isAlive, Instance} from 'mobx-state-tree';
 import {IRendererStore} from './index';
 import {ServiceStore} from './service';
@@ -585,9 +586,17 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
     };
 
     const exportAsCSV = async (
-      options: {loadDataOnce?: boolean; api?: Api; data?: any} = {}
+      options: {
+        loadDataOnce?: boolean;
+        api?: Api;
+        data?: any;
+        filename?: string;
+      } = {}
     ) => {
       let items = options.loadDataOnce ? self.data.itemsRaw : self.data.items;
+      const filename = options.filename
+        ? filter(options.filename, options.data, '| raw')
+        : 'data';
 
       if (options.api) {
         const env = getEnv(self);
@@ -626,7 +635,7 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
               type: 'text/plain;charset=utf-8'
             }
           );
-          saveAs(blob, 'data.csv');
+          saveAs(blob, `${filename}.csv`);
         }
       });
     };

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -2044,6 +2044,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
   renderExportCSV(toolbar: Schema) {
     const {store, classPrefix: ns, translate: __, loadDataOnce} = this.props;
     const api = (toolbar as Schema).api;
+    const filename = toolbar.filename;
 
     return (
       <Button
@@ -2052,6 +2053,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
           store.exportAsCSV({
             loadDataOnce,
             api,
+            filename,
             data: store.filterData /* 因为filter区域可能设置了过滤字段值，所以query信息也要写入数据域 */
           })
         }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 85d77a7</samp>

This pull request enhances the CSV export feature of the `CRUD` component and its documentation. It allows users to specify a custom filename for the exported CSV file using a template string. It also fixes a minor issue with the documentation heading level.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 85d77a7</samp>

> _Oh we are the `CRUD` crew and we work with CSV_
> _We export our data with a name that we can see_
> _We use a template string to set the filename right_
> _And we refactor code with `amis-core` so tight_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 85d77a7</samp>

*  Add a new feature to allow users to customize the filename of the exported CSV file in `CRUD` component ([link](https://github.com/baidu/amis/pull/7231/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653R1935-R1989), [link](https://github.com/baidu/amis/pull/7231/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL588-R599), [link](https://github.com/baidu/amis/pull/7231/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R2047), [link](https://github.com/baidu/amis/pull/7231/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R2056))
*  Use the `filter` function from `amis-core` module to interpolate the filename template string with the data object ([link](https://github.com/baidu/amis/pull/7231/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdR2), [link](https://github.com/baidu/amis/pull/7231/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL588-R599))
*  Modify the `saveAs` function to use the filename parameter instead of the hardcoded string `'data'` ([link](https://github.com/baidu/amis/pull/7231/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL629-R638))
*  Adjust the heading level of the subsection `通过 api 导出 CSV` in the documentation to match the other subsections ([link](https://github.com/baidu/amis/pull/7231/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653L1884-R1884))
