### PR TITLE
chore: 调整 debug 样式 补充销毁逻辑, 适配 react 18

### DIFF
--- a/packages/amis-core/src/index.tsx
+++ b/packages/amis-core/src/index.tsx
@@ -98,7 +98,13 @@ import Overlay from './components/Overlay';
 import PopOver from './components/PopOver';
 import {FormRenderer} from './renderers/Form';
 import type {FormHorizontal, FormSchemaBase} from './renderers/Form';
-import {enableDebug, promisify, replaceText, wrapFetcher} from './utils/index';
+import {
+  enableDebug,
+  disableDebug,
+  promisify,
+  replaceText,
+  wrapFetcher
+} from './utils/index';
 import type {OnEventProps} from './utils/index';
 import {valueMap as styleMap} from './utils/style-helper';
 import {RENDERER_TRANSMISSION_OMIT_PROPS} from './SchemaRenderer';
@@ -195,7 +201,9 @@ export {
   OnEventProps,
   FormSchemaBase,
   filterTarget,
-  CustomStyle
+  CustomStyle,
+  enableDebug,
+  disableDebug
 };
 
 export function render(
@@ -257,13 +265,6 @@ function AMISRenderer({
         translate
       } as any;
 
-      if (options.enableAMISDebug) {
-        // 因为里面还有 render
-        setTimeout(() => {
-          enableDebug();
-        }, 10);
-      }
-
       store = RendererStore.create({}, options);
       stores[options.session || 'global'] = store;
     } else {
@@ -290,6 +291,11 @@ function AMISRenderer({
     theme = 'cxd';
   }
   env.theme = getTheme(theme);
+
+  React.useEffect(() => {
+    env.enableAMISDebug ? enableDebug() : disableDebug();
+    return () => env.enableAMISDebug || disableDebug();
+  }, [env.enableAMISDebug]);
 
   if (props.locale !== undefined) {
     env.translate = translate;

--- a/packages/amis-core/src/utils/debug.tsx
+++ b/packages/amis-core/src/utils/debug.tsx
@@ -2,9 +2,10 @@
  * amis 运行时调试功能，为了避免循环引用，这个组件不要依赖 amis 里的组件
  */
 
-import React, {Component, useEffect, useRef, useState} from 'react';
+import React, {Component, useEffect, useRef, useState, version} from 'react';
 import cx from 'classnames';
-import {findDOMNode, render} from 'react-dom';
+import {findDOMNode, render, unmountComponentAtNode} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import {autorun, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import {uuidv4} from './helper';
@@ -84,16 +85,18 @@ const LogView = observer(({store}: {store: AMISDebugStore}) => {
               [{log.cat}] {log.msg}
             </div>
             {log.ext ? (
-              <JsonView
-                name={null}
-                theme="monokai"
-                src={JSON.parse(log.ext)}
-                collapsed={true}
-                enableClipboard={false}
-                displayDataTypes={false}
-                collapseStringsAfterLength={ellipsisThreshold}
-                iconStyle="square"
-              />
+              <React.Suspense fallback={<div>Loading...</div>}>
+                <JsonView
+                  name={null}
+                  theme="monokai"
+                  src={JSON.parse(log.ext)}
+                  collapsed={true}
+                  enableClipboard={false}
+                  displayDataTypes={false}
+                  collapseStringsAfterLength={ellipsisThreshold}
+                  iconStyle="square"
+                />
+              </React.Suspense>
             ) : null}
           </div>
         );
@@ -126,16 +129,18 @@ const AMISDebug = observer(({store}: {store: AMISDebugStore}) => {
       stackDataView.push(
         <div key={`data-${level}`}>
           <h3>Data Level-{level}</h3>
-          <JsonView
-            key={`dataview-${stack}`}
-            name={null}
-            theme="monokai"
-            src={stack}
-            collapsed={level === 0 ? false : true}
-            enableClipboard={false}
-            displayDataTypes={false}
-            iconStyle="square"
-          />
+          <React.Suspense fallback={<div>Loading...</div>}>
+            <JsonView
+              key={`dataview-${stack}`}
+              name={null}
+              theme="monokai"
+              src={stack}
+              collapsed={level === 0 ? false : true}
+              enableClipboard={false}
+              displayDataTypes={false}
+              iconStyle="square"
+            />
+          </React.Suspense>
         </div>
       );
       level += 1;
@@ -319,7 +324,7 @@ function handleMouseclick(e: MouseEvent) {
   }
   const dom = e.target as HTMLElement;
   const target = dom.closest(`[data-debug-id]`);
-  if (target) {
+  if (target && !target.closest('.AMISDebug')) {
     store.activeId = target.getAttribute('data-debug-id')!;
     store.tab = 'inspect';
   }
@@ -366,6 +371,7 @@ autorun(() => {
 
 // 页面中只能有一个实例
 let isEnabled = false;
+let unmount: () => void;
 
 export function enableDebug() {
   if (isEnabled) {
@@ -376,12 +382,38 @@ export function enableDebug() {
   const amisDebugElement = document.createElement('div');
   document.body.appendChild(amisDebugElement);
   const element = <AMISDebug store={store} />;
-  render(element, amisDebugElement);
+
+  if (parseInt(version.split('.')[0], 10) >= 18) {
+    const root = createRoot(amisDebugElement);
+    root.render(element);
+    unmount = () => {
+      root.unmount();
+      document.body.removeChild(amisDebugElement);
+    };
+  } else {
+    render(element, amisDebugElement);
+    unmount = () => {
+      unmountComponentAtNode(amisDebugElement);
+      document.body.removeChild(amisDebugElement);
+    };
+  }
 
   document.body.appendChild(amisHoverBox);
   document.body.appendChild(amisActiveBox);
   document.addEventListener('mousemove', handleMouseMove);
   document.addEventListener('click', handleMouseclick);
+}
+
+export function disableDebug() {
+  if (!isEnabled) {
+    return;
+  }
+  isEnabled = false;
+  unmount?.();
+  document.body.removeChild(amisHoverBox);
+  document.body.removeChild(amisActiveBox);
+  document.removeEventListener('mousemove', handleMouseMove);
+  document.removeEventListener('click', handleMouseclick);
 }
 
 interface DebugWrapperProps {

--- a/packages/amis-ui/scss/components/_debug.scss
+++ b/packages/amis-ui/scss/components/_debug.scss
@@ -40,6 +40,7 @@
 
   &-tab {
     overflow: hidden;
+    border-bottom: 1px solid #3d3d3d;
   }
 
   &-tab > button {
@@ -90,6 +91,7 @@
   &-content {
     pointer-events: all;
     display: none;
+    height: 100%;
   }
 
   &-resize {
@@ -122,7 +124,7 @@
 
   &.is-expanded {
     width: 420px;
-    overflow: auto;
+
     background: #272821;
     color: #cccccc;
     box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
@@ -166,6 +168,37 @@
 
   &-inspect {
     padding: var(--gap-sm);
+  }
+
+  &-log,
+  &-inspect {
+    height: 100%;
+    overflow: auto;
+
+    // 火狐浏览器
+    scrollbar-width: thin;
+    scrollbar-color: #6b6b6b #2b2b2b;
+    &::-webkit-scrollbar {
+      position: relative;
+      z-index: 10;
+      background-color: #2c2c2c;
+      width: 16px;
+      height: 16px;
+      border-left: 1px solid #3d3d3d;
+      // border-top: 1px solid #3d3d3d;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: #6b6b6b;
+      background-clip: content-box;
+      border: 4px solid transparent;
+      border-radius: 500px;
+
+      &:hover {
+        background: #939393;
+        background-clip: content-box;
+      }
+    }
   }
 
   &-logLine {

--- a/packages/amis-ui/scss/components/_drawer.scss
+++ b/packages/amis-ui/scss/components/_drawer.scss
@@ -89,11 +89,20 @@
   }
 
   &-body {
-    padding: var(--drawer-content-paddingTop) var(--drawer-content-paddingRight)
+    padding: 0 var(--drawer-content-paddingRight)
       var(--drawer-content-paddingBottom) var(--drawer-content-paddingLeft);
     flex-basis: 0;
     flex-grow: 1;
     overflow: auto;
+
+    // 因为如果成员里面有 position:sticky 的内容
+    // 用 padding 会导致位置不正确
+    // 所以改成这种写法
+    &:before {
+      content: '';
+      display: block;
+      height: var(--drawer-content-paddingTop);
+    }
   }
 
   &-footer {

--- a/packages/amis-ui/src/components/Alert.tsx
+++ b/packages/amis-ui/src/components/Alert.tsx
@@ -3,7 +3,7 @@
  * @author fex
  */
 
-import React from 'react';
+import React, {version} from 'react';
 import {render} from 'react-dom';
 import Modal from './Modal';
 import Button from './Button';
@@ -11,6 +11,7 @@ import {ClassNamesFn, themeable, ThemeProps} from 'amis-core';
 import {LocaleProps, localeable} from 'amis-core';
 import Html from './Html';
 import type {PlainObject} from 'amis-core';
+import {createRoot} from 'react-dom/client';
 export interface AlertProps extends ThemeProps, LocaleProps {
   container?: any;
   confirmText?: string;
@@ -52,13 +53,21 @@ export interface AlertState {
 
 export class Alert extends React.Component<AlertProps, AlertState> {
   static instance: any = null;
-  static getInstance() {
+  static async getInstance() {
     if (!Alert.instance) {
       console.warn('Alert 组件应该没有被渲染，所以隐性的渲染到 body 了');
       const container = document.body;
       const div = document.createElement('div');
       container.appendChild(div);
-      render(<FinnalAlert />, div);
+
+      if (parseInt(version.split('.')[0], 10) >= 18) {
+        const root = createRoot(div);
+        await new Promise<void>(resolve =>
+          root.render(<FinnalAlert ref={() => resolve()} />)
+        );
+      } else {
+        render(<FinnalAlert />, div);
+      }
     }
 
     return Alert.instance;
@@ -346,23 +355,35 @@ function renderForm(
   return renderSchemaFn?.(controls, value, callback, scopeRef, theme);
 }
 
-export const alert: (content: string, title?: string) => void = (
+export const alert: (content: string, title?: string) => Promise<void> = async (
   content,
   title
-) => Alert.getInstance().alert(content, title);
+) => {
+  const instance = await Alert.getInstance();
+  return instance.alert(content, title);
+};
 export const confirm: (
   content: string | React.ReactNode,
   title?: string,
   optionsOrCofnrimText?: string | ConfirmOptions,
   cancelText?: string
-) => Promise<any> = (content, title, optionsOrCofnrimText, cancelText) =>
-  Alert.getInstance().confirm(content, title, optionsOrCofnrimText, cancelText);
+) => Promise<any> = async (
+  content,
+  title,
+  optionsOrCofnrimText,
+  cancelText
+) => {
+  const instance = await Alert.getInstance();
+  return instance.confirm(content, title, optionsOrCofnrimText, cancelText);
+};
 export const prompt: (
   controls: any,
   defaultvalue?: any,
   title?: string,
   confirmText?: string
-) => Promise<any> = (controls, defaultvalue, title, confirmText) =>
-  Alert.getInstance().prompt(controls, defaultvalue, title, confirmText);
+) => Promise<any> = async (controls, defaultvalue, title, confirmText) => {
+  const instance = await Alert.getInstance();
+  return instance.prompt(controls, defaultvalue, title, confirmText);
+};
 export const FinnalAlert = themeable(localeable(Alert));
 export default FinnalAlert;

--- a/packages/amis-ui/src/components/ContextMenu.tsx
+++ b/packages/amis-ui/src/components/ContextMenu.tsx
@@ -1,5 +1,5 @@
 import {ClassNamesFn, themeable} from 'amis-core';
-import React from 'react';
+import React, {version} from 'react';
 import {render} from 'react-dom';
 import {autobind, calculatePosition} from 'amis-core';
 import Transition, {
@@ -7,6 +7,7 @@ import Transition, {
   ENTERING,
   EXITING
 } from 'react-transition-group/Transition';
+import {createRoot} from 'react-dom/client';
 const fadeStyles: {
   [propName: string]: string;
 } = {
@@ -49,12 +50,20 @@ export class ContextMenu extends React.Component<
   ContextMenuState
 > {
   static instance: any = null;
-  static getInstance() {
+  static async getInstance() {
     if (!ContextMenu.instance) {
       const container = document.body;
       const div = document.createElement('div');
       container.appendChild(div);
-      render(<ThemedContextMenu />, div);
+
+      if (parseInt(version.split('.')[0], 10) >= 18) {
+        const root = createRoot(div);
+        await new Promise<void>(resolve =>
+          root.render(<ThemedContextMenu ref={() => resolve()} />)
+        );
+      } else {
+        render(<ThemedContextMenu />, div);
+      }
     }
 
     return ContextMenu.instance;
@@ -309,5 +318,7 @@ export function openContextMenus(
   menus: Array<MenuItem | MenuDivider>,
   onClose?: () => void
 ) {
-  return ContextMenu.getInstance().openContextMenus(info, menus, onClose);
+  return ContextMenu.getInstance().then(instance =>
+    instance.openContextMenus(info, menus, onClose)
+  );
 }

--- a/packages/amis/__tests__/renderers/Action.test.tsx
+++ b/packages/amis/__tests__/renderers/Action.test.tsx
@@ -342,7 +342,7 @@ test('Renderers:Action tooltip', async () => {
 // });
 
 // 14. confirmText
-test('Renderers:Action with confirmText & actionType ajax', () => {
+test('Renderers:Action with confirmText & actionType ajax', async () => {
   const fetcher = jest.fn().mockImplementation(() =>
     Promise.resolve({
       data: {
@@ -372,7 +372,7 @@ test('Renderers:Action with confirmText & actionType ajax', () => {
     )
   );
   fireEvent.click(container.querySelector('.cxd-Button'));
-  wait(500);
+  await wait(500);
   expect(baseElement).toMatchSnapshot();
 
   expect(baseElement.querySelector('.cxd-Modal-content')!).toHaveTextContent(
@@ -380,14 +380,16 @@ test('Renderers:Action with confirmText & actionType ajax', () => {
   );
 
   fireEvent.click(getByText('取消'));
-  wait(500);
+  await wait(500);
   expect(fetcher).not.toBeCalled();
 
-  // fireEvent.click(container.querySelector('.cxd-Button'));
-  // wait(500);
-  // fireEvent.click(getByText('确认'));
-  // fetcher 不生效
-  // expect(fetcher).toBeCalled();
+  fireEvent.click(container.querySelector('.cxd-Button'));
+  await wait(500);
+  fireEvent.click(getByText('确认'));
+
+  await wait(200);
+  // fetcher 该被执行了
+  expect(fetcher).toBeCalled();
 });
 
 // 15.Action 作为容器组件

--- a/packages/amis/src/renderers/Dialog.tsx
+++ b/packages/amis/src/renderers/Dialog.tsx
@@ -465,6 +465,10 @@ export default class Dialog extends React.Component<DialogProps> {
       syncLocation: false // 弹框中的 crud 一般不需要同步地址栏
     };
 
+    if (this.props.size === 'full') {
+      subProps.affixOffsetTop = 0;
+    }
+
     if (!(body as Schema).type) {
       return render(`body${key ? `/${key}` : ''}`, body, subProps);
     }

--- a/packages/amis/src/renderers/Drawer.tsx
+++ b/packages/amis/src/renderers/Drawer.tsx
@@ -465,7 +465,8 @@ export default class Drawer extends React.Component<DrawerProps> {
       onInit: this.handleFormInit,
       onSaved: this.handleFormSaved,
       onActionSensor: this.handleActionSensor,
-      syncLocation: false
+      syncLocation: false,
+      affixOffsetTop: 0
     };
 
     if (schema.type === 'form') {

--- a/packages/amis/src/renderers/Table/TableBody.tsx
+++ b/packages/amis/src/renderers/Table/TableBody.tsx
@@ -272,7 +272,7 @@ export class TableBody extends React.Component<TableBodyProps> {
           return (
             <Com
               key={index}
-              colSpan={item.colSpan}
+              colSpan={item.colSpan == 1 ? undefined : item.colSpan}
               className={item.cellClassName}
             >
               {render(`summary-row/${index}`, item, {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 96ccec5</samp>

This pull request enhances the debug mode, concurrent mode, and affix element support for various components in the `amis` and `amis-core` packages. It also fixes some bugs and improves the styles of the debug and drawer components. It modifies the files `packages/amis-core/src/index.tsx`, `packages/amis-core/src/utils/debug.tsx`, `packages/amis-ui/scss/components/_debug.scss`, `packages/amis-ui/src/components/Alert.tsx`, `packages/amis-ui/src/components/ContextMenu.tsx`, `packages/amis-ui/scss/components/_drawer.scss`, `packages/amis/src/renderers/Dialog.tsx`, and `packages/amis/src/renderers/Drawer.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 96ccec5</samp>

> _Sing, O Muse, of the skillful coder who refined the `AMISRenderer`_
> _And made it easier to debug and test the `Dialog` and the `Drawer`_
> _He added props and styles to fix the position of the affix elements_
> _And used `createRoot` and `version` to support concurrent mode_

### Why

Close: #7533

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 96ccec5</samp>

*  Enable or disable the debug mode for AMISRenderer based on the env prop and clean up the debug component on unmount ([link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-ed2759a19afd843ed555f6c368bef12e2d0dab8b1b113f0ff059a4575bad00c2L101-R107), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-ed2759a19afd843ed555f6c368bef12e2d0dab8b1b113f0ff059a4575bad00c2L198-R206), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-ed2759a19afd843ed555f6c368bef12e2d0dab8b1b113f0ff059a4575bad00c2L260-L266), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-ed2759a19afd843ed555f6c368bef12e2d0dab8b1b113f0ff059a4575bad00c2R295-R299), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-267ff9b13396c5c999812bf56a8daa603837b2764942c35a0c077b53692bf177R374), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-267ff9b13396c5c999812bf56a8daa603837b2764942c35a0c077b53692bf177L379-R400), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-267ff9b13396c5c999812bf56a8daa603837b2764942c35a0c077b53692bf177R407-R418))
*  Support different versions of React and concurrent mode rendering for the debug, alert, and context menu components ([link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-267ff9b13396c5c999812bf56a8daa603837b2764942c35a0c077b53692bf177L5-R8), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-267ff9b13396c5c999812bf56a8daa603837b2764942c35a0c077b53692bf177L379-R400), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-2acdd4d7456e360c65cda3ac871a7516411e2d90f43aab161418272388cc45fdL6-R6), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-2acdd4d7456e360c65cda3ac871a7516411e2d90f43aab161418272388cc45fdR14), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-2acdd4d7456e360c65cda3ac871a7516411e2d90f43aab161418272388cc45fdL61-R68), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-aac8cfd184853a8924093dd047a9f55d4030711c6bb72cb5572071db78697e41L2-R2), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-aac8cfd184853a8924093dd047a9f55d4030711c6bb72cb5572071db78697e41R10), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-aac8cfd184853a8924093dd047a9f55d4030711c6bb72cb5572071db78697e41L57-R64))
*  Enable lazy loading and fallback rendering of the JSON data in the debug log and inspect panels ([link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-267ff9b13396c5c999812bf56a8daa603837b2764942c35a0c077b53692bf177L87-R99), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-267ff9b13396c5c999812bf56a8daa603837b2764942c35a0c077b53692bf177L129-R143))
*  Ignore clicks on the debug component itself to avoid changing the active debug id ([link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-267ff9b13396c5c999812bf56a8daa603837b2764942c35a0c077b53692bf177L322-R327))
*  Improve the appearance and functionality of the debug component by adding a border, adjusting the height and overflow, and customizing the scrollbars ([link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-27b6b866202028bb1df930de39a5aabc2242900cd98ead38c88b27048f61ea4aR43), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-27b6b866202028bb1df930de39a5aabc2242900cd98ead38c88b27048f61ea4aR94), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-27b6b866202028bb1df930de39a5aabc2242900cd98ead38c88b27048f61ea4aL125-R127), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-27b6b866202028bb1df930de39a5aabc2242900cd98ead38c88b27048f61ea4aR173-R203))
*  Fix the position of sticky elements inside the drawer body by adding padding and before styles ([link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-f6a8eda750f44f4d1331fb1b29318aed95982b95055ce2430b1c8392a99b2d20L92-R105))
*  Add the affixOffsetTop prop to the dialog and drawer components to set the offset top of the affix elements inside the body when the size is full ([link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bR468-R471), [link](https://github.com/baidu/amis/pull/7535/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L468-R469))
