### PR TITLE
feat: api 的 requestAdaptor 支持拦截请求

### DIFF
--- a/docs/zh-CN/start/getting-started.md
+++ b/docs/zh-CN/start/getting-started.md
@@ -155,6 +155,8 @@ let amisScoped = amis.embed(
     // 另外在 amis 配置项中的 api 也可以配置适配器，针对某个特定接口单独处理。
     //
     // requestAdaptor(api) {
+    //   // 支持异步，可以通过 api.mockResponse 来设置返回结果，跳过真正的请求发送
+    //   // 此功能自定义 fetcher 的话会失效
     //   return api;
     // }
     //

--- a/docs/zh-CN/types/api.md
+++ b/docs/zh-CN/types/api.md
@@ -659,6 +659,7 @@ const schema = {
     url: '/api/mock2/form/saveForm',
     requestAdaptor: function (api, context) {
       console.log(context); // 打印上下文数据
+
       return {
         ...api,
         data: {
@@ -686,6 +687,47 @@ const schema = {
 上面例子中，我们获取暴露的`api`对象中的`data`变量，并且为其添加了一个新的字段`foo`，并且一起返回出去就可以了，这样我们的请求数据体中就会加上我们这个新的字段。
 
 你也可以使用`debugger`自行进行调试。
+
+#### 拦截请求
+
+如果 api 发送适配器中，修改 api 对象，在 api 对象里面放入 `mockReponse` 属性，则会拦截请求发送，amis 内部会直接使用 `mockReponse` 的结果返回。
+
+```js
+const schema = {
+  type: 'form',
+  api: {
+    method: 'post',
+    url: '/api/mock2/form/saveForm',
+    requestAdaptor: function (api, context) {
+      return {
+        // 模拟 http 请求返回
+        mockResponse: {
+          status: 200, // http 返回状态
+          data: {
+            // http 返回结果
+            status: 0, // amis 返回数据的状态
+            data: {
+              name: '模拟返回的值'
+            }
+          }
+        }
+      };
+    }
+  },
+  body: [
+    {
+      type: 'input-text',
+      name: 'name',
+      label: '姓名：'
+    },
+    {
+      name: 'text',
+      type: 'input-email',
+      label: '邮箱：'
+    }
+  ]
+};
+```
 
 ### 配置接收适配器
 

--- a/examples/embed.tsx
+++ b/examples/embed.tsx
@@ -51,12 +51,12 @@ export function embed(
   container.classList.add('amis-scope');
   let scoped = {};
 
-  const requestAdaptor = (config: any) => {
+  const requestAdaptor = async (config: any) => {
     const fn =
       env && typeof env.requestAdaptor === 'function'
         ? env.requestAdaptor.bind()
-        : (config: any) => config;
-    const request = fn(config) || config;
+        : async (config: any) => config;
+    const request = (await fn(config)) || config;
 
     return request;
   };
@@ -189,7 +189,7 @@ export function embed(
       config.method = method;
       config.data = data;
 
-      config = requestAdaptor(config);
+      config = await requestAdaptor(config);
 
       if (method === 'get' && data) {
         config.params = data;
@@ -210,7 +210,9 @@ export function embed(
         return true;
       };
 
-      let response = await axios(config);
+      let response = config.mockResponse
+        ? config.mockResponse
+        : await axios(config);
       response = await attachmentAdpator(response, __);
       response = responseAdaptor(api)(response);
 

--- a/packages/amis-core/src/types.ts
+++ b/packages/amis-core/src/types.ts
@@ -217,6 +217,7 @@ export interface ApiObject extends BaseApiObject {
   operationName?: string;
   body?: PlainObject;
   query?: PlainObject;
+  mockResponse?: PlainObject;
   adaptor?: (
     payload: object,
     response: fetcherResult,

--- a/packages/amis-core/src/utils/api.ts
+++ b/packages/amis-core/src/utils/api.ts
@@ -505,6 +505,12 @@ export function wrapFetcher(
       api.headers['Content-Type'] = 'application/json';
     }
 
+    // 如果发送适配器中设置了 mockResponse
+    // 则直接跳过请求发送
+    if (api.mockResponse) {
+      return wrapAdaptor(Promise.resolve(api.mockResponse) as any, api, data);
+    }
+
     if (!isValidApi(api.url)) {
       throw new Error(`invalid api url:${api.url}`);
     }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0d9ae38</samp>

This pull request adds a new feature to the `api` configuration that allows mocking the response data of an API request using the `mockResponse` property. It also updates the documentation and the test cases to explain and demonstrate this feature. The changes affect the `api.ts`, `types.ts`, `api.test.ts`, and `embed.tsx` files in the `packages/amis-core` and `examples` directories, and the `api.md` and `getting-started.md` files in the `docs/zh-CN` directory.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0d9ae38</samp>

> _Sing, O Muse, of the cunning code that mocks the swift response_
> _Of the `api` object, whose `mockResponse` property holds the key_
> _To test and debug the `fetcher` function, and to adapt the source_
> _And the result of the request, with the `wrapAdaptor` skillfully._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0d9ae38</samp>

*  Add `mockResponse` feature to allow mocking API responses without sending real requests ([link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-cecdf20aaa84e6464093def72aee232955ad9649b13e7187284dfb7176b3cdacR158-R159), [link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-00d0e84a1779e47502d96b34c102949f10dacf775ca91423e751dffbc7ce7683R691-R731), [link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-87941d3a37b91c5deb23aa31d74dd4260118b71257f89262cce39dcac1d5dd2aL213-R215), [link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-9795a06699f88c4c144fccb14b9ddca83b8d9639d2062c27b01495b6b80e7d7dR220), [link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cR508-R513))
  *  Explain how to use `api.mockResponse` in the documentation ([link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-cecdf20aaa84e6464093def72aee232955ad9649b13e7187284dfb7176b3cdacR158-R159))
  *  Document the `拦截请求` feature for the function form of `api` configuration in `docs/zh-CN/types/api.md` ([link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-00d0e84a1779e47502d96b34c102949f10dacf775ca91423e751dffbc7ce7683R691-R731))
  *  Add an empty line to separate the sections in `docs/zh-CN/types/api.md` ([link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-00d0e84a1779e47502d96b34c102949f10dacf775ca91423e751dffbc7ce7683R662))
  *  Modify the `embed` function in `examples/embed.tsx` to support `mockResponse` ([link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-87941d3a37b91c5deb23aa31d74dd4260118b71257f89262cce39dcac1d5dd2aL54-R59), [link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-87941d3a37b91c5deb23aa31d74dd4260118b71257f89262cce39dcac1d5dd2aL192-R192), [link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-87941d3a37b91c5deb23aa31d74dd4260118b71257f89262cce39dcac1d5dd2aL213-R215))
    *  Make the `requestAdaptor` function asynchronous ([link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-87941d3a37b91c5deb23aa31d74dd4260118b71257f89262cce39dcac1d5dd2aL54-R59), [link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-87941d3a37b91c5deb23aa31d74dd4260118b71257f89262cce39dcac1d5dd2aL192-R192))
    *  Return the `mockResponse` value instead of sending the API request with `axios` ([link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-87941d3a37b91c5deb23aa31d74dd4260118b71257f89262cce39dcac1d5dd2aL213-R215))
  *  Add the `mockResponse` property to the `ApiObject` interface in `packages/amis-core/src/types.ts` ([link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-9795a06699f88c4c144fccb14b9ddca83b8d9639d2062c27b01495b6b80e7d7dR220))
  *  Modify the `wrapFetcher` function in `packages/amis-core/src/utils/api.ts` to support `mockResponse` ([link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cR508-R513))
    *  Return the result of the `wrapAdaptor` function with the `mockResponse` value instead of calling the `fetcher` function ([link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cR508-R513))
*  Add test cases to verify the `mockResponse` feature in `packages/amis/__tests__/utils/api.test.ts` ([link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-42dba9595cf16673bf6fe7f237d7cf2ba3647c1fcbcf944118da8961e3460c44L362-R362), [link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-42dba9595cf16673bf6fe7f237d7cf2ba3647c1fcbcf944118da8961e3460c44R432-R511))
  *  Rename the existing test case for `requestAdaptor` to avoid confusion ([link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-42dba9595cf16673bf6fe7f237d7cf2ba3647c1fcbcf944118da8961e3460c44L362-R362))
  *  Add a new test case for `requestAdaptor` with `mockResponse` ([link](https://github.com/baidu/amis/pull/7566/files?diff=unified&w=0#diff-42dba9595cf16673bf6fe7f237d7cf2ba3647c1fcbcf944118da8961e3460c44R432-R511))
