### PR TITLE
docs: add title props for `Alert` docs

### DIFF
--- a/docs/zh-CN/components/alert.md
+++ b/docs/zh-CN/components/alert.md
@@ -207,6 +207,7 @@ order: 27
 | 属性名               | 类型                                      | 默认值    | 说明                                                     |
 | -------------------- | ----------------------------------------- | --------- | -------------------------------------------------------- |
 | type                 | `string`                                  | `"alert"` | 指定为 alert 渲染器                                      |
+| title                | `string`                                  |           | alert标题                                                |
 | className            | `string`                                  |           | 外层 Dom 的类名                                          |
 | level                | `string`                                  | `info`    | 级别，可以是：`info`、`success`、`warning` 或者 `danger` |
 | body                 | [SchemaNode](../../docs/types/schemanode) |           | 显示内容                                                 |


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e707822</samp>

Added documentation for the `title` property of the alert component. This property allows users to customize the alert title in `alert.md`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e707822</samp>

> _`title` for alert_
> _a new string property_
> _autumn documentation_

### Why

添加`Alert`组件文档属性表`title`属性描述

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e707822</samp>

* Add documentation for the `title` property of the alert component ([link](https://github.com/baidu/amis/pull/7603/files?diff=unified&w=0#diff-7e136e02aaaf3ee2a336154117eee1b1ad86b78e550e8d5aba4c225618389776R210))
