### PR TITLE
chore: form 获取表单项应该排除子表单项内部的

### DIFF
--- a/packages/amis-core/src/store/form.ts
+++ b/packages/amis-core/src/store/form.ts
@@ -51,7 +51,9 @@ export const FormStore = ServiceStore.named('FormStore')
 
         if (current.storeType === 'FormItemStore') {
           formItems.push(current);
-        } else {
+        } else if (
+          !['ComboStore', 'TableStore', 'FormStore'].includes(current.storeType)
+        ) {
           pool.push(...current.children);
         }
       }
@@ -68,33 +70,10 @@ export const FormStore = ServiceStore.named('FormStore')
         return getItems();
       },
 
-      /**
-       * 相对于 items(), 只收集直接子formItem
-       * 避免 子form 表单项的重复验证
-       */
-      get directItems() {
-        const formItems: Array<IFormItemStore> = [];
-
-        // 查找孩子节点中是 formItem 的表单项
-        const pool = self.children.concat();
-        while (pool.length) {
-          const current = pool.shift()!;
-          if (current.storeType === 'FormItemStore') {
-            formItems.push(current);
-          } else if (
-            !['ComboStore', 'TableStore'].includes(current.storeType)
-          ) {
-            pool.push(...current.children);
-          }
-        }
-
-        return formItems;
-      },
-
       /** 获取InputGroup的子元素 */
       get inputGroupItems() {
         const formItems: Record<string, IFormItemStore[]> = {};
-        const children: Array<any> = this.directItems.concat();
+        const children: Array<any> = this.items.concat();
 
         while (children.length) {
           const current = children.shift();
@@ -578,7 +557,7 @@ export const FormStore = ServiceStore.named('FormStore')
       validateErrCb?: () => void
     ) {
       self.validated = true;
-      const items = self.directItems.concat();
+      const items = self.items.concat();
       for (let i = 0, len = items.length; i < len; i++) {
         let item = items[i] as IFormItemStore;
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b4f8ed</samp>

Fix nested form validation bug and simplify form item collection in `FormStore`. Refactor `form.ts` to avoid redundant calls to `items` getter.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4b4f8ed</samp>

> _`FormStore` excluded_
> _No more double validation_
> _Logic simplified_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4b4f8ed</samp>

*  Exclude `FormStore` from the pool of children to be pushed in the `getItems` function to fix a bug that causes nested forms to be validated twice and trigger unnecessary requests ([link](https://github.com/baidu/amis/pull/7549/files?diff=unified&w=0#diff-c8aefd7686b13cf0a0b440b598f20cc50e9abac39fcd9281de29dc6e9d3b358eL54-R56))
* Replace the `directItems` getter with the `items` getter in the `inputGroupItems` and `validate` functions to simplify the logic and avoid duplication or inconsistency of code ([link](https://github.com/baidu/amis/pull/7549/files?diff=unified&w=0#diff-c8aefd7686b13cf0a0b440b598f20cc50e9abac39fcd9281de29dc6e9d3b358eL71-R76), [link](https://github.com/baidu/amis/pull/7549/files?diff=unified&w=0#diff-c8aefd7686b13cf0a0b440b598f20cc50e9abac39fcd9281de29dc6e9d3b358eL581-R560))
