### PR TITLE
fix: 修复英文环境下日程展示问题

### DIFF
--- a/packages/amis-ui/src/components/calendar/DaysView.tsx
+++ b/packages/amis-ui/src/components/calendar/DaysView.tsx
@@ -472,6 +472,11 @@ export class CustomDaysView extends React.Component<CustomDaysViewProps> {
           });
           // 最多展示3个
           showSchedule = showSchedule.slice(0, 3);
+
+          const locale = this.props.viewDate.localeData();
+          // 以周几作为一周的开始，0表示周日，1表示周一
+          const firstDayOfWeek = locale.firstDayOfWeek();
+
           const scheduleDiv = showSchedule.map((item: any, index: number) => {
             let diffDays = moment(item.endTime).diff(
               moment(item.startTime),
@@ -486,9 +491,9 @@ export class CustomDaysView extends React.Component<CustomDaysViewProps> {
             /* 前面的计算结果是闭区间，所以最终结果要补足1 */
             diffDays += 1;
 
-            const width =
-              item.width ||
-              Math.min(diffDays, 7 - moment(item.startTime).weekday());
+            const endWidth =
+              7 - (moment(item.startTime).weekday() - firstDayOfWeek + 1);
+            const width = item.width || Math.min(diffDays, endWidth) || 1;
 
             return (
               <div


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b8fac87</samp>

This pull request enhances the calendar component by respecting the locale and the first day of the week settings. It also fixes a rendering issue with the events width.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b8fac87</samp>

> _To render the calendar events_
> _We use the locale and `viewDate` contents_
> _They give us the week's start_
> _And the language's part_
> _And fix the bug with zero widths events_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b8fac87</samp>

* Add locale and first day of week variables to get user preferences from viewDate prop ([link](https://github.com/baidu/amis/pull/7290/files?diff=unified&w=0#diff-206e06fca060056b2ec3db9f17011b6ceeeb01ac290df0fdeb7d49c7ab7e91d7R475-R479))
* Adjust width calculation to account for first day of week and prevent zero width bug ([link](https://github.com/baidu/amis/pull/7290/files?diff=unified&w=0#diff-206e06fca060056b2ec3db9f17011b6ceeeb01ac290df0fdeb7d49c7ab7e91d7L489-R496))
