### PR TITLE
feat: api 发送适配器支持异步

### DIFF
--- a/packages/amis-core/src/types.ts
+++ b/packages/amis-core/src/types.ts
@@ -223,7 +223,10 @@ export interface ApiObject extends BaseApiObject {
     api: ApiObject,
     context: any
   ) => any;
-  requestAdaptor?: (api: ApiObject, context: any) => ApiObject;
+  requestAdaptor?: (
+    api: ApiObject,
+    context: any
+  ) => ApiObject | Promise<ApiObject>;
   /** 是否过滤为空字符串的 query 参数 */
   filterEmptyQuery?: boolean;
 }

--- a/packages/amis-core/src/utils/api.ts
+++ b/packages/amis-core/src/utils/api.ts
@@ -76,7 +76,7 @@ export function buildApi(
   }
 
   if (api.requestAdaptor && typeof api.requestAdaptor === 'string') {
-    api.requestAdaptor = str2function(
+    api.requestAdaptor = str2AsyncFunction(
       api.requestAdaptor,
       'api',
       'context'
@@ -84,7 +84,7 @@ export function buildApi(
   }
 
   if (api.adaptor && typeof api.adaptor === 'string') {
-    api.adaptor = str2function(
+    api.adaptor = str2AsyncFunction(
       api.adaptor,
       'payload',
       'response',
@@ -464,12 +464,16 @@ export function wrapFetcher(
     return fn as any;
   }
 
-  const wrappedFetcher = function (api: Api, data: object, options?: object) {
+  const wrappedFetcher = async function (
+    api: Api,
+    data: object,
+    options?: object
+  ) {
     api = buildApi(api, data, options) as ApiObject;
 
     if (api.requestAdaptor) {
       debug('api', 'before requestAdaptor', api);
-      api = api.requestAdaptor(api, data) || api;
+      api = (await api.requestAdaptor(api, data)) || api;
       debug('api', 'after requestAdaptor', api);
     }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fee9bb2</samp>

The pull request adds support for async functions in the `requestAdaptor` and `adaptor` options of the api object, which can modify the request and response data. It also updates the `ApiObject` interface and adds a test case for the new feature. The files `packages/amis-core/src/utils/api.ts`, `packages/amis/__tests__/utils/api.test.ts`, and `packages/amis-core/src/types.ts` are modified.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fee9bb2</samp>

> _Sing, O Muse, of the cunning code review_
> _That changed the ApiObject interface_
> _And made the requestAdaptor property_
> _Able to return a promise or a value._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fee9bb2</samp>

* Allow `requestAdaptor` to return a promise of an api object ([link](https://github.com/baidu/amis/pull/7525/files?diff=unified&w=0#diff-9795a06699f88c4c144fccb14b9ddca83b8d9639d2062c27b01495b6b80e7d7dL226-R229), [link](https://github.com/baidu/amis/pull/7525/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL79-R79), [link](https://github.com/baidu/amis/pull/7525/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL467-R476))
* Allow `adaptor` to return a promise of a response object ([link](https://github.com/baidu/amis/pull/7525/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL87-R87))
* Import `waitFor` function from `@testing-library/react` to `api.test.ts` ([link](https://github.com/baidu/amis/pull/7525/files?diff=unified&w=0#diff-42dba9595cf16673bf6fe7f237d7cf2ba3647c1fcbcf944118da8961e3460c44L3-R3))
