### PR TITLE
fix: 修复直接传入react组件icon渲染异常问题

### DIFF
--- a/packages/amis-ui/src/components/icons.tsx
+++ b/packages/amis-ui/src/components/icons.tsx
@@ -275,7 +275,10 @@ export function Icon({
   if (React.isValidElement(icon)) {
     return React.cloneElement(icon, {
       ...((icon.props as any) || {}),
-      className: cx(className, classNameProp, (icon.props as any).className),
+      className: cxClass(
+        cx(className, classNameProp),
+        (icon.props as any).className
+      ),
       style,
       onClick
     });

--- a/packages/amis-ui/src/components/icons.tsx
+++ b/packages/amis-ui/src/components/icons.tsx
@@ -273,7 +273,12 @@ export function Icon({
 
   // 直接的icon dom
   if (React.isValidElement(icon)) {
-    return icon;
+    return React.cloneElement(icon, {
+      ...((icon.props as any) || {}),
+      className: cx(className, classNameProp),
+      style,
+      onClick
+    });
   }
 
   // 从css变量中获取icon

--- a/packages/amis-ui/src/components/icons.tsx
+++ b/packages/amis-ui/src/components/icons.tsx
@@ -256,6 +256,8 @@ export function Icon({
   vendor,
   cx: iconCx,
   onClick = () => {},
+  onMouseEnter = () => {},
+  onMouseLeave = () => {},
   style
 }: {
   icon: string;
@@ -280,7 +282,9 @@ export function Icon({
         (icon.props as any).className
       ),
       style,
-      onClick
+      onClick,
+      onMouseEnter,
+      onMouseLeave
     });
   }
 
@@ -306,6 +310,8 @@ export function Icon({
     return (
       <div
         onClick={onClick}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         className={cx(iconContent, className, classNameProp)}
         ref={refFn}
         style={style}
@@ -319,6 +325,8 @@ export function Icon({
     return (
       <Component
         onClick={onClick}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         className={cx(className, `icon-${icon}`, classNameProp)}
         // @ts-ignore
         icon={icon}
@@ -345,6 +353,8 @@ export function Icon({
     return (
       <svg
         onClick={onClick}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         className={cx('icon', 'icon-object', className, classNameProp)}
         style={style}
       >
@@ -361,6 +371,8 @@ export function Icon({
     return (
       <img
         onClick={onClick}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         className={cx(`${classPrefix}Icon`, className, classNameProp)}
         src={icon}
         style={style}
@@ -386,6 +398,8 @@ export function Icon({
     return (
       <i
         onClick={onClick}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         className={cx(icon, className, classNameProp, iconPrefix)}
         style={style}
       />

--- a/packages/amis-ui/src/components/icons.tsx
+++ b/packages/amis-ui/src/components/icons.tsx
@@ -275,7 +275,7 @@ export function Icon({
   if (React.isValidElement(icon)) {
     return React.cloneElement(icon, {
       ...((icon.props as any) || {}),
-      className: cx(className, classNameProp),
+      className: cx(className, classNameProp, (icon.props as any).className),
       style,
       onClick
     });

--- a/packages/amis-ui/src/components/icons.tsx
+++ b/packages/amis-ui/src/components/icons.tsx
@@ -256,8 +256,6 @@ export function Icon({
   vendor,
   cx: iconCx,
   onClick = () => {},
-  onMouseEnter = () => {},
-  onMouseLeave = () => {},
   style
 }: {
   icon: string;
@@ -282,9 +280,7 @@ export function Icon({
         (icon.props as any).className
       ),
       style,
-      onClick,
-      onMouseEnter,
-      onMouseLeave
+      onClick
     });
   }
 
@@ -310,8 +306,6 @@ export function Icon({
     return (
       <div
         onClick={onClick}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
         className={cx(iconContent, className, classNameProp)}
         ref={refFn}
         style={style}
@@ -325,8 +319,6 @@ export function Icon({
     return (
       <Component
         onClick={onClick}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
         className={cx(className, `icon-${icon}`, classNameProp)}
         // @ts-ignore
         icon={icon}
@@ -353,8 +345,6 @@ export function Icon({
     return (
       <svg
         onClick={onClick}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
         className={cx('icon', 'icon-object', className, classNameProp)}
         style={style}
       >
@@ -371,8 +361,6 @@ export function Icon({
     return (
       <img
         onClick={onClick}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
         className={cx(`${classPrefix}Icon`, className, classNameProp)}
         src={icon}
         style={style}
@@ -398,8 +386,6 @@ export function Icon({
     return (
       <i
         onClick={onClick}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
         className={cx(icon, className, classNameProp, iconPrefix)}
         style={style}
       />

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/combo.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/combo.test.tsx.snap
@@ -1072,7 +1072,7 @@ exports[`Renderer:combo with conditions: add button open 1`] = `
                               class="cxd-Button cxd-Button--info cxd-Button--size-sm"
                             >
                               <icon-mock
-                                classname="icon icon-plus-fine"
+                                classname="icon m-r-xs icon icon-plus-fine"
                                 icon="plus-fine"
                               />
                               新增

--- a/packages/amis/src/renderers/Collapse.tsx
+++ b/packages/amis/src/renderers/Collapse.tsx
@@ -190,7 +190,11 @@ export default class Collapse extends React.Component<CollapseProps, {}> {
         expandIcon={
           expandIcon ? (
             typeof (expandIcon as any).icon === 'object' ? (
-              <Icon cx={cx} icon={(expandIcon as any).icon} />
+              <Icon
+                cx={cx}
+                icon={(expandIcon as any).icon}
+                className={cx('Collapse-icon-tranform')}
+              />
             ) : (
               render('arrow-icon', expandIcon || '', {
                 className: cx('Collapse-icon-tranform')

--- a/packages/amis/src/renderers/Icon.tsx
+++ b/packages/amis/src/renderers/Icon.tsx
@@ -73,8 +73,11 @@ export class Icon extends React.Component<IconProps, object> {
       css,
       env
     } = this.props;
+    let icon = this.props.icon;
 
-    const icon = filter(this.props.icon, data);
+    if (typeof icon === 'string') {
+      icon = filter(this.props.icon, data);
+    }
 
     return (
       <>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aef0258</samp>

This pull request enhances the icon component and the Collapse renderer in `amis-ui` and `amis`. It enables passing custom props to the icon element and adds a CSS transition effect to the Collapse renderer.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at aef0258</samp>

> _`icon` gets new props_
> _customizing its look and feel_
> _a winter blossom_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aef0258</samp>

* Add a transition effect to the Collapse renderer by applying a CSS transform to the icon element ([link](https://github.com/baidu/amis/pull/7526/files?diff=unified&w=0#diff-6d636c959477c3d20a94c5164699349a52ed6df375d22be5b60dc7b6fefd498eL193-R197))
* Allow passing additional props to the icon element in the Icon component, such as `className`, `style` and `onClick` ([link](https://github.com/baidu/amis/pull/7526/files?diff=unified&w=0#diff-1db9a23d0ea625849dbe5c523e7ccab192bfa73c87891759c8a7de36e2d874efL276-R281))
