### PR TITLE
fix: combo 唯一验证触发后，当删除其中一个时，唯一验证的报错没有消失

### DIFF
--- a/packages/amis-core/src/store/combo.ts
+++ b/packages/amis-core/src/store/combo.ts
@@ -1,4 +1,4 @@
-import {types, SnapshotIn, Instance} from 'mobx-state-tree';
+import {types, SnapshotIn, Instance, isAlive} from 'mobx-state-tree';
 import {iRendererStore} from './iRenderer';
 import type {IFormStore, IFormItemStore} from './form';
 import {getStoreById} from './manager';
@@ -150,6 +150,14 @@ export const ComboStore = iRendererStore
             form.items.forEach(
               item => item.unique && item.syncOptions(undefined, form.data)
             )
+          );
+
+          self.forms.forEach(
+            form =>
+              isAlive(form) &&
+              form.items.forEach(item => {
+                item.unique && item.errors.length && item.validate(item.value);
+              })
           );
         }
       }

--- a/packages/amis-core/src/store/combo.ts
+++ b/packages/amis-core/src/store/combo.ts
@@ -1,4 +1,4 @@
-import {types, SnapshotIn, Instance, isAlive} from 'mobx-state-tree';
+import {types, SnapshotIn, Instance} from 'mobx-state-tree';
 import {iRendererStore} from './iRenderer';
 import type {IFormStore, IFormItemStore} from './form';
 import {getStoreById} from './manager';
@@ -147,17 +147,15 @@ export const ComboStore = iRendererStore
           });
 
           self.forms.forEach(form =>
-            form.items.forEach(
-              item => item.unique && item.syncOptions(undefined, form.data)
-            )
-          );
+            form.items.forEach(item => {
+              if (item.unique) {
+                item.syncOptions(undefined, form.data);
 
-          self.forms.forEach(
-            form =>
-              isAlive(form) &&
-              form.items.forEach(item => {
-                item.unique && item.errors.length && item.validate(item.value);
-              })
+                if (item.errors.length) {
+                  item.validate(item.tmpValue);
+                }
+              }
+            })
           );
         }
       }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9135135</samp>

This pull request fixes some issues with the combo store in `amis-core`, such as avoiding errors with detached nodes and ensuring unique combo items.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9135135</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A cunning function, `isAlive`, to thwart the errors_
> _That lurk in the dark abyss of detached nodes_
> _And vex the noble users of the combo store._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9135135</samp>

* Import `isAlive` function from `mobx-state-tree` to check node liveliness ([link](https://github.com/baidu/amis/pull/7388/files?diff=unified&w=0#diff-b3e0f20412e925b4924b11ad118984d46d639321feb22920e29075b417f15d2eL1-R1))
* Add unique validation logic to `submit` action of `ComboStore` model ([link](https://github.com/baidu/amis/pull/7388/files?diff=unified&w=0#diff-b3e0f20412e925b4924b11ad118984d46d639321feb22920e29075b417f15d2eR154-R161))
