### PR TITLE
fix: input-image 多选时失败校验提示失效问题

### DIFF
--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -779,16 +779,16 @@ export default class ImageControl extends React.Component<
                 newFile.state =
                   file.state !== 'uploading' ? file.state : 'error';
                 newFile.error = error;
-                if (!multiple) {
-                  this.current = null;
-                  return this.setState(
-                    {
-                      files: (this.files = []),
-                      error
-                    },
-                    this.tick
-                  );
-                }
+
+                this.current = null;
+                files.splice(idx, 1);
+                return this.setState(
+                  {
+                    files: (this.files = files),
+                    error
+                  },
+                  this.tick
+                );
               } else {
                 newFile = {
                   name: file.name || this.state.cropFileName,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9f11824</samp>

Fix input image component bug in single mode. Clear the current file and the files array when an upload error occurs in `InputImage.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9f11824</samp>

> _`input-image` clears_
> _file on upload error_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9f11824</samp>

* Fix a bug that prevented input image component from clearing current file on upload error in single mode ([link](https://github.com/baidu/amis/pull/7460/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L782-R791) in `InputImage.tsx`)
