### PR TITLE
feat:弹窗&树选择框上下文优化

### DIFF
--- a/packages/amis-editor-core/src/component/Editor.tsx
+++ b/packages/amis-editor-core/src/component/Editor.tsx
@@ -128,6 +128,8 @@ export interface EditorProps extends PluginEventListener {
       manager?: EditorManager;
     }
   ) => Promise<void | boolean>;
+
+  getHostNodeDataSchema?: () => Promise<any>;
 }
 
 export default class Editor extends Component<EditorProps> {
@@ -176,6 +178,7 @@ export default class Editor extends Component<EditorProps> {
     if (showCustomRenderersPanel !== undefined) {
       this.store.setShowCustomRenderersPanel(showCustomRenderersPanel);
     }
+
     this.manager = new EditorManager(config, this.store);
 
     // 子编辑器不再重新设置 editorStore

--- a/packages/amis-editor-core/src/component/SubEditor.tsx
+++ b/packages/amis-editor-core/src/component/SubEditor.tsx
@@ -107,23 +107,8 @@ export class SubEditor extends React.Component<SubEditorProps> {
         subEditorContext?.data
       );
     }
-    const variables: any = [
-      ...(manager.config?.variables || []).filter(
-        item => item.title !== '页面变量'
-      ),
-      // 解决打开子编辑器 公式输入框汇总没有页面变量的问题
-      {
-        name: 'pageParams',
-        title: '页面变量',
-        parentId: 'root',
-        order: 0,
-        schema: {
-          type: 'object',
-          $id: 'pageParams',
-          properties: {}
-        }
-      }
-    ];
+    const variables: any = manager.config?.variables || [];
+
     return {
       size: 'full',
       title: store.subEditorContext?.title,
@@ -197,6 +182,9 @@ export class SubEditor extends React.Component<SubEditorProps> {
                       }
                       return;
                     }}
+                    getHostNodeDataSchema={() =>
+                      manager.getContextSchemas(manager.store.activeId)
+                    }
                   />
                 )
               }

--- a/packages/amis-editor/src/plugin/CRUD.tsx
+++ b/packages/amis-editor/src/plugin/CRUD.tsx
@@ -2096,7 +2096,7 @@ export class CRUDPlugin extends BasePlugin {
             }
           },
           unSelectedItems: {
-            ...childSchame.properties.selectedItems,
+            ...childSchame.properties.unSelectedItems,
             items: {
               ...childSchame.properties.unSelectedItems.items,
               properties: itemsSchema

--- a/packages/amis-editor/src/plugin/Dialog.tsx
+++ b/packages/amis-editor/src/plugin/Dialog.tsx
@@ -8,9 +8,12 @@ import {
   RendererInfo,
   getSchemaTpl,
   noop,
-  defaultValue
+  defaultValue,
+  EditorNodeType,
+  isEmpty
 } from 'amis-editor-core';
 import {getEventControlConfig} from '../renderer/event-control/helper';
+import omit from 'lodash/omit';
 
 export class DialogPlugin extends BasePlugin {
   static id = 'DialogPlugin';
@@ -303,6 +306,49 @@ export class DialogPlugin extends BasePlugin {
   };
 
   buildSubRenderers() {}
+
+  async buildDataSchemas(
+    node: EditorNodeType,
+    region?: EditorNodeType,
+    trigger?: EditorNodeType
+  ) {
+    const renderer = this.manager.store.getNodeById(node.id)?.getComponent();
+    const data = omit(renderer.props.$schema.data, '$$id');
+    let dataSchema: any = {};
+
+    if (renderer.props.$schema.data === undefined || !isEmpty(data)) {
+      // 静态数据
+      for (const key in data) {
+        if (!['&'].includes(key)) {
+          dataSchema[key] = {
+            type: typeof data[key] ?? 'string', // 默认文本，不好确定类型
+            title: key
+          };
+        }
+      }
+
+      // 数据链
+      const hostNodeDataSchema =
+        await this.manager.config.getHostNodeDataSchema?.();
+      hostNodeDataSchema
+        .filter(
+          (item: any) => !['system-variable', 'page-global'].includes(item.$id)
+        )
+        ?.forEach((item: any) => {
+          dataSchema = {
+            ...dataSchema,
+            ...item.properties
+          };
+        });
+    }
+
+    return {
+      $id: 'dialog',
+      type: 'object',
+      title: node.schema?.label || node.schema?.name,
+      properties: dataSchema
+    };
+  }
 }
 
 registerEditorPlugin(DialogPlugin);

--- a/packages/amis-editor/src/plugin/Drawer.tsx
+++ b/packages/amis-editor/src/plugin/Drawer.tsx
@@ -6,11 +6,14 @@ import {
   RendererInfo,
   defaultValue,
   getSchemaTpl,
-  noop
+  noop,
+  EditorNodeType,
+  isEmpty
 } from 'amis-editor-core';
 import {getEventControlConfig} from '../renderer/event-control/helper';
 import {InlineModal} from './Dialog';
 import {tipedLabel} from 'amis-editor-core';
+import omit from 'lodash/omit';
 
 export class DrawerPlugin extends BasePlugin {
   static id = 'DrawerPlugin';
@@ -284,6 +287,49 @@ export class DrawerPlugin extends BasePlugin {
   };
 
   buildSubRenderers() {}
+
+  async buildDataSchemas(
+    node: EditorNodeType,
+    region?: EditorNodeType,
+    trigger?: EditorNodeType
+  ) {
+    const renderer = this.manager.store.getNodeById(node.id)?.getComponent();
+    const data = omit(renderer.props.$schema.data, '$$id');
+    let dataSchema: any = {};
+
+    if (renderer.props.$schema.data === undefined || !isEmpty(data)) {
+      // 静态数据
+      for (const key in data) {
+        if (!['&'].includes(key)) {
+          dataSchema[key] = {
+            type: typeof data[key] ?? 'string', // 默认文本，不好确定类型
+            title: key
+          };
+        }
+      }
+
+      // 数据链
+      const hostNodeDataSchema =
+        await this.manager.config.getHostNodeDataSchema?.();
+      hostNodeDataSchema
+        .filter(
+          (item: any) => !['system-variable', 'page-global'].includes(item.$id)
+        )
+        ?.forEach((item: any) => {
+          dataSchema = {
+            ...dataSchema,
+            ...item.properties
+          };
+        });
+    }
+
+    return {
+      $id: 'drawer',
+      type: 'object',
+      title: node.schema?.label || node.schema?.name,
+      properties: dataSchema
+    };
+  }
 }
 
 registerEditorPlugin(DrawerPlugin);

--- a/packages/amis-editor/src/plugin/Form/InputTree.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTree.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  EditorNodeType,
   getI18nEnabled,
   RendererPluginAction,
   RendererPluginEvent
@@ -14,6 +15,7 @@ import {
 } from '../../renderer/event-control/helper';
 import {tipedLabel} from 'amis-editor-core';
 import {ValidatorTag} from '../../validator';
+import {resolveOptionType} from '../../util';
 
 export class TreeControlPlugin extends BasePlugin {
   static id = 'TreeControlPlugin';
@@ -630,6 +632,56 @@ export class TreeControlPlugin extends BasePlugin {
       }
     ]);
   };
+
+  buildDataSchemas(node: EditorNodeType, region: EditorNodeType) {
+    const type = resolveOptionType(node.schema?.options);
+    // todo:异步数据case
+    let dataSchema: any = {
+      type,
+      title: node.schema?.label || node.schema?.name,
+      originalValue: node.schema?.value // 记录原始值，循环引用检测需要
+    };
+
+    if (node.schema?.joinValues === false) {
+      dataSchema = {
+        ...dataSchema,
+        type: 'object',
+        title: node.schema?.label || node.schema?.name,
+        properties: {
+          label: {
+            type: 'string',
+            title: '文本'
+          },
+          value: {
+            type,
+            title: '值'
+          }
+        }
+      };
+    }
+
+    if (node.schema?.multiple) {
+      if (node.schema?.extractValue) {
+        dataSchema = {
+          type: 'array',
+          title: node.schema?.label || node.schema?.name
+        };
+      } else if (node.schema?.joinValues === false) {
+        dataSchema = {
+          type: 'array',
+          title: node.schema?.label || node.schema?.name,
+          items: {
+            type: 'object',
+            title: '成员',
+            properties: dataSchema.properties
+          },
+          originalValue: dataSchema.originalValue
+        };
+      }
+    }
+
+    return dataSchema;
+  }
 }
 
 registerEditorPlugin(TreeControlPlugin);

--- a/packages/amis-editor/src/plugin/Form/TreeSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/TreeSelect.tsx
@@ -1,4 +1,5 @@
 import {
+  EditorNodeType,
   getI18nEnabled,
   RendererPluginAction,
   RendererPluginEvent
@@ -10,6 +11,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {ValidatorTag} from '../../validator';
 import {tipedLabel} from 'amis-editor-core';
+import {resolveOptionType} from '../../util';
 
 export class TreeSelectControlPlugin extends BasePlugin {
   static id = 'TreeSelectControlPlugin';
@@ -633,6 +635,56 @@ export class TreeSelectControlPlugin extends BasePlugin {
       }
     ]);
   };
+
+  buildDataSchemas(node: EditorNodeType, region: EditorNodeType) {
+    const type = resolveOptionType(node.schema?.options);
+    // todo:异步数据case
+    let dataSchema: any = {
+      type,
+      title: node.schema?.label || node.schema?.name,
+      originalValue: node.schema?.value // 记录原始值，循环引用检测需要
+    };
+
+    if (node.schema?.joinValues === false) {
+      dataSchema = {
+        ...dataSchema,
+        type: 'object',
+        title: node.schema?.label || node.schema?.name,
+        properties: {
+          label: {
+            type: 'string',
+            title: '文本'
+          },
+          value: {
+            type,
+            title: '值'
+          }
+        }
+      };
+    }
+
+    if (node.schema?.multiple) {
+      if (node.schema?.extractValue) {
+        dataSchema = {
+          type: 'array',
+          title: node.schema?.label || node.schema?.name
+        };
+      } else if (node.schema?.joinValues === false) {
+        dataSchema = {
+          type: 'array',
+          title: node.schema?.label || node.schema?.name,
+          items: {
+            type: 'object',
+            title: '成员',
+            properties: dataSchema.properties
+          },
+          originalValue: dataSchema.originalValue
+        };
+      }
+    }
+
+    return dataSchema;
+  }
 }
 
 registerEditorPlugin(TreeSelectControlPlugin);

--- a/packages/amis-editor/src/util.ts
+++ b/packages/amis-editor/src/util.ts
@@ -1,4 +1,4 @@
-import {resolveVariableAndFilter} from 'amis';
+import {findTree, resolveVariableAndFilter} from 'amis';
 import isString from 'lodash/isString';
 
 /**
@@ -49,8 +49,18 @@ export const schemaArrayFormat = (value: any) => {
  * @returns
  */
 export const resolveOptionType = (options: any) => {
+  if (!options) {
+    return 'string';
+  }
+
   // 默认options内选项是同类型
-  const value =
-    typeof options?.[0] === 'object' ? options?.[0]?.value : options?.[0];
-  return options ? (value !== undefined ? typeof value : 'string') : 'string';
+  let option = options[0];
+
+  if (typeof option === 'object') {
+    option = findTree(options, item => item.value !== undefined);
+  }
+
+  const value = option?.value ?? option;
+
+  return value !== undefined ? typeof value : 'string';
 };


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a7c7d63</samp>

This pull request enhances the data binding capabilities of the `amis-editor` package by adding new methods and props to the editor and some plugins. It allows the dialog, input tree, and tree select components to generate and use data schemas based on their configuration and the host node data. It also improves the option resolution function in `util.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a7c7d63</samp>

> _We bind the data to the dialog_
> _We generate the schema from the node_
> _We find the tree and resolve the option_
> _We unleash the power of the editor mode_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a7c7d63</samp>

*  Add a new optional property `getHostNodeDataSchema` to the `EditorProps` and `SubEditorProps` interfaces to allow the editor and sub-editor to access the data schema of the host node ([link](https://github.com/baidu/amis/pull/7486/files?diff=unified&w=0#diff-18115adfb822b0c3059aa7b00cc9dcab379f5c15781d48b9acca0d863d27a0edR131-R132), [link](https://github.com/baidu/amis/pull/7486/files?diff=unified&w=0#diff-18115adfb822b0c3059aa7b00cc9dcab379f5c15781d48b9acca0d863d27a0edR181))
*  Pass the `getHostNodeDataSchema` prop from the sub-editor props to the editor component in the `SubEditor` class ([link](https://github.com/baidu/amis/pull/7486/files?diff=unified&w=0#diff-6d734e24dd983184fd036bb62cec9ac5cf70a17ffd14cd375cb0d98c494b7008R185-R187))
*  Remove the hard-coded `pageParams` variable from the `variables` array in the `SubEditor` class to avoid duplicating the page variables from the editor config ([link](https://github.com/baidu/amis/pull/7486/files?diff=unified&w=0#diff-6d734e24dd983184fd036bb62cec9ac5cf70a17ffd14cd375cb0d98c494b7008L110-R111))
*  Add a new method `buildDataSchemas` to the `DialogPlugin`, `InputTreePlugin` and `TreeSelectPlugin` classes to generate the data schema for the dialog, input tree and tree select nodes based on their schema and data or options properties ([link](https://github.com/baidu/amis/pull/7486/files?diff=unified&w=0#diff-d3bebdf8ee046a9260ff973d8fc59a35ef327db18d55902021b571b045359e1aR309-R351), [link](https://github.com/baidu/amis/pull/7486/files?diff=unified&w=0#diff-55fdd7d5626a1567f50acdbe20595be990fee38dbea26e0ea0e235f7cba3c57fR635-R684), [link](https://github.com/baidu/amis/pull/7486/files?diff=unified&w=0#diff-90baebf200b81ed14dd4240db28e6f322004b03cd30f304d5757560f6b7b65ecR638-R687))
*  Import `EditorNodeType` from `amis-editor-core` to use the type for the `buildDataSchemas` method in the `Dialog.tsx`, `InputTree.tsx` and `TreeSelect.tsx` files ([link](https://github.com/baidu/amis/pull/7486/files?diff=unified&w=0#diff-d3bebdf8ee046a9260ff973d8fc59a35ef327db18d55902021b571b045359e1aL11-R16), [link](https://github.com/baidu/amis/pull/7486/files?diff=unified&w=0#diff-55fdd7d5626a1567f50acdbe20595be990fee38dbea26e0ea0e235f7cba3c57fR3), [link](https://github.com/baidu/amis/pull/7486/files?diff=unified&w=0#diff-90baebf200b81ed14dd4240db28e6f322004b03cd30f304d5757560f6b7b65ecR2))
*  Modify the `resolveOptionType` function in the `util.ts` file to use the `findTree` function from `amis` to find the first valid option and handle the empty or undefined options cases ([link](https://github.com/baidu/amis/pull/7486/files?diff=unified&w=0#diff-fd6dff8a62844e14ff74534f45068fb544e0944e3ff8a4f1c265a476988fa53dL52-R65))
*  Import `resolveOptionType` from `util.ts` to use the function for the `buildDataSchemas` method in the `InputTree.tsx` and `TreeSelect.tsx` files ([link](https://github.com/baidu/amis/pull/7486/files?diff=unified&w=0#diff-55fdd7d5626a1567f50acdbe20595be990fee38dbea26e0ea0e235f7cba3c57fR18), [link](https://github.com/baidu/amis/pull/7486/files?diff=unified&w=0#diff-90baebf200b81ed14dd4240db28e6f322004b03cd30f304d5757560f6b7b65ecR14))
*  Import `findTree` from `amis` to use the function for the `resolveOptionType` function in the `util.ts` file ([link](https://github.com/baidu/amis/pull/7486/files?diff=unified&w=0#diff-fd6dff8a62844e14ff74534f45068fb544e0944e3ff8a4f1c265a476988fa53dL1-R1))
