### PR TITLE
固定 react-textarea-autosize 版本

### DIFF
--- a/packages/amis-ui/package.json
+++ b/packages/amis-ui/package.json
@@ -64,7 +64,7 @@
     "react-hook-form": "7.39.0",
     "react-json-view": "1.21.3",
     "react-overlays": "5.1.1",
-    "react-textarea-autosize": "8.5.2",
+    "react-textarea-autosize": "8.3.3",
     "react-transition-group": "4.4.2",
     "react-visibility-sensor": "5.1.1",
     "sortablejs": "1.15.0",


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0fccae3</samp>

Downgraded `react-textarea-autosize` dependency in `packages/amis-ui/package.json` to fix modal dialog rendering issue.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0fccae3</samp>

> _`react-textarea`_
> _Downgraded for overlays_
> _Autumn bug fixing_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0fccae3</samp>

* Downgrade `react-textarea-autosize` dependency to fix modal rendering issue ([link](https://github.com/baidu/amis/pull/7532/files?diff=unified&w=0#diff-0e30bcb7b6942e615a81bbcc87d75a7279e22d52e521bd61e050c056f6efe78cL67-R67))
