### PR TITLE
fix: transfer组件disabled的选项 在全选父级的时候，仍然可以被选到

### DIFF
--- a/packages/amis/__tests__/renderers/Tree.test.tsx
+++ b/packages/amis/__tests__/renderers/Tree.test.tsx
@@ -430,3 +430,103 @@ test('Tree: add child & cancel', async () => {
     expect(!!container.querySelector('[icon="close"]')).toBeFalsy()
   );
 });
+
+test('Tree: item disabled', async () => {
+  const onSubmit = jest.fn();
+  const {container, findByText, findByPlaceholderText} = render(
+    amisRender(
+      {
+        "type": "form",
+        "api": "/api/mock2/form/saveForm",
+        "body": [
+          {
+            "label": "树型展示",
+            "type": "transfer",
+            "name": "transfer",
+            "selectMode": "tree",
+            "searchable": true,
+            "options": [
+              {
+                "label": "法师",
+                "children": [
+                  {
+                    "label": "诸葛亮",
+                    "value": "zhugeliang"
+                  }
+                ]
+              },
+              {
+                "label": "战士",
+                "children": [
+                  {
+                    "label": "曹操",
+                    "value": "caocao"
+                  },
+                  {
+                    "label": "曹操1",
+                    "value": "caocao1",
+                    "children": [
+                      {
+                        "label": "李白1",
+                        "value": "libai1"
+                      },
+                      {
+                        "label": "韩信1",
+                        "value": "hanxin1"
+                      },
+                      {
+                        "label": "云中君1",
+                        "value": "yunzhongjun1"
+                      }
+                    ]
+                  },
+                  {
+                    "disabled": true,
+                    "label": "钟无艳",
+                    "value": "zhongwuyan"
+                  }
+                ]
+              },
+              {
+                "label": "打野",
+                "children": [
+                  {
+                    "label": "李白",
+                    "value": "libai"
+                  },
+                  {
+                    "label": "韩信",
+                    "value": "hanxin"
+                  },
+                  {
+                    "label": "云中君",
+                    "value": "yunzhongjun"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {onSubmit},
+      makeEnv({})
+    )
+  );
+  const node = await findByText('战士');
+  const submitBtn = await findByText('提交');
+  fireEvent.click(node);
+  fireEvent.click(submitBtn);
+
+  await wait(100);
+
+  expect(onSubmit.mock.calls[0][0]).toEqual({
+    transfer: 'caocao,libai1,hanxin1,yunzhongjun1'
+  });
+
+  fireEvent.click(node);
+  fireEvent.click(submitBtn);
+  await wait(100);
+  expect(onSubmit.mock.calls[1][0]).toEqual({
+    transfer: ''
+  });
+});


### PR DESCRIPTION
fix: transfer组件disabled的选项 在全选父级的时候，仍然可以被选到

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8f50031</samp>

This pull request enhances the `TreeSelector` component to handle disabled nodes better. It adds a new function to flatten the tree and check the leaf nodes, and modifies the selection logic to skip the disabled nodes. It also adds a new test case to verify the functionality of the `TreeSelector` in a `transfer` component.

copilot:poem

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8f50031</samp>

*  Import `flattenTreeWithLeafNodes` function to get leaf nodes of a tree ([link](https://github.com/baidu/amis/pull/7514/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L29-R30))
*  Add `hasDisabled` and `isAllChecked` variables to handle selection logic of tree nodes ([link](https://github.com/baidu/amis/pull/7514/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L484-R495))
*  Modify loop over children nodes to skip disabled nodes and keep parent node checked ([link](https://github.com/baidu/amis/pull/7514/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L494-R525))
*  Modify logic of selecting and deselecting current node to toggle non-disabled nodes ([link](https://github.com/baidu/amis/pull/7514/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L504-R543))
*  Add condition to avoid deselecting disabled nodes when parent node is deselected ([link](https://github.com/baidu/amis/pull/7514/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L553-R587))
*  Add test case to verify changes in `TreeSelector` class using `transfer` component ([link](https://github.com/baidu/amis/pull/7514/files?diff=unified&w=0#diff-4d7700aaaa14921467975840001b3ea0a4f4970f4a54acd391b2bbb5e4071e47R433-R532))
