### PR TITLE
chore: select 默认的搜索调整相关性参数 Close: #7410

### DIFF
--- a/packages/amis-ui/src/components/Select.tsx
+++ b/packages/amis-ui/src/components/Select.tsx
@@ -51,7 +51,11 @@ export const defaultFilterOption = (
   options: Option[],
   inputValue: string,
   option: {keys: string[]}
-): Option[] => matchSorter(options, inputValue, option);
+): Option[] =>
+  matchSorter(options, inputValue, {
+    threshold: matchSorter.rankings.CONTAINS,
+    ...option
+  });
 
 export type FilterOption = typeof defaultFilterOption;
 

--- a/packages/amis/__tests__/renderers/Form/select.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/select.test.tsx
@@ -954,3 +954,59 @@ test('should call the string style user filterOption if it is provided', async (
     expect(screen.getByText('label3')).toBeInTheDocument();
   });
 });
+
+test('Choose default search results should be more relevant', async () => {
+  const options = [
+    {
+      label: 'Display in the top right corner of the list',
+      value: 'list'
+    },
+    {
+      label:
+        'Displayed in the top right corner of the record viewing page and in the drop-down menu for each item in the list view',
+      value: 'record'
+    },
+    {
+      label:
+        'Displayed in the "More" dropdown menu in the upper right corner of the record viewing page, as well as in the dropdown menu for each item in the list view',
+      value: 'record_more'
+    },
+    {
+      label: 'Display in the drop-down menu for each item in the list view',
+      value: 'list_item'
+    },
+    {
+      label: 'Displayed in the upper right corner of the record viewing page',
+      value: 'record_only'
+    },
+    {
+      label:
+        'Displayed in the "More" drop-down menu in the upper right corner of the record viewing page',
+      value: 'record_only_more'
+    }
+  ];
+
+  const {container} = render(
+    amisRender(
+      {
+        type: 'select',
+        name: 'select',
+        searchable: true,
+        options
+      },
+      {},
+      makeEnv()
+    )
+  );
+
+  const select = screen.getByText('请选择');
+  fireEvent.click(select);
+
+  expect(container.querySelectorAll('[role="option"]').length).toBe(6);
+
+  fireEvent.change(screen.getByPlaceholderText('搜索'), {
+    target: {value: 'more'}
+  });
+
+  expect(container.querySelectorAll('[role="option"]').length).toBe(2);
+});


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b44320</samp>

This pull request improves the search functionality of the `Select` component by changing the default filter option to use a substring match. It also adds a test case to verify the new filter option in `packages/amis/__tests__/renderers/Form/select.test.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2b44320</samp>

> _`Select` component_
> _Filter option improved_
> _Autumn leaves fewer_

### Why

Close: #7410

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2b44320</samp>

*  Lower the default filter threshold for Select component to show more relevant options ([link](https://github.com/baidu/amis/pull/7420/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL54-R58))
*  Add a test case for the default filter option of Select component in `select.test.tsx` ([link](https://github.com/baidu/amis/pull/7420/files?diff=unified&w=0#diff-f57fc982660a1b963ba24153bbbe13aa6de3b8543536443886480d084ef71b2aR957-R1012))
