### PR TITLE
feat:表达式输入框高亮改为源码

### DIFF
--- a/packages/amis-core/src/utils/DataScope.ts
+++ b/packages/amis-core/src/utils/DataScope.ts
@@ -1,7 +1,7 @@
 import {JSONSchema} from '../types';
 import {guid, keyToPath, mapTree} from './helper';
 
-const TYPE_MAP: {[type: string]: string} = {
+export const DATASCHEMA_TYPE_MAP: {[type: string]: string} = {
   boolean: '布尔',
   integer: '整数',
   number: '数字',
@@ -222,7 +222,10 @@ export class DataScope {
       value: schema.title === '成员' ? '' : path.value,
       path: schema.title === '成员' ? '' : path.label,
       type: schema.type,
-      tag: schema.typeLabel ?? TYPE_MAP[schema.type as string] ?? schema.type,
+      tag:
+        schema.typeLabel ??
+        DATASCHEMA_TYPE_MAP[schema.type as string] ??
+        schema.type,
       description: schema.description,
       isMember,
       disabled: schema.title === '成员'

--- a/packages/amis-editor-core/src/variable.ts
+++ b/packages/amis-editor-core/src/variable.ts
@@ -7,7 +7,14 @@ import sortBy from 'lodash/sortBy';
 import cloneDeep from 'lodash/cloneDeep';
 import reverse from 'lodash/reverse';
 import pick from 'lodash/pick';
-import {JSONSchema, DataSchema, mapTree, findTree, eachTree} from 'amis-core';
+import {
+  JSONSchema,
+  DataSchema,
+  mapTree,
+  findTree,
+  eachTree,
+  DATASCHEMA_TYPE_MAP
+} from 'amis-core';
 import type {Option} from 'amis-core';
 
 export interface VariableGroup {
@@ -169,7 +176,7 @@ export class VariableManager {
           const children = mapTree(varScope.getDataPropsAsOptions(), item => ({
             ...item,
             /** tag默认会被赋值为description，这里得替换回来 */
-            tag: item.type
+            tag: DATASCHEMA_TYPE_MAP[item.type] ?? item.type
           }));
 
           if (varScope.tag) {

--- a/packages/amis-ui/src/components/formula/Editor.tsx
+++ b/packages/amis-ui/src/components/formula/Editor.tsx
@@ -228,7 +228,7 @@ export class FormulaEditor extends React.Component<
         if (reg.test(encodeHtml)) {
           html = encodeHtml.replace(
             REPLACE_KEY,
-            `<span class="c-field">${varMap[v]}</span>`
+            `<span class="c-field">${v}</span>`
           );
         } else {
           html = encodeHtml.replace(REPLACE_KEY, v);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0cb5d98</samp>

Refactored the code to use a common object for data schema type labels across modules. Simplified the formula editor component by removing the variable description mapping.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0cb5d98</samp>

> _No more varMap, no more lies_
> _We use the names as the labels of our cries_
> _DATASCHEMA_TYPE_MAP is our guide_
> _We refactor the code with metal pride_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0cb5d98</samp>

*  Rename and export `TYPE_MAP` object as `DATASCHEMA_TYPE_MAP` in `DataScope.ts` ([link](https://github.com/baidu/amis/pull/7266/files?diff=unified&w=0#diff-7f6ffdabe1409210084f9b8d81e0168b8a472165749c0cb640fb847e8e4c2acdL4-R4))
*  Use `DATASCHEMA_TYPE_MAP` object for `tag` property of `DataScopeItem` interface in `DataScope.ts` ([link](https://github.com/baidu/amis/pull/7266/files?diff=unified&w=0#diff-7f6ffdabe1409210084f9b8d81e0168b8a472165749c0cb640fb847e8e4c2acdL225-R228))
*  Import `DATASCHEMA_TYPE_MAP` object from `amis-core` in `variable.ts` ([link](https://github.com/baidu/amis/pull/7266/files?diff=unified&w=0#diff-b96f4e79e2f89c35143b7bd285380090604cf12f7b89dbb2ba8c41b13825a0dbL10-R17))
*  Use `DATASCHEMA_TYPE_MAP` object for `tag` property of `Variable` interface in `variable.ts` ([link](https://github.com/baidu/amis/pull/7266/files?diff=unified&w=0#diff-b96f4e79e2f89c35143b7bd285380090604cf12f7b89dbb2ba8c41b13825a0dbL172-R179))
*  Remove `varMap` object from `FormulaEditor` class in `Editor.tsx` ([link](https://github.com/baidu/amis/pull/7266/files?diff=unified&w=0#diff-893fd27e1fa6dd194d6e17f9bb62a1a3144bdf0e24063ef0426990e28d7b7c19L231-R231))
