### PR TITLE
fix: Service同步数据问题

### DIFF
--- a/packages/amis/src/renderers/Service.tsx
+++ b/packages/amis/src/renderers/Service.tsx
@@ -513,7 +513,7 @@ export default class Service extends React.Component<ServiceProps> {
     // 初始化接口返回的是整个 response，
     // 保存 ajax 请求的时候返回时数据部分。
     const data = result?.hasOwnProperty('ok') ? result.data ?? {} : result;
-    const {onBulkChange, dispatchEvent, store} = this.props;
+    const {onBulkChange, dispatchEvent, store, formStore} = this.props;
 
     dispatchEvent?.(
       'fetchInited',
@@ -527,7 +527,7 @@ export default class Service extends React.Component<ServiceProps> {
       })
     );
 
-    if (!isEmpty(data) && onBulkChange) {
+    if (!isEmpty(data) && onBulkChange && formStore) {
       onBulkChange(data);
     }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 272e0cc</samp>

Added `formStore` prop to `Service` component to enable parent form data update. Modified `Service` component logic to use the ajax response to update the `formStore` data.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 272e0cc</samp>

> _To update the parent form data_
> _The `Service` component had a great idea_
> _It added a prop called `formStore`_
> _To access and modify the form core_
> _And used ajax to fetch the data_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 272e0cc</samp>

*  Add `formStore` prop to `Service` component to access and update parent form data ([link](https://github.com/baidu/amis/pull/7538/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852L516-R516), [link](https://github.com/baidu/amis/pull/7538/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852L530-R530))
*  Use `formStore` prop to check if parent form is mounted before calling `onBulkChange` prop function ([link](https://github.com/baidu/amis/pull/7538/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852L530-R530))
