### PR TITLE
fix(amis-editor): chart配置/同时放开api和config配置

### DIFF
--- a/packages/amis-editor/src/plugin/Chart.tsx
+++ b/packages/amis-editor/src/plugin/Chart.tsx
@@ -209,6 +209,7 @@ export class ChartPlugin extends BasePlugin {
               {
                 title: '数据设置',
                 body: [
+                  /*
                   {
                     type: 'select',
                     name: 'chartDataType',
@@ -233,10 +234,10 @@ export class ChartPlugin extends BasePlugin {
                       }
                     ]
                   },
-
+                  */
                   getSchemaTpl('apiControl', {
                     label: '数据接口',
-                    visibleOn: 'chartDataType === "dataApi"',
+                    // visibleOn: 'chartDataType === "dataApi"',
                     description:
                       '接口可以返回echart图表完整配置，或者图表数据，建议返回图表数据映射到 Echarts 配置中'
                   }),
@@ -244,7 +245,8 @@ export class ChartPlugin extends BasePlugin {
                   getSchemaTpl('switch', {
                     label: '初始是否拉取',
                     name: 'initFetch',
-                    visibleOn: 'chartDataType === "dataApi" && data.api',
+                    // visibleOn: 'chartDataType === "dataApi" && data.api',
+                    visibleOn: 'data.api',
                     pipeIn: defaultValue(true)
                   }),
 
@@ -253,13 +255,14 @@ export class ChartPlugin extends BasePlugin {
                     label: '定时刷新间隔',
                     type: 'input-number',
                     step: 500,
-                    visibleOn: 'chartDataType === "dataApi" && data.api',
+                    // visibleOn: 'chartDataType === "dataApi" && data.api',
+                    visibleOn: 'data.api',
                     description: '设置后将自动定时刷新，最小3000, 单位 ms'
                   },
                   {
                     name: 'config',
                     asFormItem: true,
-                    visibleOn: 'chartDataType === "json"',
+                    // visibleOn: 'chartDataType === "json"',
                     component: ChartConfigEditor,
                     // type: 'json-editor',
                     label: tipedLabel(

--- a/packages/amis-editor/src/plugin/Container.tsx
+++ b/packages/amis-editor/src/plugin/Container.tsx
@@ -204,34 +204,30 @@ export class ContainerPlugin extends LayoutBasePlugin {
               // 自由容器不需要 display 相关配置项
               ...(!isFreeContainer ? displayTpl : []),
 
-              isFlexItem
-                ? getSchemaTpl('layout:flex', {
-                    isFlexColumnItem,
-                    label: isFlexColumnItem ? '高度设置' : '宽度设置',
-                    visibleOn:
-                      'data.style && (data.style.position === "static" || data.style.position === "relative")'
-                  })
-                : null,
-              isFlexItem
-                ? getSchemaTpl('layout:flex-grow', {
-                    visibleOn:
-                      'data.style && data.style.flex === "1 1 auto" && (data.style.position === "static" || data.style.position === "relative")'
-                  })
-                : null,
-              isFlexItem
-                ? getSchemaTpl('layout:flex-basis', {
-                    label: isFlexColumnItem ? '弹性高度' : '弹性宽度',
-                    visibleOn:
-                      'data.style && (data.style.position === "static" || data.style.position === "relative") && data.style.flex === "1 1 auto"'
-                  })
-                : null,
-              isFlexItem
-                ? getSchemaTpl('layout:flex-basis', {
-                    label: isFlexColumnItem ? '固定高度' : '固定宽度',
-                    visibleOn:
-                      'data.style && (data.style.position === "static" || data.style.position === "relative") && data.style.flex === "0 0 150px"'
-                  })
-                : null,
+              ...(isFlexItem
+                ? [
+                    getSchemaTpl('layout:flex', {
+                      isFlexColumnItem,
+                      label: isFlexColumnItem ? '高度设置' : '宽度设置',
+                      visibleOn:
+                        'data.style && (data.style.position === "static" || data.style.position === "relative")'
+                    }),
+                    getSchemaTpl('layout:flex-grow', {
+                      visibleOn:
+                        'data.style && data.style.flex === "1 1 auto" && (data.style.position === "static" || data.style.position === "relative")'
+                    }),
+                    getSchemaTpl('layout:flex-basis', {
+                      label: isFlexColumnItem ? '弹性高度' : '弹性宽度',
+                      visibleOn:
+                        'data.style && (data.style.position === "static" || data.style.position === "relative") && data.style.flex === "1 1 auto"'
+                    }),
+                    getSchemaTpl('layout:flex-basis', {
+                      label: isFlexColumnItem ? '固定高度' : '固定宽度',
+                      visibleOn:
+                        'data.style && (data.style.position === "static" || data.style.position === "relative") && data.style.flex === "0 0 150px"'
+                    })
+                  ]
+                : []),
 
               getSchemaTpl('layout:overflow-x', {
                 visibleOn: `${

--- a/packages/amis-editor/src/plugin/Container.tsx
+++ b/packages/amis-editor/src/plugin/Container.tsx
@@ -308,7 +308,11 @@ export class ContainerPlugin extends LayoutBasePlugin {
         title: '外观',
         className: 'p-none',
         body: getSchemaTpl('collapseGroup', [
-          ...getSchemaTpl('theme:common', {exclude: ['layout']})
+          ...getSchemaTpl('theme:common', {exclude: ['layout']}),
+          {
+            title: '自定义 CSS 类名',
+            body: [getSchemaTpl('className')]
+          }
         ])
       },
       {

--- a/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
+++ b/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
@@ -113,34 +113,30 @@ export class FlexPluginBase extends LayoutBasePlugin {
 
                   getSchemaTpl('layout:flex-wrap'),
 
-                  isFlexItem
-                    ? getSchemaTpl('layout:flex', {
-                        isFlexColumnItem,
-                        label: isFlexColumnItem ? '高度设置' : '宽度设置',
-                        visibleOn:
-                          'data.style && (data.style.position === "static" || data.style.position === "relative")'
-                      })
-                    : null,
-                  isFlexItem
-                    ? getSchemaTpl('layout:flex-grow', {
-                        visibleOn:
-                          'data.style && data.style.flex === "1 1 auto" && (data.style.position === "static" || data.style.position === "relative")'
-                      })
-                    : null,
-                  isFlexItem
-                    ? getSchemaTpl('layout:flex-basis', {
-                        label: isFlexColumnItem ? '弹性高度' : '弹性宽度',
-                        visibleOn:
-                          'data.style && (data.style.position === "static" || data.style.position === "relative") && data.style.flex === "1 1 auto"'
-                      })
-                    : null,
-                  isFlexItem
-                    ? getSchemaTpl('layout:flex-basis', {
-                        label: isFlexColumnItem ? '固定高度' : '固定宽度',
-                        visibleOn:
-                          'data.style && (data.style.position === "static" || data.style.position === "relative") && data.style.flex === "0 0 150px"'
-                      })
-                    : null,
+                  ...(isFlexItem
+                    ? [
+                        getSchemaTpl('layout:flex', {
+                          isFlexColumnItem,
+                          label: isFlexColumnItem ? '高度设置' : '宽度设置',
+                          visibleOn:
+                            'data.style && (data.style.position === "static" || data.style.position === "relative")'
+                        }),
+                        getSchemaTpl('layout:flex-grow', {
+                          visibleOn:
+                            'data.style && data.style.flex === "1 1 auto" && (data.style.position === "static" || data.style.position === "relative")'
+                        }),
+                        getSchemaTpl('layout:flex-basis', {
+                          label: isFlexColumnItem ? '弹性高度' : '弹性宽度',
+                          visibleOn:
+                            'data.style && (data.style.position === "static" || data.style.position === "relative") && data.style.flex === "1 1 auto"'
+                        }),
+                        getSchemaTpl('layout:flex-basis', {
+                          label: isFlexColumnItem ? '固定高度' : '固定宽度',
+                          visibleOn:
+                            'data.style && (data.style.position === "static" || data.style.position === "relative") && data.style.flex === "0 0 150px"'
+                        })
+                      ]
+                    : []),
 
                   getSchemaTpl('layout:overflow-x', {
                     visibleOn: `${

--- a/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
+++ b/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
@@ -212,7 +212,11 @@ export class FlexPluginBase extends LayoutBasePlugin {
           title: '外观',
           className: 'p-none',
           body: getSchemaTpl('collapseGroup', [
-            ...getSchemaTpl('theme:common', {exclude: ['layout']})
+            ...getSchemaTpl('theme:common', {exclude: ['layout']}),
+            {
+              title: '自定义 CSS 类名',
+              body: [getSchemaTpl('className')]
+            }
           ])
         }
       ])

--- a/packages/amis-editor/src/plugin/Wrapper.tsx
+++ b/packages/amis-editor/src/plugin/Wrapper.tsx
@@ -78,34 +78,30 @@ export class WrapperPlugin extends LayoutBasePlugin {
                       'data.style && (data.style.display === "flex" || data.style.display === "inline-flex")'
                   }),
 
-                  isFlexItem
-                    ? getSchemaTpl('layout:flex', {
-                        isFlexColumnItem,
-                        label: isFlexColumnItem ? '高度设置' : '宽度设置',
-                        visibleOn:
-                          'data.style && (data.style.position === "static" || data.style.position === "relative")'
-                      })
-                    : null,
-                  isFlexItem
-                    ? getSchemaTpl('layout:flex-grow', {
-                        visibleOn:
-                          'data.style && data.style.flex === "1 1 auto" && (data.style.position === "static" || data.style.position === "relative")'
-                      })
-                    : null,
-                  isFlexItem
-                    ? getSchemaTpl('layout:flex-basis', {
-                        label: isFlexColumnItem ? '弹性高度' : '弹性宽度',
-                        visibleOn:
-                          'data.style && (data.style.position === "static" || data.style.position === "relative") && data.style.flex === "1 1 auto"'
-                      })
-                    : null,
-                  isFlexItem
-                    ? getSchemaTpl('layout:flex-basis', {
-                        label: isFlexColumnItem ? '固定高度' : '固定宽度',
-                        visibleOn:
-                          'data.style && (data.style.position === "static" || data.style.position === "relative") && data.style.flex === "0 0 150px"'
-                      })
-                    : null,
+                  ...(isFlexItem
+                    ? [
+                        getSchemaTpl('layout:flex', {
+                          isFlexColumnItem,
+                          label: isFlexColumnItem ? '高度设置' : '宽度设置',
+                          visibleOn:
+                            'data.style && (data.style.position === "static" || data.style.position === "relative")'
+                        }),
+                        getSchemaTpl('layout:flex-grow', {
+                          visibleOn:
+                            'data.style && data.style.flex === "1 1 auto" && (data.style.position === "static" || data.style.position === "relative")'
+                        }),
+                        getSchemaTpl('layout:flex-basis', {
+                          label: isFlexColumnItem ? '弹性高度' : '弹性宽度',
+                          visibleOn:
+                            'data.style && (data.style.position === "static" || data.style.position === "relative") && data.style.flex === "1 1 auto"'
+                        }),
+                        getSchemaTpl('layout:flex-basis', {
+                          label: isFlexColumnItem ? '固定高度' : '固定宽度',
+                          visibleOn:
+                            'data.style && (data.style.position === "static" || data.style.position === "relative") && data.style.flex === "0 0 150px"'
+                        })
+                      ]
+                    : []),
 
                   getSchemaTpl('layout:overflow-x', {
                     visibleOn: `${

--- a/packages/amis-editor/src/tpl/layout.tsx
+++ b/packages/amis-editor/src/tpl/layout.tsx
@@ -599,6 +599,9 @@ setSchemaTpl(
           // 适配
           form.setValueByName('style.flexGrow', undefined);
           form.setValueByName('style.flexBasis', undefined);
+          form.setValueByName('style.overflowX', undefined);
+          form.setValueByName('style.overflowY', undefined);
+          form.setValueByName('style.overflow', undefined);
 
           if (config?.isFlexColumnItem) {
             form.setValueByName('style.height', undefined);
@@ -893,7 +896,7 @@ setSchemaTpl(
         config?.label ||
         tipedLabel(' x轴滚动模式', '用于设置水平方向的滚动模式'),
       name: config?.name || 'style.overflowX',
-      value: config?.value || 'auto',
+      value: config?.value || 'visible',
       visibleOn: config?.visibleOn,
       pipeIn: config?.pipeIn,
       pipeOut: config?.pipeOut,
@@ -1099,7 +1102,7 @@ setSchemaTpl(
         config?.label ||
         tipedLabel(' y轴滚动模式', '用于设置垂直方向的滚动模式'),
       name: config?.name || 'style.overflowY',
-      value: config?.value || 'auto',
+      value: config?.value || 'visible',
       visibleOn: config?.visibleOn,
       pipeIn: config?.pipeIn,
       pipeOut: config?.pipeOut,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 841e209</samp>

Simplify chart plugin configuration and improve field visibility logic in `Chart.tsx`

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 841e209</samp>

> _The chart plugin had a field called `chartDataType`_
> _But it caused confusion and some code bloat_
> _So we removed it and its options_
> _And fixed the visibility conditions_
> _Now the configuration is simpler and more straight_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 841e209</samp>

*  Simplify the chart plugin configuration by removing the `chartDataType` field and its related options ([link](https://github.com/baidu/amis/pull/7570/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0R212), [link](https://github.com/baidu/amis/pull/7570/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L236-R240), [link](https://github.com/baidu/amis/pull/7570/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L247-R249), [link](https://github.com/baidu/amis/pull/7570/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L256-R259), [link](https://github.com/baidu/amis/pull/7570/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L262-R265))
*  Make the `apiControl` field always visible for users who want to provide a data API for the chart ([link](https://github.com/baidu/amis/pull/7570/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L236-R240))
*  Make the `initFetch` and `interval` fields only dependent on the `data.api` field for users who want to control the chart data fetching behavior ([link](https://github.com/baidu/amis/pull/7570/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L247-R249), [link](https://github.com/baidu/amis/pull/7570/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L256-R259))
*  Make the `config` field always visible for users who want to provide a JSON config for the chart ([link](https://github.com/baidu/amis/pull/7570/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L262-R265))
