### PR TITLE
fix: transfer组件disabled的选项 在全选父级的时候，仍然可以被选到

### DIFF
--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -26,7 +26,8 @@ import {
   hasAbility,
   getTreeParent,
   getTreeAncestors,
-  flattenTree
+  flattenTree,
+  flattenTreeWithLeafNodes
 } from 'amis-core';
 import {Option, Options, value2array} from './Select';
 import {themeable, ThemeProps, highlight} from 'amis-core';
@@ -488,55 +489,65 @@ export class TreeSelector extends React.Component<
       // cascade 为 true 表示父节点跟子节点没有级联关系。
       if (autoCheckChildren) {
         const children = item.children ? item.children.concat([]) : [];
+        const hasDisabled = flattenTree(children).some(item => item?.disabled);
+
         if (onlyChildren) {
           // 父级选中的时候，子节点也都选中，但是自己不选中
           !~idx && children.length && value.pop();
 
-          // 取消下选择
-          if (
-            flattenTree(children)
-              .filter(item => !item?.disabled)
-              .some(v => ~value.indexOf(v))
-          ) {
-            while (children.length) {
-              let child = children.shift();
-              let index = value.indexOf(child);
+          // 这个 isAllChecked 主要是判断如果有disabled的item项，这时父节点还是选中的话，针对性的处理逻辑
+          const isAllChecked = flattenTreeWithLeafNodes(children)
+            .filter(item => !item?.disabled)
+            .every(v => ~value.indexOf(v));
 
-              if (child.children && child.children.length) {
-                children.push.apply(children, child.children);
-              }
-              if (~index && children.value !== 'undefined' && !child.disabled) {
-                value.splice(index, 1);
-              }
+          while (children.length) {
+            let child = children.shift();
+            let index = value.indexOf(child);
+
+            if (child.children && child.children.length) {
+              children.push.apply(children, child.children);
+              continue;
             }
-          } else {
-            while (children.length) {
-              let child = children.shift();
-              let index = value.indexOf(child);
 
-              if (child.children && child.children.length) {
-                children.push.apply(children, child.children);
-              } else if (
-                !~index &&
-                child.value !== 'undefined' &&
+            if (hasDisabled && isAllChecked) {
+              if (
+                ~index &&
+                children.value !== 'undefined' &&
                 !child?.disabled
               ) {
-                value.push(child);
+                value.splice(index, 1);
               }
+              continue;
+            }
+
+            if (!~index && child.value !== 'undefined' && !child?.disabled) {
+              value.push(child);
             }
           }
         } else {
+          // 这个 isAllChecked 主要是判断如果有disabled的item项，这时父节点还是选中的话，针对性的处理逻辑
+          const isAllChecked = flattenTree(children)
+            .filter(item => !item?.disabled)
+            .every(v => ~value.indexOf(v));
+
           // 只要父节点选择了,子节点就不需要了,全部去掉勾选.  withChildren时相反
           while (children.length) {
             let child = children.shift();
             let index = value.indexOf(child);
 
-            if (~index) {
-              value.splice(index, 1);
-            }
+            if (!child?.disabled) {
+              // 判断下下面是否有禁用项
+              if (!hasDisabled) {
+                if (~index) {
+                  value.splice(index, 1);
+                }
 
-            if (withChildren || cascade) {
-              value.push(child);
+                if (withChildren || cascade) {
+                  value.push(child);
+                }
+              } else {
+                isAllChecked ? value.splice(index, 1) : value.push(child);
+              }
             }
 
             if (child.children && child.children.length) {

--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -492,14 +492,37 @@ export class TreeSelector extends React.Component<
           // 父级选中的时候，子节点也都选中，但是自己不选中
           !~idx && children.length && value.pop();
 
-          while (children.length) {
-            let child = children.shift();
-            let index = value.indexOf(child);
+          // 取消下选择
+          if (
+            flattenTree(children)
+              .filter(item => !item?.disabled)
+              .some(v => ~value.indexOf(v))
+          ) {
+            while (children.length) {
+              let child = children.shift();
+              let index = value.indexOf(child);
 
-            if (child.children && child.children.length) {
-              children.push.apply(children, child.children);
-            } else if (!~index && child.value !== 'undefined') {
-              value.push(child);
+              if (child.children && child.children.length) {
+                children.push.apply(children, child.children);
+              }
+              if (~index && children.value !== 'undefined' && !child.disabled) {
+                value.splice(index, 1);
+              }
+            }
+          } else {
+            while (children.length) {
+              let child = children.shift();
+              let index = value.indexOf(child);
+
+              if (child.children && child.children.length) {
+                children.push.apply(children, child.children);
+              } else if (
+                !~index &&
+                child.value !== 'undefined' &&
+                !child?.disabled
+              ) {
+                value.push(child);
+              }
             }
           }
         } else {
@@ -557,7 +580,7 @@ export class TreeSelector extends React.Component<
           while (children.length) {
             let child = children.shift();
             let index = value.indexOf(child);
-            if (~index) {
+            if (~index && !child?.disabled) {
               value.splice(index, 1);
             }
             if (child.children && child.children.length) {

--- a/packages/amis/__tests__/renderers/Tree.test.tsx
+++ b/packages/amis/__tests__/renderers/Tree.test.tsx
@@ -523,7 +523,6 @@ test('Tree: item disabled', async () => {
     transfer: 'caocao,libai1,hanxin1,yunzhongjun1'
   });
 
-
   fireEvent.click(node);
   fireEvent.click(submitBtn);
   await wait(100);

--- a/packages/amis/__tests__/renderers/Tree.test.tsx
+++ b/packages/amis/__tests__/renderers/Tree.test.tsx
@@ -430,3 +430,104 @@ test('Tree: add child & cancel', async () => {
     expect(!!container.querySelector('[icon="close"]')).toBeFalsy()
   );
 });
+
+test('Tree: item disabled', async () => {
+  const onSubmit = jest.fn();
+  const {container, findByText, findByPlaceholderText} = render(
+    amisRender(
+      {
+        "type": "form",
+        "api": "/api/mock2/form/saveForm",
+        "body": [
+          {
+            "label": "树型展示",
+            "type": "transfer",
+            "name": "transfer",
+            "selectMode": "tree",
+            "searchable": true,
+            "options": [
+              {
+                "label": "法师",
+                "children": [
+                  {
+                    "label": "诸葛亮",
+                    "value": "zhugeliang"
+                  }
+                ]
+              },
+              {
+                "label": "战士",
+                "children": [
+                  {
+                    "label": "曹操",
+                    "value": "caocao"
+                  },
+                  {
+                    "label": "曹操1",
+                    "value": "caocao1",
+                    "children": [
+                      {
+                        "label": "李白1",
+                        "value": "libai1"
+                      },
+                      {
+                        "label": "韩信1",
+                        "value": "hanxin1"
+                      },
+                      {
+                        "label": "云中君1",
+                        "value": "yunzhongjun1"
+                      }
+                    ]
+                  },
+                  {
+                    "disabled": true,
+                    "label": "钟无艳",
+                    "value": "zhongwuyan"
+                  }
+                ]
+              },
+              {
+                "label": "打野",
+                "children": [
+                  {
+                    "label": "李白",
+                    "value": "libai"
+                  },
+                  {
+                    "label": "韩信",
+                    "value": "hanxin"
+                  },
+                  {
+                    "label": "云中君",
+                    "value": "yunzhongjun"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {onSubmit},
+      makeEnv({})
+    )
+  );
+  const node = await findByText('战士');
+  const submitBtn = await findByText('提交');
+  fireEvent.click(node);
+  fireEvent.click(submitBtn);
+
+  await wait(100);
+
+  expect(onSubmit.mock.calls[0][0]).toEqual({
+    transfer: 'caocao,libai1,hanxin1,yunzhongjun1'
+  });
+
+
+  fireEvent.click(node);
+  fireEvent.click(submitBtn);
+  await wait(100);
+  expect(onSubmit.mock.calls[1][0]).toEqual({
+    transfer: ''
+  });
+});


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a8c808</samp>

This pull request enhances the `TreeSelector` component to respect the disabled status of the tree nodes and their children. It also adds a new test case to the `Tree.test.tsx` file to ensure the correctness and compatibility of the changes.

copilot:poem

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0a8c808</samp>

* Import a new function `flattenTreeWithLeafNodes` to get a flat array of all the leaf nodes in a tree structure ([link](https://github.com/baidu/amis/pull/7493/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L29-R30))
* Add two new variables `hasDisabled` and `isAllChecked` to handle the logic of selecting and deselecting the tree nodes when the `autoCheckChildren` and `onlyChildren` props are true ([link](https://github.com/baidu/amis/pull/7493/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L491-R502))
* Modify the loop that iterates over the children of the current tree node to check the `hasDisabled` and `isAllChecked` variables, and to skip the disabled children ([link](https://github.com/baidu/amis/pull/7493/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L501-R532))
* Modify the logic of selecting and deselecting the current tree node to check the `hasDisabled` and `isAllChecked` variables, and to skip the disabled node ([link](https://github.com/baidu/amis/pull/7493/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L511-R550))
* Add a condition to check the disabled status of the child node to avoid deselecting the disabled child node when the parent node is deselected ([link](https://github.com/baidu/amis/pull/7493/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L560-R594))
* Add a new test case to verify the expected behavior of the `onSubmit` function when the tree nodes are selected or deselected in the `transfer` component with the `tree` mode ([link](https://github.com/baidu/amis/pull/7493/files?diff=unified&w=0#diff-4d7700aaaa14921467975840001b3ea0a4f4970f4a54acd391b2bbb5e4071e47R433-R532))
