### PR TITLE
fix: 修复 table 在 jssdk 下 table-layout fixed 模式初始宽度计算问题

### DIFF
--- a/packages/amis/__tests__/renderers/Form/inputFormula.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/inputFormula.test.tsx
@@ -78,7 +78,7 @@ test('Renderer:input-formula', async () => {
     )
   );
 
-  await wait(200);
+  await wait(500);
   expect(container).toMatchSnapshot();
 
   await findByDisplayValue('SUM(1 + 2)');

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -1145,7 +1145,7 @@ export default class Table extends React.Component<TableProps, object> {
       const div = document.createElement('div');
       div.className = 'amis-scope'; // jssdk 里面 css 会在这一层
       div.style.cssText = `position:absolute;top:0;left:0;pointer-events:none;visibility: hidden;`;
-      div.innerHTML = `<table style="table-layout:auto!important;" class="${cx(
+      div.innerHTML = `<table style="table-layout:auto!important;width:0!important;min-width:0!important;" class="${cx(
         'Table-table'
       )}"><thead><tr>${ths
         .map(


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cd2b421</samp>

Fix table width overflow bug by adding inline styles to the measuring table element in `Table/index.tsx`

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cd2b421</samp>

> _`table` element_
> _gets some styles to fix bug_
> _hidden in winter_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cd2b421</samp>

* Fix table width overflow bug by adding inline styles to the table element used for measuring column widths ([link](https://github.com/baidu/amis/pull/7571/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1148-R1148))
