### PR TITLE
feat: form 的自动提交支持设置 close 来避免关闭弹框

### DIFF
--- a/docs/zh-CN/components/drawer.md
+++ b/docs/zh-CN/components/drawer.md
@@ -400,6 +400,30 @@ order: 43
 }
 ```
 
+> 3.3.0 及以上版本
+
+如果是表单，可以在表单上配置 `close: false`
+
+```schema: scope="body"
+{
+    "type": "button",
+    "label": "弹个框",
+    "actionType": "drawer",
+    "drawer": {
+      "type": "form",
+      "api": "/api/mock2/form/saveForm",
+      "body": [
+        {
+          "type": "input-text",
+          "name": "name",
+          "label": "姓名"
+        }
+      ],
+      "close": false
+    }
+}
+```
+
 ## 配置弹窗的按钮
 
 默认弹窗会自动生成两个按钮，一个取消，一个确认。如果通过 `actions` 来自定义配置，则以配置的为准。

--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -1019,7 +1019,7 @@ export default class Form extends React.Component<FormProps, object> {
   }
 
   handleFormSubmit(e: React.UIEvent<any>) {
-    const {preventEnterSubmit, onActionSensor} = this.props;
+    const {preventEnterSubmit, onActionSensor, close} = this.props;
 
     e.preventDefault();
     if (preventEnterSubmit) {
@@ -1029,7 +1029,8 @@ export default class Form extends React.Component<FormProps, object> {
     const sensor: any = this.handleAction(
       e,
       {
-        type: 'submit'
+        type: 'submit',
+        close
       },
       this.props.store.data
     );


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6fe03e0</samp>

This pull request adds a feature to the drawer component that allows it to close automatically after a form submission. It also updates the documentation of the drawer component with the new `close` property and an example schema.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6fe03e0</samp>

> _If you want to control when the drawer closes_
> _You can use the `close` prop that it exposes_
> _Just set it to false_
> _In your form action clause_
> _And the drawer will stay open for your purposes_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6fe03e0</samp>

*  Add `close` property to drawer actions to control whether the drawer closes after an action ([link](https://github.com/baidu/amis/pull/7555/files?diff=unified&w=0#diff-b456ae77effbc1656b68be0d0cd4580ba5c90f28c7f0ef02d2827953b93b04ccR403-R426), [link](https://github.com/baidu/amis/pull/7555/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1022-R1022), [link](https://github.com/baidu/amis/pull/7555/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1032-R1033))
