### PR TITLE
fix:去掉editor里api请求适配器里关于api.body的说明,统一使用api.data

### DIFF
--- a/packages/amis-editor/src/renderer/APIAdaptorControl.tsx
+++ b/packages/amis-editor/src/renderer/APIAdaptorControl.tsx
@@ -397,9 +397,8 @@ setSchemaTpl('apiRequestAdaptor', {
     &nbsp;1. <span style="color: #108CEE">api</span>：接口的schema配置对象<br/>
     &nbsp;2. <span style="color: #108CEE">api.data</span>：请求数据<br/>
     &nbsp;3. <span style="color: #108CEE">api.query</span>：请求查询参数<br/>
-    &nbsp;4. <span style="color: #108CEE">api.body</span>：请求体（针对POST/PUT/PATCH）<br/>
-    &nbsp;5. <span style="color: #108CEE">api.headers</span>：请求头<br/>
-    &nbsp;6. <span style="color: #108CEE">api.url</span>：请求地址<br/>`
+    &nbsp;4. <span style="color: #108CEE">api.headers</span>：请求头<br/>
+    &nbsp;5. <span style="color: #108CEE">api.url</span>：请求地址<br/>`
   ),
   name: 'requestAdaptor',
   type: 'ae-apiAdaptorControl',


### PR DESCRIPTION
## 背景
- 用户配置请求发送适配器时，api.data与api.body界限不清晰，不知道要从body中写数据还是在data中写数据
- 实测 在api的请求适配器里，将数据放在 api.body 里并不会生效

## 解决
-  去掉api.body 的说明，统一都使用 api.data 作为标准