### PR TITLE
chore: Combo组件的deleteBtn数据域透传index

### DIFF
--- a/docs/zh-CN/components/form/combo.md
+++ b/docs/zh-CN/components/form/combo.md
@@ -824,7 +824,7 @@ combo 还有一个作用是增加层级，比如返回的数据是一个深层�
 }
 ```
 
-如果想要赋予删除按钮更多能力，则需要将 deleteBtn 配置成[Button](../button.md)类型
+如果想要赋予删除按钮更多能力，则需要将 deleteBtn 配置成[Button](../button.md)类型，还可以利用`index`参数动态控制按钮的显隐或禁用状态等。
 
 ```schema: scope="body"
 {
@@ -844,7 +844,8 @@ combo 还有一个作用是增加层级，比如返回的数据是一个深层�
           "level": "danger",
           "tooltip": "提示文本",
           "tooltipPlacement": "top",
-          "onClick": "alert(index)"
+          "onClick": "alert(index)",
+          "disabledOn": "${index % 2 === 1}"
         },
         "items": [
             {

--- a/packages/amis/src/renderers/Form/Combo.tsx
+++ b/packages/amis/src/renderers/Form/Combo.tsx
@@ -1293,7 +1293,8 @@ export default class ComboControl extends React.Component<ComboProps> {
       disabled,
       removable,
       deleteBtn,
-      useMobileUI
+      useMobileUI,
+      data
     } = this.props;
 
     const mobileUI = useMobileUI && isMobile();
@@ -1315,38 +1316,44 @@ export default class ComboControl extends React.Component<ComboProps> {
 
     // deleteBtn是对象，则根据自定义配置渲染按钮
     if (isObject(deleteBtn)) {
-      return render('delete-btn', {
-        ...deleteBtn,
-        type: 'button',
-        className: cx(
-          'Combo-delController',
-          deleteBtn ? deleteBtn.className : ''
-        ),
-        onClick: (e: any) => {
-          if (!deleteBtn.onClick) {
-            this.deleteItem(index);
-            return;
-          }
-
-          let originClickHandler = deleteBtn.onClick;
-          if (typeof originClickHandler === 'string') {
-            originClickHandler = str2AsyncFunction(
-              deleteBtn.onClick,
-              'e',
-              'index',
-              'props'
-            );
-          }
-          const result = originClickHandler(e, index, this.props);
-          if (result && result.then) {
-            result.then(() => {
+      return render(
+        'delete-btn',
+        {
+          ...deleteBtn,
+          type: 'button',
+          className: cx(
+            'Combo-delController',
+            deleteBtn ? deleteBtn.className : ''
+          ),
+          onClick: (e: any) => {
+            if (!deleteBtn.onClick) {
               this.deleteItem(index);
-            });
-          } else {
-            this.deleteItem(index);
+              return;
+            }
+
+            let originClickHandler = deleteBtn.onClick;
+            if (typeof originClickHandler === 'string') {
+              originClickHandler = str2AsyncFunction(
+                deleteBtn.onClick,
+                'e',
+                'index',
+                'props'
+              );
+            }
+            const result = originClickHandler(e, index, this.props);
+            if (result && result.then) {
+              result.then(() => {
+                this.deleteItem(index);
+              });
+            } else {
+              this.deleteItem(index);
+            }
           }
+        },
+        {
+          data: extendObject(data, {index})
         }
-      });
+      );
     }
 
     // deleteBtn是string，则渲染按钮文本


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d177bb2</samp>

This pull request improves the `combo` component by allowing more customization and flexibility for the delete button. It updates the documentation and the code to support passing the item data and index to the button renderer, and adds an example to demonstrate the usage.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d177bb2</samp>

> _`deleteBtn` is the key to your fate_
> _Customize your combo with power and hate_
> _Pass the item data and index to the renderer_
> _Unleash your logic and display your splendor_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d177bb2</samp>

*  Add `data` prop to `Combo` component and pass it to custom delete button renderer ([link](https://github.com/baidu/amis/pull/7361/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1296-R1297), [link](https://github.com/baidu/amis/pull/7361/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1318-R1356))
*  Update documentation of `deleteBtn` property of `combo` component with `index` parameter usage ([link](https://github.com/baidu/amis/pull/7361/files?diff=unified&w=0#diff-6095450b85f0a3d4ee5a6887a19d1b926ef9026684f5271078719a0c1e675e31L827-R827))
*  Add example of using `disabledOn` property of `deleteBtn` object to disable delete button for odd-indexed items ([link](https://github.com/baidu/amis/pull/7361/files?diff=unified&w=0#diff-6095450b85f0a3d4ee5a6887a19d1b926ef9026684f5271078719a0c1e675e31L847-R848))
