### PR TITLE
fix: nav图标展示问题、菜单浮层支持指定挂载

### DIFF
--- a/packages/amis-ui/scss/components/_menu.scss
+++ b/packages/amis-ui/scss/components/_menu.scss
@@ -350,6 +350,7 @@
 
   &-submenu-title {
     display: flex;
+    align-items: center;
     justify-content: space-between;
 
     .#{$ns}Nav-Menu-item-wrap {

--- a/packages/amis/__tests__/renderers/Nav.test.tsx
+++ b/packages/amis/__tests__/renderers/Nav.test.tsx
@@ -517,3 +517,181 @@ test('Renderer:Nav with itemActions', async () => {
   expect(container).toMatchSnapshot();
   expect(getByText('编辑')).toBeInTheDocument();
 });
+
+// 8.各种图标展示
+test('Renderer:Nav with icons', async () => {
+  const {container} = render(
+    amisRender(
+      {
+        type: 'page',
+        body: {
+          type: 'nav',
+          stacked: true,
+          links: [
+            {
+              label: 'Nav 1',
+              to: '?cat=1',
+              value: '1',
+              icon: 'fa fa-user',
+              __id: 1
+            },
+            {
+              label: 'Nav 2',
+              __id: 2,
+              unfolded: true,
+              children: [
+                {
+                  __id: 2.1,
+                  label: 'Nav 2-1',
+                  icon: [
+                    {
+                      icon: 'star',
+                      position: 'before'
+                    },
+                    {
+                      icon: 'search',
+                      position: 'before'
+                    },
+                    {
+                      icon: 'https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg',
+                      position: 'after'
+                    }
+                  ],
+                  children: [
+                    {
+                      label: 'Nav 2-1-1',
+                      to: '?cat=2-1',
+                      value: '2-1',
+                      __id: 2.11
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {},
+      makeEnv({})
+    )
+  );
+  expect(container).toMatchSnapshot();
+  expect(container.querySelectorAll('.fa-user').length).toBe(1);
+  expect(container.querySelectorAll('[icon=search]').length).toBe(1);
+  expect(container.querySelectorAll('img').length).toBe(1);
+});
+
+// 9.Nav在Dialog里
+test('Renderer:Nav with Dialog', async () => {
+  const {container, getByText} = render(
+    amisRender(
+      {
+        type: 'page',
+        body: {
+          type: 'button',
+          label: '点击弹框',
+          actionType: 'dialog',
+          dialog: {
+            title: '弹框',
+            body: [
+              {
+                type: 'nav',
+                stacked: true,
+                className: 'w-md',
+                draggable: true,
+                saveOrderApi: '/api/options/nav',
+                source: '/api/options/nav?parentId=${value}',
+                itemActions: [
+                  {
+                    type: 'icon',
+                    icon: 'cloud',
+                    visibleOn: "this.to === '?cat=1'"
+                  },
+                  {
+                    type: 'dropdown-button',
+                    level: 'link',
+                    icon: 'fa fa-ellipsis-h',
+                    hideCaret: true,
+                    buttons: [
+                      {
+                        type: 'button',
+                        label: '编辑'
+                      },
+                      {
+                        type: 'button',
+                        label: '删除'
+                      }
+                    ]
+                  }
+                ],
+                links: [
+                  {
+                    label: 'Nav 1',
+                    to: '?cat=1',
+                    value: '1',
+                    icon: 'fa fa-user',
+                    __id: 1
+                  },
+                  {
+                    label: 'Nav 2',
+                    __id: 2,
+                    unfolded: true,
+                    children: [
+                      {
+                        __id: 2.1,
+                        label: 'Nav 2-1',
+                        children: [
+                          {
+                            label: 'Nav 2-1-1',
+                            to: '?cat=2-1',
+                            value: '2-1',
+                            __id: 2.11
+                          }
+                        ]
+                      },
+                      {
+                        label: 'Nav 2-2',
+                        to: '?cat=2-2',
+                        value: '2-2',
+                        __id: 2.2
+                      }
+                    ]
+                  },
+                  {
+                    label: 'Nav 3',
+                    to: '?cat=3',
+                    value: '3',
+                    defer: true,
+                    __id: 3
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {},
+      makeEnv({
+        getModalContainer: () => container
+      })
+    )
+  );
+  expect(container).toMatchSnapshot();
+
+  fireEvent.click(getByText('点击弹框'));
+  await waitFor(() => {
+    expect(container.querySelector('[role="dialog"]')).toBeInTheDocument();
+  });
+
+  fireEvent.click(
+    container.querySelector(
+      '[role="dialog"] .cxd-Nav-Menu-item-extra .cxd-Button'
+    )!
+  );
+
+  await waitFor(() => {
+    expect(
+      container.querySelector('[role="dialog"] .cxd-PopOver')
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/amis/__tests__/renderers/__snapshots__/Nav.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Nav.test.tsx.snap
@@ -208,6 +208,228 @@ exports[`Renderer:Nav 1`] = `
 </div>
 `;
 
+exports[`Renderer:Nav with Dialog 1`] = `
+<div>
+  <div
+    class="cxd-Page"
+  >
+    <div
+      class="cxd-Page-content"
+    >
+      <div
+        class="cxd-Page-main"
+      >
+        <div
+          class="cxd-Page-body"
+          role="page-body"
+        >
+          <button
+            class="cxd-Button cxd-Button--default cxd-Button--size-default"
+            type="button"
+          >
+            <span>
+              点击弹框
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Renderer:Nav with icons 1`] = `
+<div>
+  <div
+    class="cxd-Page"
+  >
+    <div
+      class="cxd-Page-content"
+    >
+      <div
+        class="cxd-Page-main"
+      >
+        <div
+          class="cxd-Page-body"
+          role="page-body"
+        >
+          <div
+            class="cxd-Nav"
+          >
+            <ul
+              class="cxd-Nav-Menu cxd-Nav-Menu-root cxd-Nav-Menu-inline cxd-Nav-Menu-ltr cxd-Nav-Menu-light cxd-Nav-Menu-expand-before"
+              data-menu-list="true"
+              dir="ltr"
+              role="menu"
+              tabindex="0"
+            >
+              <ul
+                class="cxd-Nav-Menu-item-tooltip-wrap"
+                style="order: 0;"
+              >
+                <li
+                  aria-disabled="false"
+                  class="cxd-Nav-Menu-item"
+                  data-menu-id="rc-menu-uuid-test-1"
+                  role="menuitem"
+                  style="padding-left: 16px;"
+                  tabindex="-1"
+                >
+                  <div
+                    class="cxd-Nav-Menu-item-wrap"
+                  >
+                    <a
+                      class="cxd-Nav-Menu-item-link"
+                      data-depth="1"
+                      data-id="1"
+                      title="Nav 1"
+                    >
+                      <i
+                        class="cxd-Nav-Menu-item-icon"
+                      >
+                        <i
+                          class="fa fa-user fa fa-user"
+                        />
+                      </i>
+                      <span
+                        class="cxd-Nav-Menu-item-label"
+                        title="Nav 1"
+                      >
+                        Nav 1
+                      </span>
+                    </a>
+                  </div>
+                </li>
+              </ul>
+              <li
+                class="cxd-Nav-Menu-submenu cxd-Nav-Menu-submenu-inline cxd-Nav-Menu-submenu cxd-Nav-Menu-submenu-open"
+                role="none"
+              >
+                <div
+                  aria-controls="rc-menu-uuid-test-2-popup"
+                  aria-expanded="true"
+                  aria-haspopup="true"
+                  class="cxd-Nav-Menu-submenu-title"
+                  data-menu-id="rc-menu-uuid-test-2"
+                  role="menuitem"
+                  style="padding-left: 16px;"
+                  tabindex="-1"
+                >
+                  <div
+                    class="cxd-Nav-Menu-item-wrap"
+                  >
+                    <a
+                      class="cxd-Nav-Menu-item-link"
+                      data-depth="1"
+                      data-id="2"
+                    >
+                      <span
+                        class="cxd-Nav-Menu-item-label cxd-Nav-Menu-item-label-subTitle"
+                        title="Nav 2"
+                      >
+                        Nav 2
+                      </span>
+                    </a>
+                  </div>
+                  <span
+                    class="cxd-Nav-Menu-submenu-arrow"
+                  >
+                    <icon-mock
+                      classname="icon icon-right-arrow-bold"
+                      icon="right-arrow-bold"
+                    />
+                  </span>
+                </div>
+                <ul
+                  class="cxd-Nav-Menu cxd-Nav-Menu-sub cxd-Nav-Menu-inline"
+                  data-menu-list="true"
+                  id="rc-menu-uuid-test-2-popup"
+                  role="menu"
+                >
+                  <li
+                    class="cxd-Nav-Menu-submenu cxd-Nav-Menu-submenu-inline cxd-Nav-Menu-submenu"
+                    role="none"
+                  >
+                    <div
+                      aria-controls="rc-menu-uuid-test-3-popup"
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      class="cxd-Nav-Menu-submenu-title"
+                      data-menu-id="rc-menu-uuid-test-3"
+                      role="menuitem"
+                      style="padding-left: 32px;"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="cxd-Nav-Menu-item-wrap"
+                      >
+                        <a
+                          class="cxd-Nav-Menu-item-link"
+                          data-depth="2"
+                          data-id="2.1"
+                        >
+                          <i
+                            class="cxd-Nav-Menu-item-icon"
+                          >
+                            <icon-mock
+                              classname="icon-star"
+                              icon="star"
+                            />
+                            <icon-mock
+                              classname="icon-search"
+                              icon="search"
+                            />
+                          </i>
+                          <span
+                            class="cxd-Nav-Menu-item-label cxd-Nav-Menu-item-label-subTitle"
+                            title="Nav 2-1"
+                          >
+                            Nav 2-1
+                          </span>
+                          <i
+                            class="cxd-Nav-Menu-item-icon-after"
+                          >
+                            <img
+                              class="cxd-Icon"
+                              src="https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg"
+                            />
+                          </i>
+                        </a>
+                      </div>
+                      <span
+                        class="cxd-Nav-Menu-submenu-arrow"
+                      >
+                        <icon-mock
+                          classname="icon icon-right-arrow-bold"
+                          icon="right-arrow-bold"
+                        />
+                      </span>
+                    </div>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+            <div
+              aria-hidden="true"
+              style="display: none;"
+            >
+              <ul
+                class="cxd-Nav-Menu-item-tooltip-wrap"
+                style="order: 0;"
+              />
+              <ul
+                class="cxd-Nav-Menu-item-tooltip-wrap"
+                style="order: 0;"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Renderer:Nav with itemActions 1`] = `
 <div>
   <div


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 66d3a3e</samp>

This pull request improves the `Nav` component by adding more icon options, using a better popover container, and simplifying the code. It also updates the `Nav.test.tsx` file with new test cases to cover the new features and scenarios. The changes affect the files `packages/amis/src/renderers/Nav.tsx`, `packages/amis-ui/scss/components/_menu.scss`, and `packages/amis/__tests__/renderers/Nav.test.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 66d3a3e</samp>

> _We're sailing on the web with a `Nav` so fine_
> _It can show us any icon that we can design_
> _We'll test it well and make it fit in any `Dialog`_
> _And heave away, me hearties, heave away with `align`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 66d3a3e</samp>

*  Add support for different types of icons (font-awesome, custom svg, and React element) in the navigation links of the `Nav` component ([link](https://github.com/baidu/amis/pull/7536/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL565-R594),[link](https://github.com/baidu/amis/pull/7536/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL645-R652),[link](https://github.com/baidu/amis/pull/7536/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL657-R665),[link](https://github.com/baidu/amis/pull/7536/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcR353))
*  Add tests for rendering icons and item actions in the `Nav` component, especially inside a `Dialog` component ([link](https://github.com/baidu/amis/pull/7536/files?diff=unified&w=0#diff-ab9cd9fdb0516bcf4e97d55efcfc40824c2a96107a3a1b4fd953fd7b14599aebR520-R697))
*  Use the `generateIcon` function from the `amis-core` package to create icon elements from various sources ([link](https://github.com/baidu/amis/pull/7536/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL28-R28),[link](https://github.com/baidu/amis/pull/7536/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL565-R594))
*  Make the `popOverContainer` prop more type-safe and flexible for the `Nav` component and its subcomponents, and use it to control the popover container for the item actions and the submenus ([link](https://github.com/baidu/amis/pull/7536/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bR317-R320),[link](https://github.com/baidu/amis/pull/7536/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bR552-R553),[link](https://github.com/baidu/amis/pull/7536/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL657-R665),[link](https://github.com/baidu/amis/pull/7536/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL696-R706),[link](https://github.com/baidu/amis/pull/7536/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bR809-R815))
*  Remove the redundant `popOverContainer` property from the `NavigationProps` interface ([link](https://github.com/baidu/amis/pull/7536/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL146-L150))
