### PR TITLE
fix:BCE-FE-1706文档目录大纲可收起

### DIFF
--- a/examples/doc.css
+++ b/examples/doc.css
@@ -453,6 +453,7 @@
   overflow: auto;
   word-break: normal;
   /* word-break: keep-all; */
+  border-left: 1px solid #ddd;
 }
 
 .markdown-body table:not(.table) th {
@@ -475,6 +476,33 @@
 
 body.dark .markdown-body table:not(.table) tr:nth-child(2n) {
   background: none;
+}
+
+.markdown-body table td:first-child,
+.markdown-body table th:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 10;
+  background-color: #fff;
+  border-left: 0px !important;
+}
+
+.markdown-body table td:first-child::after,
+.markdown-body table th:first-child::after {
+  box-shadow: inset 10px 0 8px -8px rgba(0, 0, 0, 0.1);
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: -1px;
+  width: 30px;
+  transform: translate(100%);
+  transition: box-shadow 0.3s;
+  content: '';
+  pointer-events: none;
+}
+
+.markdown-body table tr:nth-child(2n) td:first-child {
+  background-color: #f8f8f8;
 }
 
 /* modified by zhangjun08


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 613da3c</samp>

This pull request enhances the appearance and usability of tables in the documentation. It modifies the `doc.css` file to apply a left border and a fixed first column to tables in the `markdown-body` class.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 613da3c</samp>

> _If you want to display some data_
> _In a table that looks great-a_
> _Use the `markdown-body` class_
> _With a border and a sticky first mass_
> _And some effects that will captivate-a_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 613da3c</samp>

*  Add styles to make the first column of the table sticky and scrollable in `doc.css` ([link](https://github.com/baidu/amis/pull/7304/files?diff=unified&w=0#diff-c8db71a7a3046bb8e2ef5dae2be04901482c88defbae793b6bc941fa12aa3608R456), [link](https://github.com/baidu/amis/pull/7304/files?diff=unified&w=0#diff-c8db71a7a3046bb8e2ef5dae2be04901482c88defbae793b6bc941fa12aa3608R481-R507))
