### PR TITLE
chore: 总结行与列显隐切换联动 Close: #7073

### DIFF
--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -2579,10 +2579,6 @@ export default class Table extends React.Component<TableProps, object> {
       return null;
     }
 
-    // 不能取消到比总结行要少
-    // 否则总结行将显示不全
-    const min = Math.max(Array.isArray(affixRow) ? affixRow.length : 0, 1);
-
     return (
       <ColumnToggler
         {...rest}
@@ -2631,7 +2627,7 @@ export default class Table extends React.Component<TableProps, object> {
                 return;
               }
 
-              store.toggleAllColumns(min);
+              store.toggleAllColumns();
             }}
           >
             <Checkbox
@@ -2677,7 +2673,7 @@ export default class Table extends React.Component<TableProps, object> {
                 return;
               }
 
-              column.toggleToggle(min);
+              column.toggleToggle();
             }}
           >
             <Checkbox size="sm" classPrefix={ns} checked={column.toggled}>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3e6e586</samp>

This pull request fixes a column toggling bug and enhances the summary row display in the `Table` renderer. It simplifies the logic in `Table/index.tsx` and adjusts the styles and calculations in `Table/TableBody.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3e6e586</samp>

> _`min` is no more_
> _table columns toggle well_
> _autumn bug is gone_

### Why

Close: #7073 

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3e6e586</samp>

*  Remove min variable and arguments that limit the minimum number of columns to show based on affixRow prop, which is unreliable and inconsistent with the dynamic rendering of summary rows ([link](https://github.com/baidu/amis/pull/7269/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2582-L2585), [link](https://github.com/baidu/amis/pull/7269/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2634-R2630), [link](https://github.com/baidu/amis/pull/7269/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2680-R2676)) in `Table/index.tsx`
*  Improve the logic of calculating the colSpan of the summary row cells in `TableBody.tsx` by filtering out hidden columns and simplifying the condition for merging special columns ([link](https://github.com/baidu/amis/pull/7269/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL193-R247))
*  Add an empty line for readability in `TableBody.tsx` ([link](https://github.com/baidu/amis/pull/7269/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efR254))
