### PR TITLE
fix:表达式编辑器回显示&非对象数组处理

### DIFF
--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -958,7 +958,9 @@ export function jsonToJsonSchema(
           title: titleBuilder?.(type, key) || key,
           ...(type === 'object'
             ? jsonToJsonSchema(value, titleBuilder, maxDepth - 1)
-            : {items: jsonToJsonSchema(value[0], titleBuilder, maxDepth - 1)})
+            : typeof value[0] === 'object'
+            ? {items: jsonToJsonSchema(value[0], titleBuilder, maxDepth - 1)}
+            : {})
         };
       } else {
         jsonschema.properties[key] = {

--- a/packages/amis-ui/src/components/formula/Editor.tsx
+++ b/packages/amis-ui/src/components/formula/Editor.tsx
@@ -196,7 +196,7 @@ export class FormulaEditor extends React.Component<
     eachTree(variables, item => {
       if (item.value) {
         const key = item.value;
-        varMap[key] = item.label;
+        varMap[key] = item.path ?? item.label;
       }
     });
     const vars = Object.keys(varMap)

--- a/packages/amis-ui/src/components/formula/plugin.ts
+++ b/packages/amis-ui/src/components/formula/plugin.ts
@@ -207,7 +207,7 @@ export class FormulaPlugin {
 
     eachTree(variables, item => {
       if (item.value) {
-        varMap[item.value] = item.path ?? '';
+        varMap[item.value] = item.path ?? item.label;
       }
     });
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f38b8be</samp>

This pull request fixes a bug in the `jsonToJsonSchema` function and enhances the display of variable labels in the formula editor and plugin components. It uses the `path` property of the variables to show the full data source path when available.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f38b8be</samp>

> _`jsonToJsonSchema`_
> _Fixes array bug in spring_
> _More clarity now_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f38b8be</samp>

* Fix a bug in `jsonToJsonSchema` function that caused an error when the input was an array of non-object values ([link](https://github.com/baidu/amis/pull/7239/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL961-R963))
* Use the `path` property of the variable if it exists, otherwise fall back to the `label` property, to improve the display of the variable labels in the formula editor and plugin components ([link](https://github.com/baidu/amis/pull/7239/files?diff=unified&w=0#diff-893fd27e1fa6dd194d6e17f9bb62a1a3144bdf0e24063ef0426990e28d7b7c19L199-R199), [link](https://github.com/baidu/amis/pull/7239/files?diff=unified&w=0#diff-81a40d3681bba7ccf8083805bb11bfcf32f2366666994b1047c49945736b2972L210-R210))
