### PR TITLE
chore: 返还到 react 16 的语法

### DIFF
--- a/packages/amis-core/src/utils/debug.tsx
+++ b/packages/amis-core/src/utils/debug.tsx
@@ -5,7 +5,7 @@
 import React, {Component, useEffect, useRef, useState, version} from 'react';
 import cx from 'classnames';
 import {findDOMNode, render, unmountComponentAtNode} from 'react-dom';
-import {createRoot} from 'react-dom/client';
+// import {createRoot} from 'react-dom/client';
 import {autorun, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import {uuidv4} from './helper';
@@ -383,20 +383,20 @@ export function enableDebug() {
   document.body.appendChild(amisDebugElement);
   const element = <AMISDebug store={store} />;
 
-  if (parseInt(version.split('.')[0], 10) >= 18) {
-    const root = createRoot(amisDebugElement);
-    root.render(element);
-    unmount = () => {
-      root.unmount();
-      document.body.removeChild(amisDebugElement);
-    };
-  } else {
-    render(element, amisDebugElement);
-    unmount = () => {
-      unmountComponentAtNode(amisDebugElement);
-      document.body.removeChild(amisDebugElement);
-    };
-  }
+  // if (parseInt(version.split('.')[0], 10) >= 18) {
+  //   const root = createRoot(amisDebugElement);
+  //   root.render(element);
+  //   unmount = () => {
+  //     root.unmount();
+  //     document.body.removeChild(amisDebugElement);
+  //   };
+  // } else {
+  render(element, amisDebugElement);
+  unmount = () => {
+    unmountComponentAtNode(amisDebugElement);
+    document.body.removeChild(amisDebugElement);
+  };
+  // }
 
   document.body.appendChild(amisHoverBox);
   document.body.appendChild(amisActiveBox);

--- a/packages/amis-ui/src/components/Alert.tsx
+++ b/packages/amis-ui/src/components/Alert.tsx
@@ -11,7 +11,7 @@ import {ClassNamesFn, themeable, ThemeProps} from 'amis-core';
 import {LocaleProps, localeable} from 'amis-core';
 import Html from './Html';
 import type {PlainObject} from 'amis-core';
-import {createRoot} from 'react-dom/client';
+// import {createRoot} from 'react-dom/client';
 export interface AlertProps extends ThemeProps, LocaleProps {
   container?: any;
   confirmText?: string;
@@ -60,14 +60,14 @@ export class Alert extends React.Component<AlertProps, AlertState> {
       const div = document.createElement('div');
       container.appendChild(div);
 
-      if (parseInt(version.split('.')[0], 10) >= 18) {
-        const root = createRoot(div);
-        await new Promise<void>(resolve =>
-          root.render(<FinnalAlert ref={() => resolve()} />)
-        );
-      } else {
-        render(<FinnalAlert />, div);
-      }
+      // if (parseInt(version.split('.')[0], 10) >= 18) {
+      //   const root = createRoot(div);
+      //   await new Promise<void>(resolve =>
+      //     root.render(<FinnalAlert ref={() => resolve()} />)
+      //   );
+      // } else {
+      render(<FinnalAlert />, div);
+      // }
     }
 
     return Alert.instance;

--- a/packages/amis-ui/src/components/ContextMenu.tsx
+++ b/packages/amis-ui/src/components/ContextMenu.tsx
@@ -7,7 +7,7 @@ import Transition, {
   ENTERING,
   EXITING
 } from 'react-transition-group/Transition';
-import {createRoot} from 'react-dom/client';
+// import {createRoot} from 'react-dom/client';
 const fadeStyles: {
   [propName: string]: string;
 } = {
@@ -56,14 +56,14 @@ export class ContextMenu extends React.Component<
       const div = document.createElement('div');
       container.appendChild(div);
 
-      if (parseInt(version.split('.')[0], 10) >= 18) {
-        const root = createRoot(div);
-        await new Promise<void>(resolve =>
-          root.render(<ThemedContextMenu ref={() => resolve()} />)
-        );
-      } else {
-        render(<ThemedContextMenu />, div);
-      }
+      // if (parseInt(version.split('.')[0], 10) >= 18) {
+      //   const root = createRoot(div);
+      //   await new Promise<void>(resolve =>
+      //     root.render(<ThemedContextMenu ref={() => resolve()} />)
+      //   );
+      // } else {
+      render(<ThemedContextMenu />, div);
+      // }
     }
 
     return ContextMenu.instance;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at af7da3d</samp>

Removed the use of `createRoot` from several AMIS components to fix compatibility issues with React 16. Replaced it with `render` in `debug.tsx`, `Alert.tsx`, and `ContextMenu.tsx`. Simplified the mounting logic of some components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at af7da3d</samp>

> _`createRoot` is the source of our pain_
> _We must renounce its evil reign_
> _With `render` we will rise again_
> _And break the chains of React 16_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at af7da3d</samp>

*  Remove the usage of `createRoot` from `react-dom/client` in three components: `AMISDebug`, `Alert`, and `ContextMenu`, because it is incompatible with React 16 and causes errors ([link](https://github.com/baidu/amis/pull/7546/files?diff=unified&w=0#diff-267ff9b13396c5c999812bf56a8daa603837b2764942c35a0c077b53692bf177L8-R8), [link](https://github.com/baidu/amis/pull/7546/files?diff=unified&w=0#diff-267ff9b13396c5c999812bf56a8daa603837b2764942c35a0c077b53692bf177L386-R399), [link](https://github.com/baidu/amis/pull/7546/files?diff=unified&w=0#diff-2acdd4d7456e360c65cda3ac871a7516411e2d90f43aab161418272388cc45fdL14-R14), [link](https://github.com/baidu/amis/pull/7546/files?diff=unified&w=0#diff-2acdd4d7456e360c65cda3ac871a7516411e2d90f43aab161418272388cc45fdL63-R70), [link](https://github.com/baidu/amis/pull/7546/files?diff=unified&w=0#diff-aac8cfd184853a8924093dd047a9f55d4030711c6bb72cb5572071db78697e41L10-R10), [link](https://github.com/baidu/amis/pull/7546/files?diff=unified&w=0#diff-aac8cfd184853a8924093dd047a9f55d4030711c6bb72cb5572071db78697e41L59-R66))
*  Use `render` instead of `createRoot` to mount the components in `debug.tsx`, `Alert.tsx`, and `ContextMenu.tsx` ([link](https://github.com/baidu/amis/pull/7546/files?diff=unified&w=0#diff-267ff9b13396c5c999812bf56a8daa603837b2764942c35a0c077b53692bf177L386-R399), [link](https://github.com/baidu/amis/pull/7546/files?diff=unified&w=0#diff-2acdd4d7456e360c65cda3ac871a7516411e2d90f43aab161418272388cc45fdL63-R70), [link](https://github.com/baidu/amis/pull/7546/files?diff=unified&w=0#diff-aac8cfd184853a8924093dd047a9f55d4030711c6bb72cb5572071db78697e41L59-R66))
