### PR TITLE
fix: transfer组件disabled的选项 在全选父级的时候，仍然可以被选到

### DIFF
--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -492,14 +492,37 @@ export class TreeSelector extends React.Component<
           // 父级选中的时候，子节点也都选中，但是自己不选中
           !~idx && children.length && value.pop();
 
-          while (children.length) {
-            let child = children.shift();
-            let index = value.indexOf(child);
+          // 取消下选择
+          if (
+            flattenTree(children)
+              .filter(item => !item?.disabled)
+              .some(v => ~value.indexOf(v))
+          ) {
+            while (children.length) {
+              let child = children.shift();
+              let index = value.indexOf(child);
 
-            if (child.children && child.children.length) {
-              children.push.apply(children, child.children);
-            } else if (!~index && child.value !== 'undefined') {
-              value.push(child);
+              if (child.children && child.children.length) {
+                children.push.apply(children, child.children);
+              }
+              if (~index && children.value !== 'undefined' && !child.disabled) {
+                value.splice(index, 1);
+              }
+            }
+          } else {
+            while (children.length) {
+              let child = children.shift();
+              let index = value.indexOf(child);
+
+              if (child.children && child.children.length) {
+                children.push.apply(children, child.children);
+              } else if (
+                !~index &&
+                child.value !== 'undefined' &&
+                !child?.disabled
+              ) {
+                value.push(child);
+              }
             }
           }
         } else {
@@ -557,7 +580,7 @@ export class TreeSelector extends React.Component<
           while (children.length) {
             let child = children.shift();
             let index = value.indexOf(child);
-            if (~index) {
+            if (~index && !child?.disabled) {
               value.splice(index, 1);
             }
             if (child.children && child.children.length) {

--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -505,7 +505,11 @@ export class TreeSelector extends React.Component<
               if (child.children && child.children.length) {
                 children.push.apply(children, child.children);
               }
-              if (~index && children.value !== 'undefined' && !child.disabled) {
+              if (
+                ~index &&
+                children.value !== 'undefined' &&
+                !child?.disabled
+              ) {
                 value.splice(index, 1);
               }
             }

--- a/packages/amis/__tests__/renderers/Tree.test.tsx
+++ b/packages/amis/__tests__/renderers/Tree.test.tsx
@@ -523,7 +523,6 @@ test('Tree: item disabled', async () => {
     transfer: 'caocao,libai1,hanxin1,yunzhongjun1'
   });
 
-
   fireEvent.click(node);
   fireEvent.click(submitBtn);
   await wait(100);

--- a/packages/amis/__tests__/renderers/Tree.test.tsx
+++ b/packages/amis/__tests__/renderers/Tree.test.tsx
@@ -430,3 +430,104 @@ test('Tree: add child & cancel', async () => {
     expect(!!container.querySelector('[icon="close"]')).toBeFalsy()
   );
 });
+
+test('Tree: item disabled', async () => {
+  const onSubmit = jest.fn();
+  const {container, findByText, findByPlaceholderText} = render(
+    amisRender(
+      {
+        "type": "form",
+        "api": "/api/mock2/form/saveForm",
+        "body": [
+          {
+            "label": "树型展示",
+            "type": "transfer",
+            "name": "transfer",
+            "selectMode": "tree",
+            "searchable": true,
+            "options": [
+              {
+                "label": "法师",
+                "children": [
+                  {
+                    "label": "诸葛亮",
+                    "value": "zhugeliang"
+                  }
+                ]
+              },
+              {
+                "label": "战士",
+                "children": [
+                  {
+                    "label": "曹操",
+                    "value": "caocao"
+                  },
+                  {
+                    "label": "曹操1",
+                    "value": "caocao1",
+                    "children": [
+                      {
+                        "label": "李白1",
+                        "value": "libai1"
+                      },
+                      {
+                        "label": "韩信1",
+                        "value": "hanxin1"
+                      },
+                      {
+                        "label": "云中君1",
+                        "value": "yunzhongjun1"
+                      }
+                    ]
+                  },
+                  {
+                    "disabled": true,
+                    "label": "钟无艳",
+                    "value": "zhongwuyan"
+                  }
+                ]
+              },
+              {
+                "label": "打野",
+                "children": [
+                  {
+                    "label": "李白",
+                    "value": "libai"
+                  },
+                  {
+                    "label": "韩信",
+                    "value": "hanxin"
+                  },
+                  {
+                    "label": "云中君",
+                    "value": "yunzhongjun"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {onSubmit},
+      makeEnv({})
+    )
+  );
+  const node = await findByText('战士');
+  const submitBtn = await findByText('提交');
+  fireEvent.click(node);
+  fireEvent.click(submitBtn);
+
+  await wait(100);
+
+  expect(onSubmit.mock.calls[0][0]).toEqual({
+    transfer: 'caocao,libai1,hanxin1,yunzhongjun1'
+  });
+
+
+  fireEvent.click(node);
+  fireEvent.click(submitBtn);
+  await wait(100);
+  expect(onSubmit.mock.calls[1][0]).toEqual({
+    transfer: ''
+  });
+});


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2bc4f40</samp>

This pull request enhances the `TreeSelector` component to handle disabled nodes properly. It modifies the `Tree.tsx` file to update the selection logic and the `Tree.test.tsx` file to add a test case for the new functionality.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2bc4f40</samp>

> _`TreeSelector` of doom, you cannot escape its grasp_
> _Disabled nodes are ignored, no matter how you ask_
> _Submit your form in vain, the value is not yours_
> _`TreeSelector` of doom, it controls your choices_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2bc4f40</samp>

*  Prevent disabled nodes from being selected or deselected by their parent node in `TreeSelector` component ([link](https://github.com/baidu/amis/pull/7490/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L495-R530), [link](https://github.com/baidu/amis/pull/7490/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L560-R587))
* Add test case to verify the behavior of `TreeSelector` component with disabled nodes ([link](https://github.com/baidu/amis/pull/7490/files?diff=unified&w=0#diff-4d7700aaaa14921467975840001b3ea0a4f4970f4a54acd391b2bbb5e4071e47R433-R533))
