### PR TITLE
fix:表达式编辑器升级增加变量normalize

### DIFF
--- a/packages/amis-ui/src/components/formula/VariableList.tsx
+++ b/packages/amis-ui/src/components/formula/VariableList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 
 import {themeable, ThemeProps, filterTree, getTreeAncestors} from 'amis-core';
 import GroupedSelection from '../GroupedSelection';
@@ -83,17 +83,18 @@ function VariableList(props: VariableListProps) {
   } = props;
   const [filterVars, setFilterVars] = React.useState(list);
   const classPrefix = `${themePrefix}FormulaEditor-VariableList`;
+
+  useEffect(() => {
+    const {data} = props;
+    if (data) {
+      setFilterVars(data);
+    }
+  }, [props.data]);
+
   const itemRender =
     props.itemRender && typeof props.itemRender === 'function'
       ? props.itemRender
       : (option: Option, states: ItemRenderStates): JSX.Element => {
-          // 控制只对第一层数组成员展示快捷操作入口
-          if (option.isMember) {
-            const arrs: any = getTreeAncestors(list, option as any);
-            option.memberDepth = arrs?.filter(
-              (item: Option) => item.type === 'array'
-            )?.length;
-          }
           return (
             <div>
               <div className={cx(`${classPrefix}-item`, itemClassName)}>
@@ -120,9 +121,12 @@ function VariableList(props: VariableListProps) {
                       <label>{option.label}</label>
                     </TooltipWrapper>
                   )}
+                {/* 控制只对第一层数组成员展示快捷操作入口 */}
                 {option.memberDepth < 2 ? (
                   <PopOverContainer
-                    popOverContainer={() => document.querySelector('body')}
+                    popOverContainer={() =>
+                      document.querySelector(`.${cx('FormulaPicker-Modal')}`)
+                    }
                     popOverRender={({onClose}) => (
                       <ul className={cx(`${classPrefix}-item-oper`)}>
                         {memberOpers.map((item, i) => {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1097892</samp>

This pull request enhances the formula editor component and fixes a UI bug. It adds a `normalizeVariables` function to `Editor.tsx` to generate paths for the variables and pass them to the `FormulaPlugin` and the `VariableList.tsx` components. It also fixes the popover menu visibility and the filtered variables state in `VariableList.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1097892</samp>

> _To edit and render formulas well_
> _We need to normalize each variable_
> _We add a `path` property_
> _To each item in the tree_
> _And use `useEffect` to filter them all_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1097892</samp>

* Import and use `getTreeAncestors` and `mapTree` functions from `amis-core` to normalize variables data with `path` property ([link](https://github.com/baidu/amis/pull/7232/files?diff=unified&w=0#diff-893fd27e1fa6dd194d6e17f9bb62a1a3144bdf0e24063ef0426990e28d7b7c19L5-R5), [link](https://github.com/baidu/amis/pull/7232/files?diff=unified&w=0#diff-893fd27e1fa6dd194d6e17f9bb62a1a3144bdf0e24063ef0426990e28d7b7c19L242-R273))
* Add and initialize `normalizeVariables` state to store normalized variables data in `FormulaEditor` class ([link](https://github.com/baidu/amis/pull/7232/files?diff=unified&w=0#diff-893fd27e1fa6dd194d6e17f9bb62a1a3144bdf0e24063ef0426990e28d7b7c19R113), [link](https://github.com/baidu/amis/pull/7232/files?diff=unified&w=0#diff-893fd27e1fa6dd194d6e17f9bb62a1a3144bdf0e24063ef0426990e28d7b7c19L122-R124))
* Pass `normalizeVariables` state instead of `variables` prop to `FormulaPlugin` constructor in `handleEditorMounted` function ([link](https://github.com/baidu/amis/pull/7232/files?diff=unified&w=0#diff-893fd27e1fa6dd194d6e17f9bb62a1a3144bdf0e24063ef0426990e28d7b7c19L267-R298))
* Remove `variables` prop and add `normalizeVariables` state to `render` function of `FormulaEditor` class ([link](https://github.com/baidu/amis/pull/7232/files?diff=unified&w=0#diff-893fd27e1fa6dd194d6e17f9bb62a1a3144bdf0e24063ef0426990e28d7b7c19L355), [link](https://github.com/baidu/amis/pull/7232/files?diff=unified&w=0#diff-893fd27e1fa6dd194d6e17f9bb62a1a3144bdf0e24063ef0426990e28d7b7c19L367-R397))
* Change `data` prop of `VariableList` component from `variables` to `normalizeVariables` in `render` function of `FormulaEditor` class ([link](https://github.com/baidu/amis/pull/7232/files?diff=unified&w=0#diff-893fd27e1fa6dd194d6e17f9bb62a1a3144bdf0e24063ef0426990e28d7b7c19L441-R471))
* Use `useEffect` hook to update `filterVars` state with `data` prop whenever `data` prop changes in `VariableList` component ([link](https://github.com/baidu/amis/pull/7232/files?diff=unified&w=0#diff-20ccd77f29dae5effdf503856c6589eb936a52ec3ac2f9a852f7c0d4b6b5a562L1-R1), [link](https://github.com/baidu/amis/pull/7232/files?diff=unified&w=0#diff-20ccd77f29dae5effdf503856c6589eb936a52ec3ac2f9a852f7c0d4b6b5a562R86-R93))
* Change `popOverContainer` prop of `PopOverContainer` component from `document.querySelector('body')` to `document.querySelector('.amis-dialog-widget')` in `VariableList` component ([link](https://github.com/baidu/amis/pull/7232/files?diff=unified&w=0#diff-20ccd77f29dae5effdf503856c6589eb936a52ec3ac2f9a852f7c0d4b6b5a562L125-R135))
