### PR TITLE
fix: 修复 office-viewer 开启变量后无限渲染问题

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
     "packages/amis-ui",
     "packages/amis"
   ],
-  "version": "3.3.0-beta.3"
+  "version": "3.3.0-beta.4"
 }

--- a/packages/amis-core/package.json
+++ b/packages/amis-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amis-core",
-  "version": "3.3.0-beta.3",
+  "version": "3.3.0-beta.4",
   "description": "amis-core",
   "main": "lib/index.js",
   "module": "esm/index.js",
@@ -45,7 +45,7 @@
     "esm"
   ],
   "dependencies": {
-    "amis-formula": "^3.3.0-beta.3",
+    "amis-formula": "^3.3.0-beta.4",
     "classnames": "2.3.1",
     "file-saver": "^2.0.2",
     "hoist-non-react-statics": "^3.3.2",

--- a/packages/amis-formula/package.json
+++ b/packages/amis-formula/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amis-formula",
-  "version": "3.3.0-beta.3",
+  "version": "3.3.0-beta.4",
   "description": "负责 amis 里面的表达式实现，内置公式，编辑器等",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/packages/amis-ui/package.json
+++ b/packages/amis-ui/package.json
@@ -3,7 +3,7 @@
   "main": "lib/index.js",
   "module": "esm/index.js",
   "types": "lib/index.d.ts",
-  "version": "3.3.0-beta.3",
+  "version": "3.3.0-beta.4",
   "description": "",
   "scripts": {
     "build": "npm run clean-dist && NODE_ENV=production rollup -c ",
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "@rc-component/mini-decimal": "^1.0.1",
-    "amis-core": "^3.3.0-beta.3",
-    "amis-formula": "^3.3.0-beta.3",
+    "amis-core": "^3.3.0-beta.4",
+    "amis-formula": "^3.3.0-beta.4",
     "classnames": "2.3.1",
     "codemirror": "^5.63.0",
     "downshift": "6.1.12",

--- a/packages/amis/package.json
+++ b/packages/amis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amis",
-  "version": "3.3.0-beta.3",
+  "version": "3.3.0-beta.4",
   "description": "一种MIS页面生成工具",
   "main": "lib/index.js",
   "module": "esm/index.js",
@@ -36,8 +36,8 @@
     }
   ],
   "dependencies": {
-    "amis-core": "^3.3.0-beta.3",
-    "amis-ui": "^3.3.0-beta.3",
+    "amis-core": "^3.3.0-beta.4",
+    "amis-ui": "^3.3.0-beta.4",
     "attr-accept": "2.2.2",
     "blueimp-canvastoblob": "2.1.0",
     "classnames": "2.3.1",

--- a/packages/office-viewer/src/util/replaceVar.ts
+++ b/packages/office-viewer/src/util/replaceVar.ts
@@ -67,7 +67,7 @@ function replaceTableRow(word: Word, tr: Element) {
           t.textContent = t.textContent!.replace(`{{#${arrayName}}}`, '');
         }
       }
-      if (text.indexOf('{{/}}')) {
+      if (text.indexOf('{{/}}') !== -1) {
         // 去掉结束变量
         t.textContent = t.textContent!.replace('{{/}}', '');
       }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3da23c</samp>

This pull request updates the version of the `amis` project and its packages to 3.3.0-beta.4, using lerna to manage the versioning. It also enhances the `OfficeViewer` component and fixes some bugs in the `office-viewer` and `amis-formula` packages.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b3da23c</samp>

> _Sing, O Muse, of the mighty amis, the framework of many forms_
> _That with skillful lerna manages its packages and versions_
> _And updates them with care and diligence, as the seasons turn_
> _Like the immortal gods who change their shapes and manifestations_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b3da23c</samp>

*  Update the versions of the amis, amis-core, amis-formula, and amis-ui packages and their dependencies to 3.3.0-beta.4 as part of the release process ([link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-2d72bdead8afa0798d18995311992d684348a694c2d5e214e8e4d2b6153e4821L8-R8), [link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-2461f3811423634aee38270e1d12bcf581b95eb845cb00a3ea5eae804a57795cL3-R3), [link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-2461f3811423634aee38270e1d12bcf581b95eb845cb00a3ea5eae804a57795cL48-R48), [link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-2a1582dd8536cd65b762f9cd79719e90b98bdc38b808db0aaf783039f53d4153L3-R3), [link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-0e30bcb7b6942e615a81bbcc87d75a7279e22d52e521bd61e050c056f6efe78cL6-R6), [link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-0e30bcb7b6942e615a81bbcc87d75a7279e22d52e521bd61e050c056f6efe78cL38-R39), [link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-b49028542a3bb14de6e47e46a9f09f23ffeff3afea2a17d5ddace75726a33e12L3-R3), [link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-b49028542a3bb14de6e47e46a9f09f23ffeff3afea2a17d5ddace75726a33e12L39-R40))
  - Changing the type of the loading state from boolean to boolean | null and adding two new properties: document and inited ([link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-5678027605574a32a150d6ff0413d70482185a65537af9bfc021c49bb95b128eL48-R49), [link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-5678027605574a32a150d6ff0413d70482185a65537af9bfc021c49bb95b128eL61-R73))
  - Checking the inited property before calling `componentDidUpdate` and fetching the document data from the remote source before rendering it ([link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-5678027605574a32a150d6ff0413d70482185a65537af9bfc021c49bb95b128eL73-R92), [link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-5678027605574a32a150d6ff0413d70482185a65537af9bfc021c49bb95b128eL133-R160))
  - Optimizing the condition to render the document only when the display property is 'all' ([link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-5678027605574a32a150d6ff0413d70482185a65537af9bfc021c49bb95b128eL101-R118))
  - Storing the document data in the document property after fetching it and setting the loading state to false in the finally block of the `fetchWord` method ([link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-5678027605574a32a150d6ff0413d70482185a65537af9bfc021c49bb95b128eL157-R183), [link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-5678027605574a32a150d6ff0413d70482185a65537af9bfc021c49bb95b128eL172-R204))
  - Using the document data stored in the document property instead of the response data in the `renderRemoteWord` method and removing the redundant statement that sets the loading state to false ([link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-5678027605574a32a150d6ff0413d70482185a65537af9bfc021c49bb95b128eL180-R210), [link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-5678027605574a32a150d6ff0413d70482185a65537af9bfc021c49bb95b128eL194-L197))
  - Fixing a typo in the spelling of the loading state in the render method ([link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-5678027605574a32a150d6ff0413d70482185a65537af9bfc021c49bb95b128eL274-R300))
*  Fix a logical error in the `replaceTableRow` function of the `replaceVar.ts` file in the `office-viewer` package by using the correct comparison operator to check whether the text contains the end variable '{{/}}' ([link](https://github.com/baidu/amis/pull/7414/files?diff=unified&w=0#diff-607afac6b5c33a99fec7a88c35b1cee40c52f6f4ceb4f538e8bac153aa2afa98L70-R70))
