### PR TITLE
fix: 修复InputNumber 数字输入框 带单位数字 表单设置为静态时会显示数字无效的问题

### DIFF
--- a/packages/amis/src/renderers/Number.tsx
+++ b/packages/amis/src/renderers/Number.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {Renderer, RendererProps, stripNumber} from 'amis-core';
 import moment from 'moment';
 import {BaseSchema} from '../Schema';
-import {getPropValue} from 'amis-core';
+import {getPropValue, Option, PlainObject, normalizeOptions} from 'amis-core';
 
 /**
  * Number 展示渲染器。
@@ -42,6 +42,11 @@ export interface NumberSchema extends BaseSchema {
    * 占位符
    */
   placeholder?: string;
+
+  /**
+   * 单位列表
+   */
+  unitOptions?: string | Array<Option> | string[] | PlainObject;
 }
 
 export interface NumberProps
@@ -63,6 +68,7 @@ export class NumberField extends React.Component<NumberProps> {
       affix,
       suffix,
       percent,
+      unitOptions,
       className,
       style,
       classnames: cx,
@@ -73,6 +79,15 @@ export class NumberField extends React.Component<NumberProps> {
     );
 
     let value = getPropValue(this.props);
+
+    let unit = '';
+    if (typeof value === 'string' && unitOptions && unitOptions.length) {
+      const units = normalizeOptions(unitOptions).map(v => v.value);
+      unit = units.find(item => value.endsWith(item)) || '';
+      if (unit) {
+        value = value.replace(unit, '');
+      }
+    }
 
     if (value) {
       // 设置了精度，但是原始数据是字符串，需要转成 float 之后再处理
@@ -114,6 +129,7 @@ export class NumberField extends React.Component<NumberProps> {
       <>
         {prefix}
         {viewValue}
+        {unit}
         {affix ?? suffix}
       </>
     );


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 59e0d7a</samp>

Add support for units in number fields. The `Number.tsx` file defines a new `unitOptions` property and renders the unit in the `NumberField` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 59e0d7a</samp>

> _Sing, O Muse, of the skillful code that added a new feature_
> _To the NumberSchema, the interface of numeric fields and measures_
> _That now can hold the unitOptions, the property of choice and grace_
> _That lets the NumberField display the unit with its value's face_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 59e0d7a</samp>

*  Add unit options feature for number fields ([link](https://github.com/baidu/amis/pull/7334/files?diff=unified&w=0#diff-6ff3d2bcdac4cb360bb57723634521396b4d2773bd58ef28dd720ee921f9f3bcL5-R5), [link](https://github.com/baidu/amis/pull/7334/files?diff=unified&w=0#diff-6ff3d2bcdac4cb360bb57723634521396b4d2773bd58ef28dd720ee921f9f3bcR45-R49), [link](https://github.com/baidu/amis/pull/7334/files?diff=unified&w=0#diff-6ff3d2bcdac4cb360bb57723634521396b4d2773bd58ef28dd720ee921f9f3bcR71), [link](https://github.com/baidu/amis/pull/7334/files?diff=unified&w=0#diff-6ff3d2bcdac4cb360bb57723634521396b4d2773bd58ef28dd720ee921f9f3bcR83-R91), [link](https://github.com/baidu/amis/pull/7334/files?diff=unified&w=0#diff-6ff3d2bcdac4cb360bb57723634521396b4d2773bd58ef28dd720ee921f9f3bcR132))
  * Import types and functions from `amis-core` for unit options ([link](https://github.com/baidu/amis/pull/7334/files?diff=unified&w=0#diff-6ff3d2bcdac4cb360bb57723634521396b4d2773bd58ef28dd720ee921f9f3bcL5-R5))
  * Add `unitOptions` property to `NumberSchema` interface to define possible units ([link](https://github.com/baidu/amis/pull/7334/files?diff=unified&w=0#diff-6ff3d2bcdac4cb360bb57723634521396b4d2773bd58ef28dd720ee921f9f3bcR45-R49))
  * Pass `unitOptions` prop to `NumberField` component ([link](https://github.com/baidu/amis/pull/7334/files?diff=unified&w=0#diff-6ff3d2bcdac4cb360bb57723634521396b4d2773bd58ef28dd720ee921f9f3bcR71))
  * Extract and store unit from value if it matches any unit option ([link](https://github.com/baidu/amis/pull/7334/files?diff=unified&w=0#diff-6ff3d2bcdac4cb360bb57723634521396b4d2773bd58ef28dd720ee921f9f3bcR83-R91))
  * Render unit next to value in UI ([link](https://github.com/baidu/amis/pull/7334/files?diff=unified&w=0#diff-6ff3d2bcdac4cb360bb57723634521396b4d2773bd58ef28dd720ee921f9f3bcR132))
