### PR TITLE
Update datascope-and-datachain.md

### DIFF
--- a/docs/zh-CN/concepts/datascope-and-datachain.md
+++ b/docs/zh-CN/concepts/datascope-and-datachain.md
@@ -414,7 +414,7 @@ amis 从 3.2.0 版本开始针对[具备数据域的组件](#具备数据域的�
 1.  `trackExpression` 配置成 `"none"` 也就是说不追踪任何数据。
 2.  `trackExpression` 配置成 `"${xxxVariable}"` 这样 xxxVariable 变化了更新当前组件的数据链。
 
-关于 `trackExpression` 的语法，请查看表达式篇章，可以监听多个变量比如: `"${xxx1},${xxx2}"`，还可以写表单时如 `"${ xxx ? xxx : yyy}"`。
+关于 `trackExpression` 的语法，请查看表达式篇章，可以监听多个变量比如: `"${xxx1},${xxx2}"`，还可以写表达式如 `"${ xxx ? xxx : yyy}"`。
 
 amis 内部是通过运算这个表达式的结果来判断。所以表达式中千万不要用随机函数，或者用当前时间等，否则每次都会更新数据链。另外如果变量是数组，或者对象，会转成统一的字符串 `[object Array]` 或者 `[object Object]` 这个其实会影响检测的，所以建议转成 json 字符串如。 `${xxxObject | json}`。还有就是既然是监控上层数据，表达式中不要写当前层数据变量，是取不到的。
 


### PR DESCRIPTION
修复文档中《数据域与数据链》章节下的“更新数据链”部分里将”表达式“写成了”表单时“的错误

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1af97d3</samp>

Fixed a typo in the Chinese documentation of `trackExpression`. Changed `表单` to `表达式` in `docs/zh-CN/concepts/datascope-and-datachain.md` to avoid confusion.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1af97d3</samp>

> _`表单` becomes `表达式`_
> _A clearer way to track changes_
> _Autumn leaves turn red_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1af97d3</samp>

* Corrected the word `表单` to `表达式` in the second paragraph of `docs/zh-CN/concepts/datascope-and-datachain.md` to match the context of `trackExpression` ([link](https://github.com/baidu/amis/pull/7255/files?diff=unified&w=0#diff-edecba6f0628b7882615502c2258047ebd6307b309bd55f4cae74b87269cbdbeL417-R417))
