### PR TITLE
chore: 进一步避免 office viewer 在 loading 时更新

### DIFF
--- a/packages/amis/src/renderers/OfficeViewer.tsx
+++ b/packages/amis/src/renderers/OfficeViewer.tsx
@@ -62,9 +62,6 @@ export default class OfficeViewer extends React.Component<
   // 文档数据，避免 update 参数的时候重复加载
   document?: any;
 
-  // 是否已经初始化过
-  inited?: boolean;
-
   constructor(props: OfficeViewerProps) {
     super(props);
     this.rootElement = React.createRef();
@@ -80,8 +77,8 @@ export default class OfficeViewer extends React.Component<
   }
 
   componentDidUpdate(prevProps: OfficeViewerProps) {
-    // 避免无限更新
-    if (!this.inited) {
+    // 避免 loading 时更新
+    if (this.state.loading) {
       return;
     }
     const props = this.props;
@@ -153,7 +150,6 @@ export default class OfficeViewer extends React.Component<
     } else if (name) {
       this.renderFormFile();
     }
-    this.inited = true;
   }
 
   async fetchWord() {
@@ -187,7 +183,6 @@ export default class OfficeViewer extends React.Component<
         this.rootElement.current.innerHTML =
           __('loadingFailed') + ' url:' + finalSrc;
       }
-      return;
     } finally {
       this.setState({
         loading: false


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e645683</samp>

Simplify state management of `OfficeViewer` component. Use `loading` instead of `inited` to control rendering and avoid extra updates.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e645683</samp>

> _We're coding on the OfficeViewer_
> _We're making it simpler and cleaner_
> _We're dropping the `inited` flag_
> _And using the `loading` instead_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e645683</samp>

*  Remove `inited` state property and use `loading` instead to control office viewer updates ([link](https://github.com/baidu/amis/pull/7432/files?diff=unified&w=0#diff-5678027605574a32a150d6ff0413d70482185a65537af9bfc021c49bb95b128eL65-L67), [link](https://github.com/baidu/amis/pull/7432/files?diff=unified&w=0#diff-5678027605574a32a150d6ff0413d70482185a65537af9bfc021c49bb95b128eL83-R81), [link](https://github.com/baidu/amis/pull/7432/files?diff=unified&w=0#diff-5678027605574a32a150d6ff0413d70482185a65537af9bfc021c49bb95b128eL156), [link](https://github.com/baidu/amis/pull/7432/files?diff=unified&w=0#diff-5678027605574a32a150d6ff0413d70482185a65537af9bfc021c49bb95b128eL190)) in `OfficeViewer.tsx`
