### PR TITLE
fix: 修复静态展示设置 style 后展示双份的问题 Close: #7381

### DIFF
--- a/packages/amis/src/renderers/Form/Static.tsx
+++ b/packages/amis/src/renderers/Form/Static.tsx
@@ -124,6 +124,7 @@ export default class StaticControl extends React.Component<StaticProps, any> {
       label,
       name,
       ...$schema,
+      style: $schema.innerStyle,
       type: subType
     };
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fc79baa</samp>

Add `style` property to `StaticControl` component to enable custom styling of static content. Update `$schema` object to define the `style` property and its type.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fc79baa</samp>

> _`StaticControl` grows_
> _`style` property added_
> _Winter of `$schema`_

### Why

Close: #7381

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fc79baa</samp>

* Add a `style` property to the `StaticControl` component to allow customizing the appearance of the static content ([link](https://github.com/baidu/amis/pull/7383/files?diff=unified&w=0#diff-ef5762f0a56812ae572954b6480f9363a56274ccdb6369d97e7fdbf8917c42cdR127))
