### PR TITLE
fix:input-text组件label为schema时，editor表达式配置报错

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Form.tsx
+++ b/packages/amis-editor/src/plugin/Form/Form.tsx
@@ -966,7 +966,8 @@ export class FormPlugin extends BasePlugin {
             ? await current.info.plugin.buildDataSchemas(current, region)
             : {
                 type: 'string',
-                title: schema.label || schema.name,
+                title:
+                  typeof schema.label === 'string' ? schema.label : schema.name,
                 originalValue: schema.value // 记录原始值，循环引用检测需要
               };
         }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0bcb6aa</samp>

Fix form plugin issues and add features. Ensure `title` is a string in `Form.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0bcb6aa</samp>

> _`title` must be string_
> _even if `label` is not_
> _form plugin improved_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0bcb6aa</samp>

* Fix some issues and add some features for the form plugin
  * Ensure the `title` property of the schema object is always a string ([link](https://github.com/baidu/amis/pull/7374/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL969-R970))
