### PR TITLE
feat: api adpator 和 requestAdaptor 添加新变量 context 可用来获取请求发送前的上下文数据 Clo…

### DIFF
--- a/docs/zh-CN/types/api.md
+++ b/docs/zh-CN/types/api.md
@@ -591,6 +591,7 @@ amis 的 API 配置，如果无法配置出你想要的请求结构，那么可�
   - method：当前请求的方式
   - data：请求的数据体
   - headers：请求的头部信息
+- **context** 发送请求时的上下文数据
 
 ##### 字符串形式
 
@@ -604,7 +605,7 @@ amis 的 API 配置，如果无法配置出你想要的请求结构，那么可�
     "api": {
         "method": "post",
         "url": "/api/mock2/form/saveForm",
-        "requestAdaptor": "return {\n    ...api,\n    data: {\n        ...api.data,    // 获取暴露的 api 中的 data 变量\n        foo: 'bar'      // 新添加数据\n    }\n}"
+        "requestAdaptor": "console.log(context); // 打印上下文数据\nreturn {\n    ...api,\n    data: {\n        ...api.data,    // 获取暴露的 api 中的 data 变量\n        foo: 'bar'      // 新添加数据\n    }\n}"
     },
     "body": [
       {
@@ -626,6 +627,8 @@ amis 的 API 配置，如果无法配置出你想要的请求结构，那么可�
 ```js
 // 进行一些操作
 
+console.log(context); // 打印上下文数据
+
 // 一定要将调整后的 api 对象 return 出去
 return {
   ...api,
@@ -639,7 +642,7 @@ return {
 字符串形式的适配器代码最后会自动包裹成函数，你只需要补充内部的函数实现，并将修改好的 `api` 对象 `return` 出去：
 
 ```js
-function (api) {
+function (api, context) {
   // 你的适配器代码在这里
 }
 ```
@@ -654,7 +657,8 @@ const schema = {
   api: {
     method: 'post',
     url: '/api/mock2/form/saveForm',
-    requestAdaptor: function (api) {
+    requestAdaptor: function (api, context) {
+      console.log(context); // 打印上下文数据
       return {
         ...api,
         data: {
@@ -698,6 +702,7 @@ const schema = {
 - **payload**：当前请求的响应 payload，即 response.data
 - **response**：当前请求的原始响应
 - **api**：api 上的配置项，还可以通过 `api.data` 获得数据域里的内容
+- **context** 发送请求时的上下文数据
 
 ##### 字符串形式
 
@@ -705,13 +710,13 @@ const schema = {
 
 用法示例：
 
-```json
+```schema: scope="body"
 {
   "type": "form",
   "api": {
     "method": "post",
     "url": "/api/mock2/form/saveForm",
-    "adaptor": "return {\n    ...payload,\n    status: payload.code === 200 ? 0 : payload.code\n}"
+    "adaptor": "console.log(context); // 打印上下文数据 \nreturn {\n    ...payload,\n    status: payload.code === 200 ? 0 : payload.code\n}"
   },
   "body": [
     {
@@ -744,7 +749,7 @@ return {
 字符串形式的适配器代码最后会自动包裹成函数，你只需要补充内部的函数实现，并将修改好的 `payload` 对象 `return` 出去：
 
 ```js
-function (payload, response, api) {
+function (payload, response, api, context) {
   // 你的适配器代码在这里
 }
 ```
@@ -759,7 +764,8 @@ const schema = {
   api: {
     method: 'post',
     url: '/api/mock2/form/saveForm',
-    adaptor: function (payload, response) {
+    adaptor: function (payload, response, api, context) {
+      console.log(context); // 打印上下文数据
       return {
         ...payload,
         status: payload.code === 200 ? 0 : payload.code

--- a/packages/amis-core/src/types.ts
+++ b/packages/amis-core/src/types.ts
@@ -217,8 +217,13 @@ export interface ApiObject extends BaseApiObject {
   operationName?: string;
   body?: PlainObject;
   query?: PlainObject;
-  adaptor?: (payload: object, response: fetcherResult, api: ApiObject) => any;
-  requestAdaptor?: (api: ApiObject) => ApiObject;
+  adaptor?: (
+    payload: object,
+    response: fetcherResult,
+    api: ApiObject,
+    context: any
+  ) => any;
+  requestAdaptor?: (api: ApiObject, context: any) => ApiObject;
   /** 是否过滤为空字符串的 query 参数 */
   filterEmptyQuery?: boolean;
 }


### PR DESCRIPTION
…se: #7454

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d4d449c</samp>

This pull request adds a new feature to the `api` type in the `amis-core` package, which enables the use of a `context` parameter in the `adaptor` and `requestAdaptor` options. The `context` parameter is the data that is passed to the request and can be used to customize the request or the response. The pull request also updates the documentation and examples of the `api` type in the `docs` folder.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d4d449c</samp>

> _`context` parameter_
> _enhances `api` object_
> _cutting through the spring_

### Why

Close: #7454

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d4d449c</samp>

*  Add `context` parameter to `requestAdaptor` and `adaptor` options in `api` type ([link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-00d0e84a1779e47502d96b34c102949f10dacf775ca91423e751dffbc7ce7683R594), [link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-00d0e84a1779e47502d96b34c102949f10dacf775ca91423e751dffbc7ce7683L642-R645), [link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-00d0e84a1779e47502d96b34c102949f10dacf775ca91423e751dffbc7ce7683R705), [link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-00d0e84a1779e47502d96b34c102949f10dacf775ca91423e751dffbc7ce7683L747-R752), [link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-9795a06699f88c4c144fccb14b9ddca83b8d9639d2062c27b01495b6b80e7d7dL220-R226))
*  Pass `context` parameter to `requestAdaptor` and `adaptor` functions in `buildApi` and `wrapFetcher` functions in `api.ts` ([link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL79-R83), [link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL87-R92), [link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL467-R472), [link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL511-R520), [link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL524-R530), [link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL536-R542), [link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL544-R554), [link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL550-R560))
*  Update examples and schema annotations of `requestAdaptor` and `adaptor` options in `api.md` ([link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-00d0e84a1779e47502d96b34c102949f10dacf775ca91423e751dffbc7ce7683L607-R608), [link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-00d0e84a1779e47502d96b34c102949f10dacf775ca91423e751dffbc7ce7683R630-R631), [link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-00d0e84a1779e47502d96b34c102949f10dacf775ca91423e751dffbc7ce7683L657-R661), [link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-00d0e84a1779e47502d96b34c102949f10dacf775ca91423e751dffbc7ce7683L708-R713), [link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-00d0e84a1779e47502d96b34c102949f10dacf775ca91423e751dffbc7ce7683L714-R719), [link](https://github.com/baidu/amis/pull/7456/files?diff=unified&w=0#diff-00d0e84a1779e47502d96b34c102949f10dacf775ca91423e751dffbc7ce7683L762-R768))
