### PR TITLE
fix: normalizeLink url处理问题

### DIFF
--- a/packages/amis-core/src/utils/normalizeLink.ts
+++ b/packages/amis-core/src/utils/normalizeLink.ts
@@ -9,13 +9,21 @@ export const normalizeLink = (to: string, location = window.location) => {
 
   const idx = to.indexOf('?');
   const idx2 = to.indexOf('#');
-  let pathname = ~idx
-    ? to.substring(0, idx)
-    : ~idx2
-    ? to.substring(0, idx2)
-    : to;
-  let search = ~idx ? to.substring(idx, ~idx2 ? idx2 : undefined) : '';
-  let hash = ~idx2 ? to.substring(idx2) : location.hash;
+  let pathname = to;
+  let search = '';
+  let hash = location.hash;
+  // host?a=a#b 的情况
+  if (idx < idx2) {
+    pathname = ~idx ? to.substring(0, idx) : ~idx2 ? to.substring(0, idx2) : to;
+    hash = ~idx2 ? to.substring(idx2) : location.hash;
+    search = ~idx ? to.substring(idx, ~idx2 ? idx2 : undefined) : '';
+  }
+  // host#b?a=a 的情况
+  else if (idx > idx2) {
+    pathname = ~idx2 ? to.substring(0, idx2) : ~idx ? to.substring(0, idx) : to;
+    hash = ~idx2 ? to.substring(idx2, ~idx ? idx : undefined) : location.hash;
+    search = ~idx ? to.substring(idx) : '';
+  }
 
   if (!pathname) {
     pathname = location.pathname;
@@ -33,5 +41,6 @@ export const normalizeLink = (to: string, location = window.location) => {
     pathname = paths.concat(pathname).join('/');
   }
 
-  return pathname + search + hash;
+  const rest = idx < idx2 ? search + hash : hash + search;
+  return pathname + rest;
 };


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6c9cbc9</samp>

Refactored and enhanced the `normalizeLink` function to support various URL components. Simplified the logic and removed redundant code in `packages/amis-core/src/utils/normalizeLink.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6c9cbc9</samp>

> _To make links more consistent and neat_
> _You improved the `normalizeLink` feat_
> _You handled more cases_
> _And reduced code bases_
> _Your function is now more complete_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6c9cbc9</samp>

*  Handle query string and hash in reverse order in `normalizeLink` function ([link](https://github.com/baidu/amis/pull/7311/files?diff=unified&w=0#diff-a252bd89b3916caedc8092f99ba61b98bee43851b8e0b2de09660b6634889c8bL12-R26))
*  Simplify return statement of `normalizeLink` function by using a single `rest` variable ([link](https://github.com/baidu/amis/pull/7311/files?diff=unified&w=0#diff-a252bd89b3916caedc8092f99ba61b98bee43851b8e0b2de09660b6634889c8bL36-R45))
