### PR TITLE
fix: 事件动作 -> 页面变量列表为空，无法选择 & 勾选框组件默认值配置fx无效

### DIFF
--- a/packages/amis-editor-core/src/variable.ts
+++ b/packages/amis-editor-core/src/variable.ts
@@ -235,11 +235,11 @@ export class VariableManager {
   getPageVariablesOptions() {
     let options: Option[] = [];
 
-    const pageScope = this.dataSchema?.root.children?.filter(
-      item => item.tag === '页面变量'
-    )[0];
-    if (pageScope) {
-      options = pageScope.getDataPropsAsOptions();
+    const rootScope = this.dataSchema?.root;
+    if (rootScope) {
+      options = rootScope
+        .getDataPropsAsOptions()
+        .filter((item: any) => ['__query', '__page'].includes(item.value));
     }
     eachTree(options, item => {
       if (item.type === 'array') {

--- a/packages/amis-editor/examples/Editor.tsx
+++ b/packages/amis-editor/examples/Editor.tsx
@@ -160,6 +160,33 @@ const schemas = [
         }
       }
     }
+  },
+  {
+    type: 'object',
+    properties: {
+      __query: {
+        title: '页面入参',
+        type: 'object',
+        required: [],
+        properties: {
+          name: {
+            type: 'string',
+            title: '用户名'
+          }
+        }
+      },
+      __page: {
+        title: '页面变量',
+        type: 'object',
+        required: [],
+        properties: {
+          num: {
+            type: 'number',
+            title: '数量'
+          }
+        }
+      }
+    }
   }
 ];
 
@@ -632,6 +659,11 @@ export default class AMisSchemaEditor extends React.Component<any, any> {
             replaceText
           } as any
         }
+        ctx={{
+          __page: {
+            num: 2
+          }
+        }}
       />
     );
   }

--- a/packages/amis-editor/src/plugin/Form/Checkbox.tsx
+++ b/packages/amis-editor/src/plugin/Form/Checkbox.tsx
@@ -148,14 +148,14 @@ export class CheckboxControlPlugin extends BasePlugin {
                 needDeleteProps: ['option'],
                 label: '默认勾选',
                 rendererWrapper: true, // 浅色线框包裹一下，增加边界感
-                valueType: 'boolean',
-                pipeIn: (value: any, data: any) => {
-                  return value === (data?.data?.trueValue ?? true);
-                },
-                pipeOut: (value: any, origin: any, data: any) => {
-                  const {trueValue = true, falseValue = false} = data;
-                  return value ? trueValue : falseValue;
-                }
+                valueType: 'boolean'
+                // pipeIn: (value: any, data: any) => {
+                //   return value === (data?.data?.trueValue ?? true);
+                // },
+                // pipeOut: (value: any, origin: any, data: any) => {
+                //   const {trueValue = true, falseValue = false} = data;
+                //   return value ? trueValue : falseValue;
+                // }
               }),
               getSchemaTpl('labelRemark'),
               getSchemaTpl('remark'),


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cfc41c2</samp>

This pull request improves the editor example and the variable selector functionality. It adds a mock data schema and some initial values to the `Editor.tsx` example, changes the scope of the variable selector to use the root schema in `variable.ts`, and removes unnecessary value conversions from the `Checkbox.tsx` plugin.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cfc41c2</samp>

> _We are the masters of the root scope_
> _We unleash the power of `__query` and `__page`_
> _We simplify the logic of the checkbox control_
> _We create our own reality with the editor_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cfc41c2</samp>

* Use root scope of data schema to get variable options for editor ([link](https://github.com/baidu/amis/pull/7280/files?diff=unified&w=0#diff-b96f4e79e2f89c35143b7bd285380090604cf12f7b89dbb2ba8c41b13825a0dbL238-R242))
* Add mock data schema with predefined variables `__query` and `__page` to `Editor.tsx` example ([link](https://github.com/baidu/amis/pull/7280/files?diff=unified&w=0#diff-ac37ef7e74b39117226be066461e8c65edafc2318cf9874536ac80f09b6f9f41R163-R189))
* Provide initial values for variables in `ctx` prop of `Editor` component in `Editor.tsx` example ([link](https://github.com/baidu/amis/pull/7280/files?diff=unified&w=0#diff-ac37ef7e74b39117226be066461e8c65edafc2318cf9874536ac80f09b6f9f41R662-R666))
* Simplify `defaultChecked` property of `CheckboxControlPlugin` by removing unnecessary `pipeIn` and `pipeOut` functions ([link](https://github.com/baidu/amis/pull/7280/files?diff=unified&w=0#diff-80480fe0b59b31f4d13fabafb069dd6b31a00cba69d23fd2f23fb55c6a42e84aL151-R158))
