### PR TITLE
chore:表达式编辑器函数选择交互还原

### DIFF
--- a/packages/amis-ui/src/components/formula/FuncList.tsx
+++ b/packages/amis-ui/src/components/formula/FuncList.tsx
@@ -80,8 +80,8 @@ export function FuncList(props: FuncListProps) {
                       className={cx('FormulaEditor-FuncList-item', {
                         'is-active': item.name === activeFunc?.name
                       })}
-                      onClick={() => setActiveFunc(item)}
-                      onDoubleClick={() => props.onSelect?.(item)}
+                      onMouseEnter={() => setActiveFunc(item)}
+                      onClick={() => props.onSelect?.(item)}
                       key={item.name}
                     >
                       {item.name}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 37b2a3d</samp>

Replaced `onDoubleClick` with `onMouseEnter` for function list items in `FuncList.tsx` to improve formula selection UX.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 37b2a3d</samp>

> _`onMouseEnter` now_
> _selects function to edit_
> _autumn of clicking_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 37b2a3d</samp>

* Improve the function selection logic for the formula component by using `onMouseEnter` and `onClick` events instead of `onClick` and `onDoubleClick` events ([link](https://github.com/baidu/amis/pull/7341/files?diff=unified&w=0#diff-0bf2b3b4dce78a6c8787d6dd5b3207933cc3550c621bf37bbdf589ffe632edbfL83-R84))
