### PR TITLE
chore: 调整 dataMapping 中 '&' 特殊 key 的逻辑 始终优先处理 Close: #7247

### DIFF
--- a/packages/amis-core/src/utils/dataMapping.ts
+++ b/packages/amis-core/src/utils/dataMapping.ts
@@ -99,19 +99,21 @@ export function dataMapping(
       );
     }
   } else {
-    Object.keys(to).forEach(key => {
-      const value = to[key];
-      let keys: Array<string>;
+    const objectKeys = Object.keys(to);
+    // 如果存在  '&' 作为 key，则特殊处理
+    // 就是无论这个 key 的位置在什么地方始终都是当放在最前面
+    const idx = objectKeys.indexOf('&');
+    if (~idx) {
+      const value = to['&'];
+      objectKeys.splice(idx, 1);
 
-      if (typeof ignoreFunction === 'function' && ignoreFunction(key, value)) {
-        // 如果被ignore，不做数据映射处理。
-        setVariable(ret, key, value, convertKeyToPath);
-      } else if (key === '&' && value === '$$') {
+      if (value === '$$') {
         ret = {
           ...ret,
           ...from
         };
-      } else if (key === '&') {
+      } else {
+        let keys: Array<string>;
         const v =
           isPlainObject(value) &&
           (keys = Object.keys(value)) &&
@@ -142,6 +144,15 @@ export function dataMapping(
             ...v
           };
         }
+      }
+    }
+
+    objectKeys.forEach(key => {
+      const value = to[key];
+
+      if (typeof ignoreFunction === 'function' && ignoreFunction(key, value)) {
+        // 如果被ignore，不做数据映射处理。
+        setVariable(ret, key, value, convertKeyToPath);
       } else if (value === '$$') {
         setVariable(ret, key, from, convertKeyToPath);
       } else if (value && value[0] === '$') {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fd84dc6</samp>

Refactor and fix data mapping function for object transformation. Improve handling of `&` key and add loop for other keys in `to` template in `dataMapping.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fd84dc6</samp>

> _We are the mappers of the data_
> _We transform the objects of fate_
> _We handle the special `&` key_
> _We loop through the keys of the template_

### Why

Close: #7247

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fd84dc6</samp>

* Refactor and fix the logic of handling '&' as a key in the `to` object ([link](https://github.com/baidu/amis/pull/7264/files?diff=unified&w=0#diff-8da5626b636dcc59740de1a18e6bba7c55f1f3176304cf074e872eda3be4dcadL102-R116), [link](https://github.com/baidu/amis/pull/7264/files?diff=unified&w=0#diff-8da5626b636dcc59740de1a18e6bba7c55f1f3176304cf074e872eda3be4dcadR147-R155))
