### PR TITLE
chore: inputText 优化下拉 popvoer 支持在 table 下下拉展示全 Close: #7075

### DIFF
--- a/packages/amis-ui/scss/components/form/_text.scss
+++ b/packages/amis-ui/scss/components/form/_text.scss
@@ -314,16 +314,15 @@
     }
   }
 
-  &-sugs {
-    position: absolute;
+  &-popover {
+    margin-top: px2rem(4px);
     background: var(--Form-select-menu-bg);
     color: var(--Form-select-menu-color);
     border-radius: px2rem(2px);
     box-shadow: var(--menu-box-shadow);
-    left: px2rem(-1px);
-    right: px2rem(-1px);
-    top: calc(100% + #{px2rem(4px)});
-    z-index: 10;
+  }
+
+  &-sugs {
     max-height: px2rem(300px);
     overflow: auto;
   }

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/text.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/text.test.tsx.snap
@@ -2204,8 +2204,9 @@ exports[`Renderer:text with options and multiple and delimiter: first option sel
               aria-haspopup="listbox"
               aria-labelledby="downshift-1-label"
               aria-owns="downshift-1-menu"
-              class="cxd-TextControl-input cxd-TextControl-input--withAC is-opened cxd-TextControl-input--multiple"
+              class="cxd-TextControl-input cxd-TextControl-input--withAC is-opened cxd-TextControl-input--multiple has-popover"
               role="combobox"
+              style="position: relative;"
             >
               <div
                 class="cxd-TextControl-value"
@@ -2233,38 +2234,122 @@ exports[`Renderer:text with options and multiple and delimiter: first option sel
                 value=""
               />
               <div
-                class="cxd-TextControl-sugs"
+                class="cxd-PopOver cxd-TextControl-popover cxd-PopOver--leftBottomLeftTop"
+                style="display: block; width: 0px; left: 0px; top: 0px; position: relative;"
+                theme="cxd"
               >
                 <div
-                  aria-selected="false"
-                  class="cxd-TextControl-sugItem"
-                  id="downshift-1-item-0"
-                  role="option"
+                  class="cxd-TextControl-sugs"
                 >
-                  <span>
-                    OptionB
-                  </span>
+                  <div
+                    aria-selected="false"
+                    class="cxd-TextControl-sugItem"
+                    id="downshift-1-item-0"
+                    role="option"
+                  >
+                    <span>
+                      OptionB
+                    </span>
+                  </div>
+                  <div
+                    aria-selected="false"
+                    class="cxd-TextControl-sugItem"
+                    id="downshift-1-item-1"
+                    role="option"
+                  >
+                    <span>
+                      OptionC
+                    </span>
+                  </div>
+                  <div
+                    aria-selected="false"
+                    class="cxd-TextControl-sugItem"
+                    id="downshift-1-item-2"
+                    role="option"
+                  >
+                    <span>
+                      OptionD
+                    </span>
+                  </div>
                 </div>
                 <div
-                  aria-selected="false"
-                  class="cxd-TextControl-sugItem"
-                  id="downshift-1-item-1"
-                  role="option"
+                  class="resize-sensor"
+                  style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
                 >
-                  <span>
-                    OptionC
-                  </span>
+                  
+  
+                  <div
+                    class="resize-sensor-expand"
+                    style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                  >
+                    
+    
+                    <div
+                      style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                    />
+                    
+  
+                  </div>
+                  
+  
+                  <div
+                    class="resize-sensor-shrink"
+                    style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                  >
+                    
+    
+                    <div
+                      style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                    />
+                    
+  
+                  </div>
+                  
+  
+                  <div
+                    class="resize-sensor-appear"
+                    style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                  />
                 </div>
+              </div>
+              <div
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
+              >
+                
+  
                 <div
-                  aria-selected="false"
-                  class="cxd-TextControl-sugItem"
-                  id="downshift-1-item-2"
-                  role="option"
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
                 >
-                  <span>
-                    OptionD
-                  </span>
+                  
+    
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
                 </div>
+                
+  
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
+  
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
               </div>
             </div>
           </div>
@@ -2405,8 +2490,9 @@ exports[`Renderer:text with options and multiple and delimiter: options is opene
               aria-haspopup="listbox"
               aria-labelledby="downshift-1-label"
               aria-owns="downshift-1-menu"
-              class="cxd-TextControl-input cxd-TextControl-input--withAC is-opened cxd-TextControl-input--multiple"
+              class="cxd-TextControl-input cxd-TextControl-input--withAC is-opened cxd-TextControl-input--multiple has-popover"
               role="combobox"
+              style="position: relative;"
             >
               <input
                 aria-autocomplete="list"
@@ -2421,48 +2507,132 @@ exports[`Renderer:text with options and multiple and delimiter: options is opene
                 value=""
               />
               <div
-                class="cxd-TextControl-sugs"
+                class="cxd-PopOver cxd-TextControl-popover cxd-PopOver--leftBottomLeftTop"
+                style="display: block; width: 0px; left: 0px; top: 0px; position: relative;"
+                theme="cxd"
               >
                 <div
-                  aria-selected="false"
-                  class="cxd-TextControl-sugItem"
-                  id="downshift-1-item-0"
-                  role="option"
+                  class="cxd-TextControl-sugs"
                 >
-                  <span>
-                    OptionA
-                  </span>
+                  <div
+                    aria-selected="false"
+                    class="cxd-TextControl-sugItem"
+                    id="downshift-1-item-0"
+                    role="option"
+                  >
+                    <span>
+                      OptionA
+                    </span>
+                  </div>
+                  <div
+                    aria-selected="false"
+                    class="cxd-TextControl-sugItem"
+                    id="downshift-1-item-1"
+                    role="option"
+                  >
+                    <span>
+                      OptionB
+                    </span>
+                  </div>
+                  <div
+                    aria-selected="false"
+                    class="cxd-TextControl-sugItem"
+                    id="downshift-1-item-2"
+                    role="option"
+                  >
+                    <span>
+                      OptionC
+                    </span>
+                  </div>
+                  <div
+                    aria-selected="false"
+                    class="cxd-TextControl-sugItem"
+                    id="downshift-1-item-3"
+                    role="option"
+                  >
+                    <span>
+                      OptionD
+                    </span>
+                  </div>
                 </div>
                 <div
-                  aria-selected="false"
-                  class="cxd-TextControl-sugItem"
-                  id="downshift-1-item-1"
-                  role="option"
+                  class="resize-sensor"
+                  style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
                 >
-                  <span>
-                    OptionB
-                  </span>
+                  
+  
+                  <div
+                    class="resize-sensor-expand"
+                    style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                  >
+                    
+    
+                    <div
+                      style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                    />
+                    
+  
+                  </div>
+                  
+  
+                  <div
+                    class="resize-sensor-shrink"
+                    style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                  >
+                    
+    
+                    <div
+                      style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                    />
+                    
+  
+                  </div>
+                  
+  
+                  <div
+                    class="resize-sensor-appear"
+                    style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                  />
                 </div>
+              </div>
+              <div
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
+              >
+                
+  
                 <div
-                  aria-selected="false"
-                  class="cxd-TextControl-sugItem"
-                  id="downshift-1-item-2"
-                  role="option"
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
                 >
-                  <span>
-                    OptionC
-                  </span>
+                  
+    
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
                 </div>
+                
+  
                 <div
-                  aria-selected="false"
-                  class="cxd-TextControl-sugItem"
-                  id="downshift-1-item-3"
-                  role="option"
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
                 >
-                  <span>
-                    OptionD
-                  </span>
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
+  
                 </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
               </div>
             </div>
           </div>
@@ -2607,8 +2777,9 @@ exports[`Renderer:text with options and multiple and delimiter: options is opene
               aria-haspopup="listbox"
               aria-labelledby="downshift-1-label"
               aria-owns="downshift-1-menu"
-              class="cxd-TextControl-input cxd-TextControl-input--withAC is-opened cxd-TextControl-input--multiple"
+              class="cxd-TextControl-input cxd-TextControl-input--withAC is-opened cxd-TextControl-input--multiple has-popover"
               role="combobox"
+              style="position: relative;"
             >
               <div
                 class="cxd-TextControl-value"
@@ -2636,38 +2807,122 @@ exports[`Renderer:text with options and multiple and delimiter: options is opene
                 value=""
               />
               <div
-                class="cxd-TextControl-sugs"
+                class="cxd-PopOver cxd-TextControl-popover cxd-PopOver--leftBottomLeftTop"
+                style="display: block; width: 0px; left: 0px; top: 0px; position: relative;"
+                theme="cxd"
               >
                 <div
-                  aria-selected="false"
-                  class="cxd-TextControl-sugItem"
-                  id="downshift-1-item-0"
-                  role="option"
+                  class="cxd-TextControl-sugs"
                 >
-                  <span>
-                    OptionB
-                  </span>
+                  <div
+                    aria-selected="false"
+                    class="cxd-TextControl-sugItem"
+                    id="downshift-1-item-0"
+                    role="option"
+                  >
+                    <span>
+                      OptionB
+                    </span>
+                  </div>
+                  <div
+                    aria-selected="false"
+                    class="cxd-TextControl-sugItem"
+                    id="downshift-1-item-1"
+                    role="option"
+                  >
+                    <span>
+                      OptionC
+                    </span>
+                  </div>
+                  <div
+                    aria-selected="false"
+                    class="cxd-TextControl-sugItem"
+                    id="downshift-1-item-2"
+                    role="option"
+                  >
+                    <span>
+                      OptionD
+                    </span>
+                  </div>
                 </div>
                 <div
-                  aria-selected="false"
-                  class="cxd-TextControl-sugItem"
-                  id="downshift-1-item-1"
-                  role="option"
+                  class="resize-sensor"
+                  style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
                 >
-                  <span>
-                    OptionC
-                  </span>
+                  
+  
+                  <div
+                    class="resize-sensor-expand"
+                    style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                  >
+                    
+    
+                    <div
+                      style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                    />
+                    
+  
+                  </div>
+                  
+  
+                  <div
+                    class="resize-sensor-shrink"
+                    style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                  >
+                    
+    
+                    <div
+                      style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                    />
+                    
+  
+                  </div>
+                  
+  
+                  <div
+                    class="resize-sensor-appear"
+                    style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                  />
                 </div>
+              </div>
+              <div
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
+              >
+                
+  
                 <div
-                  aria-selected="false"
-                  class="cxd-TextControl-sugItem"
-                  id="downshift-1-item-2"
-                  role="option"
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
                 >
-                  <span>
-                    OptionD
-                  </span>
+                  
+    
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
                 </div>
+                
+  
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
+  
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
               </div>
             </div>
           </div>
@@ -2808,8 +3063,9 @@ exports[`Renderer:text with options and multiple and delimiter: second option se
               aria-haspopup="listbox"
               aria-labelledby="downshift-1-label"
               aria-owns="downshift-1-menu"
-              class="cxd-TextControl-input cxd-TextControl-input--withAC is-opened cxd-TextControl-input--multiple"
+              class="cxd-TextControl-input cxd-TextControl-input--withAC is-opened cxd-TextControl-input--multiple has-popover"
               role="combobox"
+              style="position: relative;"
             >
               <div
                 class="cxd-TextControl-value"
@@ -2850,28 +3106,112 @@ exports[`Renderer:text with options and multiple and delimiter: second option se
                 value=""
               />
               <div
-                class="cxd-TextControl-sugs"
+                class="cxd-PopOver cxd-TextControl-popover cxd-PopOver--leftBottomLeftTop"
+                style="display: block; width: 0px; left: 0px; top: 0px; position: relative;"
+                theme="cxd"
               >
                 <div
-                  aria-selected="false"
-                  class="cxd-TextControl-sugItem"
-                  id="downshift-1-item-0"
-                  role="option"
+                  class="cxd-TextControl-sugs"
                 >
-                  <span>
-                    OptionC
-                  </span>
+                  <div
+                    aria-selected="false"
+                    class="cxd-TextControl-sugItem"
+                    id="downshift-1-item-0"
+                    role="option"
+                  >
+                    <span>
+                      OptionC
+                    </span>
+                  </div>
+                  <div
+                    aria-selected="false"
+                    class="cxd-TextControl-sugItem"
+                    id="downshift-1-item-1"
+                    role="option"
+                  >
+                    <span>
+                      OptionD
+                    </span>
+                  </div>
                 </div>
                 <div
-                  aria-selected="false"
-                  class="cxd-TextControl-sugItem"
-                  id="downshift-1-item-1"
-                  role="option"
+                  class="resize-sensor"
+                  style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
                 >
-                  <span>
-                    OptionD
-                  </span>
+                  
+  
+                  <div
+                    class="resize-sensor-expand"
+                    style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                  >
+                    
+    
+                    <div
+                      style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                    />
+                    
+  
+                  </div>
+                  
+  
+                  <div
+                    class="resize-sensor-shrink"
+                    style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                  >
+                    
+    
+                    <div
+                      style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                    />
+                    
+  
+                  </div>
+                  
+  
+                  <div
+                    class="resize-sensor-appear"
+                    style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                  />
                 </div>
+              </div>
+              <div
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
+              >
+                
+  
+                <div
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
+  
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
               </div>
             </div>
           </div>
@@ -3203,8 +3543,9 @@ exports[`Renderer:text with options: options is open 1`] = `
               aria-haspopup="listbox"
               aria-labelledby="downshift-0-label"
               aria-owns="downshift-0-menu"
-              class="cxd-TextControl-input cxd-TextControl-input--withAC is-opened"
+              class="cxd-TextControl-input cxd-TextControl-input--withAC is-opened has-popover"
               role="combobox"
+              style="position: relative;"
             >
               <input
                 aria-autocomplete="list"
@@ -3219,28 +3560,112 @@ exports[`Renderer:text with options: options is open 1`] = `
                 value=""
               />
               <div
-                class="cxd-TextControl-sugs"
+                class="cxd-PopOver cxd-TextControl-popover cxd-PopOver--leftBottomLeftTop"
+                style="display: block; width: 0px; left: 0px; top: 0px; position: relative;"
+                theme="cxd"
               >
                 <div
-                  aria-selected="false"
-                  class="cxd-TextControl-sugItem"
-                  id="downshift-0-item-0"
-                  role="option"
+                  class="cxd-TextControl-sugs"
                 >
-                  <span>
-                    Option A
-                  </span>
+                  <div
+                    aria-selected="false"
+                    class="cxd-TextControl-sugItem"
+                    id="downshift-0-item-0"
+                    role="option"
+                  >
+                    <span>
+                      Option A
+                    </span>
+                  </div>
+                  <div
+                    aria-selected="false"
+                    class="cxd-TextControl-sugItem"
+                    id="downshift-0-item-1"
+                    role="option"
+                  >
+                    <span>
+                      Option B
+                    </span>
+                  </div>
                 </div>
                 <div
-                  aria-selected="false"
-                  class="cxd-TextControl-sugItem"
-                  id="downshift-0-item-1"
-                  role="option"
+                  class="resize-sensor"
+                  style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
                 >
-                  <span>
-                    Option B
-                  </span>
+                  
+  
+                  <div
+                    class="resize-sensor-expand"
+                    style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                  >
+                    
+    
+                    <div
+                      style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                    />
+                    
+  
+                  </div>
+                  
+  
+                  <div
+                    class="resize-sensor-shrink"
+                    style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                  >
+                    
+    
+                    <div
+                      style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                    />
+                    
+  
+                  </div>
+                  
+  
+                  <div
+                    class="resize-sensor-appear"
+                    style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                  />
                 </div>
+              </div>
+              <div
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
+              >
+                
+  
+                <div
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
+  
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
               </div>
             </div>
           </div>

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -6,7 +6,9 @@ import {
   FormOptionsControl,
   resolveEventData,
   CustomStyle,
-  getValueByPath
+  getValueByPath,
+  PopOver,
+  Overlay
 } from 'amis-core';
 import {ActionObject} from 'amis-core';
 import Downshift, {StateChangeOptions} from 'downshift';
@@ -141,6 +143,8 @@ export interface TextProps extends OptionsControlProps, SpinnerExtraProps {
   inputControlClassName?: string;
   /** 原生input标签的CSS类名 */
   nativeInputClassName?: string;
+
+  popOverContainer?: any;
 }
 
 export interface TextState {
@@ -372,6 +376,13 @@ export default class TextControl extends React.PureComponent<
     }
 
     onBlur && onBlur(e);
+  }
+
+  @autobind
+  close() {
+    this.setState({
+      isFocused: false
+    });
   }
 
   async handleInputChange(evt: React.ChangeEvent<HTMLInputElement>) {
@@ -641,6 +652,11 @@ export default class TextControl extends React.PureComponent<
       : JSON.stringify(value);
   }
 
+  @autobind
+  getTarget() {
+    return this.input?.parentElement;
+  }
+
   renderSugestMode() {
     const {
       className,
@@ -668,7 +684,8 @@ export default class TextControl extends React.PureComponent<
       maxLength,
       minLength,
       translate: __,
-      loadingConfig
+      loadingConfig,
+      popOverContainer
     } = this.props;
     let type = this.props.type?.replace(/^(?:native|input)\-/, '');
 
@@ -812,42 +829,56 @@ export default class TextControl extends React.PureComponent<
                 />
               ) : null}
 
-              {isOpen && filtedOptions.length ? (
-                <div className={cx('TextControl-sugs')}>
-                  {filtedOptions.map((option: any) => {
-                    const label = option[labelField || 'label'];
-                    const value = option[valueField || 'value'];
+              <Overlay
+                container={popOverContainer || this.getTarget}
+                target={this.getTarget}
+                show={!!(isOpen && filtedOptions.length)}
+              >
+                <PopOver
+                  className={cx('TextControl-popover')}
+                  style={{
+                    width: this.input
+                      ? this.input.parentElement!.offsetWidth
+                      : 'auto'
+                  }}
+                >
+                  <div className={cx('TextControl-sugs')}>
+                    {filtedOptions.map((option: any) => {
+                      const label = option[labelField || 'label'];
+                      const value = option[valueField || 'value'];
 
-                    return (
-                      <div
-                        {...getItemProps({
-                          item: value,
-                          disabled: option.disabled,
-                          className: cx(`TextControl-sugItem`, {
-                            'is-highlight': highlightedIndex === indices[value],
-                            'is-disabled': option.disabled
-                          })
-                        })}
-                        key={value}
-                      >
-                        {option.isNew ? (
-                          <span>
-                            {__('Text.add', {label: label})}
-                            <Icon icon="enter" className="icon" />
-                          </span>
-                        ) : (
-                          <span>
-                            {option.disabled
-                              ? label
-                              : highlight(label, inputValue as string)}
-                            {option.tip}
-                          </span>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-              ) : null}
+                      return (
+                        <div
+                          {...getItemProps({
+                            item: value,
+                            disabled: option.disabled,
+                            className: cx(`TextControl-sugItem`, {
+                              'is-highlight':
+                                highlightedIndex === indices[value],
+                              'is-disabled': option.disabled
+                            })
+                          })}
+                          key={value}
+                        >
+                          {option.isNew ? (
+                            <span>
+                              {__('Text.add', {label: label})}
+                              <Icon icon="enter" className="icon" />
+                            </span>
+                          ) : (
+                            <span>
+                              {option.disabled
+                                ? label
+                                : highlight(label, inputValue as string)}
+                              {option.tip}
+                            </span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </PopOver>
+              </Overlay>
             </div>
           );
         }}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7fa5c09</samp>

The suggestions menu for the `InputText` component was refactored to use the `PopOver` and `Overlay` components from `amis-core`. This improved the menu's positioning and visibility, and added a new prop to customize the menu's container. The corresponding SCSS file was also updated to reflect the changes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7fa5c09</samp>

> _To fix the suggestions menu's position_
> _We used `PopOver` and `Overlay` with vision_
> _We renamed the class_
> _And added a prop pass_
> _To make `TextControl-popover` our mission_

### Why

Close: #7075

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7fa5c09</samp>

*  Rename `TextControl-sugs` class to `TextControl-popover` and move it to a separate block in `_text.scss` ([link](https://github.com/baidu/amis/pull/7268/files?diff=unified&w=0#diff-aedc9f281ebd4c0afb4c461346e012147ad3689cdcdbae90a75bbea0bd445cf9L317-R325)). This prepares the CSS for using `PopOver` and `Overlay` components to render the suggestions menu for the text input.
