### PR TITLE
chore: Combo组件的deleteBtn数据域透传index

### DIFF
--- a/docs/zh-CN/components/form/combo.md
+++ b/docs/zh-CN/components/form/combo.md
@@ -824,7 +824,7 @@ combo 还有一个作用是增加层级，比如返回的数据是一个深层�
 }
 ```
 
-如果想要赋予删除按钮更多能力，则需要将 deleteBtn 配置成[Button](../button.md)类型
+如果想要赋予删除按钮更多能力，则需要将 deleteBtn 配置成[Button](../button.md)类型，还可以利用`index`参数动态控制按钮的显隐或禁用状态等。
 
 ```schema: scope="body"
 {
@@ -844,7 +844,8 @@ combo 还有一个作用是增加层级，比如返回的数据是一个深层�
           "level": "danger",
           "tooltip": "提示文本",
           "tooltipPlacement": "top",
-          "onClick": "alert(index)"
+          "onClick": "alert(index)",
+          "disabledOn": "${index % 2 === 1}"
         },
         "items": [
             {

--- a/packages/amis/src/renderers/Form/Combo.tsx
+++ b/packages/amis/src/renderers/Form/Combo.tsx
@@ -1259,7 +1259,8 @@ export default class ComboControl extends React.Component<ComboProps> {
       itemRemovableOn,
       disabled,
       removable,
-      deleteBtn
+      deleteBtn,
+      data
     } = this.props;
 
     const finnalRemovable =
@@ -1279,38 +1280,44 @@ export default class ComboControl extends React.Component<ComboProps> {
 
     // deleteBtn是对象，则根据自定义配置渲染按钮
     if (isObject(deleteBtn)) {
-      return render('delete-btn', {
-        ...deleteBtn,
-        type: 'button',
-        className: cx(
-          'Combo-delController',
-          deleteBtn ? deleteBtn.className : ''
-        ),
-        onClick: (e: any) => {
-          if (!deleteBtn.onClick) {
-            this.deleteItem(index);
-            return;
-          }
-
-          let originClickHandler = deleteBtn.onClick;
-          if (typeof originClickHandler === 'string') {
-            originClickHandler = str2AsyncFunction(
-              deleteBtn.onClick,
-              'e',
-              'index',
-              'props'
-            );
-          }
-          const result = originClickHandler(e, index, this.props);
-          if (result && result.then) {
-            result.then(() => {
+      return render(
+        'delete-btn',
+        {
+          ...deleteBtn,
+          type: 'button',
+          className: cx(
+            'Combo-delController',
+            deleteBtn ? deleteBtn.className : ''
+          ),
+          onClick: (e: any) => {
+            if (!deleteBtn.onClick) {
               this.deleteItem(index);
-            });
-          } else {
-            this.deleteItem(index);
+              return;
+            }
+
+            let originClickHandler = deleteBtn.onClick;
+            if (typeof originClickHandler === 'string') {
+              originClickHandler = str2AsyncFunction(
+                deleteBtn.onClick,
+                'e',
+                'index',
+                'props'
+              );
+            }
+            const result = originClickHandler(e, index, this.props);
+            if (result && result.then) {
+              result.then(() => {
+                this.deleteItem(index);
+              });
+            } else {
+              this.deleteItem(index);
+            }
           }
+        },
+        {
+          data: extendObject(data, {index})
         }
-      });
+      );
     }
 
     // deleteBtn是string，则渲染按钮文本


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3cfa129</samp>

This pull request enhances the `Combo` component and its documentation. It adds a new feature to the `deleteBtn` property that lets users control the visibility and appearance of the delete button based on the item data and index. It also updates the `docs/zh-CN/components/form/combo.md` file with more examples and explanations of this feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3cfa129</samp>

> _`Combo` of doom, unleash your power_
> _Delete the items that make you cower_
> _Use the `index` and the `disabledOn`_
> _To render the button as you want_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3cfa129</samp>

*  Add `data` property to `props` object in `renderDeleteBtn` method of `Combo` component, and pass it to custom delete button renderer ([link](https://github.com/baidu/amis/pull/7453/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1262-R1263), [link](https://github.com/baidu/amis/pull/7453/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1282-R1320))
*  Update documentation of `deleteBtn` property of `combo` component, and add example of using `disabledOn` expression to disable delete button based on index ([link](https://github.com/baidu/amis/pull/7453/files?diff=unified&w=0#diff-6095450b85f0a3d4ee5a6887a19d1b926ef9026684f5271078719a0c1e675e31L827-R827), [link](https://github.com/baidu/amis/pull/7453/files?diff=unified&w=0#diff-6095450b85f0a3d4ee5a6887a19d1b926ef9026684f5271078719a0c1e675e31L847-R848))
