### PR TITLE
feat:表单校验和提交动作面板支持配置结果存储

### DIFF
--- a/packages/amis-editor/src/renderer/event-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/event-control/helper.tsx
@@ -780,7 +780,7 @@ export const ACTION_TYPE_TREE = (manager: any): RendererPluginAction[] => {
               {
                 name: 'outputVar',
                 type: 'input-text',
-                label: '存储结果',
+                label: '请求结果',
                 placeholder: '请输入存储请求结果的变量名称',
                 description:
                   '如需执行多次发送请求，可以修改此变量名用于区分不同请求返回的结果',
@@ -1588,7 +1588,45 @@ export const ACTION_TYPE_TREE = (manager: any): RendererPluginAction[] => {
             );
           },
           supportComponents: 'form',
-          schema: renderCmptSelect('目标组件', true)
+          schema: [
+            ...renderCmptSelect('目标组件', true),
+            {
+              name: 'outputVar',
+              type: 'input-text',
+              label: '提交结果',
+              placeholder: '请输入存储提交结果的变量名称',
+              description:
+                '如需执行多次表单提交，可以修改此变量名用于区分不同的提交结果',
+              mode: 'horizontal',
+              size: 'lg',
+              value: 'submitResult',
+              required: true
+            }
+          ],
+          outputVarDataSchema: [
+            {
+              type: 'object',
+              title: 'submitResult',
+              properties: {
+                error: {
+                  type: 'string',
+                  title: '错误提示'
+                },
+                errors: {
+                  type: 'object',
+                  title: '错误信息'
+                },
+                payload: {
+                  type: 'object',
+                  title: '提交的表单数据'
+                },
+                responseData: {
+                  type: 'object',
+                  title: '提交请求返回的响应结果数据'
+                }
+              }
+            }
+          ]
         },
         {
           actionLabel: '清空表单',
@@ -1642,7 +1680,41 @@ export const ACTION_TYPE_TREE = (manager: any): RendererPluginAction[] => {
             );
           },
           supportComponents: 'form',
-          schema: renderCmptSelect('目标组件', true)
+          schema: [
+            ...renderCmptSelect('目标组件', true),
+            {
+              name: 'outputVar',
+              type: 'input-text',
+              label: '校验结果',
+              placeholder: '请输入存储校验结果的变量名称',
+              description:
+                '如需执行多次表单校验，可以修改此变量名用于区分不同的校验结果',
+              mode: 'horizontal',
+              size: 'lg',
+              value: 'validateResult',
+              required: true
+            }
+          ],
+          outputVarDataSchema: [
+            {
+              type: 'object',
+              title: 'validateResult',
+              properties: {
+                error: {
+                  type: 'string',
+                  title: '错误提示'
+                },
+                errors: {
+                  type: 'object',
+                  title: '错误信息'
+                },
+                payload: {
+                  type: 'object',
+                  title: '提交的表单数据'
+                }
+              }
+            }
+          ]
         },
         {
           actionLabel: '组件特性动作',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 30b3754</samp>

Added support for output variables in form actions and fixed a label inconsistency in `request` action. This allows users to store and access the results of `submit`, `validate`, and `request` actions in `outputVar` fields in `packages/amis-editor/src/renderer/event-control/helper.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 30b3754</samp>

> _`submit` and `validate` the forms of doom_
> _Store the results in `outputVar` fields of gloom_
> _`request` the data with a matching label_
> _Or face the wrath of the `ACTION_TYPE_TREE` fable_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 30b3754</samp>

* Changed the label of the `outputVar` field for request actions to '请求结果' to match the description and placeholder ([link](https://github.com/baidu/amis/pull/7495/files?diff=unified&w=0#diff-f55d29e93a330da662e7a91960e5ed88c12f80e9e38564d3a4497ff543da26b8L783-R783))
* Added a new `outputVar` field for form submission actions to store the result data, and defined the `outputVarDataSchema` property to describe the data structure ([link](https://github.com/baidu/amis/pull/7495/files?diff=unified&w=0#diff-f55d29e93a330da662e7a91960e5ed88c12f80e9e38564d3a4497ff543da26b8L1591-R1629))
* Added a new `outputVar` field for form validation actions to store the result data, and defined the `outputVarDataSchema` property to describe the data structure ([link](https://github.com/baidu/amis/pull/7495/files?diff=unified&w=0#diff-f55d29e93a330da662e7a91960e5ed88c12f80e9e38564d3a4497ff543da26b8L1645-R1717))
