### PR TITLE
fix: 修复 dropdownbutton 配置 confirmText 弹出来两次的问题 Close: #7378

### DIFF
--- a/packages/amis/src/renderers/DropDownButton.tsx
+++ b/packages/amis/src/renderers/DropDownButton.tsx
@@ -250,7 +250,7 @@ export default class DropDownButton extends React.Component<
     button: DropdownButton,
     index: number | string
   ): React.ReactNode {
-    const {render, classnames: cx, data} = this.props;
+    const {render, classnames: cx, data, ignoreConfirm} = this.props;
     index = typeof index === 'number' ? index.toString() : index;
 
     if (typeof button !== 'string' && Array.isArray(button?.children)) {
@@ -282,11 +282,17 @@ export default class DropDownButton extends React.Component<
             ['is-disabled']: isDisabled(button, data)
           })}
         >
-          {render(`button/${index}`, {
-            type: 'button',
-            ...(button as any),
-            isMenuItem: true
-          })}
+          {render(
+            `button/${index}`,
+            {
+              type: 'button',
+              ...(button as any)
+            },
+            {
+              isMenuItem: true,
+              ignoreConfirm: ignoreConfirm
+            }
+          )}
         </li>
       );
     }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 260e78c</samp>

Add `ignoreConfirm` option for `DropDownButton` actions. This allows users to skip the confirmation dialog when triggering actions from a `DropDownButton` component in the schema.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 260e78c</samp>

> _If you want to skip confirmation_
> _When you trigger a `DropDownButton` action_
> _You can use a new prop_
> _Called `ignoreConfirm` to stop_
> _The annoying dialog from showing its caption_

### Why

Close: #7378

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 260e78c</samp>

* Add a new prop `ignoreConfirm` to `DropDownButton` component to control confirmation dialog ([link](https://github.com/baidu/amis/pull/7385/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L253-R253))
* Pass `ignoreConfirm` prop from `DropDownButton` component to `render` function for button items ([link](https://github.com/baidu/amis/pull/7385/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L285-R295))
