### PR TITLE
fix: input-number 值为0时静态展示问题

### DIFF
--- a/packages/amis/__tests__/renderers/Form/number.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/number.test.tsx
@@ -10,7 +10,7 @@
  * 7. 边框模式：无边框 & 半边框
  * 8. 大数模式
  */
-
+import React = require('react');
 import {render, fireEvent, waitFor} from '@testing-library/react';
 import '../../../src';
 import {render as amisRender} from '../../../src';
@@ -272,4 +272,16 @@ test('Renderer:number with big value', async () => {
   expect(input.value).toEqual('99999999999999999.99'); // 最大值
 
   expect(container).toMatchSnapshot();
+});
+
+test('Renderer:number with static', async () => {
+  const {input: stringValInput} = await setup({
+    value: '123'
+  });
+  const {input: numberValInput} = await setup({
+    value: 123
+  });
+
+  expect(stringValInput.value).toEqual('123');
+  expect(numberValInput.value).toEqual('123');
 });

--- a/packages/amis/src/renderers/Number.tsx
+++ b/packages/amis/src/renderers/Number.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import {Renderer, RendererProps, stripNumber} from 'amis-core';
+import {Renderer, RendererProps, numberFormatter, stripNumber} from 'amis-core';
 import moment from 'moment';
 import {BaseSchema} from '../Schema';
+import isNumber from 'lodash/isNumber';
 import {getPropValue, Option, PlainObject, normalizeOptions} from 'amis-core';
 
 /**
@@ -89,7 +90,7 @@ export class NumberField extends React.Component<NumberProps> {
       }
     }
 
-    if (value) {
+    if (typeof value === 'number' || typeof value === 'string') {
       // 设置了精度，但是原始数据是字符串，需要转成 float 之后再处理
       if (typeof value === 'string' && precision) {
         value = stripNumber(parseFloat(value));
@@ -114,9 +115,7 @@ export class NumberField extends React.Component<NumberProps> {
         }
 
         if (kilobitSeparator) {
-          let parts = String(value).split('.');
-          parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-          value = parts.join('.');
+          value = numberFormatter(value, precision);
         }
 
         viewValue = <span>{value}</span>;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9c37f14</samp>

Refactor `NumberField` component to use external functions for formatting and validating numeric values. This improves code readability and localization support in `packages/amis/src/renderers/Number.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9c37f14</samp>

> _Sing, O Muse, of the skillful refactorer_
> _Who made the `NumberField` component shine_
> _With external functions, clear and clever,_
> _For formatting and validating each line._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9c37f14</samp>

*  Import and use `numberFormatter` and `isNumber` functions to format and validate numeric values in `NumberField` component ([link](https://github.com/baidu/amis/pull/7416/files?diff=unified&w=0#diff-6ff3d2bcdac4cb360bb57723634521396b4d2773bd58ef28dd720ee921f9f3bcL2-R5), [link](https://github.com/baidu/amis/pull/7416/files?diff=unified&w=0#diff-6ff3d2bcdac4cb360bb57723634521396b4d2773bd58ef28dd720ee921f9f3bcL92-R93), [link](https://github.com/baidu/amis/pull/7416/files?diff=unified&w=0#diff-6ff3d2bcdac4cb360bb57723634521396b4d2773bd58ef28dd720ee921f9f3bcL117-R118))
