### PR TITLE
fix(amis): input-sub-form优先使用input-sub-form

### DIFF
--- a/packages/amis-editor-core/src/plugin.ts
+++ b/packages/amis-editor-core/src/plugin.ts
@@ -13,7 +13,6 @@ import find from 'lodash/find';
 import type {RendererConfig} from 'amis-core';
 import type {MenuDivider, MenuItem} from 'amis-ui/lib/components/ContextMenu';
 import type {BaseSchema, SchemaCollection} from 'amis';
-import {DSFieldGroup} from './builder/DSBuilder';
 
 /**
  * 区域的定义，容器渲染器都需要定义区域信息。

--- a/packages/amis/src/renderers/Form/InputSubForm.tsx
+++ b/packages/amis/src/renderers/Form/InputSubForm.tsx
@@ -145,7 +145,7 @@ export default class SubFormControl extends React.PureComponent<
     addButtonClassName: '',
     itemClassName: '',
     labelField: 'label',
-    btnLabel: 'SubForm.button',
+    defaultLabel: 'SubForm.button',
     placeholder: 'placeholder.empty'
   };
 
@@ -397,6 +397,7 @@ export default class SubFormControl extends React.PureComponent<
       disabled,
       maxLength,
       labelField,
+      defaultLabel,
       value,
       btnLabel,
       render,
@@ -434,10 +435,7 @@ export default class SubFormControl extends React.PureComponent<
                 ) : null}
 
                 <span className={cx('SubForm-valueLabel')}>
-                  {(item &&
-                    labelField &&
-                    item[labelField] &&
-                    stripTag(item[labelField])) ||
+                  {btnLabel &&
                     render(
                       'label',
                       {
@@ -448,6 +446,12 @@ export default class SubFormControl extends React.PureComponent<
                         data: createObject(data, item)
                       }
                     )}
+                  {!btnLabel &&
+                    ((item &&
+                      labelField &&
+                      item[labelField] &&
+                      stripTag(item[labelField])) ||
+                      defaultLabel)}
                 </span>
                 <a
                   data-index={key}
@@ -514,6 +518,7 @@ export default class SubFormControl extends React.PureComponent<
       disabled,
       value,
       labelField,
+      defaultLabel,
       btnLabel,
       render,
       data,
@@ -535,10 +540,7 @@ export default class SubFormControl extends React.PureComponent<
           data-position="bottom"
         >
           <span className={cx('SubForm-valueLabel')}>
-            {(value &&
-              labelField &&
-              value[labelField] &&
-              stripTag(value[labelField])) ||
+            {btnLabel &&
               render(
                 'label',
                 {
@@ -549,6 +551,12 @@ export default class SubFormControl extends React.PureComponent<
                   data: createObject(data, value)
                 }
               )}
+            {!btnLabel &&
+              ((value &&
+                labelField &&
+                value[labelField] &&
+                stripTag(value[labelField])) ||
+                defaultLabel)}
           </span>
           <a className={cx('SubForm-valueEdit')}>
             <Icon icon="pencil" className="icon" />


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2255469</samp>

This pull request adds a new feature to the `InputSubForm` renderer and cleans up an unused import in `plugin.ts`. The new feature allows customizing the subform button label in `amis` forms.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2255469</samp>

> _Sing, O Muse, of the skillful coder who refined his craft_
> _And from his plugin purged the needless import of `DSFieldGroup`_
> _That once adorned his builder like a golden brooch of Hephaestus_
> _But now was cast aside like a broken toy of Eris._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2255469</samp>

* Remove unused import of `DSFieldGroup` in `plugin.ts` ([link](https://github.com/baidu/amis/pull/7331/files?diff=unified&w=0#diff-2eb003bbc6f49ecb3f8b56411f1c1d02f055f595b7d9998f326a9c7ff41cc266L16))
* Add fallback logic to `InputSubForm` renderer to use `labelField` from item data if `btnLabel` is not provided or falsy ([link](https://github.com/baidu/amis/pull/7331/files?diff=unified&w=0#diff-2c4ae5b25ab00009bb38d0723797124a995223ee12f048e29e9724ab2173527aL450-R451))
