### PR TITLE
fix input-number 前后缀问题

### DIFF
--- a/packages/amis-ui/src/components/NumberInput.tsx
+++ b/packages/amis-ui/src/components/NumberInput.tsx
@@ -202,6 +202,9 @@ export class NumberInput extends React.Component<NumberProps, NumberState> {
 
     // 严格判断大数模式，因为初始化value为empty string时，修改value值格式仍然为string
     this.isBig = !!props.big;
+    this.state = {
+      focused: false
+    };
   }
 
   componentDidUpdate(prevProps: NumberProps) {

--- a/packages/amis/src/renderers/Form/InputNumber.tsx
+++ b/packages/amis/src/renderers/Form/InputNumber.tsx
@@ -150,7 +150,6 @@ interface NumberState {
   // 数字单位，将会影响输出
   unit?: string;
   unitOptions?: Option[];
-  inputing: boolean;
 }
 
 export type InputNumberRendererEvent = 'blur' | 'focus' | 'change';
@@ -164,8 +163,7 @@ export default class NumberControl extends React.Component<
   static defaultProps: Partial<NumberProps> = {
     step: 1,
     resetValue: '',
-    clearValueOnEmpty: false,
-    inputing: false
+    clearValueOnEmpty: false
   };
 
   constructor(props: NumberProps) {
@@ -200,7 +198,7 @@ export default class NumberControl extends React.Component<
       }
     }
 
-    this.state = {unit, unitOptions, inputing: false};
+    this.state = {unit, unitOptions};
   }
 
   /**
@@ -391,7 +389,7 @@ export default class NumberControl extends React.Component<
       id,
       env
     } = this.props;
-    const {inputing, unit} = this.state;
+    const {unit} = this.state;
     const finalPrecision = this.filterNum(precision);
     // 数据格式化
     const formatter =
@@ -437,7 +435,7 @@ export default class NumberControl extends React.Component<
           step={step}
           max={this.filterNum(max, big)}
           min={this.filterNum(min, big)}
-          formatter={!inputing ? formatter : undefined}
+          formatter={formatter}
           parser={parser}
           onChange={this.handleChange}
           disabled={disabled}
@@ -446,14 +444,8 @@ export default class NumberControl extends React.Component<
           showSteps={showSteps}
           borderMode={borderMode}
           readOnly={readOnly}
-          onFocus={() => {
-            this.setState({inputing: true});
-            this.dispatchEvent('focus');
-          }}
-          onBlur={() => {
-            this.setState({inputing: false});
-            this.dispatchEvent('blur');
-          }}
+          onFocus={() => this.dispatchEvent('focus')}
+          onBlur={() => this.dispatchEvent('blur')}
           keyboard={keyboard}
           displayMode={displayMode}
           big={big}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b14ec3</samp>

This pull request refactors the `InputNumber` and `NumberInput` components to improve their usability and maintainability. It removes some redundant props and states from `InputNumber`, and adds a focus indicator and unit options to `NumberInput`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2b14ec3</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The `InputNumber` component, and with keen mind_
> _Removed the `inputing` state and `formatter` prop_
> _That tangled the logic and made the code a crop_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2b14ec3</samp>

*  Remove `inputing` state and `formatter` prop from `InputNumber` component, which were unnecessary and inconsistent with the input focus ([link](https://github.com/baidu/amis/pull/7436/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685L153), [link](https://github.com/baidu/amis/pull/7436/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685L167-R166), [link](https://github.com/baidu/amis/pull/7436/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685L203-R201), [link](https://github.com/baidu/amis/pull/7436/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685L394-R392), [link](https://github.com/baidu/amis/pull/7436/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685L440-R438), [link](https://github.com/baidu/amis/pull/7436/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685L449-R448))
* Add `focused` state to `NumberInput` component, which controls the border color and the unit options display ([link](https://github.com/baidu/amis/pull/7436/files?diff=unified&w=0#diff-546e57e204289f8983a75b6d74448711dc7fd5461cbc03acb7fdaa1548252954R205-R207))
* Simplify `onFocus` and `onBlur` props of `NumberInput` component, which dispatch the corresponding events directly ([link](https://github.com/baidu/amis/pull/7436/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685L449-R448))
