### PR TITLE
fix(amis): flex组件/合并flex和flexBasis，并优先使用flexBasis

### DIFF
--- a/packages/amis-ui/scss/base/_common.scss
+++ b/packages/amis-ui/scss/base/_common.scss
@@ -5,3 +5,7 @@
 .is-keyword {
   color: var(--primary-onActive);
 }
+
+.visibility-sensor {
+  min-height: 5px;
+}

--- a/packages/amis/src/renderers/Flex.tsx
+++ b/packages/amis/src/renderers/Flex.tsx
@@ -112,6 +112,14 @@ export default class Flex extends React.Component<FlexProps, object> {
       ...styleVar
     };
 
+    if (flexStyle.flexBasis !== undefined && flexStyle.flex) {
+      // 合并flex和flexBasis，并优先使用flexBasis
+      const flexValArr = flexStyle.flex.split(' ');
+      flexStyle.flex = `${flexValArr[0]} ${flexValArr[1] || flexValArr[0]} ${
+        flexStyle.flexBasis
+      }`;
+    }
+
     return (
       <div style={flexStyle} className={className}>
         {(Array.isArray(items) ? items : items ? [items] : []).map(


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 92d24f9</samp>

Fix `flexBasis` bug in `Flex` component. Use `flexBasis` instead of `flex` when defined in `Flex.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 92d24f9</samp>

> _`flex` and `flexBasis`_
> _merge to fix a browser bug_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 92d24f9</samp>

* Fix a bug where `flexBasis` was ignored by some browsers in `Flex` component ([link](https://github.com/baidu/amis/pull/7451/files?diff=unified&w=0#diff-3c803fbe826ef61d46f35e8fa870aaf229c1bb83bad98847a11f8d70b3bd7095R115-R122))
