### PR TITLE
fix:schemaApi在设计器设计态报错

### DIFF
--- a/packages/amis-editor-core/src/component/factory.tsx
+++ b/packages/amis-editor-core/src/component/factory.tsx
@@ -164,7 +164,7 @@ export function makeWrapper(
       const {render} = this.props; // render: amis渲染器
 
       // $$id 变化，渲染器最好也变化
-      if (node.$$id) {
+      if (node?.$$id) {
         props = props || {}; // props 可能为 undefined
         props.key = node.$$id || props.key;
       }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c7e6909</samp>

Added optional chaining to avoid errors when accessing `node.$$id` in `factory.tsx`. This is part of a code quality improvement pull request.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c7e6909</samp>

> _`node` may be empty_
> _optional chaining saves us_
> _a winter bug fix_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c7e6909</samp>

*  Add optional chaining operator to prevent error when accessing `node.$$id` ([link](https://github.com/baidu/amis/pull/7474/files?diff=unified&w=0#diff-5bcb2370bda7a8f3b1b692f3d568f62e4fd6aadd951424c0b7340c1ef5f40fe1L167-R167))
