### PR TITLE
feat(amis): 日历组件日程内容支持富文本

### DIFF
--- a/packages/amis-editor-core/src/component/Preview.tsx
+++ b/packages/amis-editor-core/src/component/Preview.tsx
@@ -15,7 +15,7 @@ import IFrameBridge from './IFrameBridge';
 import {isAlive} from 'mobx-state-tree';
 import {findTree} from 'amis-core';
 import BackTop from './base/BackTop';
-import {RendererConfig} from 'amis-core';
+import type {RendererConfig} from 'amis-core';
 
 export interface PreviewProps {
   // isEditorEnabled?: (

--- a/packages/amis-ui/src/components/DatePicker.tsx
+++ b/packages/amis-ui/src/components/DatePicker.tsx
@@ -23,6 +23,7 @@ import {isMobile, ucFirst} from 'amis-core';
 import CalendarMobile from './CalendarMobile';
 import Input from './Input';
 import type {PlainObject} from 'amis-core';
+import type {RendererEnv} from 'amis-core';
 
 const availableShortcuts: {[propName: string]: any} = {
   now: {
@@ -295,6 +296,7 @@ export interface DateProps extends LocaleProps, ThemeProps {
     className?: string;
   }>;
   scheduleClassNames?: Array<string>;
+  env?: RendererEnv;
   largeMode?: boolean;
   todayActiveStyle?: React.CSSProperties;
   onScheduleClick?: (scheduleData: any) => void;
@@ -720,7 +722,8 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
       todayActiveStyle,
       onScheduleClick,
       mobileCalendarMode,
-      label
+      label,
+      env
     } = this.props;
 
     const __ = this.props.translate;
@@ -806,6 +809,7 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
             maxDate={maxDate}
             // utc={utc}
             schedules={schedulesData}
+            env={env}
             largeMode={largeMode}
             todayActiveStyle={todayActiveStyle}
             onScheduleClick={onScheduleClick}

--- a/packages/amis-ui/src/components/calendar/Calendar.tsx
+++ b/packages/amis-ui/src/components/calendar/Calendar.tsx
@@ -15,6 +15,7 @@ import {PickerOption} from '../PickerColumn';
 import 'moment/locale/zh-cn';
 import 'moment/locale/de';
 import {isMobile} from 'amis-core';
+import type {RendererEnv} from 'amis-core';
 
 export type DateType =
   | 'year'
@@ -91,6 +92,7 @@ interface BaseDatePickerProps {
     content: string | React.ReactElement;
     color?: string;
   }>;
+  env?: RendererEnv;
   largeMode?: boolean;
   todayActiveStyle?: React.CSSProperties;
   onScheduleClick?: (scheduleData: any) => void;
@@ -420,7 +422,8 @@ class BaseDatePicker extends React.Component<
       'updateOn',
       'useMobileUI',
       'showToolbar',
-      'embed'
+      'embed',
+      'env'
     ].forEach(key => (props[key] = (this.props as any)[key]));
 
     return props;

--- a/packages/amis-ui/src/components/calendar/DaysView.tsx
+++ b/packages/amis-ui/src/components/calendar/DaysView.tsx
@@ -17,6 +17,7 @@ import {
   convertArrayValueToMoment,
   isMobile
 } from 'amis-core';
+import type {RendererEnv} from 'amis-core';
 import Picker from '../Picker';
 import {PickerOption} from '../PickerColumn';
 import {DateType} from './Calendar';
@@ -73,6 +74,7 @@ interface CustomDaysViewProps extends LocaleProps {
     content: any;
     className?: string;
   }>;
+  env?: RendererEnv;
   largeMode?: boolean;
   todayActiveStyle?: React.CSSProperties;
   onScheduleClick?: (scheduleData: any) => void;
@@ -356,9 +358,17 @@ export class CustomDaysView extends React.Component<CustomDaysViewProps> {
     this.props.onClose && this.props.onClose();
   };
 
+  curfilterHtml = (content: any) => {
+    const {env} = this.props;
+    if (env?.filterHtml) {
+      return env.filterHtml(content);
+    }
+    return content;
+  };
+
   renderDay = (props: any, currentDate: moment.Moment) => {
     const {todayActiveStyle} = props; /** 只有today才会传入这个属性 */
-    const {classnames: cx, translate: __} = this.props;
+    const {classnames: cx, translate: __, env} = this.props;
     const injectedProps = omit(props, ['todayActiveStyle']);
     /** 某些情况下需要用inline style覆盖动态class，需要hack important的样式 */
     const todayDomRef = (node: HTMLSpanElement | null) => {
@@ -493,9 +503,12 @@ export class CustomDaysView extends React.Component<CustomDaysViewProps> {
                   this.props.onScheduleClick(scheduleData)
                 }
               >
-                <div className={cx('ScheduleCalendar-text-overflow')}>
-                  {item.content}
-                </div>
+                <div
+                  className={cx('ScheduleCalendar-text-overflow')}
+                  dangerouslySetInnerHTML={{
+                    __html: this.curfilterHtml(item.content)
+                  }}
+                ></div>
               </div>
             );
           });

--- a/packages/amis/src/renderers/Form/InputDate.tsx
+++ b/packages/amis/src/renderers/Form/InputDate.tsx
@@ -508,6 +508,7 @@ export default class DateControl extends React.PureComponent<
       >
         <DatePicker
           {...rest}
+          env={env}
           placeholder={placeholder ?? this.placeholder}
           useMobileUI={useMobileUI}
           popOverContainer={

--- a/packages/amis/src/renderers/Page.tsx
+++ b/packages/amis/src/renderers/Page.tsx
@@ -406,7 +406,7 @@ export default class Page extends React.Component<PageProps> {
 
     // Page加载完成时触发 pageLoaded 事件
     if (env?.tracker) {
-      env.tracker({eventType: 'pageLoaded'});
+      env.tracker({eventType: 'pageLoaded'}, this.props);
     }
 
     if (rendererEvent?.prevented) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 79ca67e</samp>

This pull request enhances the integration of `amis-core` and `amis-ui` by passing the `RendererEnv` object as a prop to various components that use date pickers and calendars. It also improves the type safety and performance of some imports and props. It adds a feature to render HTML content of schedule items on the calendar.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 79ca67e</samp>

> _Sing, O Muse, of the skillful coder who improved the `amis` project_
> _By adding the `env` prop to the `DatePicker` and `Calendar` components_
> _And by importing the `type` keyword and the `RendererEnv` type_
> _To enhance the performance, readability, and safety of the code._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 79ca67e</samp>

*  Import and use `RendererEnv` type from `amis-core` to specify the `amisEnv` prop in `RightPanelsProps` interface ([link](https://github.com/baidu/amis/pull/7241/files?diff=unified&w=0#diff-d3c81e20d56a4882dbecc7a467e1d265e41139cb2fad2f33269ea24f23470373R12),[link](https://github.com/baidu/amis/pull/7241/files?diff=unified&w=0#diff-d3c81e20d56a4882dbecc7a467e1d265e41139cb2fad2f33269ea24f23470373L18-R19))
* Add `type` keyword to import of `RendererConfig` from `amis-core` in `Preview.tsx` to indicate type-only import ([link](https://github.com/baidu/amis/pull/7241/files?diff=unified&w=0#diff-d9b508133ad06e8946597f0255a1b4529b6fb9f0c2bf3c170e0fcef582fff0e9L18-R18))
* Import and use `RendererEnv` type from `amis-core` to specify the `env` prop in `BaseDatePickerProps` interface in `Calendar.tsx` ([link](https://github.com/baidu/amis/pull/7241/files?diff=unified&w=0#diff-95af3120d1ccfbc45e4d5e68e1139a6a5da04bb3209049f4482822284aa46ad1R18),[link](https://github.com/baidu/amis/pull/7241/files?diff=unified&w=0#diff-95af3120d1ccfbc45e4d5e68e1139a6a5da04bb3209049f4482822284aa46ad1R95))
* Copy `env` prop from `this.props` to `props` object in `BaseDatePicker` component in `Calendar.tsx` and pass it to `Calendar` component from `react-datetime` ([link](https://github.com/baidu/amis/pull/7241/files?diff=unified&w=0#diff-95af3120d1ccfbc45e4d5e68e1139a6a5da04bb3209049f4482822284aa46ad1L423-R426))
* Import and use `RendererEnv` type from `amis-core` to specify the `env` prop in `CustomDaysViewProps` interface in `DaysView.tsx` ([link](https://github.com/baidu/amis/pull/7241/files?diff=unified&w=0#diff-206e06fca060056b2ec3db9f17011b6ceeeb01ac290df0fdeb7d49c7ab7e91d7R20),[link](https://github.com/baidu/amis/pull/7241/files?diff=unified&w=0#diff-206e06fca060056b2ec3db9f17011b6ceeeb01ac290df0fdeb7d49c7ab7e91d7R77))
* Define `curfilterHtml` method in `CustomDaysView` component in `DaysView.tsx` to filter HTML content using `filterHtml` function from `env` prop ([link](https://github.com/baidu/amis/pull/7241/files?diff=unified&w=0#diff-206e06fca060056b2ec3db9f17011b6ceeeb01ac290df0fdeb7d49c7ab7e91d7L359-R371))
* Render `item.content` as HTML using `dangerouslySetInnerHTML` attribute and `curfilterHtml` method in `CustomDaysView` component in `DaysView.tsx` ([link](https://github.com/baidu/amis/pull/7241/files?diff=unified&w=0#diff-206e06fca060056b2ec3db9f17011b6ceeeb01ac290df0fdeb7d49c7ab7e91d7L496-R511))
* Import and use `RendererEnv` type from `amis-core` to specify the `env` prop in `DateProps` interface in `DatePicker.tsx` ([link](https://github.com/baidu/amis/pull/7241/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cR26),[link](https://github.com/baidu/amis/pull/7241/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cR299))
* Destructure and pass `env` prop to `BaseDatePicker` component in `DatePicker` component in `DatePicker.tsx` ([link](https://github.com/baidu/amis/pull/7241/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL723-R726),[link](https://github.com/baidu/amis/pull/7241/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cR812))
* Pass `env` prop to `DatePicker` component in `InputDate` component in `InputDate.tsx` ([link](https://github.com/baidu/amis/pull/7241/files?diff=unified&w=0#diff-56835df54b63fc25653bc9cb41f895a4e75843bbbf719028fbcc740ae394a94fR511))
