### PR TITLE
fix: 编辑器添加文档预览组件

### DIFF
--- a/packages/amis-editor/src/index.tsx
+++ b/packages/amis-editor/src/index.tsx
@@ -117,7 +117,7 @@ import './plugin/Divider'; // 分隔线
 import './plugin/CodeView'; // 代码高亮
 import './plugin/Markdown';
 import './plugin/Collapse'; // 折叠器
-// import './plugin/OfficeViewer'; // 文档预览
+import './plugin/OfficeViewer'; // 文档预览
 import './plugin/Log'; // 日志
 
 // 其他


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 452ee22</samp>

Enabled the `OfficeViewer` plugin in `amis-editor` to allow previewing office documents in the editor. Uncommented the plugin import and usage in `packages/amis-editor/src/index.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 452ee22</samp>

> _`OfficeViewer` on_
> _Preview documents in spring_
> _A fresh feature blooms_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 452ee22</samp>

* Enable office document preview in the editor by uncommenting the `OfficeViewer` plugin ([link](https://github.com/baidu/amis/pull/7284/files?diff=unified&w=0#diff-fa77f562c6a58cf12dee0f269ae4d27bbbdd30fb852016af309b4bd6fe1b6cd5L120-R120))
