### PR TITLE
fix: inputFormula 弹窗位置错误

### DIFF
--- a/packages/amis/src/renderers/Form/InputFormula.tsx
+++ b/packages/amis/src/renderers/Form/InputFormula.tsx
@@ -222,7 +222,7 @@ export class InputFormulaRenderer extends React.Component<InputFormulaProps> {
 
     return (
       <FormulaPicker
-        popOverContainer={popOverContainer || env.getModalContainer}
+        popOverContainer={env.getModalContainer}
         ref={this.formulaRef}
         className={className}
         value={value}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bb7c08e</samp>

Removed `popOverContainer` prop from `FormulaPicker` component and used `env.getModalContainer` instead. This fixed a bug where the formula picker would not show up in some scenarios.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bb7c08e</samp>

> _`popOverContainer`_
> _gone, use `env` instead_
> _bug fix for winter_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bb7c08e</samp>

*  Removed `popOverContainer` prop and used `env.getModalContainer` instead for `FormulaPicker` component to fix formula picker visibility bug ([link](https://github.com/baidu/amis/pull/7601/files?diff=unified&w=0#diff-913fb8d07888e592949feed6847e6997721160c1df681059970998dbe0f0bb45L225-R225))
