### PR TITLE
chore: tinymce 修复 video 插入后显示两份的问题 Close: #7370

### DIFF
--- a/packages/amis-ui/src/components/Tinymce.tsx
+++ b/packages/amis-ui/src/components/Tinymce.tsx
@@ -137,6 +137,8 @@ export default class TinymceEditor extends React.Component<TinymceEditorProps> {
         help: {title: 'Help', items: 'help'}
       },
       paste_data_images: true,
+      // 很诡异的问题，video 会被复制放在光标上，直接用样式隐藏先
+      content_style: '[data-mce-bogus] video {display:none;}',
       ...this.props.config,
       target: this.elementRef.current,
       readOnly: this.props.disabled,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c0f1a1</samp>

Fix video duplication bug in `Tinymce` component. Add a `content_style` option to hide bogus video elements with CSS.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3c0f1a1</samp>

> _`content_style` hides_
> _video bug in tinymce_
> _autumn leaves falling_

### Why

Close: #7370

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c0f1a1</samp>

*  Add video support to the tinymce editor component (                             
