### PR TITLE
feat: inputDateTime 支持 isEndDate 配置自动选中 23:59:59 Close: #7277

### DIFF
--- a/docs/zh-CN/components/form/input-datetime.md
+++ b/docs/zh-CN/components/form/input-datetime.md
@@ -370,6 +370,7 @@ order: 14
 | clearable       | `boolean`                                                      | `true`                 | 是否可清除                                                                                                      |
 | embed           | `boolean`                                                      | `false`                | 是否内联                                                                                                        |
 | timeConstraints | `object`                                                       | `true`                 | 请参考 [input-time](./input-time#控制输入范围) 里的说明                                                         |
+| isEndDate       | `boolean`                                                      | `false`                | 如果配置为 true，会自动默认为 23:59:59 秒                                                                       |
 
 ## 事件表
 

--- a/packages/amis-ui/src/components/CalendarMobile.tsx
+++ b/packages/amis-ui/src/components/CalendarMobile.tsx
@@ -49,6 +49,7 @@ export interface CalendarMobileProps extends ThemeProps, LocaleProps {
     };
   };
   defaultDate?: moment.Moment;
+  isEndDate?: boolean;
 }
 
 export interface CalendarMobileState {
@@ -574,7 +575,8 @@ export class CalendarMobile extends React.Component<
       viewMode = 'days',
       close,
       defaultDate,
-      showViewMode
+      showViewMode,
+      isEndDate
     } = this.props;
     const __ = this.props.translate;
 
@@ -654,6 +656,7 @@ export class CalendarMobile extends React.Component<
                 hideHeader={true}
                 updateOn={viewMode}
                 key={'calendar' + index}
+                isEndDate={isEndDate}
               />
             </div>
           );
@@ -671,7 +674,8 @@ export class CalendarMobile extends React.Component<
       close,
       timeConstraints,
       defaultDate,
-      isDatePicker
+      isDatePicker,
+      isEndDate
     } = this.props;
     const __ = this.props.translate;
 
@@ -705,6 +709,7 @@ export class CalendarMobile extends React.Component<
           })}
           timeConstraints={timeConstraints}
           isValidDate={this.checkIsValidDate}
+          isEndDate={isEndDate}
         />
       </div>
     );

--- a/packages/amis-ui/src/components/DatePicker.tsx
+++ b/packages/amis-ui/src/components/DatePicker.tsx
@@ -310,6 +310,9 @@ export interface DateProps extends LocaleProps, ThemeProps {
   onBlur?: Function;
   onRef?: any;
   data?: any;
+
+  // 是否为结束时间
+  isEndDate?: boolean;
 }
 
 export interface DatePickerState {
@@ -708,6 +711,7 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
       clearable,
       shortcuts,
       utc,
+      isEndDate,
       overlayPlacement,
       locale,
       format,
@@ -749,6 +753,7 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
           viewMode === 'quarters' || viewMode === 'months' ? 'years' : 'months'
         }
         timeConstraints={timeConstraints}
+        isEndDate={isEndDate}
       />
     );
     const CalendarMobileTitle = (
@@ -815,6 +820,7 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
             onScheduleClick={onScheduleClick}
             embed={embed}
             useMobileUI={useMobileUI}
+            isEndDate={isEndDate}
           />
         </div>
       );
@@ -902,6 +908,7 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
                 minDate={minDate}
                 maxDate={maxDate}
                 useMobileUI={useMobileUI}
+                isEndDate={isEndDate}
                 // utc={utc}
               />
             </PopOver>

--- a/packages/amis/src/renderers/Form/InputDate.tsx
+++ b/packages/amis/src/renderers/Form/InputDate.tsx
@@ -145,6 +145,11 @@ export interface DateTimeControlSchema extends InputDateBaseControlSchema {
    * 时间输入范围限制
    */
   timeConstraints?: any;
+
+  /**
+   * 是否为结束时间，如果是，那么会自动加上 23:59:59
+   */
+  isEndDate?: boolean;
 }
 
 /**


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e4aefb7</samp>

This pull request adds a new `isEndDate` prop to various components related to date and time selection, such as `CalendarMobile`, `DatePicker`, and `InputDate`. This prop enables the components to support date range pickers with different modes and formats. It also updates the documentation of the `input-date` component to reflect the new prop.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e4aefb7</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever prop for the `input-date` component,_
> _The `isEndDate`, which marks the final hour_
> _Of the chosen span of days and nights sublime._

### Why

 Close: #7277

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e4aefb7</samp>

*  Add `isEndDate` prop to `InputDate`, `DatePicker`, `CalendarMobile`, and `Calendar` components to enable setting the input value as an end date ([link](https://github.com/baidu/amis/pull/7302/files?diff=unified&w=0#diff-56835df54b63fc25653bc9cb41f895a4e75843bbbf719028fbcc740ae394a94fR148-R152), [link](https://github.com/baidu/amis/pull/7302/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cR313-R315), [link](https://github.com/baidu/amis/pull/7302/files?diff=unified&w=0#diff-80967da8259dea2a003e86d0b30ce42c9189358c119600662101a971276ee521R52), [link](https://github.com/baidu/amis/pull/7302/files?diff=unified&w=0#diff-1df5e88733871e92d86ce0af46616a0c2d8e894285da4e8726c0db67081cfbbcR373))
*  Pass `isEndDate` prop from `InputDate` to `DatePicker` and from `DatePicker` to `CalendarMobile` or `Calendar` depending on the `showMode` prop ([link](https://github.com/baidu/amis/pull/7302/files?diff=unified&w=0#diff-56835df54b63fc25653bc9cb41f895a4e75843bbbf719028fbcc740ae394a94fR148-R152), [link](https://github.com/baidu/amis/pull/7302/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cR756), [link](https://github.com/baidu/amis/pull/7302/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cR823), [link](https://github.com/baidu/amis/pull/7302/files?diff=unified&w=0#diff-80967da8259dea2a003e86d0b30ce42c9189358c119600662101a971276ee521R659))
*  Pass `isEndDate` prop from `CalendarMobile` and `DatePicker` to `TimePicker` when the `isDatePicker` prop is true ([link](https://github.com/baidu/amis/pull/7302/files?diff=unified&w=0#diff-80967da8259dea2a003e86d0b30ce42c9189358c119600662101a971276ee521R712), [link](https://github.com/baidu/amis/pull/7302/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cR911))
*  Destructure `isEndDate` prop from `this.props` in `CalendarMobile`, `DatePicker`, and `TimePicker` components ([link](https://github.com/baidu/amis/pull/7302/files?diff=unified&w=0#diff-80967da8259dea2a003e86d0b30ce42c9189358c119600662101a971276ee521L577-R579), [link](https://github.com/baidu/amis/pull/7302/files?diff=unified&w=0#diff-80967da8259dea2a003e86d0b30ce42c9189358c119600662101a971276ee521L674-R678), [link](https://github.com/baidu/amis/pull/7302/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cR714), [link](https://github.com/baidu/amis/pull/7302/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cR911))
