### PR TITLE
feat:input-table&combo&table上下文细化

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Form.tsx
+++ b/packages/amis-editor/src/plugin/Form/Form.tsx
@@ -11,7 +11,7 @@ import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {jsonToJsonSchema} from 'amis-editor-core';
 import {EditorNodeType} from 'amis-editor-core';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
-import {setVariable} from 'amis-core';
+import {setVariable, someTree} from 'amis-core';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 
 // 用于脚手架的常用表单控件
@@ -933,7 +933,11 @@ export class FormPlugin extends BasePlugin {
     }
   }
 
-  async buildDataSchemas(node: EditorNodeType, region: EditorNodeType) {
+  async buildDataSchemas(
+    node: EditorNodeType,
+    region: EditorNodeType,
+    trigger?: EditorNodeType
+  ) {
     const jsonschema: any = {
       $id: 'formItems',
       type: 'object',
@@ -943,27 +947,87 @@ export class FormPlugin extends BasePlugin {
     const pool = node.children.concat();
     while (pool.length) {
       const current = pool.shift() as EditorNodeType;
+      const schema = current.schema;
 
       if (current.rendererConfig?.type === 'combo') {
-        const schema = current.schema;
+        if (trigger) {
+          const items = current.children?.find(
+            child => child.isRegion && child.region === 'items'
+          );
+          const isItemsChild = someTree(
+            items.children,
+            item => item.id === trigger?.id
+          );
+
+          if (isItemsChild) {
+            const itemsChilds = items.children.concat();
+
+            while (itemsChilds.length) {
+              const currentItem = itemsChilds.shift() as EditorNodeType;
+              const itemSchema = currentItem.schema;
+
+              if (itemSchema.name) {
+                jsonschema.properties[itemSchema.name] = {
+                  ...(currentItem.info?.plugin?.buildDataSchemas
+                    ? await currentItem.info.plugin.buildDataSchemas(
+                        currentItem,
+                        region,
+                        trigger
+                      )
+                    : {
+                        type: 'string',
+                        title: itemSchema.label || itemSchema.name
+                      }),
+                  group: `${schema.label || schema.name}的当前行记录`
+                };
+              }
+            }
+          }
+        }
+
         if (schema.name) {
-          jsonschema.properties[schema.name] = {
-            type: 'array',
-            title: schema.label || schema.name,
-            items: current.info?.plugin?.buildDataSchemas
-              ? await current.info.plugin.buildDataSchemas(current, region)
-              : {
-                  type: 'object',
-                  properties: {}
-                }
-          };
+          jsonschema.properties[schema.name] =
+            await current.info.plugin.buildDataSchemas?.(current, region);
+        }
+      } else if (current.rendererConfig?.type === 'input-table') {
+        if (trigger) {
+          const columns: EditorNodeType = current.children.find(
+            item => item.isRegion && item.region === 'columns'
+          );
+          const isColumnChild = someTree(
+            columns?.children,
+            item => item.id === trigger.id
+          );
+
+          if (isColumnChild) {
+            for (let col of schema?.columns) {
+              if (col.name) {
+                jsonschema.properties[col.name] = {
+                  type: 'string',
+                  title: col.label || col.name,
+                  group: `${schema.label || schema.name}的当前行记录`
+                };
+              }
+            }
+          }
+        }
+        if (schema.name) {
+          jsonschema.properties[schema.name] =
+            await current.info.plugin.buildDataSchemas?.(
+              current,
+              region,
+              trigger
+            );
         }
       } else if (current.rendererConfig?.isFormItem) {
-        const schema = current.schema;
         if (schema.name) {
           jsonschema.properties[schema.name] = current.info?.plugin
             ?.buildDataSchemas
-            ? await current.info.plugin.buildDataSchemas(current, region)
+            ? await current.info.plugin.buildDataSchemas(
+                current,
+                region,
+                trigger
+              )
             : {
                 type: 'string',
                 title:

--- a/packages/amis-editor/src/plugin/Table.tsx
+++ b/packages/amis-editor/src/plugin/Table.tsx
@@ -770,29 +770,29 @@ export class TablePlugin extends BasePlugin {
     const columns: EditorNodeType = node.children.find(
       item => item.isRegion && item.region === 'columns'
     );
+    const cells: any = columns.children.concat();
 
-    // todo：以下的处理无效，需要cell实现才能深层细化
-    // for (let current of columns?.children) {
-    //   const schema = current.schema;
-    //   if (schema.name) {
-    //     itemsSchema.properties[schema.name] = current.info?.plugin
-    //       ?.buildDataSchemas
-    //       ? await current.info.plugin.buildDataSchemas(current, region)
-    //       : {
-    //           type: 'string',
-    //           title: schema.label || schema.name
-    //         };
-    //   }
-    // }
+    while (cells.length > 0 && cells.length <= columns.children?.length) {
+      const cell = cells.shift() as EditorNodeType;
+      // cell的孩子貌似只会有一个
+      const items = cell.children.concat();
+      while (items.length) {
+        const current = items.shift() as EditorNodeType;
+        const schema = current.schema;
 
-    // 一期先简单处理，上面todo实现之后，这里可以废弃
-    // 收集table配置的列成员
-    for (let current of node.schema?.columns) {
-      if (current.name) {
-        itemsSchema.properties[current.name] = {
-          type: 'string',
-          title: current.label || current.name
-        };
+        if (schema.name) {
+          itemsSchema.properties[schema.name] = current.info?.plugin
+            ?.buildDataSchemas
+            ? await current.info.plugin.buildDataSchemas(
+                current,
+                region,
+                trigger
+              )
+            : {
+                type: 'string',
+                title: schema.label || schema.name
+              };
+        }
       }
     }
 

--- a/packages/amis-ui/scss/components/_formula.scss
+++ b/packages/amis-ui/scss/components/_formula.scss
@@ -51,7 +51,8 @@
 
   &-editor {
     @include scrollbar();
-    height: px2rem(200px);
+    min-height: px2rem(200px);
+    height: calc(100% - 35px);
     padding: #{px2rem(5px)};
     padding-right: 0;
 

--- a/packages/amis-ui/src/components/formula/Editor.tsx
+++ b/packages/amis-ui/src/components/formula/Editor.tsx
@@ -277,7 +277,8 @@ export class FormulaEditor extends React.Component<
         return {
           ...item,
           path: `${path}${path ? '.' : ''}${item.label}`,
-          ...(item.isMember
+          // 自己是数组成员或者父级有数组成员
+          ...(item.isMember || paths.some(item => item.isMember)
             ? {
                 memberDepth: paths?.filter((item: any) => item.type === 'array')
                   ?.length

--- a/packages/amis-ui/src/components/formula/VariableList.tsx
+++ b/packages/amis-ui/src/components/formula/VariableList.tsx
@@ -112,7 +112,8 @@ function VariableList(props: VariableListProps) {
                       <label>{option.label}</label>
                     </Badge>
                   )}
-                {option.label &&
+                {option.memberDepth === undefined &&
+                  option.label &&
                   (!selfVariableName || option.value !== selfVariableName) && (
                     <TooltipWrapper
                       tooltip={option.description ?? option.label}
@@ -122,7 +123,10 @@ function VariableList(props: VariableListProps) {
                     </TooltipWrapper>
                   )}
                 {/* 控制只对第一层数组成员展示快捷操作入口 */}
-                {option.memberDepth < 2 ? (
+                {option.memberDepth !== undefined &&
+                option.memberDepth < 2 &&
+                option.label &&
+                (!selfVariableName || option.value !== selfVariableName) ? (
                   <PopOverContainer
                     popOverContainer={() =>
                       document.querySelector(`.${cx('FormulaPicker-Modal')}`)
@@ -149,7 +153,12 @@ function VariableList(props: VariableListProps) {
                     )}
                   >
                     {({onClick, ref, isOpened}) => (
-                      <i className="fa fa-ellipsis-h" onClick={onClick} />
+                      <TooltipWrapper
+                        tooltip={option.description ?? option.label}
+                        tooltipTheme="dark"
+                      >
+                        <label onClick={onClick}>{option.label}</label>
+                      </TooltipWrapper>
                     )}
                   </PopOverContainer>
                 ) : null}
@@ -165,9 +174,10 @@ function VariableList(props: VariableListProps) {
 
   function handleMemberClick(item: any, option: any, onClose?: any) {
     // todo：暂时只提供一层的快捷操作
-    const lastPointIdx = option.value.lastIndexOf('.');
-    const arr = option.value.substring(0, lastPointIdx);
-    const member = option.value.substring(lastPointIdx + 1);
+    // const lastPointIdx = option.value.lastIndexOf('.');
+    const firstPointIdx = option.value.indexOf('.');
+    const arr = option.value.substring(0, firstPointIdx);
+    const member = option.value.substring(firstPointIdx + 1);
 
     const value = item.value
       .replace('${arr}', arr)
@@ -208,7 +218,7 @@ function VariableList(props: VariableListProps) {
   }
 
   function handleChange(item: any) {
-    if (item.isMember) {
+    if (item.isMember || item.memberDepth !== undefined) {
       return;
     }
     onSelect?.(item);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b37cb1</samp>

This pull request enhances the AMIS editor and UI packages, by improving the data schema generation and rendering of various form and table controls, such as `combo`, `input-table`, and `formula`. It also fixes some issues with the style and logic of the formula editor, and imports some utility functions from `amis-core`. The main files affected are `Combo.tsx`, `Form.tsx`, `InputTable.tsx`, `VariableList.tsx`, `Table.tsx`, `Editor.tsx`, and `_formula.scss`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7b37cb1</samp>

> _We are the masters of the schema_
> _We build the logic of the table_
> _We traverse the tree of the combo_
> _We render the array of the member_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7b37cb1</samp>

*  Import `someTree` function from `amis-core` to use in `Combo.tsx` and `Form.tsx` ([link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-785d17e956a3abfd5fcf93db4ac2b50aed00bb5bf2eb2a3f9c3776e81774d097L17-R17), [link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL14-R14))
* Add `trigger` parameter to `buildDataSchemas` methods of `FormPlugin`, `TableControlPlugin`, and `TablePlugin` classes to represent the node that triggered the data schema update ([link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL936-R940), [link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-01999eae047ec7fdb8502c22801699d39f7a54c994a9414462c0fbe21634ecd8L1105-R1109), [link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-d01a7abf584cd914dc4d94abbeb0f35326953f6b5b19bbd9efbbb846b29f0194L773-R795))
* Modify `buildDataSchemas` methods of `FormPlugin`, `TableControlPlugin`, and `TablePlugin` classes to handle the cases when the trigger node is a child of a combo or an input-table control, and to delegate the schema generation to the corresponding plugin methods ([link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL946-R1030), [link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-01999eae047ec7fdb8502c22801699d39f7a54c994a9414462c0fbe21634ecd8L1116-R1142), [link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-d01a7abf584cd914dc4d94abbeb0f35326953f6b5b19bbd9efbbb846b29f0194L773-R795))
* Add `buildDataSchemas` method to `ComboControlPlugin` class to generate a JSON schema for the combo control based on its children and schema properties ([link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-785d17e956a3abfd5fcf93db4ac2b50aed00bb5bf2eb2a3f9c3776e81774d097R664-R705))
* Modify the title of the input-table schema to use the label or name of the node schema, instead of a fixed string ([link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-01999eae047ec7fdb8502c22801699d39f7a54c994a9414462c0fbe21634ecd8L1147-R1153))
* Modify the style of the formula editor to make its height adaptive to the container, and to set a minimum height of 200px (`_formula.scss`, [link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-f47fc8341294613d4ce27fd9352821306195cd2d1b8be120b13dde559c5f169dL54-R55))
* Modify the logic of the `buildVariableTree` method of the `FormulaEditor` class to mark the option as a member if it is a child of an array or its parent is a member, and to pass the member depth to the option (`Editor.tsx`, [link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-893fd27e1fa6dd194d6e17f9bb62a1a3144bdf0e24063ef0426990e28d7b7c19L280-R281))
* Modify the logic of the `VariableList` component to skip rendering the label and tooltip for the option if it has a member depth, to render the pop over container for the option only if it has a member depth and meets other conditions, to render the tooltip wrapper for the option inside the pop over container, to use the label as the trigger instead of the icon, to use the first point index instead of the last point index to split the option value into the array and the member parts, and to prevent changing the formula value if the option is a member or has a member depth (`VariableList.tsx`, [link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-20ccd77f29dae5effdf503856c6589eb936a52ec3ac2f9a852f7c0d4b6b5a562L115-R116), [link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-20ccd77f29dae5effdf503856c6589eb936a52ec3ac2f9a852f7c0d4b6b5a562L125-R129), [link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-20ccd77f29dae5effdf503856c6589eb936a52ec3ac2f9a852f7c0d4b6b5a562L152-R161), [link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-20ccd77f29dae5effdf503856c6589eb936a52ec3ac2f9a852f7c0d4b6b5a562L168-R180), [link](https://github.com/baidu/amis/pull/7472/files?diff=unified&w=0#diff-20ccd77f29dae5effdf503856c6589eb936a52ec3ac2f9a852f7c0d4b6b5a562L211-R221))
