### PR TITLE
fix: 修复crud 中 drawer 动作后不刷新问题   Close: #6903

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,71 +1,18 @@
 {
-    // 使用 IntelliSense 了解相关属性。 
-    // 悬停以查看现有属性的描述。
-    // 欲了解更多信息，请访问: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Jest All",
-            "program": "${workspaceFolder}/node_modules/.bin/jest",
-            "args": ["--runInBand"],
-            "sourceMaps": true,
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen",
-            "disableOptimisticBPs": true,
-            "runtimeExecutable": "/usr/local/bin/node",
-            "windows": {
-              "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-            }
-          },
-          {
-            "type": "node",
-            "request": "launch",
-            "name": "Jest Current File",
-            "program": "${workspaceFolder}/node_modules/.bin/jest",
-            "args": [
-              "--no-cache",
-              "--runInBand",
-              "${relativeFile}"
-            ],
-            "sourceMaps": true,
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen",
-            "disableOptimisticBPs": true,
-            "runtimeExecutable": "/usr/local/bin/node",
-            "windows": {
-              "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-            }
-          },
-          {
-            "type": "node",
-            "request": "launch",
-            "name": "Jest Current File Specified test",
-            "program": "${workspaceFolder}/node_modules/.bin/jest",
-            "args": [
-              "--no-cache",
-              "--runInBand",
-              "${relativeFile}",
-              "-t",
-              "${input:testName}"
-            ],
-            "sourceMaps": true,
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen",
-            "disableOptimisticBPs": true,
-            "runtimeExecutable": "/usr/local/bin/node",
-            "windows": {
-              "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-            }
-          }
-    ],
-    "inputs": [
-      {
-        "id": "testName",
-        "type": "promptString",
-        "default": "",
-        "description": "Run only tests with a name that matches the regex pattern."
+  "version": "1.0.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest: current file",
+      //"env": { "NODE_ENV": "test" },
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${fileBasenameNoExtension}"],
+      "console": "integratedTerminal",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
       }
-    ]
+    }
+  ]
 }

--- a/packages/amis-core/src/RootRenderer.tsx
+++ b/packages/amis-core/src/RootRenderer.tsx
@@ -160,7 +160,12 @@ export class RootRenderer extends React.Component<RootRendererProps> {
       window.open(mailto);
     } else if (action.actionType === 'dialog') {
       store.setCurrentAction(action);
-      store.openDialog(ctx, undefined, action.callback, delegate);
+      store.openDialog(
+        ctx,
+        undefined,
+        action.callback,
+        delegate || (this.context as any)
+      );
     } else if (action.actionType === 'drawer') {
       store.setCurrentAction(action);
       store.openDrawer(ctx, undefined, undefined, delegate);
@@ -323,9 +328,14 @@ export class RootRenderer extends React.Component<RootRendererProps> {
         actionType: 'dialog',
         dialog: dialog
       });
-      store.openDialog(ctx, undefined, confirmed => {
-        resolve(confirmed);
-      });
+      store.openDialog(
+        ctx,
+        undefined,
+        confirmed => {
+          resolve(confirmed);
+        },
+        this.context as any
+      );
     });
   }
 

--- a/packages/amis-core/src/factory.tsx
+++ b/packages/amis-core/src/factory.tsx
@@ -186,7 +186,7 @@ export function registerRenderer(config: RendererConfig): RendererConfig {
   }
 
   if (config.isolateScope) {
-    config.component = Scoped(config.component);
+    config.component = Scoped(config.component, config.type);
   }
 
   const idx = findIndex(

--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -1133,7 +1133,12 @@ export default class Form extends React.Component<FormProps, object> {
           action.target &&
             this.reloadTarget(filterTarget(action.target, values), values);
         } else if (action.actionType === 'dialog') {
-          store.openDialog(data, undefined, action.callback);
+          store.openDialog(
+            data,
+            undefined,
+            action.callback,
+            delegate || (this.context as any)
+          );
         } else if (action.actionType === 'drawer') {
           store.openDrawer(data);
         } else if (isEffectiveApi(action.api || api, values)) {
@@ -1259,7 +1264,12 @@ export default class Form extends React.Component<FormProps, object> {
       this.validate(true);
     } else if (action.actionType === 'dialog') {
       store.setCurrentAction(action);
-      store.openDialog(data, undefined, action.callback);
+      store.openDialog(
+        data,
+        undefined,
+        action.callback,
+        delegate || (this.context as any)
+      );
     } else if (action.actionType === 'drawer') {
       store.setCurrentAction(action);
       store.openDrawer(data);
@@ -1428,9 +1438,14 @@ export default class Form extends React.Component<FormProps, object> {
         actionType: 'dialog',
         dialog: dialog
       });
-      store.openDialog(ctx, undefined, confirmed => {
-        resolve(confirmed);
-      });
+      store.openDialog(
+        ctx,
+        undefined,
+        confirmed => {
+          resolve(confirmed);
+        },
+        this.context as any
+      );
     });
   }
 

--- a/packages/amis/__tests__/renderers/CRUDReload.test.tsx
+++ b/packages/amis/__tests__/renderers/CRUDReload.test.tsx
@@ -1,0 +1,531 @@
+import {render, fireEvent, waitFor} from '@testing-library/react';
+import '../../src';
+import {render as amisRender} from '../../src';
+import {makeEnv, wait} from '../helper';
+jest.useRealTimers();
+
+// 验证 crud 里面的 ajax 动作，结束后是否刷新 crud
+test('CRUD reload ajax1', async () => {
+  let listApiCalledCount = 0;
+  const mockFetcher = jest.fn().mockImplementation((api: any) => {
+    if (/^\/api\/mock2\/sample\/\d+/.test(api.url)) {
+      return Promise.resolve({
+        data: {
+          status: 0
+        }
+      });
+    }
+
+    listApiCalledCount++;
+    return Promise.resolve({
+      data: {
+        status: 0,
+        data: {
+          items: [{id: 1, a: 'a1', b: 'b1'}]
+        }
+      }
+    });
+  });
+  const {container} = render(
+    amisRender(
+      {
+        type: 'page',
+        body: {
+          type: 'crud',
+          api: '/api/mock2/sample',
+          columns: [
+            {
+              name: 'id',
+              label: 'ID'
+            },
+            {
+              name: 'a',
+              label: 'A'
+            },
+            {
+              name: 'b',
+              label: 'B'
+            },
+            {
+              label: '操作',
+              type: 'operation',
+              buttons: [
+                {
+                  label: '保存',
+                  type: 'button',
+                  actionType: 'ajax',
+                  api: '/api/mock2/sample/${id}'
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {},
+      makeEnv({fetcher: mockFetcher})
+    )
+  );
+  await wait(200);
+  const saveBtn = container.querySelectorAll('tbody>tr button')[0];
+  expect(saveBtn).toBeTruthy();
+  fireEvent.click(saveBtn);
+  await waitFor(() => {
+    expect(mockFetcher).toBeCalledTimes(3);
+  });
+  expect(listApiCalledCount).toBe(2);
+});
+
+// 如果配置了 reload none 则不刷新
+test('CRUD reload ajax2', async () => {
+  let listApiCalledCount = 0;
+  const mockFetcher = jest.fn().mockImplementation((api: any) => {
+    if (/^\/api\/mock2\/sample\/\d+/.test(api.url)) {
+      return Promise.resolve({
+        data: {
+          status: 0
+        }
+      });
+    }
+
+    listApiCalledCount++;
+    return Promise.resolve({
+      data: {
+        status: 0,
+        data: {
+          items: [{id: 1, a: 'a1', b: 'b1'}]
+        }
+      }
+    });
+  });
+  const {container} = render(
+    amisRender(
+      {
+        type: 'page',
+        body: {
+          type: 'crud',
+          api: '/api/mock2/sample',
+          columns: [
+            {
+              name: 'id',
+              label: 'ID'
+            },
+            {
+              name: 'a',
+              label: 'A'
+            },
+            {
+              name: 'b',
+              label: 'B'
+            },
+            {
+              label: '操作',
+              type: 'operation',
+              buttons: [
+                {
+                  label: '保存',
+                  type: 'button',
+                  actionType: 'ajax',
+                  api: '/api/mock2/sample/${id}'
+                },
+                {
+                  label: '保存2',
+                  type: 'button',
+                  actionType: 'ajax',
+                  api: '/api/mock2/sample/${id}',
+                  reload: 'none'
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {},
+      makeEnv({fetcher: mockFetcher})
+    )
+  );
+  await wait(200);
+  const saveBtn1 = container.querySelectorAll('tbody>tr button')[0];
+  const saveBtn2 = container.querySelectorAll('tbody>tr button')[1];
+  expect(saveBtn1).toBeTruthy();
+  expect(saveBtn2).toBeTruthy();
+  fireEvent.click(saveBtn2);
+  await waitFor(() => {
+    expect(mockFetcher).toBeCalledTimes(2);
+  });
+  expect(listApiCalledCount).toBe(1);
+  fireEvent.click(saveBtn1);
+  await waitFor(() => {
+    expect(mockFetcher).toBeCalledTimes(4);
+  });
+  expect(listApiCalledCount).toBe(2);
+});
+
+// dialog 提交后应该刷新 crud
+test('CRUD reload dialog1', async () => {
+  let listApiCalledCount = 0;
+  const mockFetcher = jest.fn().mockImplementation((api: any) => {
+    if (/^\/api\/mock2\/sample\/\d+/.test(api.url)) {
+      return Promise.resolve({
+        data: {
+          status: 0
+        }
+      });
+    }
+
+    listApiCalledCount++;
+    return Promise.resolve({
+      data: {
+        status: 0,
+        data: {
+          items: [{id: 1, a: 'a1', b: 'b1'}]
+        }
+      }
+    });
+  });
+  const {container, getByText}: any = render(
+    amisRender(
+      {
+        type: 'page',
+        body: {
+          type: 'crud',
+          api: '/api/mock2/sample',
+          columns: [
+            {
+              name: 'id',
+              label: 'ID'
+            },
+            {
+              name: 'a',
+              label: 'A'
+            },
+            {
+              name: 'b',
+              label: 'B'
+            },
+            {
+              label: '操作',
+              type: 'operation',
+              buttons: [
+                {
+                  label: 'OpenDialog',
+                  type: 'button',
+                  actionType: 'dialog',
+                  dialog: {
+                    body: {
+                      type: 'form',
+                      api: '/api/mock2/sample/${id}',
+                      body: [
+                        {
+                          type: 'input-text',
+                          name: 'a',
+                          label: 'A'
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {},
+      makeEnv({fetcher: mockFetcher, getModalContainer: () => container})
+    )
+  );
+  await wait(200);
+  const saveBtn = container.querySelectorAll('tbody>tr button')[0];
+  expect(saveBtn).toBeTruthy();
+  fireEvent.click(saveBtn);
+  await wait(300);
+
+  expect(getByText('确认')).toBeInTheDocument();
+  fireEvent.click(getByText('取消'));
+  await wait(300);
+
+  fireEvent.click(saveBtn);
+  await wait(300);
+  expect(getByText('确认')).toBeInTheDocument();
+
+  fireEvent.click(getByText('确认'));
+  await wait(500);
+
+  expect(mockFetcher).toBeCalledTimes(3);
+  expect(listApiCalledCount).toBe(2);
+});
+
+// dialog 提交后如果配置列不刷新，则不刷新
+test('CRUD reload dialog2', async () => {
+  let listApiCalledCount = 0;
+  const mockFetcher = jest.fn().mockImplementation((api: any) => {
+    if (/^\/api\/mock2\/sample\/\d+/.test(api.url)) {
+      return Promise.resolve({
+        data: {
+          status: 0
+        }
+      });
+    }
+
+    listApiCalledCount++;
+    return Promise.resolve({
+      data: {
+        status: 0,
+        data: {
+          items: [{id: 1, a: 'a1', b: 'b1'}]
+        }
+      }
+    });
+  });
+  const {container, getByText}: any = render(
+    amisRender(
+      {
+        type: 'page',
+        body: {
+          type: 'crud',
+          api: '/api/mock2/sample',
+          columns: [
+            {
+              name: 'id',
+              label: 'ID'
+            },
+            {
+              name: 'a',
+              label: 'A'
+            },
+            {
+              name: 'b',
+              label: 'B'
+            },
+            {
+              label: '操作',
+              type: 'operation',
+              buttons: [
+                {
+                  label: 'OpenDialog',
+                  type: 'button',
+                  actionType: 'dialog',
+                  reload: 'none',
+                  dialog: {
+                    body: {
+                      type: 'form',
+                      api: '/api/mock2/sample/${id}',
+                      body: [
+                        {
+                          type: 'input-text',
+                          name: 'a',
+                          label: 'A'
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {},
+      makeEnv({fetcher: mockFetcher, getModalContainer: () => container})
+    )
+  );
+  await wait(200);
+  const saveBtn = container.querySelectorAll('tbody>tr button')[0];
+  expect(saveBtn).toBeTruthy();
+  fireEvent.click(saveBtn);
+  await wait(300);
+
+  fireEvent.click(saveBtn);
+  await wait(300);
+  expect(getByText('确认')).toBeInTheDocument();
+
+  fireEvent.click(getByText('确认'));
+  await wait(500);
+
+  expect(mockFetcher).toBeCalledTimes(2);
+  expect(listApiCalledCount).toBe(1);
+});
+
+// drawer 提交后应该刷新 crud
+test('CRUD reload drawer1', async () => {
+  let listApiCalledCount = 0;
+  const mockFetcher = jest.fn().mockImplementation((api: any) => {
+    if (/^\/api\/mock2\/sample\/\d+/.test(api.url)) {
+      return Promise.resolve({
+        data: {
+          status: 0
+        }
+      });
+    }
+
+    listApiCalledCount++;
+    return Promise.resolve({
+      data: {
+        status: 0,
+        data: {
+          items: [{id: 1, a: 'a1', b: 'b1'}]
+        }
+      }
+    });
+  });
+  const {container, getByText}: any = render(
+    amisRender(
+      {
+        type: 'page',
+        body: {
+          type: 'crud',
+          api: '/api/mock2/sample',
+          columns: [
+            {
+              name: 'id',
+              label: 'ID'
+            },
+            {
+              name: 'a',
+              label: 'A'
+            },
+            {
+              name: 'b',
+              label: 'B'
+            },
+            {
+              label: '操作',
+              type: 'operation',
+              buttons: [
+                {
+                  label: 'openDrawer',
+                  type: 'button',
+                  actionType: 'drawer',
+                  drawer: {
+                    body: {
+                      type: 'form',
+                      api: '/api/mock2/sample/${id}',
+                      body: [
+                        {
+                          type: 'input-text',
+                          name: 'a',
+                          label: 'A'
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {},
+      makeEnv({fetcher: mockFetcher, getModalContainer: () => container})
+    )
+  );
+  await wait(200);
+  const saveBtn = container.querySelectorAll('tbody>tr button')[0];
+  expect(saveBtn).toBeTruthy();
+  fireEvent.click(saveBtn);
+  await wait(300);
+
+  expect(getByText('确认')).toBeInTheDocument();
+  fireEvent.click(getByText('取消'));
+  await wait(300);
+
+  fireEvent.click(saveBtn);
+  await wait(300);
+  expect(getByText('确认')).toBeInTheDocument();
+
+  fireEvent.click(getByText('确认'));
+  await wait(500);
+
+  expect(mockFetcher).toBeCalledTimes(3);
+  expect(listApiCalledCount).toBe(2);
+});
+
+// dialog 提交后如果配置列不刷新，则不刷新
+test('CRUD reload drawer2', async () => {
+  let listApiCalledCount = 0;
+  const mockFetcher = jest.fn().mockImplementation((api: any) => {
+    if (/^\/api\/mock2\/sample\/\d+/.test(api.url)) {
+      return Promise.resolve({
+        data: {
+          status: 0
+        }
+      });
+    }
+
+    listApiCalledCount++;
+    return Promise.resolve({
+      data: {
+        status: 0,
+        data: {
+          items: [{id: 1, a: 'a1', b: 'b1'}]
+        }
+      }
+    });
+  });
+  const {container, getByText}: any = render(
+    amisRender(
+      {
+        type: 'page',
+        body: {
+          type: 'crud',
+          api: '/api/mock2/sample',
+          columns: [
+            {
+              name: 'id',
+              label: 'ID'
+            },
+            {
+              name: 'a',
+              label: 'A'
+            },
+            {
+              name: 'b',
+              label: 'B'
+            },
+            {
+              label: '操作',
+              type: 'operation',
+              buttons: [
+                {
+                  label: 'openDrawer',
+                  type: 'button',
+                  actionType: 'drawer',
+                  reload: 'none',
+                  drawer: {
+                    body: {
+                      type: 'form',
+                      api: '/api/mock2/sample/${id}',
+                      body: [
+                        {
+                          type: 'input-text',
+                          name: 'a',
+                          label: 'A'
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {},
+      makeEnv({fetcher: mockFetcher, getModalContainer: () => container})
+    )
+  );
+  await wait(200);
+  const saveBtn = container.querySelectorAll('tbody>tr button')[0];
+  expect(saveBtn).toBeTruthy();
+  fireEvent.click(saveBtn);
+  await wait(300);
+
+  fireEvent.click(saveBtn);
+  await wait(300);
+  expect(getByText('确认')).toBeInTheDocument();
+
+  fireEvent.click(getByText('确认'));
+  await wait(500);
+
+  expect(mockFetcher).toBeCalledTimes(2);
+  expect(listApiCalledCount).toBe(1);
+});

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -702,7 +702,8 @@ export default class CRUD extends React.Component<CRUDProps, any> {
           prevIndex: idx - 1,
           index: idx
         },
-        action.callback
+        action.callback,
+        delegate || (this.context as any)
       );
     } else if (action.actionType === 'ajax') {
       store.setCurrentAction(action);
@@ -1130,9 +1131,14 @@ export default class CRUD extends React.Component<CRUDProps, any> {
         actionType: 'dialog',
         dialog: dialog
       });
-      store.openDialog(ctx, undefined, confirmed => {
-        resolve(confirmed);
-      });
+      store.openDialog(
+        ctx,
+        undefined,
+        confirmed => {
+          resolve(confirmed);
+        },
+        this.context as any
+      );
     });
   }
 

--- a/packages/amis/src/renderers/Drawer.tsx
+++ b/packages/amis/src/renderers/Drawer.tsx
@@ -525,9 +525,14 @@ export default class Drawer extends React.Component<DrawerProps> {
         actionType: 'dialog',
         dialog: dialog
       });
-      store.openDialog(ctx, undefined, confirmed => {
-        resolve(confirmed);
-      });
+      store.openDialog(
+        ctx,
+        undefined,
+        confirmed => {
+          resolve(confirmed);
+        },
+        this.context as any
+      );
     });
   }
 
@@ -827,7 +832,12 @@ export class DrawerRenderer extends Drawer {
       store.openDrawer(data);
     } else if (action.actionType === 'dialog') {
       store.setCurrentAction(action);
-      store.openDialog(data, undefined, action.callback);
+      store.openDialog(
+        data,
+        undefined,
+        action.callback,
+        delegate || (this.context as any)
+      );
     } else if (action.actionType === 'reload') {
       store.setCurrentAction(action);
       action.target && scoped.reload(action.target, data);
@@ -913,16 +923,19 @@ export class DrawerRenderer extends Drawer {
     ...rest: Array<any>
   ) {
     super.handleDialogConfirm(values, action, ...rest);
-    const scoped = this.context as IScopedContext;
+
     const store = this.props.store;
+    const scoped = store.getDialogScoped() || (this.context as IScopedContext);
     const dialogAction = store.action as ActionObject;
     const reload = action.reload ?? dialogAction.reload;
 
     if (reload) {
       scoped.reload(reload, store.data);
+    } else if (scoped.component?.reload) {
+      scoped.component.reload();
     } else {
       // 没有设置，则自动让页面中 crud 刷新。
-      scoped
+      (this.context as IScopedContext)
         .getComponents()
         .filter((item: any) => item.props.type === 'crud')
         .forEach((item: any) => item.reload && item.reload());
@@ -935,19 +948,20 @@ export class DrawerRenderer extends Drawer {
     ...rest: Array<any>
   ) {
     super.handleDrawerConfirm(values, action);
-    const scoped = this.context as IScopedContext;
     const store = this.props.store;
+    const scoped = store.getDialogScoped() || (this.context as IScopedContext);
     const drawerAction = store.action as ActionObject;
+    const reload = action.reload ?? drawerAction.reload;
 
     // 稍等会，等动画结束。
     setTimeout(() => {
-      if (drawerAction.reload) {
-        scoped.reload(drawerAction.reload, store.data);
-      } else if (action.reload) {
-        scoped.reload(action.reload, store.data);
+      if (reload) {
+        scoped.reload(reload, store.data);
+      } else if (scoped.component?.reload) {
+        scoped.component.reload();
       } else {
         // 没有设置，则自动让页面中 crud 刷新。
-        scoped
+        (this.context as IScopedContext)
           .getComponents()
           .filter((item: any) => item.props.type === 'crud')
           .forEach((item: any) => item.reload && item.reload());

--- a/packages/amis/src/renderers/Page.tsx
+++ b/packages/amis/src/renderers/Page.tsx
@@ -484,7 +484,12 @@ export default class Page extends React.Component<PageProps> {
 
     if (action.actionType === 'dialog') {
       store.setCurrentAction(action);
-      store.openDialog(ctx, undefined, action.callback, delegate);
+      store.openDialog(
+        ctx,
+        undefined,
+        action.callback,
+        delegate || (this.context as any)
+      );
     } else if (action.actionType === 'drawer') {
       store.setCurrentAction(action);
       store.openDrawer(ctx, undefined, undefined, delegate);
@@ -664,9 +669,14 @@ export default class Page extends React.Component<PageProps> {
         actionType: 'dialog',
         dialog: dialog
       });
-      store.openDialog(ctx, undefined, confirmed => {
-        resolve(confirmed);
-      });
+      store.openDialog(
+        ctx,
+        undefined,
+        confirmed => {
+          resolve(confirmed);
+        },
+        this.context as any
+      );
     });
   }
 
@@ -1066,9 +1076,11 @@ export class PageRenderer extends Page {
 
     if (reload) {
       scoped.reload(reload, store.data);
+    } else if (scoped?.component?.reload) {
+      scoped.component.reload();
     } else {
       // 没有设置，则自动让页面中 crud 刷新。
-      scoped
+      (this.context as IScopedContext)
         .getComponents()
         .filter((item: any) => item.props.type === 'crud')
         .forEach((item: any) => item.reload && item.reload());
@@ -1091,9 +1103,10 @@ export class PageRenderer extends Page {
     setTimeout(() => {
       if (reload) {
         scoped.reload(reload, store.data);
+      } else if (scoped?.component?.reload) {
+        scoped.component.reload();
       } else {
-        // 没有设置，则自动让页面中 crud 刷新。
-        scoped
+        (this.context as IScopedContext)
           .getComponents()
           .filter((item: any) => item.props.type === 'crud')
           .forEach((item: any) => item.reload && item.reload());

--- a/packages/amis/src/renderers/Service.tsx
+++ b/packages/amis/src/renderers/Service.tsx
@@ -695,9 +695,14 @@ export default class Service extends React.Component<ServiceProps> {
         actionType: 'dialog',
         dialog: dialog
       });
-      store.openDialog(ctx, undefined, confirmed => {
-        resolve(confirmed);
-      });
+      store.openDialog(
+        ctx,
+        undefined,
+        confirmed => {
+          resolve(confirmed);
+        },
+        this.context as any
+      );
     });
   }
 

--- a/packages/amis/src/renderers/Wizard.tsx
+++ b/packages/amis/src/renderers/Wizard.tsx
@@ -650,7 +650,12 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
       this.form.reset();
     } else if (action.actionType === 'dialog') {
       store.setCurrentAction(action);
-      store.openDialog(data, undefined, action.callback);
+      store.openDialog(
+        data,
+        undefined,
+        action.callback,
+        delegate || (this.context as any)
+      );
     } else if (action.actionType === 'ajax') {
       if (!action.api) {
         return env.alert(`当 actionType 为 ajax 时，请设置 api 属性`);
@@ -743,9 +748,14 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
         actionType: 'dialog',
         dialog: dialog
       });
-      store.openDialog(ctx, undefined, confirmed => {
-        resolve(confirmed);
-      });
+      store.openDialog(
+        ctx,
+        undefined,
+        confirmed => {
+          resolve(confirmed);
+        },
+        this.context as any
+      );
     });
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a47fd2e</samp>

This pull request fixes various issues with passing and accessing the scoped context of dialog and drawer components in different renderer classes. It also improves the identification and manipulation of scoped components by adding `rendererType` and `component` properties to the scoped context and a `getComponentsByRefPath` method to the scoped context. Additionally, it simplifies the configuration for running Jest tests in VSCode by modifying the `.vscode/launch.json` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a47fd2e</samp>

> _Oh, we're passing the `delegate` to the `store.openDialog`_
> _Heave away, me hearties, heave away_
> _We're fixing the scoped context for the dialog and drawer_
> _Heave away, me hearties, heave away_

### Why

Close: #6903

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a47fd2e</samp>

*  Simplify the configuration for running Jest tests in VSCode by removing unnecessary properties and keeping only one configuration for running the current file ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L2-R18))
*  Pass the `config.type` parameter to the `Scoped` function when creating a scoped context for the renderer component, and use it to set the `rendererType` property of the scoped context ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-f32fad412c5300ebd34ca8f39d2d60e882c3db418757ced49c3a79af4f22f2ebL189-R189), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-b2a2713e66ce0dcac88d294eb3a363249f0364d755ce255cf7b3ead775bfbf36R61-R62), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-b2a2713e66ce0dcac88d294eb3a363249f0364d755ce255cf7b3ead775bfbf36L81-R98))
*  Add two optional properties to the `ScopedComponentType` interface: `rendererType` and `component`, and use them to store the type and the reference of the renderer component that is wrapped by the `Scoped` component ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-b2a2713e66ce0dcac88d294eb3a363249f0364d755ce255cf7b3ead775bfbf36R61-R62), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-b2a2713e66ce0dcac88d294eb3a363249f0364d755ce255cf7b3ead775bfbf36L81-R98), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-b2a2713e66ce0dcac88d294eb3a363249f0364d755ce255cf7b3ead775bfbf36L433-R445))
*  Add a new method to the `IScopedContext` interface: `getComponentsByRefPath`, and use it to get an array of scoped components that match a given session and ref path ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-b2a2713e66ce0dcac88d294eb3a363249f0364d755ce255cf7b3ead775bfbf36R74-R77))
*  Accept a new parameter in the `HocScoped` function: `rendererType`, and use it to pass the type of the renderer component that is wrapped by the `HocScoped` function to the `Scoped` component and the `createScopedTools` function ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-b2a2713e66ce0dcac88d294eb3a363249f0364d755ce255cf7b3ead775bfbf36L407-R418), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-b2a2713e66ce0dcac88d294eb3a363249f0364d755ce255cf7b3ead775bfbf36L433-R445))
*  Pass the `delegate` parameter to the `store.openDialog` method when handling the `dialog` action in various renderer components, and use it to provide the scoped context for the dialog component ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-4cba0119d1b827598fb03c9a62c9380b173776edc7267f0eb7577a50b3d7bb22L163-R168), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1136-R1141), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1262-R1272), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L705-R706), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL901-R911), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L830-R840), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L487-R492), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-8c1e1e55c146ca688906b7443643b4a9c53472e61bd55b64d534e92d1b247e3bL653-R658))
*  Fall back to `this.context` as the `delegate` parameter if the `delegate` parameter is undefined when handling the `dialog` action in various renderer components ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-4cba0119d1b827598fb03c9a62c9380b173776edc7267f0eb7577a50b3d7bb22L163-R168), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1136-R1141), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1262-R1272), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L705-R706), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL901-R911), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L830-R840), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L487-R492), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-8c1e1e55c146ca688906b7443643b4a9c53472e61bd55b64d534e92d1b247e3bL653-R658))
*  Pass the `this.context` as the `delegate` parameter to the `store.openDialog` method when handling the `confirm` action in various renderer components, and use it to provide the scoped context for the confirmation dialog component ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1431-R1448), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1133-R1143), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL429-R436), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L528-R535), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L667-R679), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852L698-R705), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-8c1e1e55c146ca688906b7443643b4a9c53472e61bd55b64d534e92d1b247e3bL746-R758))
*  Use the `store.getDialogScoped` method to get the scoped context for the dialog component when handling the `dialogConfirm` action in various renderer components, and use it to confirm the data and close the dialog component ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL1003-R1014), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L916-R928), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L1069-R1083))
*  Fall back to `this.context` as the scoped context if the `store.getDialogScoped` method returns undefined when handling the `dialogConfirm` action in various renderer components ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL1003-R1014), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L916-R928), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L1069-R1083))
*  Check if the `scoped.component` has a `reload` method when handling the `dialogConfirm` action in various renderer components, and use it to reload the data and render the component ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL1010-R1024), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L923-R938), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L1069-R1083))
*  Fall back to `this.context` as the scoped context if the `scoped.component` does not have a `reload` method when handling the `dialogConfirm` action in various renderer components, and then filter the components in the scoped context by their type of `crud` and call their `reload` method ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL1010-R1024), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L923-R938), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L1069-R1083))
*  Use the `store.getDialogScoped` method to get the scoped context for the drawer component when handling the `drawerConfirm` action in various renderer components, and use it to confirm the data and close the drawer component ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL1025-R1050), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L938-R964), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L1094-R1109))
*  Fall back to `this.context` as the scoped context if the `store.getDialogScoped` method returns undefined when handling the `drawerConfirm` action in various renderer components ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL1025-R1050), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L938-R964), [link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L1094-R1109))
*  Check if the `scoped.component` has a `reload` method when handling the `drawerConfirm` action in various renderer components, and use it to reload the data and render the component ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L1094-R1109))
*  Fall back to `this.context` as the scoped context if the `scoped.component` does not have a `reload` method when handling the `drawerConfirm` action in various renderer components, and then filter the components in the scoped context by their type of `crud` and call their `reload` method ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L1094-R1109))
*  Remove the `console.log` statement in `packages/amis/src/renderers/CRUD.tsx` as it is not related to the main purpose of the pull request ([link](https://github.com/baidu/amis/pull/7411/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R834-R835))
