### PR TITLE
fix: 修复 jssdk 中 popOver 问题 Close: #7372

### DIFF
--- a/packages/amis-core/src/renderers/Item.tsx
+++ b/packages/amis-core/src/renderers/Item.tsx
@@ -1015,11 +1015,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
                       tooltip: labelRemark,
                       useMobileUI,
                       className: cx(`Form-labelRemark`),
-                      container: props.popOverContainer
-                        ? props.popOverContainer
-                        : env && env.getModalContainer
-                        ? env.getModalContainer
-                        : undefined
+                      container: props.popOverContainer || env.getModalContainer
                     })
                   : null}
               </span>
@@ -1048,11 +1044,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
                   tooltip: remark,
                   className: cx(`Form-remark`),
                   useMobileUI,
-                  container: props.popOverContainer
-                    ? props.popOverContainer
-                    : env && env.getModalContainer
-                    ? env.getModalContainer
-                    : undefined
+                  container: props.popOverContainer || env.getModalContainer
                 })
               : null}
 
@@ -1146,11 +1138,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
                       tooltip: labelRemark,
                       className: cx(`Form-lableRemark`),
                       useMobileUI,
-                      container: props.popOverContainer
-                        ? props.popOverContainer
-                        : env && env.getModalContainer
-                        ? env.getModalContainer
-                        : undefined
+                      container: props.popOverContainer || env.getModalContainer
                     })
                   : null}
               </span>
@@ -1174,10 +1162,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
                     className: cx(`Form-remark`),
                     tooltip: remark,
                     useMobileUI,
-                    container:
-                      env && env.getModalContainer
-                        ? env.getModalContainer
-                        : undefined
+                    container: props.popOverContainer || env.getModalContainer
                   })
                 : null}
 
@@ -1221,10 +1206,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
                     className: cx(`Form-remark`),
                     tooltip: remark,
                     useMobileUI,
-                    container:
-                      env && env.getModalContainer
-                        ? env.getModalContainer
-                        : undefined
+                    container: props.popOverContainer || env.getModalContainer
                   })
                 : null}
 
@@ -1322,11 +1304,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
                       tooltip: labelRemark,
                       className: cx(`Form-lableRemark`),
                       useMobileUI,
-                      container: props.popOverContainer
-                        ? props.popOverContainer
-                        : env && env.getModalContainer
-                        ? env.getModalContainer
-                        : undefined
+                      container: props.popOverContainer || env.getModalContainer
                     })
                   : null}
               </span>
@@ -1349,11 +1327,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
                   className: cx(`Form-remark`),
                   tooltip: remark,
                   useMobileUI,
-                  container: props.popOverContainer
-                    ? props.popOverContainer
-                    : env && env.getModalContainer
-                    ? env.getModalContainer
-                    : undefined
+                  container: props.popOverContainer || env.getModalContainer
                 })
               : null}
 
@@ -1449,11 +1423,8 @@ export class FormItemWrap extends React.Component<FormItemProps> {
                         tooltip: labelRemark,
                         className: cx(`Form-lableRemark`),
                         useMobileUI,
-                        container: props.popOverContainer
-                          ? props.popOverContainer
-                          : env && env.getModalContainer
-                          ? env.getModalContainer
-                          : undefined
+                        container:
+                          props.popOverContainer || env.getModalContainer
                       })
                     : null}
                 </span>
@@ -1474,10 +1445,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
                   icon: remark.icon || 'warning-mark',
                   className: cx(`Form-remark`),
                   tooltip: remark,
-                  container:
-                    env && env.getModalContainer
-                      ? env.getModalContainer
-                      : undefined
+                  container: props.popOverContainer || env.getModalContainer
                 })
               : null}
           </div>

--- a/packages/amis-editor/src/renderer/APIControl.tsx
+++ b/packages/amis-editor/src/renderer/APIControl.tsx
@@ -411,11 +411,7 @@ export default class APIControl extends React.Component<
                 tooltip: labelRemark,
                 className: cx(`Form-lableRemark`, labelRemark?.className),
                 useMobileUI,
-                container: popOverContainer
-                  ? popOverContainer
-                  : env && env.getModalContainer
-                  ? env.getModalContainer
-                  : undefined
+                container: popOverContainer || env.getModalContainer
               })
             : null}
         </label>

--- a/packages/amis-editor/src/renderer/MapSourceControl.tsx
+++ b/packages/amis-editor/src/renderer/MapSourceControl.tsx
@@ -158,11 +158,7 @@ export default class MapSourceControl extends React.Component<
                 tooltip: labelRemark,
                 className: cx(`Form-lableRemark`, labelRemark?.className),
                 useMobileUI,
-                container: popOverContainer
-                  ? popOverContainer
-                  : env && env.getModalContainer
-                  ? env.getModalContainer
-                  : undefined
+                container: popOverContainer || env.getModalContainer
               })
             : null}
         </label>

--- a/packages/amis-editor/src/renderer/NavSourceControl.tsx
+++ b/packages/amis-editor/src/renderer/NavSourceControl.tsx
@@ -197,11 +197,7 @@ export default class NavSourceControl extends React.Component<
                 tooltip: labelRemark,
                 className: cx(`Form-lableRemark`, labelRemark?.className),
                 useMobileUI,
-                container: popOverContainer
-                  ? popOverContainer
-                  : env && env.getModalContainer
-                  ? env.getModalContainer
-                  : undefined
+                container: popOverContainer || env.getModalContainer
               })
             : null}
         </label>

--- a/packages/amis-editor/src/renderer/OptionControl.tsx
+++ b/packages/amis-editor/src/renderer/OptionControl.tsx
@@ -513,11 +513,7 @@ export default class OptionControl extends React.Component<
                 tooltip: labelRemark,
                 className: cx(`Form-lableRemark`, labelRemark?.className),
                 useMobileUI,
-                container: popOverContainer
-                  ? popOverContainer
-                  : env && env.getModalContainer
-                  ? env.getModalContainer
-                  : undefined
+                container: popOverContainer || env.getModalContainer
               })
             : null}
         </label>

--- a/packages/amis-editor/src/renderer/TimelineItemControl.tsx
+++ b/packages/amis-editor/src/renderer/TimelineItemControl.tsx
@@ -360,11 +360,7 @@ export default class TimelineItemControl extends React.Component<
                 tooltip: labelRemark,
                 className: cx(`Form-lableRemark`, labelRemark?.className),
                 useMobileUI,
-                container: popOverContainer
-                  ? popOverContainer
-                  : env && env.getModalContainer
-                  ? env.getModalContainer
-                  : undefined
+                container: popOverContainer || env.getModalContainer
               })
             : null}
         </label>

--- a/packages/amis-editor/src/renderer/TransferTableControl.tsx
+++ b/packages/amis-editor/src/renderer/TransferTableControl.tsx
@@ -189,11 +189,7 @@ function BaseOptionControl(Cmpt: React.JSXElementConstructor<any>) {
                   tooltip: labelRemark,
                   className: cx(`Form-lableRemark`, labelRemark?.className),
                   useMobileUI,
-                  container: popOverContainer
-                    ? popOverContainer
-                    : env && env.getModalContainer
-                    ? env.getModalContainer
-                    : undefined
+                  container: popOverContainer || env.getModalContainer
                 })
               : null}
           </label>

--- a/packages/amis-editor/src/renderer/TreeOptionControl.tsx
+++ b/packages/amis-editor/src/renderer/TreeOptionControl.tsx
@@ -192,11 +192,7 @@ export default class TreeOptionControl extends React.Component<
                 tooltip: labelRemark,
                 className: cx(`Form-lableRemark`, labelRemark?.className),
                 useMobileUI,
-                container: popOverContainer
-                  ? popOverContainer
-                  : env && env.getModalContainer
-                  ? env.getModalContainer
-                  : undefined
+                container: popOverContainer || env.getModalContainer
               })
             : null}
         </label>

--- a/packages/amis/src/renderers/Action.tsx
+++ b/packages/amis/src/renderers/Action.tsx
@@ -1083,9 +1083,7 @@ export class ActionRenderer extends React.Component<ActionRendererProps> {
         onMouseLeave={this.handleMouseLeave}
         loading={loading}
         isCurrentUrl={this.isCurrentAction}
-        tooltipContainer={
-          env.getModalContainer ? env.getModalContainer : undefined
-        }
+        tooltipContainer={rest.popOverContainer || env.getModalContainer}
       />
     );
   }

--- a/packages/amis/src/renderers/Cards.tsx
+++ b/packages/amis/src/renderers/Cards.tsx
@@ -860,6 +860,7 @@ export default class Cards extends React.Component<GridProps, object> {
       store,
       multiple,
       selectable,
+      popOverContainer,
       env,
       translate: __,
       dragIcon
@@ -874,9 +875,7 @@ export default class Cards extends React.Component<GridProps, object> {
         iconOnly
         key="dragging-toggle"
         tooltip={__('Card.toggleDrag')}
-        tooltipContainer={
-          env && env.getModalContainer ? env.getModalContainer : undefined
-        }
+        tooltipContainer={popOverContainer || env?.getModalContainer}
         size="sm"
         active={store.dragging}
         onClick={(e: React.MouseEvent<any>) => {

--- a/packages/amis/src/renderers/Dialog.tsx
+++ b/packages/amis/src/renderers/Dialog.tsx
@@ -550,7 +550,8 @@ export default class Dialog extends React.Component<DialogProps> {
       cancelText,
       confirmText,
       confirmBtnLevel,
-      cancelBtnLevel
+      cancelBtnLevel,
+      popOverContainer
     } = {
       ...this.props,
       ...store.schema
@@ -573,9 +574,7 @@ export default class Dialog extends React.Component<DialogProps> {
         show={show}
         onEntered={this.handleEntered}
         onExited={this.handleExited}
-        container={
-          env && env.getModalContainer ? env.getModalContainer : undefined
-        }
+        container={env?.getModalContainer}
         enforceFocus={false}
         disabled={store.loading}
         overlay={overlay}

--- a/packages/amis/src/renderers/Drawer.tsx
+++ b/packages/amis/src/renderers/Drawer.tsx
@@ -557,7 +557,8 @@ export default class Drawer extends React.Component<DrawerProps> {
       classPrefix: ns,
       classnames: cx,
       drawerContainer,
-      loadingConfig
+      loadingConfig,
+      popOverContainer
     } = {
       ...this.props,
       ...store.schema
@@ -586,13 +587,7 @@ export default class Drawer extends React.Component<DrawerProps> {
         closeOnOutside={
           !store.drawerOpen && !store.dialogOpen && closeOnOutside
         }
-        container={
-          drawerContainer
-            ? drawerContainer
-            : env && env.getModalContainer
-            ? env.getModalContainer
-            : undefined
-        }
+        container={drawerContainer ? drawerContainer : env?.getModalContainer}
       >
         <div className={cx('Drawer-header', headerClassName)}>
           {title ? (

--- a/packages/amis/src/renderers/Form/ChainedSelect.tsx
+++ b/packages/amis/src/renderers/Form/ChainedSelect.tsx
@@ -336,9 +336,9 @@ export default class ChainedSelectControl extends React.Component<
           {...rest}
           useMobileUI={useMobileUI}
           popOverContainer={
-            mobileUI && env && env.getModalContainer
-              ? env.getModalContainer
-              : rest.popOverContainer
+            mobileUI
+              ? env?.getModalContainer
+              : rest.popOverContainer || env?.getModalContainer
           }
           classPrefix={ns}
           key="base"
@@ -356,9 +356,9 @@ export default class ChainedSelectControl extends React.Component<
               {...rest}
               useMobileUI={useMobileUI}
               popOverContainer={
-                mobileUI && env && env.getModalContainer
+                mobileUI
                   ? env.getModalContainer
-                  : rest.popOverContainer
+                  : rest.popOverContainer || env?.getModalContainer
               }
               classPrefix={ns}
               key={`x-${index + 1}`}

--- a/packages/amis/src/renderers/Form/ConditionBuilder.tsx
+++ b/packages/amis/src/renderers/Form/ConditionBuilder.tsx
@@ -146,6 +146,7 @@ export default class ConditionBuilderControl extends React.PureComponent<Conditi
       style,
       pickerIcon,
       env,
+      popOverContainer,
       ...rest
     } = this.props;
 
@@ -173,7 +174,7 @@ export default class ConditionBuilderControl extends React.PureComponent<Conditi
           pickerIcon={this.renderPickerIcon()}
           isAddBtnVisibleOn={this.getAddBtnVisible}
           isAddGroupBtnVisibleOn={this.getAddGroupBtnVisible}
-          popOverContainer={env.getModalContainer}
+          popOverContainer={popOverContainer || env.getModalContainer}
           {...rest}
           formula={formula}
         />

--- a/packages/amis/src/renderers/Form/InputCity.tsx
+++ b/packages/amis/src/renderers/Form/InputCity.tsx
@@ -80,6 +80,7 @@ export interface CityPickerProps
   style?: {
     [propName: string]: any;
   };
+  popOverContainer?: any;
 }
 
 export interface CityDb {
@@ -411,7 +412,8 @@ export class CityPicker extends React.Component<
       allowStreet,
       searchable,
       translate: __,
-      loadingConfig
+      loadingConfig,
+      popOverContainer
     } = this.props;
 
     const {provinceCode, cityCode, districtCode, street, db} = this.state;
@@ -427,6 +429,7 @@ export class CityPicker extends React.Component<
           }))}
           value={provinceCode || ''}
           onChange={this.handleProvinceChange}
+          popOverContainer={popOverContainer}
         />
 
         {allowCity && db.city[provinceCode] && db.city[provinceCode].length ? (
@@ -439,6 +442,7 @@ export class CityPicker extends React.Component<
             }))}
             value={cityCode || ''}
             onChange={this.handleCityChange}
+            popOverContainer={popOverContainer}
           />
         ) : null}
 
@@ -456,6 +460,7 @@ export class CityPicker extends React.Component<
             )}
             value={districtCode || ''}
             onChange={this.handleDistrictChange}
+            popOverContainer={popOverContainer}
           />
         ) : null}
 
@@ -562,15 +567,14 @@ export class LocationControl extends React.Component<LocationControlProps> {
       disabled,
       searchable,
       env,
-      useMobileUI
+      useMobileUI,
+      popOverContainer
     } = this.props;
     const mobileUI = useMobileUI && isMobile();
     return mobileUI ? (
       <CityArea
         value={value}
-        popOverContainer={
-          env && env.getModalContainer ? env.getModalContainer : undefined
-        }
+        popOverContainer={env?.getModalContainer}
         onChange={this.handleChange}
         allowCity={allowCity}
         allowDistrict={allowDistrict}
@@ -582,6 +586,7 @@ export class LocationControl extends React.Component<LocationControlProps> {
       />
     ) : (
       <ThemedCity
+        popOverContainer={popOverContainer || env?.getModalContainer}
         searchable={searchable}
         value={value}
         onChange={this.handleChange}

--- a/packages/amis/src/renderers/Form/InputColor.tsx
+++ b/packages/amis/src/renderers/Form/InputColor.tsx
@@ -92,11 +92,9 @@ export default class ColorControl extends React.PureComponent<
             {...rest}
             useMobileUI={useMobileUI}
             popOverContainer={
-              mobileUI && env && env.getModalContainer
-                ? env.getModalContainer
-                : mobileUI
-                ? undefined
-                : rest.popOverContainer
+              mobileUI
+                ? env?.getModalContainer
+                : rest.popOverContainer || env.getModalContainer
             }
             value={value || ''}
           />

--- a/packages/amis/src/renderers/Form/InputDate.tsx
+++ b/packages/amis/src/renderers/Form/InputDate.tsx
@@ -517,11 +517,9 @@ export default class DateControl extends React.PureComponent<
           placeholder={placeholder ?? this.placeholder}
           useMobileUI={useMobileUI}
           popOverContainer={
-            mobileUI && env && env.getModalContainer
-              ? env.getModalContainer
-              : mobileUI
-              ? undefined
-              : rest.popOverContainer
+            mobileUI
+              ? env?.getModalContainer
+              : rest.popOverContainer || env.getModalContainer
           }
           timeFormat={timeFormat}
           format={valueFormat || format}

--- a/packages/amis/src/renderers/Form/InputDateRange.tsx
+++ b/packages/amis/src/renderers/Form/InputDateRange.tsx
@@ -277,11 +277,9 @@ export default class DateRangeControl extends React.Component<DateRangeProps> {
           useMobileUI={useMobileUI}
           classPrefix={ns}
           popOverContainer={
-            mobileUI && env && env.getModalContainer
-              ? env.getModalContainer
-              : mobileUI
-              ? undefined
-              : rest.popOverContainer
+            mobileUI
+              ? env?.getModalContainer
+              : rest.popOverContainer || env.getModalContainer
           }
           onRef={this.getRef}
           data={data}

--- a/packages/amis/src/renderers/Form/InputFormula.tsx
+++ b/packages/amis/src/renderers/Form/InputFormula.tsx
@@ -197,6 +197,7 @@ export class InputFormulaRenderer extends React.Component<InputFormulaProps> {
       data,
       onPickerOpen,
       selfVariableName,
+      popOverContainer,
       env,
       useMobileUI
     } = this.props;
@@ -214,7 +215,7 @@ export class InputFormulaRenderer extends React.Component<InputFormulaProps> {
 
     return (
       <FormulaPicker
-        popOverContainer={env.getModalContainer}
+        popOverContainer={popOverContainer || env.getModalContainer}
         ref={this.formulaRef}
         className={className}
         value={value}

--- a/packages/amis/src/renderers/Form/InputMonthRange.tsx
+++ b/packages/amis/src/renderers/Form/InputMonthRange.tsx
@@ -44,11 +44,9 @@ export default class MonthRangeControl extends InputDateRange {
           format={format}
           classPrefix={ns}
           popOverContainer={
-            mobileUI && env && env.getModalContainer
-              ? env.getModalContainer
-              : mobileUI
-              ? undefined
-              : rest.popOverContainer
+            mobileUI
+              ? env?.getModalContainer
+              : rest.popOverContainer || env.getModalContainer
           }
           data={data}
           {...rest}

--- a/packages/amis/src/renderers/Form/InputQuarterRange.tsx
+++ b/packages/amis/src/renderers/Form/InputQuarterRange.tsx
@@ -42,11 +42,9 @@ export default class QuarterRangeControl extends InputDateRange {
           useMobileUI={useMobileUI}
           classPrefix={ns}
           popOverContainer={
-            mobileUI && env && env.getModalContainer
-              ? env.getModalContainer
-              : mobileUI
-              ? undefined
-              : rest.popOverContainer
+            mobileUI
+              ? env?.getModalContainer
+              : rest.popOverContainer || env.getModalContainer
           }
           data={data}
           {...rest}

--- a/packages/amis/src/renderers/Form/InputRepeat.tsx
+++ b/packages/amis/src/renderers/Form/InputRepeat.tsx
@@ -224,10 +224,8 @@ export default class RepeatControl extends React.Component<RepeatProps, any> {
             joinValues={false}
             useMobileUI={useMobileUI}
             popOverContainer={
-              mobileUI && env && env.getModalContainer
-                ? env.getModalContainer
-                : mobileUI
-                ? undefined
+              mobileUI
+                ? env?.getModalContainer
                 : popOverContainer || env.getModalContainer
             }
           />

--- a/packages/amis/src/renderers/Form/InputSubForm.tsx
+++ b/packages/amis/src/renderers/Form/InputSubForm.tsx
@@ -599,11 +599,9 @@ export default class SubFormControl extends React.PureComponent<
             onConfirm={this.handlePopupConfirm}
             onHide={this.close}
             container={
-              mobileUI && env && env.getModalContainer
-                ? env.getModalContainer
-                : mobileUI
-                ? undefined
-                : popOverContainer
+              mobileUI
+                ? env?.getModalContainer
+                : popOverContainer || env.getModalContainer
             }
           >
             <div className="flex-1 pl-10 pr-10">

--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -939,9 +939,7 @@ export default class FormTable extends React.Component<TableProps, TableState> {
               key={key}
               level="link"
               tooltip={__('Table.addRow')}
-              tooltipContainer={
-                env && env.getModalContainer ? env.getModalContainer : undefined
-              }
+              tooltipContainer={props.popOverContainer || env.getModalContainer}
               disabled={disabled}
               onClick={this.addItem.bind(this, rowIndex + offset, undefined)}
             >
@@ -976,9 +974,7 @@ export default class FormTable extends React.Component<TableProps, TableState> {
               key={key}
               level="link"
               tooltip={__('Table.copyRow')}
-              tooltipContainer={
-                env && env.getModalContainer ? env.getModalContainer : undefined
-              }
+              tooltipContainer={props.popOverContainer || env.getModalContainer}
               disabled={disabled}
               onClick={this.copyItem.bind(this, rowIndex + offset, undefined)}
             >
@@ -1066,9 +1062,7 @@ export default class FormTable extends React.Component<TableProps, TableState> {
                 level="link"
                 tooltip={__('Table.editRow')}
                 tooltipContainer={
-                  env && env.getModalContainer
-                    ? env.getModalContainer
-                    : undefined
+                  props.popOverContainer || env.getModalContainer
                 }
                 disabled={disabled}
                 onClick={() => this.editItem(rowIndex + offset)}
@@ -1115,9 +1109,7 @@ export default class FormTable extends React.Component<TableProps, TableState> {
                 level="link"
                 tooltip={__('save')}
                 tooltipContainer={
-                  env && env.getModalContainer
-                    ? env.getModalContainer
-                    : undefined
+                  props.popOverContainer || env.getModalContainer
                 }
                 onClick={this.confirmEdit}
               >
@@ -1154,9 +1146,7 @@ export default class FormTable extends React.Component<TableProps, TableState> {
                 level="link"
                 tooltip={__('cancel')}
                 tooltipContainer={
-                  env && env.getModalContainer
-                    ? env.getModalContainer
-                    : undefined
+                  props.popOverContainer || env.getModalContainer
                 }
                 onClick={this.cancelEdit}
               >
@@ -1211,9 +1201,7 @@ export default class FormTable extends React.Component<TableProps, TableState> {
               key={key}
               level="link"
               tooltip={__('Table.deleteRow')}
-              tooltipContainer={
-                env && env.getModalContainer ? env.getModalContainer : undefined
-              }
+              tooltipContainer={props.popOverContainer || env.getModalContainer}
               disabled={disabled}
               onClick={this.removeItem.bind(this, rowIndex + offset)}
             >

--- a/packages/amis/src/renderers/Form/InputTag.tsx
+++ b/packages/amis/src/renderers/Form/InputTag.tsx
@@ -623,7 +623,7 @@ export default class TagControl extends React.PureComponent<
                 clearable={clearable}
                 maxTagCount={maxTagCount}
                 overflowTagPopover={overflowTagPopover}
-                popOverContainer={env.getModalContainer}
+                popOverContainer={popOverContainer || env.getModalContainer}
                 allowInput={!mobileUI || (mobileUI && !options?.length)}
                 useMobileUI={useMobileUI}
               >
@@ -637,11 +637,9 @@ export default class TagControl extends React.PureComponent<
                   <PopUp
                     className={cx(`Tag-popup`)}
                     container={
-                      mobileUI && env && env.getModalContainer
-                        ? env.getModalContainer
-                        : mobileUI
-                        ? undefined
-                        : popOverContainer
+                      mobileUI
+                        ? env?.getModalContainer
+                        : popOverContainer || env.getModalContainer
                     }
                     isShow={isOpen && !!finnalOptions.length}
                     showConfirm={true}

--- a/packages/amis/src/renderers/Form/InputYearRange.tsx
+++ b/packages/amis/src/renderers/Form/InputYearRange.tsx
@@ -43,11 +43,9 @@ export default class YearRangeControl extends InputDateRange {
           useMobileUI={useMobileUI}
           classPrefix={ns}
           popOverContainer={
-            mobileUI && env && env.getModalContainer
-              ? env.getModalContainer
-              : mobileUI
-              ? undefined
-              : rest.popOverContainer
+            mobileUI
+              ? env?.getModalContainer
+              : rest.popOverContainer || env.getModalContainer
           }
           data={data}
           {...rest}

--- a/packages/amis/src/renderers/Form/JSONSchemaEditor.tsx
+++ b/packages/amis/src/renderers/Form/JSONSchemaEditor.tsx
@@ -150,11 +150,9 @@ export default class JSONSchemaEditorControl extends React.PureComponent<JSONSch
         enableAdvancedSetting={enableAdvancedSetting}
         renderModalProps={this.renderModalProps}
         popOverContainer={
-          mobileUI && env && env.getModalContainer
-            ? env.getModalContainer
-            : mobileUI
-            ? undefined
-            : rest.popOverContainer
+          mobileUI
+            ? env?.getModalContainer
+            : rest.popOverContainer || env.getModalContainer
         }
       />
     );

--- a/packages/amis/src/renderers/Form/NestedSelect.tsx
+++ b/packages/amis/src/renderers/Form/NestedSelect.tsx
@@ -912,6 +912,7 @@ export default class NestedSelectControl extends React.Component<
       loading,
       borderMode,
       useMobileUI,
+      popOverContainer,
       env,
       loadingConfig
     } = this.props;
@@ -965,9 +966,7 @@ export default class NestedSelectControl extends React.Component<
         {mobileUI ? (
           <PopUp
             className={cx(`NestedSelect-popup`)}
-            container={
-              env && env.getModalContainer ? env.getModalContainer : undefined
-            }
+            container={env.getModalContainer}
             isShow={this.state.isOpened}
             onHide={this.close}
             showConfirm={false}

--- a/packages/amis/src/renderers/Form/Select.tsx
+++ b/packages/amis/src/renderers/Form/Select.tsx
@@ -487,10 +487,8 @@ export default class SelectControl extends React.Component<SelectProps, any> {
             {...rest}
             useMobileUI={useMobileUI}
             popOverContainer={
-              mobileUI && env && env.getModalContainer
-                ? env.getModalContainer
-                : mobileUI
-                ? undefined
+              mobileUI
+                ? env?.getModalContainer
                 : rest.popOverContainer || env.getModalContainer
             }
             borderMode={borderMode}
@@ -625,7 +623,7 @@ class TransferDropdownRenderer extends BaseTransferRenderer<TransferDropDownProp
           leftOptions={leftOptions}
           borderMode={borderMode}
           useMobileUI={useMobileUI}
-          popOverContainer={env.getModalContainer}
+          popOverContainer={popOverContainer || env.getModalContainer}
           maxTagCount={maxTagCount}
           overflowTagPopover={overflowTagPopover}
           placeholder={placeholder}

--- a/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
@@ -146,11 +146,9 @@ export class TabsTransferPickerRenderer extends BaseTabsTransferRenderer<TabsTra
           valueField={valueField}
           useMobileUI={useMobileUI}
           popOverContainer={
-            mobileUI && env && env.getModalContainer
-              ? env.getModalContainer
-              : mobileUI
-              ? undefined
-              : popOverContainer
+            mobileUI
+              ? env?.getModalContainer
+              : popOverContainer || env.getModalContainer
           }
         />
 

--- a/packages/amis/src/renderers/Form/TransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TransferPicker.tsx
@@ -142,10 +142,8 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
           virtualThreshold={virtualThreshold}
           useMobileUI={useMobileUI}
           popOverContainer={
-            mobileUI && env && env.getModalContainer
-              ? env.getModalContainer
-              : mobileUI
-              ? undefined
+            mobileUI
+              ? env?.getModalContainer
               : popOverContainer || env.getModalContainer
           }
         />

--- a/packages/amis/src/renderers/Form/TreeSelect.tsx
+++ b/packages/amis/src/renderers/Form/TreeSelect.tsx
@@ -702,7 +702,7 @@ export default class TreeSelectControl extends React.Component<
     return (
       <div ref={this.container} className={cx(`TreeSelectControl`, className)}>
         <ResultBox
-          popOverContainer={env.getModalContainer}
+          popOverContainer={popOverContainer || env.getModalContainer}
           maxTagCount={maxTagCount}
           overflowTagPopover={overflowTagPopover}
           disabled={disabled}
@@ -765,9 +765,7 @@ export default class TreeSelectControl extends React.Component<
         ) : null}
         {mobileUI ? (
           <PopUp
-            container={
-              env && env.getModalContainer ? env.getModalContainer : undefined
-            }
+            container={env.getModalContainer}
             className={cx(`${ns}TreeSelect-popup`)}
             isShow={isOpened}
             onHide={this.close}

--- a/packages/amis/src/renderers/List.tsx
+++ b/packages/amis/src/renderers/List.tsx
@@ -907,7 +907,7 @@ export default class List extends React.Component<ListProps, object> {
   }
 
   renderDragToggler() {
-    const {store, multiple, selectable, env} = this.props;
+    const {store, multiple, selectable, popOverContainer, env} = this.props;
 
     if (!store.draggable || store.items.length < 2) {
       return null;
@@ -918,9 +918,7 @@ export default class List extends React.Component<ListProps, object> {
         iconOnly
         key="dragging-toggle"
         tooltip="对列表进行排序操作"
-        tooltipContainer={
-          env && env.getModalContainer ? env.getModalContainer : undefined
-        }
+        tooltipContainer={popOverContainer || env?.getModalContainer}
         size="sm"
         active={store.dragging}
         onClick={(e: React.MouseEvent<any>) => {

--- a/packages/amis/src/renderers/Page.tsx
+++ b/packages/amis/src/renderers/Page.tsx
@@ -776,6 +776,7 @@ export default class Page extends React.Component<PageProps> {
       render,
       store,
       initApi,
+      popOverContainer,
       env,
       classnames: cx,
       regions,
@@ -801,10 +802,7 @@ export default class Page extends React.Component<PageProps> {
                     type: 'remark',
                     tooltip: remark,
                     placement: remarkPlacement || 'bottom',
-                    container:
-                      env && env.getModalContainer
-                        ? env.getModalContainer
-                        : undefined
+                    container: popOverContainer || env.getModalContainer
                   })
                 : null}
             </h2>

--- a/packages/amis/src/renderers/Remark.tsx
+++ b/packages/amis/src/renderers/Remark.tsx
@@ -161,6 +161,7 @@ class Remark extends React.Component<RemarkProps> {
       rootClose,
       trigger,
       container,
+      popOverContainer,
       classPrefix: ns,
       classnames: cx,
       content,
@@ -202,7 +203,7 @@ class Remark extends React.Component<RemarkProps> {
         placement={(tooltip && tooltip.placement) || placement}
         rootClose={(tooltip && tooltip.rootClose) || rootClose}
         trigger={(tooltip && tooltip.trigger) || trigger}
-        container={container || env.getModalContainer}
+        container={container || popOverContainer || env.getModalContainer}
         delay={tooltip && tooltip.delay}
       >
         <div

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -2183,10 +2183,7 @@ export default class Table extends React.Component<TableProps, object> {
             ? render('remark', {
                 type: 'remark',
                 tooltip: column.remark,
-                container:
-                  env && env.getModalContainer
-                    ? env.getModalContainer
-                    : undefined
+                container: this.getPopOverContainer
               })
             : null}
         </div>
@@ -2301,7 +2298,7 @@ export default class Table extends React.Component<TableProps, object> {
             canAccessSuperData ? item.locals : item.data
           )
         : column.value,
-      popOverContainer: popOverContainer || this.getPopOverContainer,
+      popOverContainer: this.getPopOverContainer,
       rowSpan: item.rowSpans[column.name as string],
       quickEditFormRef: this.subFormRef,
       cellPrefix: prefix,
@@ -2597,9 +2594,7 @@ export default class Table extends React.Component<TableProps, object> {
           content: config?.tooltip || __('Table.columnsVisibility'),
           placement: 'bottom'
         }}
-        tooltipContainer={
-          env && env.getModalContainer ? env.getModalContainer : undefined
-        }
+        tooltipContainer={rest.popOverContainer || env.getModalContainer}
         align={config?.align ?? 'left'}
         isActived={store.hasColumnHidden()}
         classnames={cx}
@@ -2696,7 +2691,14 @@ export default class Table extends React.Component<TableProps, object> {
   }
 
   renderDragToggler() {
-    const {store, env, draggable, classPrefix: ns, translate: __} = this.props;
+    const {
+      store,
+      env,
+      draggable,
+      classPrefix: ns,
+      translate: __,
+      popOverContainer
+    } = this.props;
 
     if (!draggable || store.isNested) {
       return null;
@@ -2708,9 +2710,7 @@ export default class Table extends React.Component<TableProps, object> {
         classPrefix={ns}
         key="dragging-toggle"
         tooltip={{content: __('Table.startSort'), placement: 'bottom'}}
-        tooltipContainer={
-          env && env.getModalContainer ? env.getModalContainer : undefined
-        }
+        tooltipContainer={popOverContainer || env.getModalContainer}
         size="sm"
         active={store.dragging}
         onClick={(e: React.MouseEvent<any>) => {

--- a/packages/amis/src/renderers/Table2/ColumnToggler.tsx
+++ b/packages/amis/src/renderers/Table2/ColumnToggler.tsx
@@ -40,6 +40,7 @@ export class ColumnTogglerRenderer extends React.Component<ColumnTogglerRenderer
       toggleToggle,
       data,
       size,
+      popOverContainer,
       ...rest
     } = this.props;
     const __ = rest.translate;
@@ -63,9 +64,7 @@ export class ColumnTogglerRenderer extends React.Component<ColumnTogglerRenderer
         {...rest}
         render={render}
         tooltip={tooltip || __('Table.columnsVisibility')}
-        tooltipContainer={
-          env && env.getModalContainer ? env.getModalContainer : undefined
-        }
+        tooltipContainer={popOverContainer || env.getModalContainer}
         isActived={cols.findIndex((column: any) => !column.toggled) !== -1}
         align={align ?? 'right'}
         size={size || 'sm'}

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -724,8 +724,7 @@ export default class Table2 extends React.Component<Table2Props, object> {
             remark = render('remark', {
               type: 'remark',
               tooltip: column.remark,
-              container:
-                env && env.getModalContainer ? env.getModalContainer : undefined
+              container: this.getPopOverContainer
             });
           }
 

--- a/packages/amis/src/renderers/TooltipWrapper.tsx
+++ b/packages/amis/src/renderers/TooltipWrapper.tsx
@@ -230,7 +230,8 @@ export default class TooltipWrapper extends React.Component<
       disabled,
       enterable,
       data,
-      env
+      env,
+      popOverContainer
     } = this.props;
 
     const tooltipObj: TooltipObject = {
@@ -243,9 +244,7 @@ export default class TooltipWrapper extends React.Component<
       container:
         container !== undefined
           ? container
-          : env && env.getModalContainer
-          ? env.getModalContainer
-          : undefined,
+          : popOverContainer || env?.getModalContainer,
       tooltipTheme,
       tooltipClassName,
       mouseEnterDelay,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b950f25</samp>

This pull request adds a new prop `popOverContainer` to various components in the `amis` and `amis-editor` packages, which allows the user to customize the container element for the tooltips that are displayed on some UI elements. It also simplifies the logic of getting the default container for the tooltips by using the logical OR operator instead of the ternary operator, which improves the code readability and conciseness. The affected components include `Cards`, `Dialog`, `Drawer`, `ConditionBuilder`, `InputFormula`, `Action`, and several form controls and custom renderers.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b950f25</samp>

> _`popOverContainer`_
> _a new prop for tooltips_
> _simpler logic too_

### Why

Close: #7372

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b950f25</samp>

*  Simplify the logic of getting the container for the label remark tooltip by using the logical OR operator instead of the ternary operator in various components and renderers ([link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1018-R1018), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1051-R1047), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1149-R1141), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1177-R1165), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1224-R1209), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1325-R1307), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1352-R1330), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1452-R1427), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1477-R1448), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-e65abd8ed33a9d63bc29309ed26eb057b2d1f780106822c5eabeeaa220f8c91fL414-R414), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-7ba74325e30da44e0fc236e6ceb4f88145731bc7c603e9aa361c94ef811385f5L161-R161), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-1057424f764f4271aefe8c270b89628708d62eb1839348271752b8642114e102L200-R200), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-9cfcdc8b6fd4efb5b016c90e20ac9e0bd7269232de6fd1aee47462f0b4a64834L516-R516), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-2f0fb376078dda760a017e1b75c762fda16deb439d53e53a9f50a3ae06331391L363-R363), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-ab2affd310e3224925e54d3f5fee2774358447362172ab2c06955cede0af19ebL192-R192), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-cc8fe36e00110e9ad28c6e6ea10e6cd2093a714526d785f0320a88a39a522c5fL195-R195), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-49e8e0d126c05b212be5134e3e5cc7e7533258b2d5637c0a775d1a9ae3993a4aL339-R341), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-49e8e0d126c05b212be5134e3e5cc7e7533258b2d5637c0a775d1a9ae3993a4aL359-R361))
* Simplify the logic of getting the container for the remark tooltip by using the logical OR operator instead of the ternary operator in various components and renderers ( [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-83895e4b0993db67cbfb774b8539e7625318f250de1b4a848611cabedf9e828bL877-R878), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL576-R577), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L589-R590), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-65a5dace85eed005c6ccfbe23167de42fdbce58a1eca3ec4bbb213b82a939212L571-R572), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-a3e0f4998d105681a0729d67a09bd58003322f4714c77a0062c4d243c5e835e2L95-R97), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-56835df54b63fc25653bc9cb41f895a4e75843bbbf719028fbcc740ae394a94fL520-R522), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-6a9d63c3962b312f04344a4c28956690724f3f476fe6b8f2802501fc10b28ce2L280-R282), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-913fb8d07888e592949feed6847e6997721160c1df681059970998dbe0f0bb45L217-R218), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-1a33091eb500b518cc27540c2165d49fe4691c0cfde475e967828db0fad04edeL47-R49))
* Add the popOverContainer prop to various components and renderers to allow the user to customize the container for the tooltips ([link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-4d89203911a9d3ef38c82118f074ad24c49244699f1f2cbb6072134908f60098L1086-R1086), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-83895e4b0993db67cbfb774b8539e7625318f250de1b4a848611cabedf9e828bR863), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL553-R554), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L560-R561), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-906d9e2040ad748797a336a0c4d855343ddbea4da6ce81fc12ad100683f27827R149), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-65a5dace85eed005c6ccfbe23167de42fdbce58a1eca3ec4bbb213b82a939212L565-R566), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-913fb8d07888e592949feed6847e6997721160c1df681059970998dbe0f0bb45R200))
* Simplify the logic of getting the container for the dialog and the drawer by using the optional chaining operator instead of the ternary operator in `Dialog.tsx` and `Drawer.tsx` ([link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL576-R577), [link](https://github.com/baidu/amis/pull/7382/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L589-R590))
