### PR TITLE
chore: crud 的 api 返回容忍返回为空 null Close: #6391

### DIFF
--- a/packages/amis-core/src/store/crud.ts
+++ b/packages/amis-core/src/store/crud.ts
@@ -289,8 +289,10 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
             items = result.items || result.rows;
           }
 
-          // 如果不按照 items 格式返回，就拿第一个数组当成 items
-          if (!Array.isArray(items)) {
+          if (items == null) {
+            items = [];
+          } else if (!Array.isArray(items)) {
+            // 如果不按照 items 格式返回，就拿第一个数组当成 items
             for (const key of Object.keys(result)) {
               if (result.hasOwnProperty(key) && Array.isArray(result[key])) {
                 items = result[key];


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d3f5c12</samp>

Fix a potential error with missing `items` property in CRUD results and add a comment for clarity. This improves the robustness and readability of the `crud.ts` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d3f5c12</samp>

> _`items` may be gone_
> _check before using as array_
> _fall is for fallback_

### Why

Close: #6391

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d3f5c12</samp>

*  Prevent error when result of CRUD operation does not have `items` property ([link](https://github.com/baidu/amis/pull/7275/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL292-R295))
*  Add comment to explain fallback logic of finding first array property in result ([link](https://github.com/baidu/amis/pull/7275/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL292-R295))
