### PR TITLE
chore: 接口轮训添加限制, 接口正常返回才轮训 Close: #7260

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
   "jest": {
     "verbose": true,
     "testEnvironment": "jsdom",
-    "collectCoverage": true,
     "coverageReporters": [
       "text",
       "cobertura"

--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -661,7 +661,7 @@ export default class Form extends React.Component<FormProps, object> {
     const {data, store, dispatchEvent} = this.props;
 
     if (store.fetching) {
-      return;
+      return value;
     }
 
     // 派发init事件，参数为初始化数据
@@ -810,7 +810,8 @@ export default class Form extends React.Component<FormProps, object> {
     const {interval, silentPolling, stopAutoRefreshWhen, data} = this.props;
 
     clearTimeout(this.timer);
-    interval &&
+    value?.ok &&
+      interval &&
       this.mounted &&
       (!stopAutoRefreshWhen || !evalExpression(stopAutoRefreshWhen, data)) &&
       (this.timer = setTimeout(

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -1245,7 +1245,8 @@ export default class CRUD extends React.Component<CRUDProps, any> {
               );
             }
 
-            interval &&
+            value?.ok && // 接口正常返回才继续轮训
+              interval &&
               this.mounted &&
               (!stopAutoRefreshWhen ||
                 !(

--- a/packages/amis/src/renderers/CRUD2.tsx
+++ b/packages/amis/src/renderers/CRUD2.tsx
@@ -579,7 +579,8 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
             isTable2: true
           })
           .then(value => {
-            interval &&
+            value?.ok && // 接口正常返回才继续轮训
+              interval &&
               !this.stopingAutoRefresh &&
               this.mounted &&
               (!stopAutoRefreshWhen ||

--- a/packages/amis/src/renderers/Page.tsx
+++ b/packages/amis/src/renderers/Page.tsx
@@ -701,7 +701,8 @@ export default class Page extends React.Component<PageProps> {
       })
     );
 
-    interval &&
+    value?.ok && // 接口正常返回才继续轮训
+      interval &&
       this.mounted &&
       (!stopAutoRefreshWhen || !evalExpression(stopAutoRefreshWhen, data)) &&
       (this.timer = setTimeout(

--- a/packages/amis/src/renderers/Service.tsx
+++ b/packages/amis/src/renderers/Service.tsx
@@ -531,7 +531,7 @@ export default class Service extends React.Component<ServiceProps> {
       onBulkChange(data);
     }
 
-    this.initInterval(data);
+    result?.ok && this.initInterval(data);
   }
 
   afterSchemaFetch(schema: any) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e22410b</samp>

Add a condition to check the API response before auto-refreshing data in various renderers. This is to improve performance and error handling in `Form`, `CRUD`, `CRUD2`, `Page`, and `Service` components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e22410b</samp>

> _`API` response_
> _check before refresh data_
> _save winter bandwidth_

### Why

 Close: #7260

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e22410b</samp>

*  Add a condition to check if the API response is ok before setting the timer for auto-refreshing data in components that support this feature ([link](https://github.com/baidu/amis/pull/7263/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L813-R814), [link](https://github.com/baidu/amis/pull/7263/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1248-R1249), [link](https://github.com/baidu/amis/pull/7263/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL582-R583), [link](https://github.com/baidu/amis/pull/7263/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L704-R705), [link](https://github.com/baidu/amis/pull/7263/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852L534-R534))
