### PR TITLE
fix:折叠器事件参数类型显示问题

### DIFF
--- a/packages/amis-editor/src/plugin/CollapseGroup.tsx
+++ b/packages/amis-editor/src/plugin/CollapseGroup.tsx
@@ -79,7 +79,7 @@ export class CollapseGroupPlugin extends BasePlugin {
                   title: '当前展开的索引列表'
                 },
                 collapseId: {
-                  type: 'string | number',
+                  type: 'string',
                   title: '折叠器索引'
                 },
                 collapsed: {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1671d3f</samp>

Fixed a type mismatch in the `CollapseGroup` plugin by changing the `collapseId` property to `string`. This improves the TypeScript compatibility and the consistency of the `Collapse` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1671d3f</samp>

> _`collapseId` changed_
> _To match `Collapse` component_
> _Type error resolved_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1671d3f</samp>

* Change the type of `collapseId` property from `string | number` to `string` in `CollapseGroup` plugin to fix TypeScript error and match `id` property of `Collapse` component ([link](https://github.com/baidu/amis/pull/7347/files?diff=unified&w=0#diff-33cf8f47f6167ca85dcfc70353f5c54cf9b8214d182806a5ae5315524864b4c6L82-R82))
