### PR TITLE
fix: 修复 inputGroup 表单项在 service 下时校验问题 Close: #7279

### DIFF
--- a/mock/cfc/index.js
+++ b/mock/cfc/index.js
@@ -56,7 +56,11 @@ function mockResponse(event, context, callback) {
 function createHeaders(headers) {
   let referer = '';
 
-  if (/^(https?\:\/\/[^:\/]+(?:\:\d+)?\/)/i.test(headers['Referer'])) {
+  if (
+    /^(https?\:\/\/[^:\/]+(?:\:\d+)?\/)/i.test(
+      headers['Referer'] || headers['referer']
+    )
+  ) {
     referer = RegExp.$1.replace(/\/$/, '');
   }
 

--- a/packages/amis-core/src/store/form.ts
+++ b/packages/amis-core/src/store/form.ts
@@ -92,7 +92,7 @@ export const FormStore = ServiceStore.named('FormStore')
       /** 获取InputGroup的子元素 */
       get inputGroupItems() {
         const formItems: Record<string, IFormItemStore[]> = {};
-        const children = self.children.concat();
+        const children: Array<any> = this.directItems.concat();
 
         while (children.length) {
           const current = children.shift();

--- a/packages/amis/src/renderers/Form/InputGroup.tsx
+++ b/packages/amis/src/renderers/Form/InputGroup.tsx
@@ -120,6 +120,9 @@ export class InputGroup extends React.Component<
     }
 
     const chidren = formStore?.inputGroupItems?.[name];
+    if (!Array.isArray(chidren)) {
+      return;
+    }
     const errorCollection = chidren
       .map((item, index) => {
         if (item.errors.length <= 0) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ccf2a2</samp>

This pull request fixes some bugs and improves some features related to the `InputGroup` and `wrapControl` components, and the mock CFC server. It enhances the validation logic and the grouping of form items, and prevents rendering errors when invalid props are passed. It also simplifies the handling of CORS headers in the mock server.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7ccf2a2</samp>

> _`FormStore` bug fixed_
> _`InputGroup` checks children_
> _Mock server refined_

### Why

 Close: #7279

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7ccf2a2</samp>

* Fix a bug where the `Referer` header could be case-sensitive and not match the expected format in the mock server ([link](https://github.com/baidu/amis/pull/7289/files?diff=unified&w=0#diff-6be4c0e3c0a7b01f8c07505496742b63fc742f6f49a2ce31bd0a1d3ba40b3b1fL59-R63))
* Simplify the logic for setting the `Access-Control-Allow-Origin` header in the mock server ([link](https://github.com/baidu/amis/pull/7289/files?diff=unified&w=0#diff-6be4c0e3c0a7b01f8c07505496742b63fc742f6f49a2ce31bd0a1d3ba40b3b1fL67-R71))
* Trigger the validation of the form item when it is mounted, instead of waiting for the user to interact with it or submit the form, in the `wrapControl` component ([link](https://github.com/baidu/amis/pull/7289/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aR426))
* Refactor the `validate` method of the `wrapControl` component to simplify the logic and avoid unnecessary promises ([link](https://github.com/baidu/amis/pull/7289/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL516-R554))
* Remove the redundant logic for checking when to validate in the `handleChange` method of the `wrapControl` component ([link](https://github.com/baidu/amis/pull/7289/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL658-R672))
* Fix a bug where the `inputGroupItems` getter of the `FormStore` class could include non-form items in the result ([link](https://github.com/baidu/amis/pull/7289/files?diff=unified&w=0#diff-c8aefd7686b13cf0a0b440b598f20cc50e9abac39fcd9281de29dc6e9d3b358eL95-R95))
* Add a defensive check for the `InputGroup` component to avoid rendering errors when the `children` prop is not an array ([link](https://github.com/baidu/amis/pull/7289/files?diff=unified&w=0#diff-87956e39e11dd7103ac1175bab63330b480aa6ee8ce36a8ed181f98ea10201e3R123-R125))
