### PR TITLE
bugfix: 事件动作文档示例错误

### DIFF
--- a/docs/zh-CN/concepts/event-action.md
+++ b/docs/zh-CN/concepts/event-action.md
@@ -1850,7 +1850,7 @@ run action ajax
 
 有时在执行自定义 JS 的时候，希望该过程中产生的数据可以分享给后面的动作使用，此时可以通过`event.setData()`来实现事件上下文的设置，这样后面动作都可以通过事件上下文来获取共享的数据。
 
-> 注意：直接调用`event.setData()`将修改事件的原有上下文，如果不希望覆盖可以通过`event.setData({...event.data, {xxx: xxx}})`来进行数据的合并。
+> 注意：直接调用`event.setData()`将修改事件的原有上下文，如果不希望覆盖可以通过`event.setData({...event.data, ...{xxx: xxx}})`来进行数据的合并。
 
 ## 触发组件的动作
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5bb906b</samp>

Fixed a code error in the documentation of `event.setData()` method. The change uses the spread operator `...` instead of the comma operator `,` to merge event data.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5bb906b</samp>

> _`event.setData()`_
> _Spread the new data, not comma_
> _Docs are clear in spring_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5bb906b</samp>

* Correct the code snippet for `event.setData()` method in the documentation ([link](https://github.com/baidu/amis/pull/7375/files?diff=unified&w=0#diff-9802ca5a2390dc6e213b3d844669c50fb10948dad8ad72a0d360c886731fbd3dL1853-R1853))
