### PR TITLE
fix: transfer 组件searchApi 不生效

### DIFF
--- a/docs/zh-CN/components/form/transfer.md
+++ b/docs/zh-CN/components/form/transfer.md
@@ -623,8 +623,8 @@ icon:
         "label": "searchApi",
         "type": "transfer",
         "name": "transfer",
-        "selectMode": "tree",
         "searchable": true,
+        "selectMode": "tree",
         "searchApi": "/api/transfer/search?name=${term}",
         "options": [
           {
@@ -638,6 +638,7 @@ icon:
           },
           {
             "label": "战士",
+            "value": "zhanshi",
             "children": [
               {
                 "label": "曹操",

--- a/docs/zh-CN/components/form/transfer.md
+++ b/docs/zh-CN/components/form/transfer.md
@@ -609,9 +609,69 @@ icon:
 
 设置这个 api，可以实现左侧选项搜索结果的检索。
 
-##### 发送
-
 默认 GET，携带 term 变量，值为搜索框输入的文字，可从上下文中取数据设置进去。
+
+
+```schema: scope="body"
+{
+  "type": "page",
+  "body": {
+    "type": "form",
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+      {
+        "label": "searchApi",
+        "type": "transfer",
+        "name": "transfer",
+        "selectMode": "tree",
+        "searchable": true,
+        "searchApi": "/api/transfer/search?name=${term}",
+        "options": [
+          {
+            "label": "法师",
+            "children": [
+              {
+                "label": "诸葛亮",
+                "value": "zhugeliang"
+              }
+            ]
+          },
+          {
+            "label": "战士",
+            "children": [
+              {
+                "label": "曹操",
+                "value": "caocao"
+              },
+              {
+                "label": "钟无艳",
+                "value": "zhongwuyan"
+              }
+            ]
+          },
+          {
+            "label": "打野",
+            "children": [
+              {
+                "label": "李白",
+                "value": "libai"
+              },
+              {
+                "label": "韩信",
+                "value": "hanxin"
+              },
+              {
+                "label": "云中君",
+                "value": "yunzhongjun"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
 
 ##### 响应
 
@@ -625,7 +685,7 @@ icon:
     "options": [
       {
         "label": "描述",
-        "value": "值" // ,
+        "value": "值"
         // "children": [] // 可以嵌套
       },
 
@@ -634,13 +694,12 @@ icon:
         "value": "值2"
       }
     ],
-
-    "value": "值" // 默认值，可以获取列表的同时设置默认值。
   }
 }
 ```
 
 适用于需选择的数据/信息源较多时，用户可直观的知道自己所选择的数据/信息的场景，一般左侧框为数据/信息源，右侧为已选数据/信息，被选中信息同时存在于 2 个框内。
+
 
 ### 结果面板跟随模式
 

--- a/mock/cfc/mock/transfer/search.json
+++ b/mock/cfc/mock/transfer/search.json
@@ -2,7 +2,6 @@
   "status": 0,
   "msg": "",
   "data": {
-    "value": "zhongwuyan",
     "options": [
       {
         "label": "法师",

--- a/mock/cfc/mock/transfer/search.json
+++ b/mock/cfc/mock/transfer/search.json
@@ -1,0 +1,28 @@
+{
+  "status": 0,
+  "msg": "",
+  "data": {
+    "value": "zhongwuyan",
+    "options": [
+      {
+        "label": "法师",
+        "children": [
+          {
+            "label": "诸葛亮",
+            "value": "zhugeliang"
+          }
+        ]
+      },
+      {
+        "label": "战士",
+        "value": "zhanshi",
+        "children": [
+          {
+            "label": "钟无艳",
+            "value": "zhongwuyan"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -18,7 +18,8 @@ import {
   findTree,
   findTreeIndex,
   getTree,
-  spliceTree
+  spliceTree,
+  mapTree
 } from 'amis-core';
 import {Spinner} from 'amis-ui';
 import {optionValueCompare} from 'amis-core';
@@ -354,7 +355,23 @@ export class BaseTransferRenderer<
           throw new Error(__('CRUD.invalidArray'));
         }
 
-        return result;
+        return mapTree(result, item => {
+          let resolved: any = null;
+          const value = item[valueField || 'value'];
+
+          // 只有 value 值有意义的时候，再去找；否则直接返回
+          if (Array.isArray(options) && value !== null && value !== undefined) {
+            resolved = find(options, optionValueCompare(value, valueField));
+            if (resolved?.children) {
+              resolved = {
+                ...resolved,
+                children: item.children
+              };
+            }
+          }
+
+          return resolved || item;
+        });
       } catch (e) {
         if (!env.isCancel(e)) {
           env.notify('error', e.message);

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -362,7 +362,7 @@ export class BaseTransferRenderer<
           // 只有 value 值有意义的时候，再去找；否则直接返回
           if (Array.isArray(options) && value !== null && value !== undefined) {
             resolved = find(options, optionValueCompare(value, valueField));
-            if (resolved?.children) {
+            if (item?.children) {
               resolved = {
                 ...resolved,
                 children: item.children

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -354,17 +354,7 @@ export class BaseTransferRenderer<
           throw new Error(__('CRUD.invalidArray'));
         }
 
-        return result.map(item => {
-          let resolved: any = null;
-          const value = item[valueField || 'value'];
-
-          // 只有 value 值有意义的时候，再去找；否则直接返回
-          if (Array.isArray(options) && value !== null && value !== undefined) {
-            resolved = find(options, optionValueCompare(value, valueField));
-          }
-
-          return resolved || item;
-        });
+        return result;
       } catch (e) {
         if (!env.isCancel(e)) {
           env.notify('error', e.message);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8950d3e</samp>

This pull request improves the functionality and documentation of the transfer component with `searchApi` property. It fixes a bug in the documentation, adds an example and a mock data file, simplifies the component logic, and adds a test case.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8950d3e</samp>

> _`searchApi` mocked_
> _transfer component tested_
> _logic simplified_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8950d3e</samp>

* Add a `searchApi` property to the transfer component, which allows filtering the left options based on the input term ([link](https://github.com/baidu/amis/pull/7575/files?diff=unified&w=0#diff-c42405aec75fcc891f2e2fd54c5a1f0a5a30f8548c3d12877330b005a46e1851L612-R675), [link](https://github.com/baidu/amis/pull/7575/files?diff=unified&w=0#diff-07debd2e776c043c2635a6714d9622ad216538a5d1a7d75a982e41f30e711e71L357-R357))
* Fix the response format of the `searchApi` section in the transfer component documentation, removing redundant comma and `value` property, and adding an empty line ([link](https://github.com/baidu/amis/pull/7575/files?diff=unified&w=0#diff-c42405aec75fcc891f2e2fd54c5a1f0a5a30f8548c3d12877330b005a46e1851L628-R688), [link](https://github.com/baidu/amis/pull/7575/files?diff=unified&w=0#diff-c42405aec75fcc891f2e2fd54c5a1f0a5a30f8548c3d12877330b005a46e1851L637-L638), [link](https://github.com/baidu/amis/pull/7575/files?diff=unified&w=0#diff-c42405aec75fcc891f2e2fd54c5a1f0a5a30f8548c3d12877330b005a46e1851R703))
* Add a mock data file for the `searchApi` endpoint, which returns a filtered list of options and a default value based on the query parameter `name` (`mock/cfc/mock/transfer/search.json`, [link](https://github.com/baidu/amis/pull/7575/files?diff=unified&w=0#diff-4025efef11639a0ed192bdfa0d10e22dc6472c9368a40fdd7fef159932df9412R1-R28))
* Add a test case for the transfer component with `searchApi` property, which verifies that the component can render the options correctly, select and submit the values, and filter the options based on the input term (`packages/amis/__tests__/renderers/Form/transfer.test.tsx`, [link](https://github.com/baidu/amis/pull/7575/files?diff=unified&w=0#diff-5f8efdd91ce02f5eb0f1e3040ac9adbb2e5dfc5ce6054c843f7e81bac4daa0f0L1109-R1231))
