### PR TITLE
fix: icon组件支持传入style

### DIFF
--- a/packages/amis-ui/src/components/icons.tsx
+++ b/packages/amis-ui/src/components/icons.tsx
@@ -250,13 +250,13 @@ export interface IconCheckedSchemaNew {
 export function Icon({
   icon,
   className,
-  wrapClassName,
   classPrefix = '',
   classNameProp,
   iconContent,
   vendor,
   cx: iconCx,
-  onClick = () => {}
+  onClick = () => {},
+  style
 }: {
   icon: string;
   iconContent?: string;
@@ -281,6 +281,7 @@ export function Icon({
         className={cx(className, `icon-${icon}`, classNameProp)}
         // @ts-ignore
         icon={icon}
+        style={style}
       />
     );
   }
@@ -309,6 +310,7 @@ export function Icon({
         onClick={onClick}
         className={cx(iconContent, className, classNameProp)}
         ref={refFn}
+        style={style}
       ></div>
     );
   }
@@ -332,6 +334,7 @@ export function Icon({
       <svg
         onClick={onClick}
         className={cx('icon', 'icon-object', className, classNameProp)}
+        style={style}
       >
         <use
           xlinkHref={`#${(icon as IconCheckedSchema).id.replace(/^svg-/, '')}`}
@@ -348,6 +351,7 @@ export function Icon({
         onClick={onClick}
         className={cx(`${classPrefix}Icon`, className, classNameProp)}
         src={icon}
+        style={style}
       />
     );
   }
@@ -371,6 +375,7 @@ export function Icon({
       <i
         onClick={onClick}
         className={cx(icon, className, classNameProp, iconPrefix)}
+        style={style}
       />
     );
   }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bb52065</samp>

Updated `Icon` component to support custom styles and removed unused prop. This improves the flexibility and simplicity of using icons in `amis-ui`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bb52065</samp>

> _To customize icons with flair_
> _The `Icon` component can wear_
> _A `style` prop that's new_
> _And bid `wrapClassName` adieu_
> _For it was redundant and rare_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bb52065</samp>

*  Add `style` prop to `Icon` component to allow custom inline styles for icon elements ([link](https://github.com/baidu/amis/pull/7494/files?diff=unified&w=0#diff-1db9a23d0ea625849dbe5c523e7ccab192bfa73c87891759c8a7de36e2d874efL259-R259), [link](https://github.com/baidu/amis/pull/7494/files?diff=unified&w=0#diff-1db9a23d0ea625849dbe5c523e7ccab192bfa73c87891759c8a7de36e2d874efR284), [link](https://github.com/baidu/amis/pull/7494/files?diff=unified&w=0#diff-1db9a23d0ea625849dbe5c523e7ccab192bfa73c87891759c8a7de36e2d874efR313), [link](https://github.com/baidu/amis/pull/7494/files?diff=unified&w=0#diff-1db9a23d0ea625849dbe5c523e7ccab192bfa73c87891759c8a7de36e2d874efR337), [link](https://github.com/baidu/amis/pull/7494/files?diff=unified&w=0#diff-1db9a23d0ea625849dbe5c523e7ccab192bfa73c87891759c8a7de36e2d874efR354), [link](https://github.com/baidu/amis/pull/7494/files?diff=unified&w=0#diff-1db9a23d0ea625849dbe5c523e7ccab192bfa73c87891759c8a7de36e2d874efR378))
* Remove unused `wrapClassName` prop from `Icon` component ([link](https://github.com/baidu/amis/pull/7494/files?diff=unified&w=0#diff-1db9a23d0ea625849dbe5c523e7ccab192bfa73c87891759c8a7de36e2d874efL253))
