### PR TITLE
feat: 范围类组件支持 extraName 拆成两个字段

### DIFF
--- a/docs/zh-CN/components/form/input-date-range.md
+++ b/docs/zh-CN/components/form/input-date-range.md
@@ -210,6 +210,26 @@ order: 15
 }
 ```
 
+## 存成两个字段
+
+默认日期范围存储一个字段，用 `delemiter` 分割，如果配置 `extraName` 则会存两个字段。
+
+```schema: scope="body"
+{
+    "type": "form",
+    "debug": true,
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+        {
+            "type": "input-date-range",
+            "name": "begin",
+            "extraName": "end",
+            "label": "日期范围"
+        }
+    ]
+}
+```
+
 ## 属性表
 
 除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置
@@ -228,6 +248,7 @@ order: 15
 | clearable   | `boolean`                                                                          | `true`                                                          | 是否可清除                                                                   |
 | embed       | `boolean`                                                                          | `false`                                                         | 是否内联模式                                                                 |
 | animation   | `boolean`                                                                          | `true`                                                          | 是否启用游标动画                                                             | `2.2.0`                 |
+| extraName   | `string`                                                                           |                                                                 | 是否存成两个字段                                                             | `3.3.0`                 |
 
 ## 事件表
 

--- a/docs/zh-CN/components/form/input-datetime-range.md
+++ b/docs/zh-CN/components/form/input-datetime-range.md
@@ -102,6 +102,26 @@ order: 16
 }
 ```
 
+## 存成两个字段
+
+默认日期范围存储一个字段，用 `delemiter` 分割，如果配置 `extraName` 则会存两个字段。
+
+```schema: scope="body"
+{
+    "type": "form",
+    "debug": true,
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+        {
+            "type": "input-datetime-range",
+            "name": "begin",
+            "extraName": "end",
+            "label": "日期范围"
+        }
+    ]
+}
+```
+
 ## 属性表
 
 除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置
@@ -117,6 +137,7 @@ order: 16
 | utc         | `boolean`                                                                          | `false`                                                         | [保存 UTC 值](./input-datetime#utc)                                                        |
 | clearable   | `boolean`                                                                          | `true`                                                          | 是否可清除                                                                                 |
 | animation   | `boolean`                                                                          | `true`                                                          | 是否启用游标动画                                                                           | `2.2.0`                 |
+| extraName   | `string`                                                                           |                                                                 | 是否存成两个字段                                                                           | `3.3.0`                 |
 
 ## 事件表
 

--- a/docs/zh-CN/components/form/input-month-range.md
+++ b/docs/zh-CN/components/form/input-month-range.md
@@ -43,6 +43,26 @@ order: 15
 }
 ```
 
+## 存成两个字段
+
+默认月份范围存储一个字段，用 `delemiter` 分割，如果配置 `extraName` 则会存两个字段。
+
+```schema: scope="body"
+{
+    "type": "form",
+    "debug": true,
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+        {
+            "type": "input-month-range",
+            "name": "begin",
+            "extraName": "end",
+            "label": "月份范围"
+        }
+    ]
+}
+```
+
 ## 属性表
 
 除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置
@@ -60,6 +80,7 @@ order: 15
 | clearable   | `boolean` | `true`             | 是否可清除                                                                   |
 | embed       | `boolean` | `false`            | 是否内联模式                                                                 |
 | animation   | `boolean` | `true`             | 是否启用游标动画                                                             | `2.2.0` |
+| extraName   | `string`  |                    | 是否存成两个字段                                                             | `3.3.0` |
 
 ## 事件表
 

--- a/docs/zh-CN/components/form/input-quarter-range.md
+++ b/docs/zh-CN/components/form/input-quarter-range.md
@@ -42,6 +42,26 @@ order: 15
 }
 ```
 
+## 存成两个字段
+
+默认季度范围存储一个字段，用 `delemiter` 分割，如果配置 `extraName` 则会存两个字段。
+
+```schema: scope="body"
+{
+    "type": "form",
+    "debug": true,
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+        {
+            "type": "input-quarter-range",
+            "name": "begin",
+            "extraName": "end",
+            "label": "季度范围"
+        }
+    ]
+}
+```
+
 ## 属性表
 
 除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置
@@ -59,6 +79,7 @@ order: 15
 | clearable   | `boolean` | `true`             | 是否可清除                                                                   |
 | embed       | `boolean` | `false`            | 是否内联模式                                                                 |
 | animation   | `boolean` | `true`             | 是否启用游标动画                                                             | `2.2.0` |
+| extraName   | `string`  |                    | 是否存成两个字段                                                             | `3.3.0` |
 
 ## 事件表
 

--- a/docs/zh-CN/components/form/input-range.md
+++ b/docs/zh-CN/components/form/input-range.md
@@ -251,6 +251,27 @@ order: 38
 }
 ```
 
+## 存成两个字段
+
+默认滑块多选存储一个字段，用 `delemiter` 分割，如果配置 `extraName` 则会存两个字段。
+
+```schema: scope="body"
+{
+    "type": "form",
+    "debug": true,
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+        {
+            "type": "input-range",
+            "multiple": true,
+            "name": "begin",
+            "extraName": "end",
+            "label": "range"
+        }
+    ]
+}
+```
+
 ## 属性表
 
 当做选择器表单项使用时，除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置

--- a/docs/zh-CN/components/form/input-time-range.md
+++ b/docs/zh-CN/components/form/input-time-range.md
@@ -65,6 +65,26 @@ order: 15
 }
 ```
 
+## 存成两个字段
+
+默认季度范围存储一个字段，用 `delemiter` 分割，如果配置 `extraName` 则会存两个字段。
+
+```schema: scope="body"
+{
+    "type": "form",
+    "debug": true,
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+        {
+            "type": "input-time-range",
+            "name": "begin",
+            "extraName": "end",
+            "label": "时间范围"
+        }
+    ]
+}
+```
+
 ## 属性表
 
 除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置
@@ -78,6 +98,7 @@ order: 15
 | clearable   | `boolean` | `true`             | 是否可清除                                                            |
 | embed       | `boolean` | `false`            | 是否内联模式                                                          |
 | animation   | `boolean` | `true`             | 是否启用游标动画                                                      | `2.2.0` |
+| extraName   | `string`  |                    | 是否存成两个字段                                                      | `3.3.0` |
 
 ## 事件表
 

--- a/docs/zh-CN/components/form/input-year-range.md
+++ b/docs/zh-CN/components/form/input-year-range.md
@@ -43,6 +43,26 @@ order: 15
 }
 ```
 
+## 存成两个字段
+
+默认年份范围存储一个字段，用 `delemiter` 分割，如果配置 `extraName` 则会存两个字段。
+
+```schema: scope="body"
+{
+    "type": "form",
+    "debug": true,
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+        {
+            "type": "input-year-range",
+            "name": "begin",
+            "extraName": "end",
+            "label": "年份范围"
+        }
+    ]
+}
+```
+
 ## 属性表
 
 除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置

--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -1000,21 +1000,20 @@ export default class Form extends React.Component<FormProps, object> {
 
   handleBulkChange(values: Object, submit: boolean) {
     const {onChange, store, formLazyChange} = this.props;
+    store.setValues(values);
+    // store.updateData(values);
 
-    store.updateData(values);
+    // store.items.forEach(formItem => {
+    //   const updatedValue = getVariable(values, formItem.name, false);
 
-    store.items.forEach(formItem => {
-      const updatedValue = getVariable(values, formItem.name, false);
-
-      if (updatedValue !== undefined) {
-        // 更新验证状态但保留错误信息
-        formItem.reset(true);
-        // 这里需要更新value，否则提交时不会使用新的字段值校验
-        formItem.changeTmpValue(updatedValue);
-        formItem.validateOnChange && formItem.validate(values);
-      }
-    });
-
+    //   if (updatedValue !== undefined) {
+    //     // 更新验证状态但保留错误信息
+    //     formItem.reset(true);
+    //     // 这里需要更新value，否则提交时不会使用新的字段值校验
+    //     formItem.changeTmpValue(updatedValue);
+    //     formItem.validateOnChange && formItem.validate(values);
+    //   }
+    // });
     (formLazyChange === false ? this.emitChange : this.lazyEmitChange)(submit);
   }
 
@@ -1639,7 +1638,8 @@ export default class Form extends React.Component<FormProps, object> {
       dispatchEvent,
       labelAlign,
       labelWidth,
-      static: isStatic
+      static: isStatic,
+      canAccessSuperData
     } = props;
 
     const subProps = {

--- a/packages/amis-core/src/renderers/Item.tsx
+++ b/packages/amis-core/src/renderers/Item.tsx
@@ -73,6 +73,11 @@ export interface FormBaseControl extends BaseSchemaWithoutType {
   name?: string;
 
   /**
+   * 额外的字段名，当为范围组件时可以用来将另外一个值打平出来
+   */
+  extraName?: string;
+
+  /**
    * 显示一个小图标, 鼠标放上去的时候显示提示内容
    */
   remark?: any;

--- a/packages/amis-core/src/renderers/wrapControl.tsx
+++ b/packages/amis-core/src/renderers/wrapControl.tsx
@@ -129,6 +129,7 @@ export function wrapControl<
                 validationErrors,
                 unique,
                 value,
+                extraName,
                 multiple,
                 delimiter,
                 valueField,
@@ -208,7 +209,8 @@ export function wrapControl<
               maxLength,
               validateOnChange,
               label,
-              inputGroupControl
+              inputGroupControl,
+              extraName
             });
 
             // issue 这个逻辑应该在 combo 里面自己实现。
@@ -224,16 +226,41 @@ export function wrapControl<
               // 同步 value: 优先使用 props 中的 value
               model.changeTmpValue(propValue, 'controlled');
             } else {
-              // 备注: 此处的 value 是 schema 中的 value（和props.defaultValue相同）
               const isExp = isExpression(value);
-              const curTmpValue = isExp
-                ? FormulaExec['formula'](value, data) // 对组件默认值进行运算
-                : store?.getValueByName(model.name) ?? replaceExpression(value); // 优先使用公式表达式
-              // 同步 value
-              model.changeTmpValue(
-                curTmpValue,
-                isExp ? 'formulaChanged' : 'defaultValue'
-              );
+
+              if (isExp) {
+                model.changeTmpValue(
+                  FormulaExec['formula'](value, data), // 对组件默认值进行运算
+                  'formulaChanged'
+                );
+              } else {
+                let initialValue = model.extraName
+                  ? [
+                      store?.getValueByName(
+                        model.name,
+                        form?.canAccessSuperData
+                      ),
+                      store?.getValueByName(
+                        model.extraName,
+                        form?.canAccessSuperData
+                      )
+                    ]
+                  : store?.getValueByName(model.name, form?.canAccessSuperData);
+
+                if (
+                  model.extraName &&
+                  initialValue.every((item: any) => item === undefined)
+                ) {
+                  initialValue = undefined;
+                }
+
+                model.changeTmpValue(
+                  initialValue ?? replaceExpression(value),
+                  typeof initialValue !== 'undefined'
+                    ? 'initialValue'
+                    : 'defaultValue'
+                );
+              }
             }
 
             if (
@@ -242,7 +269,13 @@ export function wrapControl<
               model.tmpValue !== undefined
             ) {
               // 组件默认值支持表达式需要: 避免初始化时上下文中丢失组件默认值
-              onChange(model.tmpValue, model.name, false, true);
+              if (model.extraName) {
+                const values = model.splitExtraValue(model.tmpValue);
+                onChange(values[0], model.name, false, true);
+                onChange(values[1], model.extraName, false, true);
+              } else {
+                onChange(model.tmpValue, model.name, false, true);
+              }
             } else if (
               onChange &&
               typeof propValue === 'undefined' &&
@@ -253,7 +286,13 @@ export function wrapControl<
               store?.storeType !== TableStore.name
             ) {
               // 如果没有初始值，通过 onChange 设置过去
-              onChange(model.tmpValue, model.name, false, true);
+              if (model.extraName) {
+                const values = model.splitExtraValue(model.tmpValue);
+                onChange(values[0], model.name, false, true);
+                onChange(values[1], model.extraName, false, true);
+              } else {
+                onChange(model.tmpValue, model.name, false, true);
+              }
             }
           }
 
@@ -318,7 +357,8 @@ export function wrapControl<
                   'validateApi',
                   'minLength',
                   'maxLength',
-                  'label'
+                  'label',
+                  'extraName'
                 ],
                 prevProps.$schema,
                 props.$schema
@@ -345,7 +385,8 @@ export function wrapControl<
                 minLength: props.$schema.minLength,
                 maxLength: props.$schema.maxLength,
                 label: props.$schema.label,
-                inputGroupControl: props?.inputGroupControl
+                inputGroupControl: props?.inputGroupControl,
+                extraName: props.$schema.extraName
               });
             }
 
@@ -385,11 +426,16 @@ export function wrapControl<
               ) {
                 // 识别上下文变动、自身数值变动、公式运算结果变动
                 model.changeTmpValue(curResult, 'formulaChanged');
-                props.onChange?.(curResult, model.name, false);
+
+                if (model.extraName) {
+                  const values = model.splitExtraValue(curResult);
+                  props.onChange?.(values[0], model.name, false);
+                  props.onChange?.(values[1], model.extraName, false);
+                } else {
+                  props.onChange?.(curResult, model.name, false);
+                }
               }
             } else if (model) {
-              const valueByName = getVariable(props.data, model.name);
-
               // value 非公式表达式时，name 值优先，若 defaultValue 主动变动时，则使用 defaultValue
               if (
                 // 然后才是查看关联的 name 属性值是否变化
@@ -398,12 +444,30 @@ export function wrapControl<
                   isEqual(model.emitedValue, model.tmpValue))
               ) {
                 model.changeEmitedValue(undefined);
-                const prevValueByName = getVariable(props.data, model.name);
+                const valueByName = model.extraName
+                  ? [
+                      getVariable(props.data, model.name, false),
+                      getVariable(props.data, model.extraName, false)
+                    ]
+                  : getVariable(props.data, model.name, false);
+
                 if (
-                  (!isEqual(valueByName, prevValueByName) ||
-                    getVariable(props.data, model.name, false) !==
-                      getVariable(prevProps.data, model.name, false)) &&
-                  !isEqual(valueByName, model.tmpValue)
+                  !isEqual(
+                    valueByName,
+                    model.extraName
+                      ? model.splitExtraValue(model.tmpValue)
+                      : model.tmpValue
+                  ) &&
+                  (!isEqual(
+                    model.extraName ? valueByName[0] : valueByName,
+                    getVariable(prevProps.data, model.name, false)
+                  ) ||
+                    // extraName
+                    (model.extraName &&
+                      !isEqual(
+                        valueByName[1],
+                        getVariable(prevProps.data, model.extraName, false)
+                      )))
                 ) {
                   model.changeTmpValue(
                     valueByName,
@@ -621,10 +685,18 @@ export function wrapControl<
             if (!this.model) {
               return;
             }
+            const model = this.model;
             const value = this.model.tmpValue;
-            const oldValue = getVariable(data, this.model.name, false);
+            const oldValue = model.extraName
+              ? [
+                  getVariable(data, model.name, false),
+                  getVariable(data, model.extraName, false)
+                ]
+              : getVariable(data, model.name, false);
 
-            if (oldValue === value) {
+            if (
+              model.extraName ? isEqual(oldValue, value) : oldValue === value
+            ) {
               return;
             }
 
@@ -656,7 +728,13 @@ export function wrapControl<
               return;
             }
 
-            onChange?.(value, name!, submitOnChange === true);
+            if (model.extraName) {
+              const values = model.splitExtraValue(value);
+              onChange?.(values[0], name!);
+              onChange?.(values[1], model.extraName, submitOnChange === true);
+            } else {
+              onChange?.(value, name!, submitOnChange === true);
+            }
             this.checkValidate();
           }
 
@@ -678,6 +756,7 @@ export function wrapControl<
               return;
             }
 
+            const model = this.model;
             const {
               formStore: form,
               name,
@@ -691,7 +770,13 @@ export function wrapControl<
               value = pipeOut(value, oldValue, data);
             }
 
-            onChange?.(value, name!, false, true);
+            if (model.extraName) {
+              const values = model.splitExtraValue(value);
+              onChange?.(values[0], name!, false, true);
+              onChange?.(values[1], model.extraName!, false, true);
+            } else {
+              onChange?.(value, name!, false, true);
+            }
           }
 
           getValue() {

--- a/packages/amis-core/src/store/formItem.ts
+++ b/packages/amis-core/src/store/formItem.ts
@@ -66,6 +66,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
     messages: types.optional(types.frozen(), {}),
     errorData: types.optional(types.array(ErrorDetail), []),
     name: types.string,
+    extraName: '',
     itemId: '', // 因为 name 可能会重名，所以加个 id 进来，如果有需要用来定位具体某一个
     unsetValueOnInvisible: false,
     itemsRef: types.optional(types.array(types.string), []),
@@ -210,6 +211,15 @@ export const FormItemStore = StoreNode.named('FormItemStore')
         });
 
         return selectedOptions;
+      },
+      splitExtraValue(value: any) {
+        const delimiter = self.delimiter || ',';
+        const values = Array.isArray(value)
+          ? value
+          : typeof value === 'string'
+          ? value.split(delimiter || ',')
+          : [];
+        return values;
       }
     };
   })
@@ -220,6 +230,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
     let loadAutoUpdateCancel: Function | null = null;
 
     function config({
+      extraName,
       required,
       unique,
       value,
@@ -244,6 +255,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
       label,
       inputGroupControl
     }: {
+      extraName?: string;
       required?: boolean;
       unique?: boolean;
       value?: any;
@@ -276,6 +288,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
         rules = str2rules(rules);
       }
 
+      typeof extraName !== 'undefined' && (self.extraName = extraName);
       typeof type !== 'undefined' && (self.type = type);
       typeof id !== 'undefined' && (self.itemId = id);
       typeof messages !== 'undefined' && (self.messages = messages);
@@ -1236,6 +1249,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
     function changeTmpValue(
       value: any,
       changeReason?:
+        | 'initialValue' // 初始值，读取与当前数据域，或者上层数据域
         | 'formInited' // 表单初始化
         | 'dataChanged' // 表单数据变化
         | 'formulaChanged' // 公式运算结果变化

--- a/packages/amis/__tests__/renderers/Form/autoFill.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/autoFill.test.tsx
@@ -391,7 +391,7 @@ test('Form:options:autoFill:validation', async () => {
   expect(option1.getAttribute('value')).toEqual('OptionB');
   expect(option1.getAttribute('value')).toEqual('OptionB');
   expect(screen.queryByText(validationMsg1)).not.toBeInTheDocument();
-  expect(screen.queryByText(validationMsg2)).toBeInTheDocument();
+  expect(screen.queryByText(validationMsg2)).not.toBeInTheDocument();
 
   // 提交后校验信息全部消除
   fireEvent.click(submitBtn);

--- a/packages/amis/src/renderers/Form/InputRange.tsx
+++ b/packages/amis/src/renderers/Form/InputRange.tsx
@@ -645,10 +645,12 @@ export default class RangeControl extends React.PureComponent<
    * 获取导出格式数据
    */
   @autobind
-  getFormatValue(value: FormatValue) {
-    const {multiple, joinValues, delimiter} = this.props;
+  getFormatValue(value: FormatValue): Value {
+    const {multiple, joinValues, delimiter, extraName} = this.props;
     return multiple
-      ? joinValues
+      ? extraName
+        ? [(value as MultipleValue).min, (value as MultipleValue).max]
+        : joinValues
         ? [(value as MultipleValue).min, (value as MultipleValue).max].join(
             delimiter || ','
           )


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ecdaa67</samp>

This pull request adds the `extraName` property to various range form controls, which allows splitting the range value into two fields for validation and submission. It updates the documentation and the code of the form controls, the `FormItemStore`, and the `FormStore` to support this feature. It also improves the data handling and scope management of the `Form` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ecdaa67</samp>

> _`extraName` adds_
> _a second value for forms_
> _cutting data scope_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ecdaa67</samp>

*  Add the `extraName` property to the range components, which allows storing the range values as two separate fields instead of one delimited field ([link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-05f312d2f6d17f335f4b7942ab35adb09e492cec2fb9cbb7d34e2d2bd13a84beR213-R232), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-05f312d2f6d17f335f4b7942ab35adb09e492cec2fb9cbb7d34e2d2bd13a84beR251), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-f0f649fb48286ca1a3355b21d5a6843d70d796c50137d19ef1741049c8e7a577R105-R124), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-f0f649fb48286ca1a3355b21d5a6843d70d796c50137d19ef1741049c8e7a577R140), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-31c08cbb4eb6e522bd4d5dba5824b553f57274e84f0129c343a896d442f13d0cR46-R65), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-31c08cbb4eb6e522bd4d5dba5824b553f57274e84f0129c343a896d442f13d0cR83), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-b145e41efdfc127270a01b355df82b7e3c4a82aa4a8f05a3da2a56ecb42bc2ddR45-R64), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-b145e41efdfc127270a01b355df82b7e3c4a82aa4a8f05a3da2a56ecb42bc2ddR82), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-8cb007029b4ce9a96f030e2815c2874a593aad1ed8aeb9b768a1e73fc7e784b8R254-R274), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-99f5600e3b4559ea539e4927d6ede206d457c399fa9321565a1766c5645f405cR68-R87), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-99f5600e3b4559ea539e4927d6ede206d457c399fa9321565a1766c5645f405cR101), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-8dad69c92f0b799f007ecd75024d9c35d27899b59032b1661f1855e67852c51eR46-R65), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8R76-R80), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aR133), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL211-R214), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL226-R234), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aR240-R255), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL245-R270), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL256-R287), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL321-R353), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL348-R381), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL388-R430), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL401-R457), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aR556-R564), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL624-R695), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL659-R733), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL694-R775), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-c8aefd7686b13cf0a0b440b598f20cc50e9abac39fcd9281de29dc6e9d3b358eL172-R187), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9R69), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9R224), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9R249), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9R282), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-1cc263ed7b5f9385af4c3b91ead6471259bb7683f677c90867f665c26ea39665L648-R653))
*  Modify the `handleBulkChange` method of the `Form` component in `packages/amis-core/src/renderers/Form.tsx` to use the `setValues` method of the `FormStore`, which handles the `extraName` logic internally ([link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1003-R1016))
*  Add the `canAccessSuperData` property to the `Form` component props, which controls whether the form can access the data from the parent scope, and pass it to the `renderFormItems` method and the `wrapControl` function ([link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1642-R1642), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1682-R1683), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aR123))
*  Modify the `wrapControl` function in `packages/amis-core/src/renderers/wrapControl.tsx` to handle the `extraName` logic when initializing, updating, validating and changing the value of the form item, and when emitting the change event ([link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aR240-R255), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL245-R270), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL256-R287), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL388-R430), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL401-R457), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL624-R695), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL659-R733), [link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL694-R775))
*  Add a helper method to the `wrapControl` function to split the value of the form item with the `extraName` property into an array of two values ([link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aR556-R564))
*  Add a local variable to store the model of the form item in the `wrapControl` function ([link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aR755))
*  Add a comment to the `changeTmpValue` method of the `FormItemStore` in `packages/amis-core/src/store/formItem.ts`, explaining the meaning of the `initialValue` source ([link](https://github.com/baidu/amis/pull/7583/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9R1243))
