### PR TITLE
fix: disabled 失效问题

### DIFF
--- a/packages/amis-core/src/utils/helper.ts
+++ b/packages/amis-core/src/utils/helper.ts
@@ -1406,7 +1406,7 @@ export function chainEvents(props: any, schema: any) {
         ret[key] = chainFunctions(schema[key], props[key]);
       }
     } else {
-      ret[key] = props[key];
+      ret[key] = props[key] ?? schema[key];
     }
   });
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b58af43</samp>

Fix a bug where data-level props could override schema-level props in `SchemaRenderer`. Omit `disabled`, `static`, `visible`, and `hidden` props from the `rest` object before passing it to `chainEvents`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b58af43</samp>

> _`disabled` prop_
> _skipped from `rest` object_
> _autumn bug is fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b58af43</samp>

*  Omit `disabled`, `static`, `visible`, and `hidden` props from the `rest` object before passing it to the `chainEvents` function to avoid overriding schema-level settings with data-level settings ([link](https://github.com/baidu/amis/pull/7292/files?diff=unified&w=0#diff-337f9a56707dbfa5917084f1e2048555a5ade95f13df3f685076114867426347L440-R443))
