### PR TITLE
fix: 修复 Page 组件快速切换可能的 warning 报错 Close: #6657

### DIFF
--- a/packages/amis/src/renderers/Page.tsx
+++ b/packages/amis/src/renderers/Page.tsx
@@ -34,7 +34,7 @@ import {
   SchemaMessage
 } from '../Schema';
 import {SchemaRemark} from './Remark';
-import {onAction} from 'mobx-state-tree';
+import {isAlive, onAction} from 'mobx-state-tree';
 import mapValues from 'lodash/mapValues';
 import {resolveVariable} from 'amis-core';
 import {buildStyle} from 'amis-core';
@@ -409,7 +409,7 @@ export default class Page extends React.Component<PageProps> {
       env.tracker({eventType: 'pageLoaded'}, this.props);
     }
 
-    if (rendererEvent?.prevented) {
+    if (rendererEvent?.prevented || !isAlive(store)) {
       return;
     }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8600320</samp>

Fixed a bug in page renderer that could cause errors when triggering actions on unmounted components. Added `isAlive` check to `packages/amis/src/renderers/Page.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8600320</samp>

> _Oh we are the coders of the web, me hearties_
> _And we write the logic for the page_
> _But before we run the action handler_
> _We check the `isAlive` of the store node's stage_

### Why

Close: #6657

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8600320</samp>

* Import `isAlive` function from `mobx-state-tree` to check node liveliness ([link](https://github.com/baidu/amis/pull/7301/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L37-R37))
* Use `isAlive` function to guard action handler in `Page` component ([link](https://github.com/baidu/amis/pull/7301/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L412-R412))
