### PR TITLE
fix: button-group-select校验配置&多个button换行

### DIFF
--- a/packages/amis-editor/src/plugin/Form/ButtonGroupSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/ButtonGroupSelect.tsx
@@ -8,6 +8,7 @@ import {
 } from 'amis-editor-core';
 import {getSchemaTpl, defaultValue} from 'amis-editor-core';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
+import {ValidatorTag} from '../../validator';
 
 export class ButtonGroupControlPlugin extends BasePlugin {
   static id = 'ButtonGroupControlPlugin';
@@ -137,7 +138,8 @@ export class ButtonGroupControlPlugin extends BasePlugin {
             },
             getSchemaTpl('status', {
               isFormItem: true
-            })
+            }),
+            getSchemaTpl('validation', {tag: ValidatorTag.MultiSelect})
           ])
         ]
       },

--- a/packages/amis-ui/scss/components/_button-group.scss
+++ b/packages/amis-ui/scss/components/_button-group.scss
@@ -2,6 +2,7 @@
   position: relative;
   display: inline-flex;
   vertical-align: middle;
+  flex-wrap: wrap;
 
   > .#{$ns}Button {
     position: relative;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 84a62f2</samp>

This pull request improves the AMIS editor and UI for the `ButtonGroupControl` component. It adds validation support and responsiveness to the component, and updates the corresponding files in `packages/amis-editor` and `packages/amis-ui`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 84a62f2</samp>

> _Wrapping the buttons of doom_
> _Flexing the power of CSS_
> _Validating the rules of the group_
> _With the `ValidatorTag` of death_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 84a62f2</samp>

*  Add `validation` property to `ButtonGroupControl` schema template ([link](https://github.com/baidu/amis/pull/7237/files?diff=unified&w=0#diff-ff3f4187b50d4f132c5ad5cec4a6ba113c8419508e8475325eebb6d3a482b24eL140-R142))
  - Import `ValidatorTag` enum from `validator` module ([link](https://github.com/baidu/amis/pull/7237/files?diff=unified&w=0#diff-ff3f4187b50d4f132c5ad5cec4a6ba113c8419508e8475325eebb6d3a482b24eR11))
*  Enable button group items to wrap to multiple lines ([link](https://github.com/baidu/amis/pull/7237/files?diff=unified&w=0#diff-77c5d145544bc877664f55f072962fee43b7152e9468862cc0dcd44990f3601dR5))
