### PR TITLE
feat:dataschema增加typeLabel

### DIFF
--- a/packages/amis-core/src/types.ts
+++ b/packages/amis-core/src/types.ts
@@ -382,6 +382,7 @@ export type FunctionPropertyNames<T> = {
 
 export type JSONSchema = JSONSchema7 & {
   group?: string; // 分组
+  typeLabel?: string; // 类型说明
 };
 
 // export type Omit<T, K extends keyof T & any> = Pick<T, Exclude<keyof T, K>>;

--- a/packages/amis-core/src/utils/DataScope.ts
+++ b/packages/amis-core/src/utils/DataScope.ts
@@ -1,6 +1,15 @@
 import {JSONSchema} from '../types';
 import {guid, keyToPath, mapTree} from './helper';
 
+const TYPE_MAP: {[type: string]: string} = {
+  boolean: '布尔',
+  integer: '整数',
+  number: '数字',
+  string: '文本',
+  array: '数组',
+  object: '对象'
+};
+
 export class DataScope {
   // 指向父级
   parent?: DataScope;
@@ -213,7 +222,7 @@ export class DataScope {
       value: schema.title === '成员' ? '' : path.value,
       path: schema.title === '成员' ? '' : path.label,
       type: schema.type,
-      tag: schema.type,
+      tag: schema.typeLabel ?? TYPE_MAP[schema.type as string] ?? schema.type,
       description: schema.description,
       isMember,
       disabled: schema.title === '成员'


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b1f5dba</samp>

This pull request adds Chinese labels for JSON schema types and uses them in the data scope component of the amis framework. It modifies the `DataScope` class, the `JSONSchema` type, and the `packages/amis-core/src/utils/DataScope.ts` and `packages/amis-core/src/types.ts` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b1f5dba</samp>

> _To display JSON schema types_
> _We added a new prop `typeLabel`_
> _And a `TYPE_MAP` to translate_
> _The types to Chinese in the state_
> _And used them in `toTree` to enable_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b1f5dba</samp>

*  Add `typeLabel` property to `JSONSchema` type for storing human-readable type descriptions ([link](https://github.com/baidu/amis/pull/7259/files?diff=unified&w=0#diff-9795a06699f88c4c144fccb14b9ddca83b8d9639d2062c27b01495b6b80e7d7dR385))
*  Define `TYPE_MAP` object for mapping JSON schema types to Chinese labels ([link](https://github.com/baidu/amis/pull/7259/files?diff=unified&w=0#diff-7f6ffdabe1409210084f9b8d81e0168b8a472165749c0cb640fb847e8e4c2acdR4-R12))
*  Use `typeLabel` or `TYPE_MAP` value to display type information in data scope component ([link](https://github.com/baidu/amis/pull/7259/files?diff=unified&w=0#diff-7f6ffdabe1409210084f9b8d81e0168b8a472165749c0cb640fb847e8e4c2acdL216-R225))
*  Update `toTree` method of `DataScope` class in `DataScope.ts` to replace `tag` property of tree node with type label ([link](https://github.com/baidu/amis/pull/7259/files?diff=unified&w=0#diff-7f6ffdabe1409210084f9b8d81e0168b8a472165749c0cb640fb847e8e4c2acdL216-R225))
