### PR TITLE
fix:修复列表选取bool类型选择错误

### DIFF
--- a/packages/amis-core/src/store/list.ts
+++ b/packages/amis-core/src/store/list.ts
@@ -100,6 +100,7 @@ export const ListStore = iRendererStore
     draggable: false,
     dragging: false,
     multiple: true,
+    strictMode: false,
     selectable: false,
     itemCheckableOn: '',
     itemDraggableOn: '',
@@ -167,6 +168,7 @@ export const ListStore = iRendererStore
       config.selectable === void 0 || (self.selectable = config.selectable);
       config.draggable === void 0 || (self.draggable = config.draggable);
       config.multiple === void 0 || (self.multiple = config.multiple);
+      config.strictMode === void 0 || (self.strictMode = config.strictMode);
       config.hideCheckToggler === void 0 ||
         (self.hideCheckToggler = config.hideCheckToggler);
 
@@ -212,11 +214,13 @@ export const ListStore = iRendererStore
         if (~selected.indexOf(item.pristine)) {
           self.selectedItems.push(item);
         } else if (
-          find(
-            selected,
-            a =>
-              a[valueField || 'value'] == item.pristine[valueField || 'value']
-          )
+          find(selected, a => {
+            const selectValue = a[valueField || 'value'];
+            const itemValue = item.pristine[valueField || 'value'];
+            return self.strictMode
+              ? selectValue === itemValue
+              : selectValue == itemValue;
+          })
         ) {
           self.selectedItems.push(item);
         }

--- a/packages/amis-editor/src/plugin/Form/Picker.tsx
+++ b/packages/amis-editor/src/plugin/Form/Picker.tsx
@@ -185,6 +185,7 @@ export class PickerControlPlugin extends BasePlugin {
                 ]
               },
 
+              getSchemaTpl('strictMode'),
               getSchemaTpl('multiple'),
               getSchemaTpl('joinValues'),
               getSchemaTpl('delimiter'),

--- a/packages/amis-editor/src/tpl/options.tsx
+++ b/packages/amis-editor/src/tpl/options.tsx
@@ -140,6 +140,25 @@ setSchemaTpl('multiple', (schema: any = {}) => {
   };
 });
 
+setSchemaTpl('strictMode', {
+  type: 'switch',
+  label: '严格模式',
+  name: 'strictMode',
+  value: false,
+  mode: 'horizontal',
+  horizontal: {
+    justify: true,
+    left: 8
+  },
+  inputClassName: 'is-inline ',
+  labelRemark: {
+    trigger: ['hover', 'focus'],
+    setting: true,
+    title: '',
+    content: '启用严格模式将采用值严格相等比较'
+  }
+});
+
 setSchemaTpl('checkAllLabel', {
   type: 'input-text',
   name: 'checkAllLabel',

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -1504,6 +1504,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       primaryField,
       multiple,
       pickerMode,
+      strictMode,
       onSelect
     } = this.props;
     let newItems = items;
@@ -1513,14 +1514,20 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       const oldItems = store.selectedItems.concat();
       const oldUnselectedItems = store.unSelectedItems.concat();
 
+      const isSameValue = (
+        a: Record<string, unknown>,
+        item: Record<string, unknown>
+      ) => {
+        const oldValue = a[primaryField || 'id'];
+        const itemValue = item[primaryField || 'id'];
+        const isSame = strictMode
+          ? oldValue === itemValue
+          : oldValue == itemValue;
+        return a === item || (oldValue && isSame);
+      };
+
       items.forEach(item => {
-        const idx = findIndex(
-          oldItems,
-          a =>
-            a === item ||
-            (a[primaryField || 'id'] &&
-              a[primaryField || 'id'] == item[primaryField || 'id'])
-        );
+        const idx = findIndex(oldItems, a => isSameValue(a, item));
 
         if (~idx) {
           oldItems[idx] = item;
@@ -1528,13 +1535,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
           oldItems.push(item);
         }
 
-        const idx2 = findIndex(
-          oldUnselectedItems,
-          a =>
-            a === item ||
-            (a[primaryField || 'id'] &&
-              a[primaryField || 'id'] == item[primaryField || 'id'])
-        );
+        const idx2 = findIndex(oldUnselectedItems, a => isSameValue(a, item));
 
         if (~idx2) {
           oldUnselectedItems.splice(idx2, 1);
@@ -1542,21 +1543,9 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       });
 
       unSelectedItems.forEach(item => {
-        const idx = findIndex(
-          oldUnselectedItems,
-          a =>
-            a === item ||
-            (a[primaryField || 'id'] &&
-              a[primaryField || 'id'] == item[primaryField || 'id'])
-        );
+        const idx = findIndex(oldUnselectedItems, a => isSameValue(a, item));
 
-        const idx2 = findIndex(
-          oldItems,
-          a =>
-            a === item ||
-            (a[primaryField || 'id'] &&
-              a[primaryField || 'id'] == item[primaryField || 'id'])
-        );
+        const idx2 = findIndex(oldItems, a => isSameValue(a, item));
 
         if (~idx) {
           oldUnselectedItems[idx] = item;
@@ -2290,6 +2279,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       bulkActions,
       pickerMode,
       multiple,
+      strictMode,
       valueField,
       primaryField,
       value,
@@ -2390,6 +2380,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
               pickerMode || keepItemSelectionOnPageChange
                 ? store.selectedItemsAsArray
                 : undefined,
+            strictMode,
             keepItemSelectionOnPageChange,
             maxKeepItemSelectionLength,
             valueField: valueField || primaryField,

--- a/packages/amis/src/renderers/Form/Picker.tsx
+++ b/packages/amis/src/renderers/Form/Picker.tsx
@@ -463,7 +463,8 @@ export default class PickerControl extends React.PureComponent<
       multiple,
       valueField,
       embed,
-      source
+      source,
+      strictMode
     } = this.props;
 
     return render('modal-body', this.state.schema, {
@@ -472,6 +473,7 @@ export default class PickerControl extends React.PureComponent<
       primaryField: valueField,
       options: source ? [] : options,
       multiple,
+      strictMode,
       onSelect: embed
         ? (selectedItems: Array<any>, unSelectedItems: Array<any>) => {
             // 选择行后，crud 会给出连续多次事件，且selectedItems会变化，会导致初始化和点击无效

--- a/packages/amis/src/renderers/List.tsx
+++ b/packages/amis/src/renderers/List.tsx
@@ -321,6 +321,7 @@ export default class List extends React.Component<ListProps, object> {
       orderBy,
       orderDir,
       multiple,
+      strictMode,
       hideCheckToggler,
       itemCheckableOn,
       itemDraggableOn
@@ -329,6 +330,7 @@ export default class List extends React.Component<ListProps, object> {
     store.update({
       /** Card嵌套List情况下该属性获取到的值为ListStore的默认值, 会导致Schema中的配置被覆盖 */
       multiple: multiple || props?.$schema.multiple,
+      strictMode: strictMode || props?.$schema.strictMode,
       selectable: selectable || props?.$schema.selectable,
       draggable: draggable || props?.$schema.draggable,
       orderBy,
@@ -399,6 +401,7 @@ export default class List extends React.Component<ListProps, object> {
           'orderBy',
           'orderDir',
           'multiple',
+          'strictMode',
           'hideCheckToggler',
           'itemCheckableOn',
           'itemDraggableOn'
@@ -409,6 +412,7 @@ export default class List extends React.Component<ListProps, object> {
     ) {
       store.update({
         multiple: props.multiple,
+        strictMode: props.strictMode,
         selectable: props.selectable,
         draggable: props.draggable,
         orderBy: props.orderBy,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 06eb06f</samp>

This pull request adds a feature to the `CRUD` renderer to support pre-selected and dynamic list item selection. It also fixes a potential bug in the `updateSelected` function of the `ListStore` class by using strict equality comparison.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 06eb06f</samp>

> _`ListStore` changes_
> _Strict equality and selection_
> _Autumn of refactor_

### Why

列表选择options设置为既有bool类型，又有number类型时，==导致选中不正确

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 06eb06f</samp>

*  Replace `==` with `===` in four functions of the `ListStore` class to use strict equality comparison and avoid type coercion ([link](https://github.com/baidu/amis/pull/7328/files?diff=unified&w=0#diff-2eddee03f9f8eb4fda9a8440b115805c197a51ce407a2f1c97e1803df54cf53fL218-R218), [link](https://github.com/baidu/amis/pull/7328/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1522-R1522), [link](https://github.com/baidu/amis/pull/7328/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1536-R1536), [link](https://github.com/baidu/amis/pull/7328/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1550-R1550), [link](https://github.com/baidu/amis/pull/7328/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1558-R1558)). These functions are defined in the files `packages/amis-core/src/store/list.ts` and `packages/amis/src/renderers/CRUD.tsx`, and they are used to update, toggle, clear, and sync the selected items in a list based on a value field.
