### PR TITLE
docs: 增加 JSON Schema 说明 Closes #7240

### DIFF
--- a/docs/zh-CN/components/form/json-schema.md
+++ b/docs/zh-CN/components/form/json-schema.md
@@ -12,6 +12,8 @@ order: 61
 
 > 1.10.0 及以上版本
 
+这个组件可以基于 JSON Schema 生成表单项，方便对接类似 OpenAPI/Swagger Specification 的接口规范，可基于接口定义自动生成 amis 表单项。
+
 > 此组件还在实验阶段，很多 json-schema 属性没有对应实现，使用前请先确认你要的功能满足了需求
 
 基于 json-schema 定义生成表单输入项。


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab2852b</samp>

Added documentation for the `JSON Schema` component in `docs/zh-CN/components/form/json-schema.md`. The component can generate form items based on JSON Schema definitions from APIs.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ab2852b</samp>

> _`JSON Schema` helps_
> _Generate form items from_
> _APIs in spring_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab2852b</samp>

*  Add a `JSON Schema` component to generate form items based on JSON Schema definitions ([link](https://github.com/baidu/amis/pull/7320/files?diff=unified&w=0#diff-6d5c244a36d041367e72587ae42110bb29d3d505be37116be2d0486f01e636c9R15-R16),                            
