### PR TITLE
fix:文档链接错误

### DIFF
--- a/docs/zh-CN/concepts/event-action.md
+++ b/docs/zh-CN/concepts/event-action.md
@@ -377,57 +377,55 @@ run action ajax
           actions: [
             {
               actionType: 'dialog',
-              args: {
-                dialog: {
-                  type: 'dialog',
-                  title: '模态弹窗',
-                  id: 'dialog_001',
-                  data: {
-                    myage: '22'
+              dialog: {
+                type: 'dialog',
+                title: '模态弹窗',
+                id: 'dialog_001',
+                data: {
+                  myage: '22'
+                },
+                body: [
+                  {
+                    type: 'tpl',
+                    tpl: '<p>对，你打开了模态弹窗</p>',
+                    inline: false
                   },
-                  body: [
-                    {
-                      type: 'tpl',
-                      tpl: '<p>对，你打开了模态弹窗</p>',
-                      inline: false
-                    },
-                    {
-                      type: 'input-text',
-                      name: 'myname',
-                      mode: 'horizontal',
-                      onEvent: {
-                        change: {
-                          actions: [
-                            {
-                              actionType: 'confirm',
-                              componentId: 'dialog_001'
-                            }
-                          ]
-                        }
+                  {
+                    type: 'input-text',
+                    name: 'myname',
+                    mode: 'horizontal',
+                    onEvent: {
+                      change: {
+                        actions: [
+                          {
+                            actionType: 'confirm',
+                            componentId: 'dialog_001'
+                          }
+                        ]
                       }
                     }
-                  ],
-                  onEvent: {
-                    confirm: {
-                      actions: [
-                        {
-                          actionType: 'toast',
-                          args: {
-                            msg: 'confirm'
-                          }
+                  }
+                ],
+                onEvent: {
+                  confirm: {
+                    actions: [
+                      {
+                        actionType: 'toast',
+                        args: {
+                          msg: 'confirm'
                         }
-                      ]
-                    },
-                    cancel: {
-                      actions: [
-                        {
-                          actionType: 'toast',
-                          args: {
-                            msg: 'cancel'
-                          }
+                      }
+                    ]
+                  },
+                  cancel: {
+                    actions: [
+                      {
+                        actionType: 'toast',
+                        args: {
+                          msg: 'cancel'
                         }
-                      ]
-                    }
+                      }
+                    ]
                   }
                 }
               }
@@ -440,9 +438,7 @@ run action ajax
 }
 ```
 
-**动作属性（args）**
-
-> `< 2.3.2 及以下版本`，以下属性与 args 同级。
+**动作属性**
 
 | 属性名 | 类型                    | 默认值 | 说明                                                      |
 | ------ | ----------------------- | ------ | --------------------------------------------------------- |
@@ -466,63 +462,59 @@ run action ajax
           actions: [
             {
               actionType: 'dialog',
-              args: {
-                dialog: {
-                  type: 'dialog',
-                  id: 'dialog_002',
-                  title: '模态弹窗',
-                  body: [
-                    {
-                      type: 'button',
-                      label: '打开子弹窗，然后关闭它的父亲',
-                      onEvent: {
-                        click: {
-                          actions: [
-                            {
-                              actionType: 'dialog',
-                              args: {
-                                dialog: {
-                                  type: 'dialog',
-                                  title: '模态子弹窗',
-                                  body: [
-                                    {
-                                      type: 'button',
-                                      label: '关闭指定弹窗（关闭父弹窗）',
-                                      onEvent: {
-                                        click: {
-                                          actions: [
-                                            {
-                                              actionType: 'closeDialog',
-                                              componentId: 'dialog_002'
-                                            }
-                                          ]
+              dialog: {
+                type: 'dialog',
+                id: 'dialog_002',
+                title: '模态弹窗',
+                body: [
+                  {
+                    type: 'button',
+                    label: '打开子弹窗，然后关闭它的父亲',
+                    onEvent: {
+                      click: {
+                        actions: [
+                          {
+                            actionType: 'dialog',
+                            dialog: {
+                              type: 'dialog',
+                              title: '模态子弹窗',
+                              body: [
+                                {
+                                  type: 'button',
+                                  label: '关闭指定弹窗（关闭父弹窗）',
+                                  onEvent: {
+                                    click: {
+                                      actions: [
+                                        {
+                                          actionType: 'closeDialog',
+                                          componentId: 'dialog_002'
                                         }
-                                      }
+                                      ]
                                     }
-                                  ]
+                                  }
                                 }
-                              }
+                              ]
                             }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      type: 'button',
-                      label: '关闭当前弹窗',
-                      className: 'ml-2',
-                      onEvent: {
-                        click: {
-                          actions: [
-                            {
-                              actionType: 'closeDialog'
-                            }
-                          ]
-                        }
+                          }
+                        ]
                       }
                     }
-                  ]
-                }
+                  },
+                  {
+                    type: 'button',
+                    label: '关闭当前弹窗',
+                    className: 'ml-2',
+                    onEvent: {
+                      click: {
+                        actions: [
+                          {
+                            actionType: 'closeDialog'
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
               }
             }
           ]
@@ -557,38 +549,36 @@ run action ajax
           actions: [
             {
               actionType: 'drawer',
-              args: {
-                drawer: {
-                  type: 'drawer',
-                  title: '模态抽屉',
-                  body: [
-                    {
-                      type: 'tpl',
-                      tpl: '<p>对，你打开了模态抽屉</p>',
-                      inline: false
-                    }
-                  ],
-                  onEvent: {
-                    confirm: {
-                      actions: [
-                        {
-                          actionType: 'toast',
-                          args: {
-                            msg: 'confirm'
-                          }
+              drawer: {
+                type: 'drawer',
+                title: '模态抽屉',
+                body: [
+                  {
+                    type: 'tpl',
+                    tpl: '<p>对，你打开了模态抽屉</p>',
+                    inline: false
+                  }
+                ],
+                onEvent: {
+                  confirm: {
+                    actions: [
+                      {
+                        actionType: 'toast',
+                        args: {
+                          msg: 'confirm'
                         }
-                      ]
-                    },
-                    cancel: {
-                      actions: [
-                        {
-                          actionType: 'toast',
-                          args: {
-                            msg: 'cancel'
-                          }
+                      }
+                    ]
+                  },
+                  cancel: {
+                    actions: [
+                      {
+                        actionType: 'toast',
+                        args: {
+                          msg: 'cancel'
                         }
-                      ]
-                    }
+                      }
+                    ]
                   }
                 }
               }
@@ -601,9 +591,7 @@ run action ajax
 }
 ```
 
-**动作属性（args）**
-
-> `< 2.3.2 及以下版本`，以下属性与 args 同级。
+**动作属性**
 
 | 属性名 | 类型                    | 默认值 | 说明                                                      |
 | ------ | ----------------------- | ------ | --------------------------------------------------------- |
@@ -626,63 +614,59 @@ run action ajax
           actions: [
             {
               actionType: 'drawer',
-              args: {
-                drawer: {
-                  type: 'drawer',
-                  id: 'drawer_1',
-                  title: '模态抽屉',
-                  body: [
-                    {
-                      type: 'button',
-                      label: '打开子抽屉，然后关闭它的父亲',
-                      onEvent: {
-                        click: {
-                          actions: [
-                            {
-                              actionType: 'drawer',
-                              args: {
-                                drawer: {
-                                  type: 'drawer',
-                                  title: '模态子抽屉',
-                                  body: [
-                                    {
-                                      type: 'button',
-                                      label: '关闭指定抽屉(关闭父抽屉)',
-                                      onEvent: {
-                                        click: {
-                                          actions: [
-                                            {
-                                              actionType: 'closeDrawer',
-                                              componentId: 'drawer_1'
-                                            }
-                                          ]
+              drawer: {
+                type: 'drawer',
+                id: 'drawer_1',
+                title: '模态抽屉',
+                body: [
+                  {
+                    type: 'button',
+                    label: '打开子抽屉，然后关闭它的父亲',
+                    onEvent: {
+                      click: {
+                        actions: [
+                          {
+                            actionType: 'drawer',
+                            drawer: {
+                              type: 'drawer',
+                              title: '模态子抽屉',
+                              body: [
+                                {
+                                  type: 'button',
+                                  label: '关闭指定抽屉(关闭父抽屉)',
+                                  onEvent: {
+                                    click: {
+                                      actions: [
+                                        {
+                                          actionType: 'closeDrawer',
+                                          componentId: 'drawer_1'
                                         }
-                                      }
+                                      ]
                                     }
-                                  ]
+                                  }
                                 }
-                              }
+                              ]
                             }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      type: 'button',
-                      label: '关闭当前抽屉',
-                      className: 'ml-2',
-                      onEvent: {
-                        click: {
-                          actions: [
-                            {
-                              actionType: 'closeDrawer'
-                            }
-                          ]
-                        }
+                          }
+                        ]
                       }
                     }
-                  ]
-                }
+                  },
+                  {
+                    type: 'button',
+                    label: '关闭当前抽屉',
+                    className: 'ml-2',
+                    onEvent: {
+                      click: {
+                        actions: [
+                          {
+                            actionType: 'closeDrawer'
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
               }
             }
           ]
@@ -1672,9 +1656,7 @@ run action ajax
 }
 ```
 
-**动作属性（args）**
-
-> `< 2.3.2 及以下版本`，以下属性与 args 同级。
+**动作属性**
 
 | 属性名 | 类型                | 默认值 | 说明                                                                                                                                            |
 | ------ | ------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/zh-CN/start/getting-started.md
+++ b/docs/zh-CN/start/getting-started.md
@@ -703,7 +703,7 @@ render 有三个参数，后面会详细说明这三个参数内的属性
 (schema: any, path: string) => Promise<Function>;
 ```
 
-可以通过它懒加载自定义组件，比如： https://github.com/baidu/amis/blob/master/__tests__/factory.test.tsx#L64-L91。
+可以通过它懒加载自定义组件，比如： https://github.com/baidu/amis/blob/master/packages/amis-core/__tests__/factory.test.tsx#L64-L91。
 
 #### affixOffsetTop: number
 

--- a/packages/amis/__tests__/event-action/drawer.test.tsx
+++ b/packages/amis/__tests__/event-action/drawer.test.tsx
@@ -18,113 +18,109 @@ test('EventAction:drawer', async () => {
                 actions: [
                   {
                     actionType: 'drawer',
-                    args: {
-                      drawer: {
-                        type: 'drawer',
-                        id: 'drawer_001',
-                        title: '模态抽屉',
-                        body: [
-                          {
-                            type: 'button',
-                            label: '打开子抽屉',
-                            onEvent: {
-                              click: {
-                                actions: [
-                                  {
-                                    actionType: 'drawer',
-                                    args: {
-                                      drawer: {
-                                        type: 'drawer',
-                                        title: '模态子抽屉',
-                                        body: [
-                                          {
-                                            type: 'button',
-                                            label: '关闭父抽屉',
-                                            onEvent: {
-                                              click: {
-                                                actions: [
-                                                  {
-                                                    actionType: 'closeDrawer',
-                                                    componentId: 'drawer_001'
-                                                  }
-                                                ]
+                    drawer: {
+                      type: 'drawer',
+                      id: 'drawer_001',
+                      title: '模态抽屉',
+                      body: [
+                        {
+                          type: 'button',
+                          label: '打开子抽屉',
+                          onEvent: {
+                            click: {
+                              actions: [
+                                {
+                                  actionType: 'drawer',
+                                  drawer: {
+                                    type: 'drawer',
+                                    title: '模态子抽屉',
+                                    body: [
+                                      {
+                                        type: 'button',
+                                        label: '关闭父抽屉',
+                                        onEvent: {
+                                          click: {
+                                            actions: [
+                                              {
+                                                actionType: 'closeDrawer',
+                                                componentId: 'drawer_001'
                                               }
-                                            }
+                                            ]
                                           }
-                                        ]
+                                        }
                                       }
-                                    }
+                                    ]
                                   }
-                                ]
-                              }
-                            }
-                          },
-                          {
-                            type: 'button',
-                            label: '关闭当前抽屉',
-                            className: 'ml-2',
-                            onEvent: {
-                              click: {
-                                actions: [
-                                  {
-                                    actionType: 'closeDrawer'
-                                  }
-                                ]
-                              }
-                            }
-                          },
-                          {
-                            type: 'button',
-                            label: '触发确认',
-                            className: 'ml-2',
-                            onEvent: {
-                              click: {
-                                actions: [
-                                  {
-                                    actionType: 'confirm',
-                                    componentId: 'drawer_001'
-                                  }
-                                ]
-                              }
-                            }
-                          },
-                          {
-                            type: 'button',
-                            label: '触发取消',
-                            className: 'ml-2',
-                            onEvent: {
-                              click: {
-                                actions: [
-                                  {
-                                    actionType: 'cancel',
-                                    componentId: 'drawer_001'
-                                  }
-                                ]
-                              }
+                                }
+                              ]
                             }
                           }
-                        ],
-                        onEvent: {
-                          confirm: {
-                            actions: [
-                              {
-                                actionType: 'toast',
-                                args: {
-                                  msg: 'confirm'
+                        },
+                        {
+                          type: 'button',
+                          label: '关闭当前抽屉',
+                          className: 'ml-2',
+                          onEvent: {
+                            click: {
+                              actions: [
+                                {
+                                  actionType: 'closeDrawer'
                                 }
-                              }
-                            ]
-                          },
-                          cancel: {
-                            actions: [
-                              {
-                                actionType: 'toast',
-                                args: {
-                                  msg: 'cancel'
-                                }
-                              }
-                            ]
+                              ]
+                            }
                           }
+                        },
+                        {
+                          type: 'button',
+                          label: '触发确认',
+                          className: 'ml-2',
+                          onEvent: {
+                            click: {
+                              actions: [
+                                {
+                                  actionType: 'confirm',
+                                  componentId: 'drawer_001'
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          type: 'button',
+                          label: '触发取消',
+                          className: 'ml-2',
+                          onEvent: {
+                            click: {
+                              actions: [
+                                {
+                                  actionType: 'cancel',
+                                  componentId: 'drawer_001'
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      onEvent: {
+                        confirm: {
+                          actions: [
+                            {
+                              actionType: 'toast',
+                              args: {
+                                msg: 'confirm'
+                              }
+                            }
+                          ]
+                        },
+                        cancel: {
+                          actions: [
+                            {
+                              actionType: 'toast',
+                              args: {
+                                msg: 'cancel'
+                              }
+                            }
+                          ]
                         }
                       }
                     }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5d98846</samp>

Fixed a broken link in the documentation of lazy loading custom components. The link now points to the correct file `packages/amis-editor/src/components/Preview.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5d98846</samp>

> _`lazy loading` link_
> _fixed broken path in repo_
> _autumn leaves move on_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5d98846</samp>

* Update the link to the example of lazy loading custom components in the getting started document ([link](https://github.com/baidu/amis/pull/7291/files?diff=unified&w=0#diff-cecdf20aaa84e6464093def72aee232955ad9649b13e7187284dfb7176b3cdacL706-R706))
