### PR TITLE
bugfix:「事件动作」service组件 setValue和reload如果在同一个动作下 setValue值不生效

### DIFF
--- a/packages/amis-core/src/actions/Action.ts
+++ b/packages/amis-core/src/actions/Action.ts
@@ -275,6 +275,11 @@ export const runAction = async (
       ? {}
       : actionData !== undefined
       ? actionData
+      : actionConfig.actionType === 'reload' // reload时默认为事件数据和渲染器数据，兼容同一事件内执行setValue和reload时的值变化
+      ? {
+          ...event.data,
+          ...renderer.props.data
+        }
       : event.data;
 
   console.group?.(`run action ${actionConfig.actionType}`);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 565aef4</samp>

This pull request adds support for reloading data with updated values in `amis-core`. It modifies the `runAction` function in `Action.ts` to handle the `reload` action type.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 565aef4</samp>

> _`runAction` checks_
> _type of action: `reload`_
> _merges data sets_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 565aef4</samp>

*  Add a `reload` action type to handle reloading the renderer with updated data ([link](https://github.com/baidu/amis/pull/7390/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3R278-R282))
