### PR TITLE
feat: amis-ui组件样式变量增加命名空间

### DIFF
--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -1,4 +1,5 @@
-:root {
+:root,
+.AMISCSSWrapper {
   --button-default-default-top-border-color: var(--colors-neutral-line-8);
   --button-default-default-top-border-style: var(--borders-style-2);
   --button-default-default-top-border-width: var(--borders-width-2);

--- a/packages/amis-ui/scss/_properties.scss
+++ b/packages/amis-ui/scss/_properties.scss
@@ -5,7 +5,8 @@ $remFactor: 16px;
 /* 此处放置需要override的变量，因为部分变量已经在variables.scss中定义 */
 $Table-strip-bg: transparent;
 
-:root {
+:root,
+.AMISCSSWrapper {
   --white: var(--colors-neutral-text-11);
   --primary: var(--colors-brand-5);
   --primary-onHover: var(--colors-brand-6);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2eff851</samp>

Added support for customizing the AMIS theme by passing a `theme` prop to the `AMIS` component. Modified the `:root` selector in `_components.scss` and `_properties.scss` to include `.AMISCSSWrapper` class.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2eff851</samp>

> _Customize AMIS_
> _`theme` prop changes `:root`_
> _CSS variables_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2eff851</samp>

*  Enable theme customization for AMIS components by adding `.AMISCSSWrapper` class to `:root` selector ([link](https://github.com/baidu/amis/pull/7405/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4L1-R2), [link](https://github.com/baidu/amis/pull/7405/files?diff=unified&w=0#diff-11e33167cf3700a03b633f75ed54c24b2e57771a316f2e113cf09c791919c795L8-R9))
