### PR TITLE
fix: 条件组选项触发弹出框后会显示底层其他条件组中select组件的删除按钮

### DIFF
--- a/packages/amis-ui/scss/components/_condition-builder.scss
+++ b/packages/amis-ui/scss/components/_condition-builder.scss
@@ -282,7 +282,7 @@
         padding: 10px;
         margin: -10px 0px;
         background: $white;
-        z-index: 1;
+        z-index: 2;
       }
       > .#{$ns}CBGroupOrItem-dragbar {
         left: px2rem(-5px);

--- a/packages/amis-ui/src/components/condition-builder/GroupOrItem.tsx
+++ b/packages/amis-ui/src/components/condition-builder/GroupOrItem.tsx
@@ -126,6 +126,7 @@ export class CBGroupOrItem extends React.Component<CBGroupOrItemProps> {
                 onDragStart={onDragStart}
                 config={config}
                 fields={fields}
+                formula={formula}
                 value={value as ConditionGroupValue}
                 onChange={this.handleItemChange}
                 fieldClassName={fieldClassName}


### PR DESCRIPTION
修复问题1：Amis组件ConditionBuilder添加《条件组》选项触发弹出框（如日期组件）后会显示底层其他条件组中select组件的删除图标
原因：
- select组件删除图标样式设为 z-index:2
- 条件组件的条件组鼠标悬浮时，原css样式设置为z-index：1

修复问题2：Amis组件ConditionBuilder开启formula后添加条件组《fx》不生效
原因：
未向ConditionGroup传递formula属性
