### PR TITLE
fix: 修复condition-builder的下拉icon和select不统一

### DIFF
--- a/packages/amis-ui/scss/components/_condition-builder.scss
+++ b/packages/amis-ui/scss/components/_condition-builder.scss
@@ -195,6 +195,7 @@
       width: px2rem(10px);
       height: px2rem(10px);
       top: 0;
+      transform: rotate(90deg);
     }
   }
 

--- a/packages/amis-ui/scss/components/form/_selection.scss
+++ b/packages/amis-ui/scss/components/form/_selection.scss
@@ -445,6 +445,7 @@
       width: px2rem(10px);
       height: px2rem(10px);
       top: 0;
+      transform: rotate(90deg);
     }
   }
 

--- a/packages/amis-ui/src/components/DropDownSelection.tsx
+++ b/packages/amis-ui/src/components/DropDownSelection.tsx
@@ -158,7 +158,7 @@ class DropDownSelection extends BaseSelection<
             >
               {!isMobile() ? (
                 <span className={cx('DropDownSelection-caret')}>
-                  <Icon icon="caret" className="icon" />
+                  <Icon icon="right-arrow-bold" className="icon" />
                 </span>
               ) : null}
             </ResultBox>

--- a/packages/amis-ui/src/components/condition-builder/Func.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Func.tsx
@@ -127,7 +127,7 @@ export class ConditionFunc extends React.Component<ConditionFuncProps> {
                 disabled={disabled}
               >
                 <span className={cx('CBGroup-fieldCaret')}>
-                  <Icon icon="caret" className="icon" />
+                  <Icon icon="right-arrow-bold" className="icon" />
                 </span>
               </ResultBox>
             </div>

--- a/packages/amis-ui/src/components/condition-builder/Item.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Item.tsx
@@ -234,7 +234,7 @@ export class ConditionItem extends React.Component<ConditionItemProps> {
                 placeholder={__('Condition.cond_placeholder')}
               >
                 <span className={cx('CBGroup-operatorCaret')}>
-                  <Icon icon="caret" className="icon" />
+                  <Icon icon="right-arrow-bold" className="icon" />
                 </span>
               </ResultBox>
             </div>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d51455d</samp>

This pull request updates the icons used in the condition builder, selection, and drop-down components to make them more consistent and intuitive. It replaces the `caret` icon with the `right-arrow-bold` icon and adds a CSS transform to rotate them 90 degrees.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d51455d</samp>

> _`Caret` icon gone_
> _`Right-arrow-bold` shows the way_
> _Winter of clarity_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d51455d</samp>

*  Rotate the caret icon 90 degrees in the condition builder and selection components to match the right-arrow-bold icon ([link](https://github.com/baidu/amis/pull/7303/files?diff=unified&w=0#diff-61a730ea77707567de025dccdfaf2f4b2014545a44075936fbc94516e9b9fcdcR198), [link](https://github.com/baidu/amis/pull/7303/files?diff=unified&w=0#diff-0f0487287579e1a13ea4e8643e44936d1aaf6c272bc335585eddb6fc06126402R448))
* Replace the caret icon with the right-arrow-bold icon in the condition function, condition item, and drop-down selection components to indicate sub-menus or nested options ([link](https://github.com/baidu/amis/pull/7303/files?diff=unified&w=0#diff-9680863ae4a8b88ad8eb80373954aa588c0d7b50e08f5385c6f9e4672dcafa20L130-R130), [link](https://github.com/baidu/amis/pull/7303/files?diff=unified&w=0#diff-bd3cef1dd1adf5cbac8db6825eccda213b5450966cc365712f22a32093048fc6L237-R237), [link](https://github.com/baidu/amis/pull/7303/files?diff=unified&w=0#diff-abb27a21bd425df5d4d689bdc6858e46ec83dd19885db52601f2658df3814201L161-R161))
