### PR TITLE
chore: CRUD列为Image组件时, placeholder属性无法覆盖兜底图片

### DIFF
--- a/packages/amis/src/renderers/Image.tsx
+++ b/packages/amis/src/renderers/Image.tsx
@@ -394,12 +394,11 @@ export interface ImageFieldProps extends RendererProps {
 export class ImageField extends React.Component<ImageFieldProps, object> {
   static defaultProps: Pick<
     ImageFieldProps,
-    'defaultImage' | 'thumbMode' | 'thumbRatio' | 'placeholder'
+    'defaultImage' | 'thumbMode' | 'thumbRatio'
   > = {
     defaultImage: imagePlaceholder,
     thumbMode: 'contain',
-    thumbRatio: '1:1',
-    placeholder: '-'
+    thumbRatio: '1:1'
   };
 
   @autobind
@@ -472,9 +471,7 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
     } = this.props;
 
     const finnalSrc = src ? filter(src, data, '| raw') : '';
-    let value =
-      finnalSrc || getPropValue(this.props) || defaultImage || imagePlaceholder;
-
+    let value = finnalSrc || getPropValue(this.props);
     const finnalHref = href ? filter(href, data, '| raw') : '';
 
     return (
@@ -489,14 +486,14 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
         style={style}
         onClick={this.handleClick}
       >
-        {value ? (
+        {value || (!value && !placeholder) ? (
           <ThemedImageThumb
             className={innerClassName}
             imageClassName={imageClassName}
             thumbClassName={thumbClassName}
             height={height}
             width={width}
-            src={value}
+            src={value ? value : defaultImage}
             href={finnalHref}
             title={filter(title, data)}
             caption={filter(imageCaption, data)}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 885c5f0</samp>

Simplified the `ImageField` component and added a `placeholder` option to hide it.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 885c5f0</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The `ImageField` component, removing what was vain_
> _And adding what was useful, so that by design_
> _He could conceal the image with a false `placeholder` name._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 885c5f0</samp>

* Remove unused `placeholder` prop from `ImageField` class ([link](https://github.com/baidu/amis/pull/7422/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9L397-R401))
* Simplify `value` variable logic and avoid redundant fallbacks to `defaultImage` or `imagePlaceholder` ([link](https://github.com/baidu/amis/pull/7422/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9L475-R474))
* Allow hiding `ThemedImageThumb` component by setting `placeholder` prop to falsy value ([link](https://github.com/baidu/amis/pull/7422/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9L492-R489))
* Ensure `ThemedImageThumb` component always has a valid `src` prop by falling back to `defaultImage` if `value` prop is falsy ([link](https://github.com/baidu/amis/pull/7422/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9L499-R496))
