### PR TITLE
chore: condition-builder 弹窗模式支持 jssdk Close: #7324

### DIFF
--- a/packages/amis/src/renderers/Form/ConditionBuilder.tsx
+++ b/packages/amis/src/renderers/Form/ConditionBuilder.tsx
@@ -135,7 +135,14 @@ export default class ConditionBuilderControl extends React.PureComponent<Conditi
   }
 
   render() {
-    const {className, classnames: cx, style, pickerIcon, ...rest} = this.props;
+    const {
+      className,
+      classnames: cx,
+      style,
+      pickerIcon,
+      env,
+      ...rest
+    } = this.props;
 
     // 处理一下formula类型值的变量列表
     let formula = this.props.formula ? {...this.props.formula} : undefined;
@@ -161,6 +168,7 @@ export default class ConditionBuilderControl extends React.PureComponent<Conditi
           pickerIcon={this.renderPickerIcon()}
           isAddBtnVisibleOn={this.getAddBtnVisible}
           isAddGroupBtnVisibleOn={this.getAddGroupBtnVisible}
+          popOverContainer={env.getModalContainer}
           {...rest}
           formula={formula}
         />


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 64fb2a0</samp>

Improved popover rendering for condition builder components. Added `env` and `popOverContainer` props to `ConditionBuilder` and `ConditionPicker` in `ConditionBuilder.tsx` to control where the popovers are appended.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 64fb2a0</samp>

> _`env` and `popOverContainer` are the keys_
> _To unleash the power of the condition builder_
> _No matter where you nest it, it will render with ease_
> _And let you create complex filters with skill and thrill_

### Why

Close: #7324

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 64fb2a0</samp>

*  Add `env` prop to `ConditionBuilder` component to access environment object ([link](https://github.com/baidu/amis/pull/7329/files?diff=unified&w=0#diff-906d9e2040ad748797a336a0c4d855343ddbea4da6ce81fc12ad100683f27827L138-R145))
*  Pass `popOverContainer` prop to `ConditionPicker` component using `env.getModalContainer` function to specify popover container element ([link](https://github.com/baidu/amis/pull/7329/files?diff=unified&w=0#diff-906d9e2040ad748797a336a0c4d855343ddbea4da6ce81fc12ad100683f27827R171))
