### PR TITLE
chore: renderTextByKeyword过滤掉非法输入

### DIFF
--- a/packages/amis-core/src/utils/dom.tsx
+++ b/packages/amis-core/src/utils/dom.tsx
@@ -279,6 +279,10 @@ export function getStyleNumber(element: HTMLElement, styleName: string) {
 
 /** 根据关键字高亮显示文本内容 */
 export function renderTextByKeyword(rendererText: string, curKeyword: string) {
+  if (!rendererText || typeof rendererText !== 'string') {
+    return rendererText;
+  }
+
   if (curKeyword && ~rendererText.indexOf(curKeyword)) {
     const keywordStartIndex = rendererText.indexOf(curKeyword);
     const keywordEndIndex = keywordStartIndex + curKeyword.length;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d2fd1d</samp>

Improved error handling in `getStyleNumber` function. Added a type check and an early return to prevent errors when the input is not a string. This affects custom renderers that use `packages/amis-core/src/utils/dom.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1d2fd1d</samp>

> _`getStyleNumber` checks_
> _rendererText is a string_
> _or returns early_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1d2fd1d</samp>

*  Add type check and early return to `getStyleNumber` function to prevent errors with non-string `rendererText` ([link](https://github.com/baidu/amis/pull/7319/files?diff=unified&w=0#diff-558d9f2c84ced3c8c32f972218757e2c3d077c8e65f2b05c6ba82c6ff92256b0R282-R285))
