### PR TITLE
chore: 修复文档中的裂图

### DIFF
--- a/docs/zh-CN/components/avatar.md
+++ b/docs/zh-CN/components/avatar.md
@@ -15,7 +15,7 @@ order: 27
 ```schema: scope="body"
 {
   "type": "avatar",
-  "src": "https://suda.cdn.bcebos.com/images/amis/ai-fake-face.jpg"
+  "src": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
 }
 ```
 
@@ -44,6 +44,7 @@ order: 27
 ## 动态图片或文字
 
 src、text 都支持变量，可以从上下文中动态获取图片或文字，下面的例子中：
+
 - 第一个获取到了，显示正常
 - 第二个没获取到，因此降级为显示 icon
 - 第三个图片没获取到，由于 text 优先级比 icon 高，所以显示 text
@@ -51,7 +52,7 @@ src、text 都支持变量，可以从上下文中动态获取图片或文字，
 ```schema
 {
   "data": {
-    "myAvatar": "https://suda.cdn.bcebos.com/images/amis/ai-fake-face.jpg"
+    "myAvatar": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
   },
   "type": "page",
   "body": [
@@ -122,16 +123,16 @@ src、text 都支持变量，可以从上下文中动态获取图片或文字，
   {
     "type": "avatar",
     "size": 60,
-    "src": "https://suda.cdn.bcebos.com/images/amis/ai-fake-face.jpg"
+    "src": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
   },
   {
     "type": "avatar",
-    "src": "https://suda.cdn.bcebos.com/images/amis/ai-fake-face.jpg"
+    "src": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
   },
   {
     "type": "avatar",
     "size": 20,
-    "src": "https://suda.cdn.bcebos.com/images/amis/ai-fake-face.jpg"
+    "src": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
   },
 ]
 
@@ -213,6 +214,7 @@ src、text 都支持变量，可以从上下文中动态获取图片或文字，
 ```
 
 ## 图片加载失败后，通过 onError 控制是否进行 text、icon 置换
+
 > 如果同时存在 text 和 icon，会优先用 text、接着 icon
 
 ```schema: scope="body"
@@ -241,18 +243,18 @@ src、text 都支持变量，可以从上下文中动态获取图片或文字，
 
 ## 属性表
 
-| 属性名    | 类型     | 默认值 | 说明                  |
-| --------- | ----------- | ------ | --------------------- |
-| className | `string`    |        | 外层 dom 的类名       |
-| style     | `object`    |        | 外层 dom 的样式       |
-| fit       |`'contain'` \| `'cover'` \| `'fill'` \| `'none'` \| `'scale-down'`    | `'cover'`  | 具体细节可以参考 MDN [文档](https://developer.mozilla.org/zh-CN/docs/Web/CSS/object-fit)          |
-| src       | `string`    |        | 图片地址              |
-| text      | `string`    |        | 文字                  |
-| icon      | `string`    | `'fa fa-user'` | 图标                  |
-| shape     | `'circle'` \| `'square'` \| `'rounded'` | `'circle'` | 形状，有三种 `'circle'` （圆形）、`'square'`（正方形）、`'rounded'`（圆角） |
-| size      | `number` \| `'default'` \| `'normal'` \| `'small'` | `'default'` | `'default' \| 'normal' \| 'small'`三种字符串类型代表不同大小（分别是48、40、32），也可以直接数字表示 |
-| gap       | `number`    |   4    | 控制字符类型距离左右两侧边界单位像素 |
-| alt       | `number`    |        | 图像无法显示时的替代文本 |
-| draggable | `boolean`   |        | 图片是否允许拖动 |
-| crossOrigin | `'anonymous'` \| `'use-credentials'` \| `''`   |    | 图片的 `CORS` 属性设置 |
-| onError   | `string`  |       | 图片加载失败的字符串，这个字符串是一个New Function内部执行的字符串，参数是event（使用event.nativeEvent获取原生dom事件），这个字符串需要返回boolean值。设置 `"return ture;"` 会在图片加载失败后，使用 `text` 或者 `icon` 代表的信息来进行替换。目前图片加载失败默认是不进行置换。注意：图片加载失败，不包括$获取数据为空情况 |
+| 属性名      | 类型                                                               | 默认值         | 说明                                                                                                                                                                                                                                                                                                                                 |
+| ----------- | ------------------------------------------------------------------ | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| className   | `string`                                                           |                | 外层 dom 的类名                                                                                                                                                                                                                                                                                                                      |
+| style       | `object`                                                           |                | 外层 dom 的样式                                                                                                                                                                                                                                                                                                                      |
+| fit         | `'contain'` \| `'cover'` \| `'fill'` \| `'none'` \| `'scale-down'` | `'cover'`      | 具体细节可以参考 MDN [文档](https://developer.mozilla.org/zh-CN/docs/Web/CSS/object-fit)                                                                                                                                                                                                                                             |
+| src         | `string`                                                           |                | 图片地址                                                                                                                                                                                                                                                                                                                             |
+| text        | `string`                                                           |                | 文字                                                                                                                                                                                                                                                                                                                                 |
+| icon        | `string`                                                           | `'fa fa-user'` | 图标                                                                                                                                                                                                                                                                                                                                 |
+| shape       | `'circle'` \| `'square'` \| `'rounded'`                            | `'circle'`     | 形状，有三种 `'circle'` （圆形）、`'square'`（正方形）、`'rounded'`（圆角）                                                                                                                                                                                                                                                          |
+| size        | `number` \| `'default'` \| `'normal'` \| `'small'`                 | `'default'`    | `'default' \| 'normal' \| 'small'`三种字符串类型代表不同大小（分别是 48、40、32），也可以直接数字表示                                                                                                                                                                                                                                |
+| gap         | `number`                                                           | 4              | 控制字符类型距离左右两侧边界单位像素                                                                                                                                                                                                                                                                                                 |
+| alt         | `number`                                                           |                | 图像无法显示时的替代文本                                                                                                                                                                                                                                                                                                             |
+| draggable   | `boolean`                                                          |                | 图片是否允许拖动                                                                                                                                                                                                                                                                                                                     |
+| crossOrigin | `'anonymous'` \| `'use-credentials'` \| `''`                       |                | 图片的 `CORS` 属性设置                                                                                                                                                                                                                                                                                                               |
+| onError     | `string`                                                           |                | 图片加载失败的字符串，这个字符串是一个 New Function 内部执行的字符串，参数是 event（使用 event.nativeEvent 获取原生 dom 事件），这个字符串需要返回 boolean 值。设置 `"return ture;"` 会在图片加载失败后，使用 `text` 或者 `icon` 代表的信息来进行替换。目前图片加载失败默认是不进行置换。注意：图片加载失败，不包括$获取数据为空情况 |

--- a/docs/zh-CN/components/carousel.md
+++ b/docs/zh-CN/components/carousel.md
@@ -26,7 +26,7 @@ order: 33
         },
         {
             "thumbMode": "contain",
-            "image": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg"
+            "image": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
         }
     ]
 }
@@ -187,7 +187,7 @@ itemSchema: {
     },
     {
       "thumbMode": "contain",
-      "image": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg"
+      "image": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
     }
   ],
   "onEvent": {
@@ -250,7 +250,7 @@ itemSchema: {
       },
       {
         "thumbMode": "contain",
-        "image": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg"
+        "image": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
       }
     ]
   }
@@ -292,7 +292,7 @@ itemSchema: {
       },
       {
         "thumbMode": "contain",
-        "image": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg"
+        "image": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
       }
     ]
   }
@@ -337,7 +337,7 @@ itemSchema: {
       },
       {
         "thumbMode": "contain",
-        "image": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg"
+        "image": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
       }
     ]
   }

--- a/docs/zh-CN/components/form/list-select.md
+++ b/docs/zh-CN/components/form/list-select.md
@@ -52,22 +52,22 @@ ListSelect 一般用来实现选择，可以单选也可以多选，和 Radio/Ch
           {
             "label": "OptionA",
             "value": "a",
-            "image": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg"
+            "image": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
           },
           {
             "label": "OptionB",
             "value": "b",
-            "image": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg"
+            "image": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
           },
           {
             "label": "OptionC",
             "value": "c",
-            "image": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg"
+            "image": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
           },
           {
             "label": "OptionD",
             "value": "d",
-            "image": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg"
+            "image": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
           }
         ]
       }

--- a/docs/zh-CN/components/form/static.md
+++ b/docs/zh-CN/components/form/static.md
@@ -94,7 +94,7 @@ order: 52
     "type": "form",
     "data": {
         "id": 1,
-        "image": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg",
+        "image": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg",
         "images": [
             {
                 "image": "https://internal-amis-res.cdn.bcebos.com/images/2020-1/1578395692722/4f3cb4202335.jpeg@s_0,w_216,l_1,f_jpg,q_80",

--- a/docs/zh-CN/components/office-viewer.md
+++ b/docs/zh-CN/components/office-viewer.md
@@ -259,7 +259,7 @@ Word 渲染支持以下功能：
     {
       "type": "input-text",
       "name": "img",
-      "value": "https://suda.cdn.bcebos.com/images/amis/ai-fake-face.jpg",
+      "value": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg",
       "label": "图片地址"
     },
     {

--- a/docs/zh-CN/components/table.md
+++ b/docs/zh-CN/components/table.md
@@ -118,7 +118,7 @@ order: 67
                 "audio": "https://news-bos.cdn.bcebos.com/mvideo/%E7%9A%87%E5%90%8E%E5%A4%A7%E9%81%93%E4%B8%9C.aac",
                 "carousel": [
                     {
-                        "image": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg"
+                        "image": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
                     },
                     {
                         "html": "<div style=\"width: 100%; height: 200px; background: #e3e3e3; text-align: center; line-height: 200px;\">carousel data in crud</div>"
@@ -128,7 +128,7 @@ order: 67
                     }
                 ],
                 "date": 1591270438,
-                "image": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg",
+                "image": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg",
                 "json": {
                     "id": 1,
                     "text": "text"
@@ -185,7 +185,7 @@ order: 67
                 "audio": "https://news-bos.cdn.bcebos.com/mvideo/%E7%9A%87%E5%90%8E%E5%A4%A7%E9%81%93%E4%B8%9C.aac",
                 "carousel": [
                     {
-                        "image": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg"
+                        "image": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
                     },
                     {
                         "html": "<div style=\"width: 100%; height: 200px; background: #e3e3e3; text-align: center; line-height: 200px;\">carousel data in crud</div>"
@@ -195,7 +195,7 @@ order: 67
                     }
                 ],
                 "date": 1591270438,
-                "image": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg",
+                "image": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg",
                 "json": {
                     "id": 1,
                     "text": "text"
@@ -244,7 +244,7 @@ order: 67
                 "audio": "https://news-bos.cdn.bcebos.com/mvideo/%E7%9A%87%E5%90%8E%E5%A4%A7%E9%81%93%E4%B8%9C.aac",
                 "carousel": [
                     {
-                        "image": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg"
+                        "image": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
                     },
                     {
                         "html": "<div style=\"width: 100%; height: 200px; background: #e3e3e3; text-align: center; line-height: 200px;\">carousel data in crud</div>"
@@ -254,7 +254,7 @@ order: 67
                     }
                 ],
                 "date": 1591270438,
-                "image": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg",
+                "image": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg",
                 "json": {
                     "id": 1,
                     "text": "text"

--- a/examples/components/EventAction/cmpt-event-action/CarouselEvent.jsx
+++ b/examples/components/EventAction/cmpt-event-action/CarouselEvent.jsx
@@ -74,8 +74,7 @@ export default {
         },
         {
           thumbMode: 'contain',
-          image:
-            'https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg'
+          image: 'https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg'
         }
       ],
       onEvent: {

--- a/mock/cfc/mock/crud/list.js
+++ b/mock/cfc/mock/crud/list.js
@@ -33,8 +33,7 @@ module.exports = function (req, res) {
           'https://news-bos.cdn.bcebos.com/mvideo/%E7%9A%87%E5%90%8E%E5%A4%A7%E9%81%93%E4%B8%9C.aac',
         carousel: [
           {
-            image:
-              'https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg'
+            image: 'https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg'
           },
           {
             html: '<div style="width: 100%; height: 200px; background: #e3e3e3; text-align: center; line-height: 200px;">carousel data in crud</div>'
@@ -45,8 +44,7 @@ module.exports = function (req, res) {
           }
         ],
         date: Math.round(Date.now() / 1000),
-        image:
-          'https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg'
+        image: 'https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg'
       }),
       parseInt(req.query.perPage, 10) || 10
     )

--- a/mock/cfc/mock/options/carousel.js
+++ b/mock/cfc/mock/options/carousel.js
@@ -6,17 +6,15 @@ module.exports = function (req, res) {
       imageList: [
         {
           image:
-            'https://internal-amis-res.cdn.bcebos.com/images/2019-12/1577157239810/da6376bf988c.png',
+            'https://internal-amis-res.cdn.bcebos.com/images/2019-12/1577157239810/da6376bf988c.png'
         },
         {
-          html:
-            '<div style="width: 100%; height: 300px; background: #e3e3e3; text-align: center; line-height: 300px;">carousel data</div>',
+          html: '<div style="width: 100%; height: 300px; background: #e3e3e3; text-align: center; line-height: 300px;">carousel data</div>'
         },
         {
-          image:
-            'https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg',
-        },
-      ],
-    },
+          image: 'https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg'
+        }
+      ]
+    }
   });
 };

--- a/mock/cfc/mock/service/data.js
+++ b/mock/cfc/mock/service/data.js
@@ -32,8 +32,7 @@ module.exports = function (req, res) {
           Math.round(Math.random() * 10)
         ),
         date: Math.round(Date.now() / 1000),
-        image:
-          'https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg'
+        image: 'https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg'
       })),
 
       table2: repeat(() => ({
@@ -50,8 +49,7 @@ module.exports = function (req, res) {
           Math.round(Math.random() * 10)
         ),
         date: Math.round(Date.now() / 1000),
-        image:
-          'https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg'
+        image: 'https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg'
       }))
     }
   });

--- a/mock/cfc/mock/upload/image.json
+++ b/mock/cfc/mock/upload/image.json
@@ -1,5 +1,5 @@
 {
   "status": 0,
   "msg": "ok",
-  "link": "https://ss0.bdstatic.com/70cFvHSh_Q1YnxGkpoWK1HF6hhy/it/u=3893101144,2877209892&fm=23&gp=0.jpg"
+  "link": "https://suda.cdn.bcebos.com/amis/images/alice-macaw.jpg"
 }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a6fcd1</samp>

This pull request updates various image sources in the documentation and mock data of the `amis` repository. The purpose is to make the images more consistent, relevant, and appealing for the readers and users of the `amis` framework. The affected files include component documentation files, mock data files, and example files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4a6fcd1</samp>

> _We're updating the docs with new images, me hearties_
> _To make them look better and match the `amis` theme_
> _So heave away, haul away, on the count of three_
> _And we'll have a fine pull request for all to see_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4a6fcd1</samp>

* Updated the image sources for the avatar, carousel, list-select, static, office-viewer, and table components in the documentation to match the theme ([link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-3fc0346e31b663c03e5dd0679141ecae7fc655f53d879aabcd03baa80dea988bL18-R18), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-3fc0346e31b663c03e5dd0679141ecae7fc655f53d879aabcd03baa80dea988bL54-R55), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-3fc0346e31b663c03e5dd0679141ecae7fc655f53d879aabcd03baa80dea988bL125-R135), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-2e8378c0be80440fd6ae4b0b98923b348876a93eec05aaae098ce834711de584L29-R29), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-2e8378c0be80440fd6ae4b0b98923b348876a93eec05aaae098ce834711de584L190-R190), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-2e8378c0be80440fd6ae4b0b98923b348876a93eec05aaae098ce834711de584L253-R253), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-2e8378c0be80440fd6ae4b0b98923b348876a93eec05aaae098ce834711de584L295-R295), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-2e8378c0be80440fd6ae4b0b98923b348876a93eec05aaae098ce834711de584L340-R340), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-9d521de9e33d63e5cab83159dbd9c439dea516fe8fa77a24d8697364ca0da921L55-R70), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-b1c018dbf8e9f8b5bd7acea3f61c09734ac3573d1329b64c1056f13b6e8c39b4L97-R97), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-bcf5de93671200d49c562ca30d13534dc98e46602e365f2330530284c704727fL262-R262), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-8a30381c7717a1ae36bd67d653324e6d01991200c0a2f1a0124f1e753d0cf380L121-R121), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-8a30381c7717a1ae36bd67d653324e6d01991200c0a2f1a0124f1e753d0cf380L131-R131), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-8a30381c7717a1ae36bd67d653324e6d01991200c0a2f1a0124f1e753d0cf380L188-R188), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-8a30381c7717a1ae36bd67d653324e6d01991200c0a2f1a0124f1e753d0cf380L198-R198), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-8a30381c7717a1ae36bd67d653324e6d01991200c0a2f1a0124f1e753d0cf380L247-R247), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-8a30381c7717a1ae36bd67d653324e6d01991200c0a2f1a0124f1e753d0cf380L257-R257))
* Reformatted the attribute table for the avatar component in `docs/zh-CN/components/avatar.md` to align the columns and add spaces between the Chinese and English words ([link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-3fc0346e31b663c03e5dd0679141ecae7fc655f53d879aabcd03baa80dea988bL244-R260))
* Added blank lines to separate the sections for the avatar component in `docs/zh-CN/components/avatar.md` ([link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-3fc0346e31b663c03e5dd0679141ecae7fc655f53d879aabcd03baa80dea988bR47), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-3fc0346e31b663c03e5dd0679141ecae7fc655f53d879aabcd03baa80dea988bR217))
* Updated the image sources for the carousel event example in `examples/components/EventAction/cmpt-event-action/CarouselEvent.jsx` to match the theme ([link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-127be2a4dbc0af555ffd613da8a87e1ddedc987c5ea292836f88310cccf42487L77-R77))
* Updated the image sources for the mock data for the crud list, carousel options, service data, and image upload in the `mock/cfc/mock` folder to match the theme ([link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-504c157855af60f09c06c0057dc6e50766fa216b323c69ba593595b6ad6ecddeL36-R36), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-504c157855af60f09c06c0057dc6e50766fa216b323c69ba593595b6ad6ecddeL48-R47), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-9a875da7163e2fa6dfd68eb8ca36f63249faabcb307f27498c26210621c5be1eL9-R18), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-8b1451999dbf38bdd0085899a513bc83a0069d960c631c688a85cd6963f6d705L35-R35), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-8b1451999dbf38bdd0085899a513bc83a0069d960c631c688a85cd6963f6d705L53-R52), [link](https://github.com/baidu/amis/pull/7545/files?diff=unified&w=0#diff-8d6cf454f7f0e918bb3c486bc0f4546dc3462e016adee31556a488ef77c0e84dL4-R4))
