### PR TITLE
fix: 修复列固定调整后总结行没有对应固定的问题 Close: #7557

### DIFF
--- a/packages/amis/src/renderers/Table/TableBody.tsx
+++ b/packages/amis/src/renderers/Table/TableBody.tsx
@@ -9,9 +9,10 @@ import {trace, reaction} from 'mobx';
 import {createObject, flattenTree} from 'amis-core';
 import {LocaleProps} from 'amis-core';
 import {ActionSchema} from '../Action';
-import type {IColumn, IRow} from 'amis-core';
+import type {IColumn, IRow, ITableStore} from 'amis-core';
 
 export interface TableBodyProps extends LocaleProps {
+  store: ITableStore;
   className?: string;
   rowsProps?: any;
   tableClassName?: string;
@@ -59,7 +60,6 @@ export interface TableBodyProps extends LocaleProps {
   prefixRow?: Array<any>;
   affixRow?: Array<any>;
   itemAction?: ActionSchema;
-  fixedPosition?: 'left' | 'right';
 }
 
 @observer
@@ -186,7 +186,7 @@ export class TableBody extends React.Component<TableBodyProps> {
       rows,
       prefixRowClassName,
       affixRowClassName,
-      fixedPosition
+      store
     } = this.props;
 
     if (!(Array.isArray(items) && items.length)) {
@@ -206,13 +206,15 @@ export class TableBody extends React.Component<TableBodyProps> {
           offset += item.colSpan - 1;
         }
 
-        colIdxs = colIdxs.filter(idx =>
-          columns.find(col => col.rawIndex === idx)
-        );
+        const matchedColumns = colIdxs
+          .map(idx => columns.find(col => col.rawIndex === idx))
+          .filter(item => item);
 
         return {
           ...item,
-          colSpan: colIdxs.length
+          colSpan: matchedColumns.length,
+          firstColumn: matchedColumns[0],
+          lastColumn: matchedColumns[matchedColumns.length - 1]
         };
       })
       .filter(item => item.colSpan);
@@ -232,7 +234,7 @@ export class TableBody extends React.Component<TableBodyProps> {
 
     // 多了则干掉一些
     while (appendLen < 0) {
-      const item = fixedPosition === 'right' ? result.shift() : result.pop();
+      const item = result.pop();
       if (!item) {
         break;
       }
@@ -247,9 +249,12 @@ export class TableBody extends React.Component<TableBodyProps> {
         type: 'html',
         html: '&nbsp;'
       };
+      const column = store.filteredColumns[store.filteredColumns.length - 1];
       result.push({
         ...item,
-        colSpan: /*(item.colSpan || 1)*/ 1 + appendLen
+        colSpan: /*(item.colSpan || 1)*/ 1 + appendLen,
+        firstColumn: column,
+        lastColumn: column
       });
     }
 
@@ -269,11 +274,22 @@ export class TableBody extends React.Component<TableBodyProps> {
       >
         {result.map((item, index) => {
           const Com = item.isHead ? 'th' : 'td';
+          const firstColumn = item.firstColumn;
+          const lastColumn = item.lastColumn;
+
+          const style = {...item.style};
+          const [stickyStyle, stickyClassName] = store.getStickyStyles(
+            lastColumn.fixed === 'right' ? lastColumn : firstColumn,
+            store.filteredColumns
+          );
+          Object.assign(style, stickyStyle);
+
           return (
             <Com
               key={index}
               colSpan={item.colSpan == 1 ? undefined : item.colSpan}
-              className={item.cellClassName}
+              style={style}
+              className={(item.cellClassName || '') + ' ' + stickyClassName}
             >
               {render(`summary-row/${index}`, item, {
                 data: ctx

--- a/packages/amis/src/renderers/Table/TableContent.tsx
+++ b/packages/amis/src/renderers/Table/TableContent.tsx
@@ -267,6 +267,7 @@ export class TableContent extends React.Component<TableContentProps> {
             </tbody>
           ) : (
             <TableBody
+              store={store}
               itemAction={itemAction}
               classnames={cx}
               render={render}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ecb364</samp>

The pull request implements the sticky feature for the table columns in `amis`. It adds the `store` prop to the `TableBody` component and removes the `fixedPosition` prop. It also adjusts the summary row cells to match the sticky columns.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4ecb364</samp>

> _Sing, O Muse, of the cunning coder who changed the table code_
> _And gave the `TableBody` component the `store` prop as its load_
> _So that it could render the columns sticky, like the chains of Hephaestus_
> _And align the summary cells with them, like the stars of the Pleiades_

### Why

Close: #7557

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4ecb364</samp>

*  Add `store` prop to `TableBody` component to access table state and methods ([link](https://github.com/baidu/amis/pull/7576/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL12-R15), [link](https://github.com/baidu/amis/pull/7576/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL189-R189), [link](https://github.com/baidu/amis/pull/7576/files?diff=unified&w=0#diff-91ac32323efbbdeeb403a100e73ac57bbc44aa103329f6734c33acb0bd323b25R270))
*  Remove `fixedPosition` prop from `TableBody` component as it is redundant with `store` prop ([link](https://github.com/baidu/amis/pull/7576/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL62), [link](https://github.com/baidu/amis/pull/7576/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL235-R237))
*  Modify summary row logic in `TableBody` component to support sticky columns feature ([link](https://github.com/baidu/amis/pull/7576/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL209-R217), [link](https://github.com/baidu/amis/pull/7576/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL250-R257), [link](https://github.com/baidu/amis/pull/7576/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL272-R292))
