### PR TITLE
feat：导出 excel 支持指定行 Closes #2738

### DIFF
--- a/docs/zh-CN/components/crud.md
+++ b/docs/zh-CN/components/crud.md
@@ -2183,6 +2183,60 @@ crud 组件支持通过配置`headerToolbar`和`footerToolbar`属性，实现在
 }
 ```
 
+#### 指定导出行
+
+> 3.2.0 及以上版本
+
+可以通过配置 `rowSlice` 属性来控制导出哪些行
+
+```schema: scope="body"
+{
+    "type": "crud",
+    "syncLocation": false,
+    "api": "/api/mock2/sample",
+    "headerToolbar": [{
+        "type": "export-excel",
+        "label": "导出 1, 4, 5 行",
+        "rowSlice": "0,3:5"
+    }],
+    "columns": [
+        {
+            "name": "id",
+            "label": "ID"
+        },
+        {
+            "name": "engine",
+            "label": "Rendering engine"
+        },
+        {
+            "name": "browser",
+            "label": "Browser"
+        },
+        {
+            "name": "platform",
+            "label": "Platform(s)"
+        },
+        {
+            "name": "version",
+            "label": "Engine version"
+        },
+        {
+            "name": "grade",
+            "label": "CSS grade"
+        }
+    ]
+}
+```
+
+`rowSlice` 支持以下写法
+
+- 取单个值 '1,2,3'，代表取 1、2、3 索引的内容
+- 取范围 '3:10'，代表取 3-9 索引的内容
+  - ':' 代表所有行
+  - '1:' 代表从第二行开始到结束
+  - 结束可以是负数 ':-1'，代表除了最后一个元素的所有元素，开始为空代表 0
+- 前两种的组合 '1,3:10'，代表取 1 索引和 3-9 索引的内容
+
 #### 通过 api 导出 Excel
 
 > 1.1.6 以上版本支持

--- a/packages/amis-core/__tests__/utils/arraySlice.test.ts
+++ b/packages/amis-core/__tests__/utils/arraySlice.test.ts
@@ -1,0 +1,11 @@
+import {arraySlice} from '../../src/utils/arraySlice';
+
+test(`arrayslice:test`, () => {
+  const testArray = [0, 1, 2, 3, 4, 5];
+  expect(arraySlice(testArray, ':')).toEqual([0, 1, 2, 3, 4, 5]);
+  expect(arraySlice(testArray, '0,3,4')).toEqual([0, 3, 4]);
+  expect(arraySlice(testArray, '1:2')).toEqual([1]);
+  expect(arraySlice(testArray, '0:-2')).toEqual([0, 1, 2, 3]);
+  expect(arraySlice(testArray, '1:-2')).toEqual([1, 2, 3]);
+  expect(arraySlice(testArray, '0,1:-2')).toEqual([0, 1, 2, 3]);
+});

--- a/packages/amis-core/src/utils/arraySlice.ts
+++ b/packages/amis-core/src/utils/arraySlice.ts
@@ -1,0 +1,67 @@
+/**
+ * 使用字符串语法来切片数组，参考了 python 中的语法
+ * 支持的语法有：
+ *   * 取单个值 1,2,3
+ *   * 取范围 3:10
+ *   * 组合 1,2,3:10
+ *   * 范围是负数 :-1，代表除了最后一个元素的所有元素
+ */
+import {toJS, isObservableArray} from 'mobx';
+
+export function arraySlice(array: any[], slice: string) {
+  if (typeof slice !== 'string') {
+    return array;
+  }
+  if (isObservableArray(array)) {
+    array = toJS(array);
+  }
+
+  slice = slice.trim();
+  if (!slice || !Array.isArray(array)) {
+    return array;
+  }
+  const parts = slice.split(',');
+  const ret: any[] = [];
+  const arrayLength = array.length;
+  if (!arrayLength) {
+    return array;
+  }
+  for (const part of parts) {
+    // 普通的场景
+    if (part.indexOf(':') === -1) {
+      const index = parseInt(part, 10);
+      if (!isNaN(index) && index < arrayLength) {
+        ret.push(array[index]);
+      }
+    } else {
+      const [start, end] = part.split(':');
+      let startIndex = parseInt(start || '0', 10);
+      if (isNaN(startIndex) || startIndex < 0) {
+        startIndex = 0;
+      }
+      // 大于就没意义了
+      if (startIndex >= arrayLength) {
+        continue;
+      }
+      let endIndex = parseInt(end, 10);
+      if (isNaN(endIndex)) {
+        endIndex = arrayLength;
+      }
+      // 负数就从后面开始取
+      if (endIndex < 0) {
+        endIndex = arrayLength + endIndex;
+      }
+      // 小于没有意义
+      if (endIndex < startIndex) {
+        continue;
+      }
+      if (endIndex > arrayLength) {
+        endIndex = arrayLength;
+      }
+
+      ret.push(...array.slice(startIndex, endIndex));
+    }
+  }
+
+  return ret;
+}

--- a/packages/amis-core/src/utils/index.ts
+++ b/packages/amis-core/src/utils/index.ts
@@ -54,6 +54,7 @@ export * from './toNumber';
 export * from './decodeEntity';
 export * from './style-helper';
 export * from './resolveCondition';
+export * from './arraySlice';
 
 import animation from './Animation';
 

--- a/packages/amis/src/renderers/Table/exportExcel.ts
+++ b/packages/amis/src/renderers/Table/exportExcel.ts
@@ -2,7 +2,7 @@
  * 导出 Excel 功能
  */
 
-import {filter, isEffectiveApi} from 'amis-core';
+import {filter, isEffectiveApi, arraySlice} from 'amis-core';
 import './ColumnToggler';
 import {TableStore} from 'amis-core';
 import {saveAs} from 'file-saver';
@@ -261,6 +261,9 @@ export async function exportExcel(
   const remoteMappingCache: any = {};
   // 数据从第二行开始
   let rowIndex = 1;
+  if (toolbar.rowSlice) {
+    rows = arraySlice(rows, toolbar.rowSlice);
+  }
   for (const row of rows) {
     const rowData = createObject(data, row.data);
     rowIndex += 1;

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -404,6 +404,7 @@ export type ExportExcelToolbar = SchemaNode & {
   api?: SchemaApi;
   columns?: string[];
   exportColumns?: any[];
+  rowSlice?: string;
   filename?: string;
 };
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 32757ed</samp>

This pull request adds a new feature to the `crud` component that allows users to export a subset of the table rows to Excel. It introduces a new property `rowSlice` to the `export-excel` toolbar, which accepts a slice string to specify the export rows. It also implements and tests a utility function `arraySlice` to handle the slicing logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 32757ed</samp>

> _Oh we are the coders of the `crud` component_
> _And we slice the rows with the `rowSlice` argument_
> _We export to Excel with a simple click_
> _And we test our code with the `arraySlice` trick_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 32757ed</samp>

*  Add `rowSlice` property to `crud` component to customize export rows ([link](https://github.com/baidu/amis/pull/7316/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653R2186-R2239), [link](https://github.com/baidu/amis/pull/7316/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR407), [link](https://github.com/baidu/amis/pull/7316/files?diff=unified&w=0#diff-8814befa6c6247c465ab39fa28f3db15c2280e238d8254286fa1f29d29500c51R264-R266))
  - Explain usage and syntax of `rowSlice` in `docs/zh-CN/components/crud.md` ([link](https://github.com/baidu/amis/pull/7316/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653R2186-R2239))
  - Define `rowSlice` as an optional string property in `ExportExcelToolbar` interface in `Table/index.tsx` ([link](https://github.com/baidu/amis/pull/7316/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR407))
  - Apply `arraySlice` function to rows array in `exportExcel` function in `Table/exportExcel.ts` if `rowSlice` is present ([link](https://github.com/baidu/amis/pull/7316/files?diff=unified&w=0#diff-8814befa6c6247c465ab39fa28f3db15c2280e238d8254286fa1f29d29500c51R264-R266))
* Implement and test `arraySlice` utility function to slice arrays by string notation ([link](https://github.com/baidu/amis/pull/7316/files?diff=unified&w=0#diff-4317ccec904e557fff997f83fd40b296a9e4ff14d89c3b7818e2883f19a52c09R1-R11), [link](https://github.com/baidu/amis/pull/7316/files?diff=unified&w=0#diff-2bdfaacb18ceb557720712afd11866ee785e932084b1ba68ca4b3d54e7f17470R1-R67), [link](https://github.com/baidu/amis/pull/7316/files?diff=unified&w=0#diff-92d7c6706a2d33962d5e9fd4cc6df5e276baa7b25bae27198b6598cf90890080R57), [link](https://github.com/baidu/amis/pull/7316/files?diff=unified&w=0#diff-8814befa6c6247c465ab39fa28f3db15c2280e238d8254286fa1f29d29500c51L5-R5))
  - Write `arraySlice` function in `amis-core/src/utils/arraySlice.ts` to take an array and a slice string and return a new sliced array ([link](https://github.com/baidu/amis/pull/7316/files?diff=unified&w=0#diff-2bdfaacb18ceb557720712afd11866ee785e932084b1ba68ca4b3d54e7f17470R1-R67))
  - Export `arraySlice` function from `amis-core/src/utils/index.ts` ([link](https://github.com/baidu/amis/pull/7316/files?diff=unified&w=0#diff-92d7c6706a2d33962d5e9fd4cc6df5e276baa7b25bae27198b6598cf90890080R57))
  - Import `arraySlice` function in `Table/exportExcel.ts` ([link](https://github.com/baidu/amis/pull/7316/files?diff=unified&w=0#diff-8814befa6c6247c465ab39fa28f3db15c2280e238d8254286fa1f29d29500c51L5-R5))
  - Write unit tests for `arraySlice` function in `amis-core/__tests__/utils/arraySlice.test.ts` to cover various cases and edge cases ([link](https://github.com/baidu/amis/pull/7316/files?diff=unified&w=0#diff-4317ccec904e557fff997f83fd40b296a9e4ff14d89c3b7818e2883f19a52c09R1-R11))
