### PR TITLE
feat: 添加只打包esm的npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "fis3-dev": "fis3 release -cwd ./public",
     "deploy-gh-page": "sh ./deploy-gh-pages.sh",
     "build": "npm run build --workspaces",
+    "build-esm": "npm run build-esm --workspaces",
     "test": "npm test --workspaces",
     "update-snapshot": "npm run update-snapshot --workspaces",
     "prepare": "husky install",

--- a/packages/amis-core/package.json
+++ b/packages/amis-core/package.json
@@ -34,6 +34,7 @@
   },
   "scripts": {
     "build": "npm run clean-dist && NODE_ENV=production rollup -c ",
+    "build-esm": "npm run clean-dist && NODE_ENV=production rollup -c rollup.esm.config.js", 
     "dev": "rollup -c -w",
     "test": "jest",
     "update-snapshot": "jest --updateSnapshot",

--- a/packages/amis-core/rollup.esm.config.js
+++ b/packages/amis-core/rollup.esm.config.js
@@ -1,0 +1,5 @@
+import config from "./rollup.config";
+
+const esmConfig = config[1];
+
+export default esmConfig;

--- a/packages/amis-editor-core/package.json
+++ b/packages/amis-editor-core/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "test": "echo \"Warnings: no test specified\"",
     "build": "npm run clean-dist && NODE_ENV=production rollup -c",
+    "build-esm": "npm run clean-dist && NODE_ENV=production rollup -c rollup.esm.config.js",
     "clean-dist": "rimraf lib/* esm/*",
     "i18n:update": "npx i18n update --config=./i18nConfig.js",
     "i18n:translate": "npx i18n translate --config=./i18nConfig.js --l=en-US",

--- a/packages/amis-editor-core/rollup.esm.config.js
+++ b/packages/amis-editor-core/rollup.esm.config.js
@@ -1,0 +1,5 @@
+import config from "./rollup.config";
+
+const esmConfig = config[1];
+
+export default esmConfig;

--- a/packages/amis-editor/package.json
+++ b/packages/amis-editor/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "test": "echo \"Warnings: no test specified\"",
     "build": "npm run clean-dist && NODE_ENV=production rollup -c ",
+    "build-esm": "npm run clean-dist && NODE_ENV=production rollup -c rollup.esm.config.js",
     "clean-dist": "rimraf lib/** esm/**",
     "i18n:update": "npx i18n update --config=./i18nConfig.js",
     "i18n:translate": "npx i18n translate --config=./i18nConfig.js --l=en-US",

--- a/packages/amis-editor/rollup.esm.config.js
+++ b/packages/amis-editor/rollup.esm.config.js
@@ -1,0 +1,5 @@
+import config from "./rollup.config";
+
+const esmConfig = config[1];
+
+export default esmConfig;

--- a/packages/amis-formula/package.json
+++ b/packages/amis-formula/package.json
@@ -7,6 +7,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "npm run clean-dist && npm run genDoc && cross-env NODE_ENV=production rollup -c && cp src/doc.md lib/doc.md && cp src/doc.md esm/doc.md",
+    "build-esm": "npm run clean-dist && cross-env NODE_ENV=production rollup -c rollup.esm.config.js",
     "lib": "npm run clean-dist && cross-env NODE_ENV=production IS_LIB=1 rollup -c",
     "clean-dist": "rimraf lib/**",
     "declaration": "tsc --project tsconfig-for-declaration.json --allowJs --declaration --emitDeclarationOnly --declarationDir ./lib --rootDir ./src",

--- a/packages/amis-formula/rollup.esm.config.js
+++ b/packages/amis-formula/rollup.esm.config.js
@@ -1,0 +1,5 @@
+import config from "./rollup.config";
+
+const esmConfig = config[1];
+
+export default esmConfig;

--- a/packages/amis-ui/package.json
+++ b/packages/amis-ui/package.json
@@ -7,6 +7,7 @@
   "description": "",
   "scripts": {
     "build": "npm run clean-dist && NODE_ENV=production rollup -c ",
+    "build-esm": "npm run clean-dist && NODE_ENV=production rollup -c rollup.esm.config.js",
     "dev": "rollup -c -w",
     "test": "jest",
     "gen-doc": "ts-node ./scripts/genDoc.ts",

--- a/packages/amis-ui/rollup.esm.config.js
+++ b/packages/amis-ui/rollup.esm.config.js
@@ -1,0 +1,5 @@
+import config from "./rollup.config";
+
+const esmConfig = config[1];
+
+export default esmConfig;

--- a/packages/amis/package.json
+++ b/packages/amis/package.json
@@ -11,6 +11,7 @@
     "coverage": "jest --coverage",
     "publish-to-internal": "sh build.sh && sh publish.sh",
     "build": "npm run clean-dist && sh build.sh",
+    "build-esm": "npm run clean-dist && NODE_ENV=production rollup -c rollup.esm.config.js",
     "prettier": "prettier --write '{src,scss,examples}/**/**/*.{js,jsx,ts,tsx,scss,json}'",
     "build-schemas": "ts-node -O '{\"target\":\"es6\"}' ../../scripts/build-schemas.ts",
     "clean-dist": "rimraf lib/** esm/**"

--- a/packages/amis/rollup.esm.config.js
+++ b/packages/amis/rollup.esm.config.js
@@ -1,0 +1,5 @@
+import config from "./rollup.config";
+
+const esmConfig = config[1];
+
+export default esmConfig;

--- a/packages/office-viewer/package.json
+++ b/packages/office-viewer/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "vite",
     "build": "npm run clean-dist &&  cross-env NODE_ENV=production rollup -c ",
+    "build-esm": "npm run clean-dist &&  cross-env NODE_ENV=production rollup -c rollup.esm.config.js",
     "test": "jest",
     "lib": "npm run clean-dist && cross-env NODE_ENV=production IS_LIB=1 rollup -c",
     "update-snapshot": "jest --updateSnapshot",

--- a/packages/office-viewer/rollup.esm.config.js
+++ b/packages/office-viewer/rollup.esm.config.js
@@ -1,0 +1,5 @@
+import config from "./rollup.config";
+
+const esmConfig = config[1];
+
+export default esmConfig;


### PR DESCRIPTION
### What
给所有子包添加打包esm模块指令build-esm，在父包添加build-esm指令，用来打包所有子包的esm模块
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9726094</samp>

This pull request adds scripts and configurations to build ES modules for all the packages in the repository. This can improve tree-shaking and bundling optimization for the consumers of the library. The changes use rollup and cross-env as the tools for building ES modules and reuse the existing rollup configurations as much as possible.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9726094</samp>

> _`build-esm` script_
> _for all workspaces and packages_
> _rollup config reused_

### Why

1. 官方的打包方式会生成cjs版本的依赖，web端使用的依赖不需要cjs，可以去掉
2. 官方的打包方式会产生一个sdk，它依赖于cjs的包，是为了给不熟悉前端的开发使用，通过cdn的方式引入，在熟悉前端的团队内，不需要此sdk

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9726094</samp>

*  Add scripts to build ES modules for all packages ([link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R19), [link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-2461f3811423634aee38270e1d12bcf581b95eb845cb00a3ea5eae804a57795cR37), [link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-a4748fb9fe2d46502c7750a6b7c1cf5b4421968cea8501b3a9aaccb825ca35ecR31), [link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-7ae8386aceb47f61a4a2b316c8113f28fa64c584162ac38e128559bda675b242R25), [link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-2a1582dd8536cd65b762f9cd79719e90b98bdc38b808db0aaf783039f53d4153R10), [link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-0e30bcb7b6942e615a81bbcc87d75a7279e22d52e521bd61e050c056f6efe78cR10), [link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-b49028542a3bb14de6e47e46a9f09f23ffeff3afea2a17d5ddace75726a33e12R14), [link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-5be2752686d7fba13016bc97913cda48bd64cf853a3aaf5e6b8d389adba79f2cR11))
*  Create separate rollup configurations for ES module output by importing and exporting the existing ones ([link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-349ddf776907510390fe03a6112dc73a26aa37b16c06df12dcfea8c70f30de86L1-R4), [link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-737a83b9bbcf02913eb4ce73f8b3b2c1e58cae22e57a1f81b7a4f7b9c5c2f93fL1-R4), [link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-6bc38cbebde8273ebff5e9bda99801e8ca83ae4dac2cbc7361b6b252458be452L1-R4), [link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-9a24cf0a9ce0a59c1418511a0a578d54465e2f358ac0bfa7032e9d20a2371765L1-R4), [link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-cbc0e40b2f54f3b2528da79e9806d527a9b7fbdb4f3f5ec45f1934b0a4076d9bL1-R4), [link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-bfe2d73113f139680f5b538474ad48da24512c21be0cdc13cb057f75f8085546L1-R4), [link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-e5f879d10595370b16e2c0d7505a00e879d3fc091d00513bb4792b53fde76a4aL1-R4))
*  Use `cross-env` to set environment variables for some packages (`amis-formula` and `office-viewer`) before building ES modules ([link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-2a1582dd8536cd65b762f9cd79719e90b98bdc38b808db0aaf783039f53d4153R10), [link](https://github.com/baidu/amis/pull/7485/files?diff=unified&w=0#diff-5be2752686d7fba13016bc97913cda48bd64cf853a3aaf5e6b8d389adba79f2cR11))
每一个子包添加一个rollup.esm.config.js，引用roll.config.js，并只返回esm的配置
