### PR TITLE
DropDownButton 支持配置 amis json 作为下拉内容 #7141

### DIFF
--- a/packages/amis/src/renderers/DropDownButton.tsx
+++ b/packages/amis/src/renderers/DropDownButton.tsx
@@ -6,7 +6,12 @@ import {TooltipWrapper} from 'amis-ui';
 import {isDisabled, isVisible, noop} from 'amis-core';
 import {filter} from 'amis-core';
 import {Icon, hasIcon} from 'amis-ui';
-import {BaseSchema, SchemaClassName, SchemaIcon} from '../Schema';
+import {
+  BaseSchema,
+  SchemaClassName,
+  SchemaCollection,
+  SchemaIcon
+} from '../Schema';
 import {ActionSchema} from './Action';
 import {DividerSchema} from './Divider';
 import {RootClose} from 'amis-core';
@@ -47,6 +52,11 @@ export interface DropdownButtonSchema extends BaseSchema {
    * 按钮集合，支持分组
    */
   buttons?: Array<DropdownButton>;
+
+  /**
+   * 内容区域
+   */
+  body?: SchemaCollection;
 
   /**
    * 按钮文字
@@ -291,6 +301,7 @@ export default class DropDownButton extends React.Component<
       classnames: cx,
       classPrefix: ns,
       children,
+      body,
       align,
       closeOnClick,
       closeOnOutside,
@@ -304,7 +315,7 @@ export default class DropDownButton extends React.Component<
         ? resolveVariableAndFilter(_buttons, data, '| raw')
         : _buttons;
 
-    let body = (
+    let popOverBody = (
       <RootClose
         disabled={!this.state.isOpened}
         onRootClose={closeOnOutside !== false ? this.close : noop}
@@ -326,6 +337,8 @@ export default class DropDownButton extends React.Component<
             >
               {children
                 ? children
+                : body
+                ? render('body', body)
                 : Array.isArray(buttons)
                 ? buttons.map((button, index) =>
                     this.renderButton(button, index)
@@ -351,13 +364,13 @@ export default class DropDownButton extends React.Component<
             className={cx('DropDown-popover', menuClassName)}
             style={{minWidth: this.target?.offsetWidth}}
           >
-            {body}
+            {popOverBody}
           </PopOver>
         </Overlay>
       );
     }
 
-    return body;
+    return popOverBody;
   }
 
   render() {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 369eaa2</samp>

Added a `body` property to `DropdownButtonSchema` to support custom dropdown content. Modified `DropDownButton.tsx` to render the `body` schemas using `PopOver`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 369eaa2</samp>

> _To render a schema collection_
> _We added a new `body` section_
> _To the `DropdownButtonSchema`_
> _And updated `PopOver` and `renderButtonGroup`-a_
> _To handle this new dropdown direction_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 369eaa2</samp>

*  Import `SchemaCollection` type and add `body` property to `DropdownButtonSchema` interface to allow rendering schemas as dropdown content ([link](https://github.com/baidu/amis/pull/7233/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L9-R14), [link](https://github.com/baidu/amis/pull/7233/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005R57-R61))
*  Destructure `body` from props and pass it to `renderButtonGroup` method in `DropDownButton` component ([link](https://github.com/baidu/amis/pull/7233/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005R304))
*  Rename `body` to `popOverBody` and use `render` method to render `body` or `buttons` as dropdown content in `renderButtonGroup` method ([link](https://github.com/baidu/amis/pull/7233/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L307-R318), [link](https://github.com/baidu/amis/pull/7233/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005R340-R341), [link](https://github.com/baidu/amis/pull/7233/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L360-R373))
*  Use `popOverBody` as child of `PopOver` component and return value of `renderButtonGroup` method ([link](https://github.com/baidu/amis/pull/7233/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L354-R367))
