### PR TITLE
chore:表单校验和提交动作支持返回结果 Close #6941

### DIFF
--- a/docs/zh-CN/components/form/index.md
+++ b/docs/zh-CN/components/form/index.md
@@ -1469,13 +1469,350 @@ Form 支持轮询初始化接口，步骤如下：
 
 当前组件对外暴露以下特性动作，其他组件可以通过指定`actionType: 动作名称`、`componentId: 该组件id`来触发这些动作，动作配置可以通过`args: {动作配置项名称: xxx}`来配置具体的参数，详细请查看[事件动作](../../docs/concepts/event-action#触发其他组件的动作)。
 
-| 动作名称  | 动作配置                       | 说明                       |
-| --------- | ------------------------------ | -------------------------- |
-| submit    | -                              | 提交表单                   |
-| reset     | -                              | 重置表单                   |
-| clear     | -                              | 清空表单                   |
-| validate  | -                              | 校验表单                   |
-| reload    | -                              | 刷新（重新加载）           |
-| setValue  | `value: object` 更新的表单数据 | 更新数据，对数据进行 merge |
-| static    | -                              | 表单切换为静态展示         |
-| nonstatic | -                              | 表单切换为普通输入态       |
+| 动作名称  | 动作配置                                            | 说明                       |
+| --------- | --------------------------------------------------- | -------------------------- |
+| validate  | `outputVar: string` 校验结果，默认为 validateResult | 校验表单                   |
+| submit    | `outputVar: string` 提交结果，默认为 submitResult   | 提交表单                   |
+| setValue  | `value: object` 更新的表单数据                      | 更新数据，对数据进行 merge |
+| reload    | -                                                   | 刷新（重新加载）           |
+| reset     | -                                                   | 重置表单                   |
+| clear     | -                                                   | 清空表单                   |
+| static    | -                                                   | 表单切换为静态展示         |
+| nonstatic | -                                                   | 表单切换为普通输入态       |
+
+### validate
+
+校验结果默认缓存在`${event.data.validateResult}`，`true`表示校验成功，`false`表示检验失败。可以通过添加`outputVar`配置来修改缓存的变量。
+
+```schema: scope="body"
+[
+  {
+    "type": "button",
+    "label": "校验表单",
+    className: "mb-2",
+    "onEvent": {
+        "click": {
+            "actions": [
+              {
+                "actionType": "validate",
+                "componentId": "form_validate",
+                "outputVar": "form_validata_result",
+                "stopPropagation": "${!event.data.form_validata_result}"
+              },
+              {
+                "actionType": "toast",
+                "args": {
+                  "msg": "校验${IF(event.data.form_validata_result , '成功', '失败')}"
+                }
+              }
+            ]
+        }
+    }
+  },
+  {
+    "type": "form",
+    "id": "form_validate",
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+      {
+        "type": "input-text",
+        "name": "name",
+        "label": "姓名：",
+        "required": true
+      },
+      {
+        "name": "email",
+        "type": "input-text",
+        "label": "邮箱：",
+        "required": true,
+        "validations": {
+          "isEmail": true
+        }
+      }
+    ]
+  }
+]
+```
+
+### submit
+
+提交结果默认缓存在`${event.data.submitResult}`，可以通过添加`outputVar`配置来修改缓存的变量。存在以下几种情况：
+
+- 1.表单校验失败：提交结果为校验失败信息，例如：`{errors: emial: ['Email 格式不正确']}`
+- 2.存在 api 配置：表示配置了提交接口，则提交结果为接口返回的数据
+- 3.不存在 api 配置：表示没有配置提交接口，则提交结果为表单数据
+
+```schema: scope="body"
+[
+  {
+    "type": "button",
+    "label": "提交表单",
+    className: "mb-2",
+    "onEvent": {
+        "click": {
+            "actions": [
+              {
+                "actionType": "submit",
+                "componentId": "form_submit",
+                "outputVar": "form_submit_result"
+              },
+              {
+                "actionType": "toast",
+                "args": {
+                  "msg": "提交结果：${event.data.form_submit_result|json}"
+                }
+              }
+            ]
+        }
+    }
+  },
+  {
+    "type": "form",
+    "id": "form_submit",
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+      {
+        "type": "input-text",
+        "name": "name",
+        "label": "姓名：",
+        "required": true
+      },
+      {
+        "name": "email",
+        "type": "input-text",
+        "label": "邮箱：",
+        "required": true,
+        "validations": {
+          "isEmail": true
+        }
+      }
+    ]
+  }
+]
+```
+
+### setValue
+
+通过`setValue`来更新表单数据，其中`value`中的数据将和目标表单的数据做合并，即同名覆盖。
+
+```schema: scope="body"
+[
+  {
+    "type": "button",
+    "label": "修改表单数据",
+    className: "mb-2",
+    "onEvent": {
+        "click": {
+            "actions": [
+              {
+                "actionType": "setValue",
+                "componentId": "form_setvalue",
+                "args": {
+                  "value": {
+                    "name": "amis",
+                    "email": "amis@baidu.com"
+                  }
+                }
+              }
+            ]
+        }
+    }
+  },
+  {
+    "type": "form",
+    "id": "form_setvalue",
+    "body": [
+      {
+        "type": "input-text",
+        "name": "name",
+        "label": "姓名："
+      },
+      {
+        "name": "email",
+        "type": "input-text",
+        "label": "邮箱："
+      }
+    ]
+  }
+]
+```
+
+### reload
+
+通过`reload`来重新请求表单的初始化接口，实现表单刷新。
+
+```schema: scope="body"
+[
+  {
+    "type": "button",
+    "label": "刷新表单",
+    className: "mb-2",
+    "onEvent": {
+        "click": {
+            "actions": [
+              {
+                "actionType": "reload",
+                "componentId": "form_reload"
+              }
+            ]
+        }
+    }
+  },
+  {
+    "type": "form",
+    "id": "form_reload",
+    "debug": true,
+    "initApi": "/api/mock2/form/initData",
+    "body": [
+      {
+        "type": "input-text",
+        "name": "name",
+        "label": "姓名："
+      },
+      {
+        "name": "author",
+        "type": "input-text",
+        "label": "作者："
+      }
+    ]
+  }
+]
+```
+
+### reset
+
+通过`reset`将表单数据重置为初始数据，初始数据可以是静态数据或初始化接口返回的数据。
+
+```schema: scope="body"
+[
+  {
+    "type": "button",
+    "label": "重置表单",
+    className: "mb-2",
+    "onEvent": {
+        "click": {
+            "actions": [
+              {
+                "actionType": "reset",
+                "componentId": "form_reset"
+              }
+            ]
+        }
+    }
+  },
+  {
+    "type": "form",
+    "id": "form_reset",
+    "initApi": "/api/mock2/form/initData",
+    "body": [
+      {
+        "type": "alert",
+        "body": "修改表单项的值，然后点击【重置表单】，表单数据将被重置为初始化数据"
+      },
+      {
+        "type": "input-text",
+        "name": "name",
+        "label": "姓名："
+      },
+      {
+        "name": "author",
+        "type": "input-text",
+        "label": "作者："
+      }
+    ]
+  }
+]
+```
+
+### clear
+
+通过`clear`来清空表单中的表单项数据，不包含`hidden`类型、未绑定表单项的初始化数据字段。
+
+```schema: scope="body"
+[
+  {
+    "type": "button",
+    "label": "清空表单",
+    className: "mb-2",
+    "onEvent": {
+        "click": {
+            "actions": [
+              {
+                "actionType": "clear",
+                "componentId": "form_clear"
+              }
+            ]
+        }
+    }
+  },
+  {
+    "type": "form",
+    "id": "form_clear",
+    "debug": true,
+    "initApi": "/api/mock2/form/initData",
+    "body": [
+      {
+        "type": "input-text",
+        "name": "name",
+        "label": "姓名："
+      },
+      {
+        "name": "author",
+        "type": "hidden",
+        "label": "作者："
+      }
+    ]
+  }
+]
+```
+
+### static和nonstatic
+
+```schema: scope="body"
+[
+  {
+    "type": "button",
+    "label": "静态模式",
+    "className": "mr-2 mb-2",
+    "onEvent": {
+      "click": {
+        "actions": [
+          {
+            "actionType": "static",
+            "componentId": "form_static"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "button",
+    "label": "非静态模式",
+    "className": "mr-2 mb-2",
+    "onEvent": {
+      "click": {
+        "actions": [
+          {
+            "actionType": "nonstatic",
+            "componentId": "form_static"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "form",
+    "id": "form_static",
+    "title": "表单",
+    "body": [
+      {
+        "type": "input-text",
+        "name": "text",
+        "label": "输入框",
+        "mode": "horizontal",
+        "value": "text"
+      }
+    ]
+  }
+]
+```

--- a/packages/amis-core/src/actions/CmptAction.ts
+++ b/packages/amis-core/src/actions/CmptAction.ts
@@ -1,4 +1,5 @@
 import {RendererEvent} from '../utils/renderer-event';
+import {createObject} from '../utils/helper';
 import {
   RendererAction,
   ListenerAction,
@@ -116,7 +117,23 @@ export class CmptAction implements RendererAction {
     }
 
     // 执行组件动作
-    return component?.doAction?.(action, action.args);
+    const result = await component?.doAction?.(action, action.args);
+
+    // 记录动作出参
+    if ((action.actionType as any) === 'validate') {
+      event.setData(
+        createObject(event.data, {
+          [action.outputVar || 'validateResult']: result
+        })
+      );
+    } else if ((action.actionType as any) === 'submit') {
+      event.setData(
+        createObject(event.data, {
+          [action.outputVar || 'submitResult']: result
+        })
+      );
+    }
+    return result;
   }
 }
 

--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -1256,7 +1256,7 @@ export default class Form extends React.Component<FormProps, object> {
       store.clear(onReset);
     } else if (action.actionType === 'validate') {
       store.setCurrentAction(action);
-      this.validate(true);
+      return this.validate(true);
     } else if (action.actionType === 'dialog') {
       store.setCurrentAction(action);
       store.openDialog(data, undefined, action.callback);
@@ -1900,12 +1900,20 @@ export class FormRenderer extends Form {
     super.componentWillUnmount();
   }
 
-  doAction(
+  async doAction(
     action: ActionObject,
     data: object = this.props.store.data,
     throwErrors: boolean = false
   ) {
-    return this.handleAction(undefined, action, data, throwErrors);
+    try {
+      const result = await this.handleAction(undefined, action, data, true);
+      return result;
+    } catch (e) {
+      const errors = this.props.store.errors;
+      return {
+        errors: isEmpty(errors) ? e : errors
+      };
+    }
   }
 
   async handleAction(


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec191ca</samp>

This pull request adds a new feature to the form component actions, which allows users to save the action output in a variable. It modifies the `CmptAction`, `Form`, and `FormStore` classes to support this feature, and updates the documentation and examples accordingly. It also reorders the actions by their frequency of use in the documentation.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ec191ca</samp>

> _Sing, O Muse, of the skillful programmers who updated the form component_
> _And added the `outputVar` configuration for the actions of validation and submission_
> _So that the users of the Chinese version could store the results in their chosen variables_
> _And access them easily from the event data, as Zeus accesses his thunderbolts_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ec191ca</samp>

*  Add `outputVar` configuration for `validate` and `submit` form actions to allow users to specify the variable name to store the action output ([link](https://github.com/baidu/amis/pull/7352/files?diff=unified&w=0#diff-9e443c48c674e408c0c5ce0070ad2479457ee17242ced9ef8c68d5441d7f1cfdL1472-R1817), [link](https://github.com/baidu/amis/pull/7352/files?diff=unified&w=0#diff-9fcca25fc37554994f4168d09ade3ba52487964b8f897e0a9de38442dc6b1ceaL119-R136), [link](https://github.com/baidu/amis/pull/7352/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1259-R1259), [link](https://github.com/baidu/amis/pull/7352/files?diff=unified&w=0#diff-c8aefd7686b13cf0a0b440b598f20cc50e9abac39fcd9281de29dc6e9d3b358eL558-R561))
  * Import `createObject` helper function in `CmptAction.ts` to create a new object with the specified property and value ([link](https://github.com/baidu/amis/pull/7352/files?diff=unified&w=0#diff-9fcca25fc37554994f4168d09ade3ba52487964b8f897e0a9de38442dc6b1ceaR2))
  * Modify `execute` method of `CmptAction` class to record the action output in the event data, using the `outputVar` configuration or the default variable name ([link](https://github.com/baidu/amis/pull/7352/files?diff=unified&w=0#diff-9fcca25fc37554994f4168d09ade3ba52487964b8f897e0a9de38442dc6b1ceaL119-R136))
  * Modify `doAction` method of `Form` component to return the validation result for the `validate` action ([link](https://github.com/baidu/amis/pull/7352/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1259-R1259))
  * Modify `validate` method of `FormStore` class to return an object with the errors property instead of throwing an error when the validation fails ([link](https://github.com/baidu/amis/pull/7352/files?diff=unified&w=0#diff-c8aefd7686b13cf0a0b440b598f20cc50e9abac39fcd9281de29dc6e9d3b358eL558-R561))
* Update documentation of form component actions in the Chinese version, reorder the actions by their frequency of use, and add some examples ([link](https://github.com/baidu/amis/pull/7352/files?diff=unified&w=0#diff-9e443c48c674e408c0c5ce0070ad2479457ee17242ced9ef8c68d5441d7f1cfdL1472-R1817))
