### PR TITLE
nav组件下的option下的label属性支持表达式 #7430

### DIFF
--- a/packages/amis/src/renderers/Nav.tsx
+++ b/packages/amis/src/renderers/Nav.tsx
@@ -592,7 +592,7 @@ export class Navigation extends React.Component<
 
       const label =
         typeof link.label === 'string'
-          ? link.label
+          ? filter(link.label, data)
           : React.isValidElement(link.label)
           ? React.cloneElement(link.label)
           : render('inline', link.label as SchemaCollection);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c2a8aee</samp>

Added support for using variables in navigation link labels. The `Nav` renderer can now use the `filter` function in the `label` expression to replace variables with data values.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c2a8aee</samp>

> _`filter` function_
> _adds variables to labels_
> _autumn leaves change color_

### Why

close #7430

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c2a8aee</samp>

*  Add `filter` function to `label` expression in `Nav.tsx` to support using variables in navigation link labels ([link](https://github.com/baidu/amis/pull/7431/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL595-R595))
