### PR TITLE
fix: curd组件如果单元格有service，service下面有form，切换分页时，form还是保留状态问题

### DIFF
--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -643,6 +643,10 @@ export default class Form extends React.Component<FormProps, object> {
         .then(this.dispatchInited)
         .then(this.initInterval);
     }
+
+    if (this.props?.tableCellRegion !== prevProps?.tableCellRegion) {
+      this.props.store.reset(undefined, true);
+    }
   }
 
   componentWillUnmount() {

--- a/packages/amis/src/renderers/Table/TableCell.tsx
+++ b/packages/amis/src/renderers/Table/TableCell.tsx
@@ -81,9 +81,6 @@ export class TableCell extends React.Component<TableCellProps> {
       delete schema.label;
     }
 
-    const {page, perPage} = rest.query;
-    const {rowIndex} = rest;
-
     let body = children
       ? children
       : render('field', schema, {
@@ -93,7 +90,9 @@ export class TableCell extends React.Component<TableCellProps> {
           /** value没有返回值时设置默认值，避免错误获取到父级数据域的值 */
           value: canAccessSuperData ? value : value ?? '',
           data,
-          tableCellRegion: `${page}${perPage}${rowIndex}${colIndex}`
+          tableCellRegion: `${rest?.query?.page}${rest?.query?.perPage ?? ''} ${
+            rest?.rowIndex
+          }${colIndex}`
         });
 
     if (width) {

--- a/packages/amis/src/renderers/Table/TableCell.tsx
+++ b/packages/amis/src/renderers/Table/TableCell.tsx
@@ -81,6 +81,9 @@ export class TableCell extends React.Component<TableCellProps> {
       delete schema.label;
     }
 
+    const {page, perPage} = rest.query;
+    const {rowIndex} = rest;
+
     let body = children
       ? children
       : render('field', schema, {
@@ -89,7 +92,8 @@ export class TableCell extends React.Component<TableCellProps> {
           inputOnly: true,
           /** value没有返回值时设置默认值，避免错误获取到父级数据域的值 */
           value: canAccessSuperData ? value : value ?? '',
-          data
+          data,
+          tableCellRegion: `${page}${perPage}${rowIndex}${colIndex}`
         });
 
     if (width) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c2f429f</samp>

This pull request adds a `tableCellRegion` prop to the `Form` and `TableCell` components to enable resetting the form store when the form is rendered in a different table cell. This prevents stale data and validation errors from affecting the form.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c2f429f</samp>

> _`tableCellRegion`_
> _Changes form store on switch_
> _Autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c2f429f</samp>

*  Add `tableCellRegion` prop to `Form` and `TableCell` components to enable form store reset when rendering in different table cells ([link](https://github.com/baidu/amis/pull/7306/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3R646-R649), [link](https://github.com/baidu/amis/pull/7306/files?diff=unified&w=0#diff-5554160d45d5319563baa9821ead14f776d100c92c9e6d06d7f8e962211163daL92-R95))
