### PR TITLE
fix(amis-editor): MatrixCheckboxes多选属性配置错误问题

### DIFF
--- a/packages/amis-editor/src/plugin/Form/MatrixCheckboxes.tsx
+++ b/packages/amis-editor/src/plugin/Form/MatrixCheckboxes.tsx
@@ -1,16 +1,15 @@
-import {defaultValue, getSchemaTpl} from 'amis-editor-core';
-import {registerEditorPlugin} from 'amis-editor-core';
 import {
+  registerEditorPlugin,
   BasePlugin,
-  BasicSubRenderInfo,
-  RendererEventContext,
-  SubRendererInfo,
   BaseEventContext,
-  tipedLabel
+  RendererPluginAction,
+  RendererPluginEvent,
+  tipedLabel,
+  defaultValue,
+  getSchemaTpl
 } from 'amis-editor-core';
 import {ValidatorTag} from '../../validator';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
-import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 
 export class MatrixControlPlugin extends BasePlugin {
   static id = 'MatrixControlPlugin';
@@ -127,8 +126,9 @@ export class MatrixControlPlugin extends BasePlugin {
                 required: true
               }),
               getSchemaTpl('label'),
-              getSchemaTpl('multiple', {
-                value: true
+              getSchemaTpl('switch', {
+                name: 'multiple',
+                label: '可多选'
               }),
               {
                 label: tipedLabel('模式', '行级、列级或者单个单元单选'),
@@ -140,7 +140,7 @@ export class MatrixControlPlugin extends BasePlugin {
                   left: 2,
                   justify: true
                 },
-                visibleOn: '!this.multiple',
+                visibleOn: '!data.multiple',
                 options: [
                   {
                     label: '行级',
@@ -157,37 +157,15 @@ export class MatrixControlPlugin extends BasePlugin {
                 ],
                 pipeIn: defaultValue('column')
               },
-              getSchemaTpl('autoFillApi'),
-              {
-                label: tipedLabel('列全选', '列级全选功能'),
+              getSchemaTpl('switch', {
                 name: 'yCheckAll',
-                type: 'select',
-                options: [
-                  {
-                    label: '是',
-                    value: true
-                  },
-                  {
-                    label: '否',
-                    value: false
-                  }
-                ]
-              },
-              {
-                label: tipedLabel('行全选', '行级全选功能'),
+                label: tipedLabel('列全选', '列级全选功能')
+              }),
+              getSchemaTpl('switch', {
                 name: 'xCheckAll',
-                type: 'select',
-                options: [
-                  {
-                    label: '是',
-                    value: true
-                  },
-                  {
-                    label: '否',
-                    value: false
-                  }
-                ]
-              }
+                label: tipedLabel('行全选', '行级全选功能')
+              }),
+              getSchemaTpl('autoFillApi')
             ]
           },
           {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea1c446</samp>

This pull request enhances the matrix control in the `amis-editor` plugin by using switch components for better visibility and interaction, and by fixing a `visibleOn` bug in the `options` property. The changes affect the file `Form/MatrixCheckboxes.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ea1c446</samp>

> _Matrix control shines_
> _`visibleOn` bug fixed_
> _Switches welcome spring_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ea1c446</samp>

*  Simplify and reorder import statements from `amis-editor-core` package ([link](https://github.com/baidu/amis/pull/7551/files?diff=unified&w=0#diff-612a356269e13018ef69d39bb792b9c55845e6dba8d9660c80f62f44569b1cc7L1-R12))
*  Change `multiple` property of matrix control from hidden field to switch component ([link](https://github.com/baidu/amis/pull/7551/files?diff=unified&w=0#diff-612a356269e13018ef69d39bb792b9c55845e6dba8d9660c80f62f44569b1cc7L130-R131))
*  Fix `visibleOn` condition of `options` property of matrix control to use `data.multiple` ([link](https://github.com/baidu/amis/pull/7551/files?diff=unified&w=0#diff-612a356269e13018ef69d39bb792b9c55845e6dba8d9660c80f62f44569b1cc7L143-R143))
*  Change `yCheckAll` and `xCheckAll` properties of matrix control from select components to switch components ([link](https://github.com/baidu/amis/pull/7551/files?diff=unified&w=0#diff-612a356269e13018ef69d39bb792b9c55845e6dba8d9660c80f62f44569b1cc7L160-R168))
*  Move `autoFillApi` property of matrix control to the end of the group ([link](https://github.com/baidu/amis/pull/7551/files?diff=unified&w=0#diff-612a356269e13018ef69d39bb792b9c55845e6dba8d9660c80f62f44569b1cc7L160-R168))
