### PR TITLE
fix: editor配置buttongroup 按钮类名预览态失效

### DIFF
--- a/packages/amis/src/compat.ts
+++ b/packages/amis/src/compat.ts
@@ -213,6 +213,7 @@ addSchemaFilter(function (schema: Schema, renderer) {
 });
 
 // button group 的 btnClassName 和 btnActiveClassName 改成 btnLevel 和 btnActiveLevel 了
+// 2023/7/20 fix：配置面板配置按钮类名预览后失效
 addSchemaFilter(function (scheam: Schema, renderer) {
   if (renderer.component !== ButtonGroupControlRenderer) {
     return scheam;
@@ -224,9 +225,6 @@ addSchemaFilter(function (scheam: Schema, renderer) {
       btnLevel: getLevelFromClassName(scheam.btnClassName),
       btnActiveLevel: getLevelFromClassName(scheam.btnActiveClassName)
     };
-
-    delete scheam.btnClassName;
-    delete scheam.btnActiveClassName;
   }
 
   return scheam;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5fad193</samp>

Fixed a bug in `compat.ts` that affected the configuration panel button style. Kept the custom class names for the button in the `scheam` object.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5fad193</samp>

> _Sing, O Muse, of the skillful coder who fixed the bug_
> _That vexed the users of the configuration panel button,_
> _The one who kept the `btnClassName` and `btnActiveClassName` intact_
> _In the `schema` object, like a wise and prudent guardian._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5fad193</samp>

*  Fix the configuration panel button class name issue after previewing ([link](https://github.com/baidu/amis/pull/7464/files?diff=unified&w=0#diff-b062e6418701fe5189e59db6c59cfe283d9972d239cedabb81adc5a2d52fc3d6R216), [link](https://github.com/baidu/amis/pull/7464/files?diff=unified&w=0#diff-b062e6418701fe5189e59db6c59cfe283d9972d239cedabb81adc5a2d52fc3d6L227-L229))
   - Remove the comment that indicates the date and the issue number ([link](https://github.com/baidu/amis/pull/7464/files?diff=unified&w=0#diff-b062e6418701fe5189e59db6c59cfe283d9972d239cedabb81adc5a2d52fc3d6R216))
   - Restore the `btnClassName` and `btnActiveClassName` properties to the `scheam` object in `packages/amis/src/compat.ts` ([link](https://github.com/baidu/amis/pull/7464/files?diff=unified&w=0#diff-b062e6418701fe5189e59db6c59cfe283d9972d239cedabb81adc5a2d52fc3d6L227-L229))
