### PR TITLE
chore:去掉组件动作调用目标为自身的判断

### DIFF
--- a/docs/zh-CN/concepts/event-action.md
+++ b/docs/zh-CN/concepts/event-action.md
@@ -1784,9 +1784,9 @@ run action ajax
 
 > 注意：直接调用`event.setData()`将修改事件的原有上下文，如果不希望覆盖可以通过`event.setData({...event.data, {xxx: xxx}})`来进行数据的合并。
 
-## 触发其他组件的动作
+## 触发组件的动作
 
-通过配置`componentId`来触发指定组件的动作，组件动作配置通过`args`传入`(> 1.9.0 及以上版本)`，动作参数请查看对应的组件的[动作表](../../components/form/index#动作表)，更多示例请查看[组件事件动作示例](../../../examples/event/form)。
+通过配置`componentId`或`componentName`来触发指定组件的动作（不配置将调用当前组件自己的动作），组件动作配置通过`args`传入`(> 1.9.0 及以上版本)`，动作参数请查看对应的组件的[动作表](../../components/form/index#动作表)，更多示例请查看[组件事件动作示例](../../../examples/event/form)。
 
 ```schema
 {

--- a/packages/amis-core/src/WithRootStore.tsx
+++ b/packages/amis-core/src/WithRootStore.tsx
@@ -25,6 +25,20 @@ export function withRootStore<
       })`;
       static contextType = RootStoreContext;
       static ComposedComponent = ComposedComponent as React.ComponentType<T>;
+      ref: any;
+
+      constructor(props: OuterProps) {
+        super(props);
+        this.refFn = this.refFn.bind(this);
+      }
+
+      getWrappedInstance() {
+        return this.ref.control;
+      }
+
+      refFn(ref: any) {
+        this.ref = ref;
+      }
 
       render() {
         const rootStore: IRendererStore = this.context as any;
@@ -41,6 +55,7 @@ export function withRootStore<
               React.ComponentProps<T>
             > as any)}
             {...injectedProps}
+            ref={this.refFn}
           />
         );
       }

--- a/packages/amis-core/src/actions/CmptAction.ts
+++ b/packages/amis-core/src/actions/CmptAction.ts
@@ -44,12 +44,11 @@ export class CmptAction implements RendererAction {
      * 触发组件未指定id或未指定响应组件componentId，则使用触发组件响应
      */
     const key = action.componentId || action.componentName;
-    let component =
-      key && renderer.props.$schema[action.componentId ? 'id' : 'name'] !== key
-        ? event.context.scoped?.[
-            action.componentId ? 'getComponentById' : 'getComponentByName'
-          ](key)
-        : renderer;
+    let component = key
+      ? event.context.scoped?.[
+          action.componentId ? 'getComponentById' : 'getComponentByName'
+        ](key)
+      : renderer;
 
     const dataMergeMode = action.dataMergeMode || 'merge';
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8715924</samp>

Simplified the logic for finding the target component in `CmptAction.ts` to fix a bug with component action. This was part of a pull request to enhance the component action feature and its test coverage.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8715924</samp>

> _`component` fixed_
> _no need to check `$schema`_
> _action works in fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8715924</samp>

*  Simplify the condition for assigning the `component` variable in the component action ([link](https://github.com/baidu/amis/pull/7297/files?diff=unified&w=0#diff-9fcca25fc37554994f4168d09ade3ba52487964b8f897e0a9de38442dc6b1ceaL47-R51))
