### PR TITLE
docs: 更新Tabs组件文档

### DIFF
--- a/docs/zh-CN/components/tabs.md
+++ b/docs/zh-CN/components/tabs.md
@@ -841,8 +841,9 @@ order: 68
 | defaultKey            | `string` / `number`               |                                     | 组件初始化时激活的选项卡，hash 值或索引值，支持使用表达式 `2.7.1 以上版本`                                 |
 | activeKey             | `string` / `number`               |                                     | 激活的选项卡，hash 值或索引值，支持使用表达式，可响应上下文数据变化                                        |
 | className             | `string`                          |                                     | 外层 Dom 的类名                                                                                            |
+| linksClassName        | `string`                          |                                     | Tabs 标题区的类名                                                                                            |
+| contentClassName      | `string`                          |                                     | Tabs 内容区的类名                                                                                            |
 | tabsMode              | `string`                          |                                     | 展示模式，取值可以是 `line`、`card`、`radio`、`vertical`、`chrome`、`simple`、`strong`、`tiled`、`sidebar` |
-| tabsClassName         | `string`                          |                                     | Tabs Dom 的类名                                                                                            |
 | tabs                  | `Array`                           |                                     | tabs 内容                                                                                                  |
 | source                | `string`                          |                                     | tabs 关联数据，关联后可以重复生成选项卡                                                                    |
 | toolbar               | [SchemaNode](../types/schemanode) |                                     | tabs 中的工具栏                                                                                            |

--- a/packages/amis/src/renderers/Tabs.tsx
+++ b/packages/amis/src/renderers/Tabs.tsx
@@ -115,11 +115,6 @@ export interface TabsSchema extends BaseSchema {
   source?: string;
 
   /**
-   * 类名
-   */
-  tabsClassName?: SchemaClassName;
-
-  /**
    * 展示形式
    */
   tabsMode?: TabsMode;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e4ac149</samp>

This pull request removes the deprecated prop `tabsClassName` from the Tabs component and updates the Chinese documentation to reflect the new props `linksClassName` and `contentClassName` that allow more style customization.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e4ac149</samp>

> _`TabsClassName` gone_
> _`linksClassName`, `contentClassName` new_
> _Spring cleaning the code_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e4ac149</samp>

* Remove unused prop `tabsClassName` from `TabsSchema` interface ([link](https://github.com/baidu/amis/pull/7417/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL118-L122))
* Update Chinese documentation of Tabs component to reflect new props `linksClassName` and `contentClassName` for customizing tabs style ([link](https://github.com/baidu/amis/pull/7417/files?diff=unified&w=0#diff-a3d5076043d377b678e8d6ca12805c7b8e4f0ab3daea536a4c2976c88c7e98b9L844-R846))
