### PR TITLE
fix:input-city上下文类型

### DIFF
--- a/packages/amis-editor/src/plugin/Form/InputCity.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputCity.tsx
@@ -244,7 +244,7 @@ export class CityControlPlugin extends BasePlugin {
             title: '区域编码'
           },
           district: {
-            type: 'number',
+            type: 'string',
             title: '区域'
           },
           street: {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 72efb17</samp>

Fixed the city input component to use string values for district names. Changed the type of the `district` field in `InputCity.tsx` and updated the validation rules accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 72efb17</samp>

> _`district` is text_
> _city input component_
> _fixed in the springtime_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 72efb17</samp>

* Change the type of the district field from number to string in the city input component ([link](https://github.com/baidu/amis/pull/7483/files?diff=unified&w=0#diff-1c7f461a21fc4884ff77f39f4a1346562ddd7d0b598ea8a571581eed4086c56bL247-R247)). This fixes the data format and validation rules for the district name.
