### PR TITLE
chore(amis-editor): 编辑器配置面板支持异步加载

### DIFF
--- a/packages/amis-editor-core/src/component/AsyncLayer.tsx
+++ b/packages/amis-editor-core/src/component/AsyncLayer.tsx
@@ -1,0 +1,45 @@
+/**
+ * @file AsyncLayer.tsx
+ * @desc 异步加载层
+ */
+import React from 'react';
+import {Spinner} from 'amis';
+
+export interface asyncLayerOptions {
+  fallback?: React.ReactNode;
+}
+
+export const makeAsyncLayer = (
+  schemaBuilderFn: () => Promise<any>,
+  options?: asyncLayerOptions
+) => {
+  const {fallback} = options || {};
+  const LazyComponent = React.lazy(async () => {
+    const schemaFormRender = await schemaBuilderFn();
+
+    return {
+      default: (...props: any[]) => <>{schemaFormRender(...props)}</>
+    };
+  });
+
+  return (props: any) => (
+    <React.Suspense
+      fallback={
+        fallback && React.isValidElement(fallback) ? (
+          fallback
+        ) : (
+          <Spinner
+            show
+            overlay
+            size="sm"
+            tip="配置面板加载中"
+            tipPlacement="bottom"
+            className="flex"
+          />
+        )
+      }
+    >
+      <LazyComponent {...props} />
+    </React.Suspense>
+  );
+};

--- a/packages/amis-editor-core/src/plugin.ts
+++ b/packages/amis-editor-core/src/plugin.ts
@@ -1,7 +1,10 @@
 /**
  * @file 定义插件的 interface，以及提供一个 BasePlugin 基类，把一些通用的方法放在这。
  */
+
+import omit from 'lodash/omit';
 import {RegionWrapperProps} from './component/RegionWrapper';
+import {makeAsyncLayer} from './component/AsyncLayer';
 import {EditorManager} from './manager';
 import {EditorStoreType} from './store/editor';
 import {EditorNodeType} from './store/node';
@@ -13,6 +16,7 @@ import find from 'lodash/find';
 import type {RendererConfig} from 'amis-core';
 import type {MenuDivider, MenuItem} from 'amis-ui/lib/components/ContextMenu';
 import type {BaseSchema, SchemaCollection} from 'amis';
+import type {asyncLayerOptions} from './component/AsyncLayer';
 
 /**
  * 区域的定义，容器渲染器都需要定义区域信息。
@@ -800,6 +804,11 @@ export interface PluginInterface
   panelJustify?: boolean;
 
   /**
+   * 配置面板内容区是否开启异步加载
+   */
+  async?: {enable: boolean} & asyncLayerOptions;
+
+  /**
    * 有数据域的容器，可以为子组件提供读取的字段绑定页面
    */
   getAvailableContextFields?: (
@@ -1044,17 +1053,34 @@ export abstract class BasePlugin implements PluginInterface {
         icon: plugin.panelIcon || plugin.icon || 'fa fa-cog',
         pluginIcon: plugin.pluginIcon,
         title: plugin.panelTitle || '设置',
-        render: this.manager.makeSchemaFormRender({
-          definitions: plugin.panelDefinitions,
-          submitOnChange: plugin.panelSubmitOnChange,
-          api: plugin.panelApi,
-          body: body,
-          controls: plugin.panelControlsCreator
-            ? plugin.panelControlsCreator(context)
-            : plugin.panelControls!,
-          justify: plugin.panelJustify,
-          panelById: store.activeId
-        })
+        render:
+          typeof plugin.async === 'object' && plugin.async?.enable === true
+            ? makeAsyncLayer(async () => {
+                const panelBody = await body;
+
+                return this.manager.makeSchemaFormRender({
+                  definitions: plugin.panelDefinitions,
+                  submitOnChange: plugin.panelSubmitOnChange,
+                  api: plugin.panelApi,
+                  body: panelBody,
+                  controls: plugin.panelControlsCreator
+                    ? plugin.panelControlsCreator(context)
+                    : plugin.panelControls!,
+                  justify: plugin.panelJustify,
+                  panelById: store.activeId
+                });
+              }, omit(plugin.async, 'enable'))
+            : this.manager.makeSchemaFormRender({
+                definitions: plugin.panelDefinitions,
+                submitOnChange: plugin.panelSubmitOnChange,
+                api: plugin.panelApi,
+                body: body,
+                controls: plugin.panelControlsCreator
+                  ? plugin.panelControlsCreator(context)
+                  : plugin.panelControls!,
+                justify: plugin.panelJustify,
+                panelById: store.activeId
+              })
       });
     } else if (
       context.info.plugin === this &&


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e7f3fc4</samp>

This pull request enhances the editor plugins with the ability to load their configuration panel content area lazily and show a custom fallback component while loading. It adds a new file `AsyncLayer.tsx` that exports a `makeAsyncLayer` function to wrap schema form render functions with React.lazy and React.Suspense. It also updates the `plugin.ts` file to use this function and modify the `PluginInterface` and the `BasePlugin` class accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e7f3fc4</samp>

> _Oh, we are the coders of the sea_
> _And we work on the editor plugins_
> _We use `makeAsyncLayer` to load them with ease_
> _And we show a fallback while we wait for the wins_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e7f3fc4</samp>

*  Add a new file `AsyncLayer.tsx` that defines a function and an interface for enabling asynchronous loading of the configuration panel content area ([link](https://github.com/baidu/amis/pull/7399/files?diff=unified&w=0#diff-42c7208489b581435faa512301c8a4974de2c745d7645088c5cbca34a7ae2b2cR1-R45))
* Import the `omit` function from lodash and the `makeAsyncLayer` function and the `asyncLayerOptions` interface from `AsyncLayer.tsx` in the `plugin.ts` file ([link](https://github.com/baidu/amis/pull/7399/files?diff=unified&w=0#diff-2eb003bbc6f49ecb3f8b56411f1c1d02f055f595b7d9998f326a9c7ff41cc266L4-R7), [link](https://github.com/baidu/amis/pull/7399/files?diff=unified&w=0#diff-2eb003bbc6f49ecb3f8b56411f1c1d02f055f595b7d9998f326a9c7ff41cc266R19))
* Add a new property `async` to the `PluginInterface` interface that allows each plugin to specify whether to enable asynchronous loading and provide the options for the fallback component ([link](https://github.com/baidu/amis/pull/7399/files?diff=unified&w=0#diff-2eb003bbc6f49ecb3f8b56411f1c1d02f055f595b7d9998f326a9c7ff41cc266R807-R811))
* Modify the `renderPanel` method of the `BasePlugin` class to check the `async` property of the plugin and wrap the schema form render function with the `makeAsyncLayer` function if enabled, or render it as before if not ([link](https://github.com/baidu/amis/pull/7399/files?diff=unified&w=0#diff-2eb003bbc6f49ecb3f8b56411f1c1d02f055f595b7d9998f326a9c7ff41cc266L1047-R1083))
