### PR TITLE
chore:调整上下文文案

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Form.tsx
+++ b/packages/amis-editor/src/plugin/Form/Form.tsx
@@ -978,7 +978,7 @@ export class FormPlugin extends BasePlugin {
                         type: 'string',
                         title: itemSchema.label || itemSchema.name
                       }),
-                  group: `${schema.label || schema.name}的当前行记录`
+                  group: `当前行记录(${schema.label || schema.name})`
                 };
               }
             }
@@ -1005,7 +1005,7 @@ export class FormPlugin extends BasePlugin {
                 jsonschema.properties[col.name] = {
                   type: 'string',
                   title: col.label || col.name,
-                  group: `${schema.label || schema.name}的当前行记录`
+                  group: `当前行记录(${schema.label || schema.name})`
                 };
               }
             }

--- a/packages/amis-editor/src/renderer/event-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/event-control/helper.tsx
@@ -1610,11 +1610,11 @@ export const ACTION_TYPE_TREE = (manager: any): RendererPluginAction[] => {
               properties: {
                 error: {
                   type: 'string',
-                  title: '错误提示'
+                  title: '错误信息'
                 },
                 errors: {
                   type: 'object',
-                  title: '错误信息'
+                  title: '错误详情'
                 },
                 payload: {
                   type: 'object',
@@ -1622,7 +1622,7 @@ export const ACTION_TYPE_TREE = (manager: any): RendererPluginAction[] => {
                 },
                 responseData: {
                   type: 'object',
-                  title: '提交请求返回的响应结果数据'
+                  title: '提交请求的响应数据'
                 }
               }
             }
@@ -1702,11 +1702,11 @@ export const ACTION_TYPE_TREE = (manager: any): RendererPluginAction[] => {
               properties: {
                 error: {
                   type: 'string',
-                  title: '错误提示'
+                  title: '错误信息'
                 },
                 errors: {
                   type: 'object',
-                  title: '错误信息'
+                  title: '错误详情'
                 },
                 payload: {
                   type: 'object',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 26a3eec</samp>

This pull request improves the usability and readability of the form plugin and the action type tree in `amis-editor`. It changes the group names of form items generated from table schemas and the titles of some properties for different actions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 26a3eec</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever way to shorten and refine the names_
> _Of form items that sprang from table schemas, like_
> _The many-headed Hydra from the blood of slain Typhon._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 26a3eec</samp>

*  Simplify the group names of the form items generated from table schemas by using parentheses instead of the word "的" ([link](https://github.com/baidu/amis/pull/7498/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL981-R981), [link](https://github.com/baidu/amis/pull/7498/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL1008-R1008)) in `Form.tsx`
