### PR TITLE
chore(amis-editor): form & dialog 的操作按钮在没有设置的情况下也可以点选

### DIFF
--- a/packages/amis-editor-core/src/plugin.ts
+++ b/packages/amis-editor-core/src/plugin.ts
@@ -13,7 +13,7 @@ import {EditorDNDManager} from './dnd';
 import React from 'react';
 import {DiffChange} from './util';
 import find from 'lodash/find';
-import type {RendererConfig} from 'amis-core';
+import type {RendererConfig, Schema} from 'amis-core';
 import type {MenuDivider, MenuItem} from 'amis-ui/lib/components/ContextMenu';
 import type {BaseSchema, SchemaCollection} from 'amis';
 import type {AsyncLayerOptions} from './component/AsyncLayer';
@@ -925,6 +925,19 @@ export interface PluginInterface
     e: any,
     data: any
   ) => void;
+
+  /**
+   * 给 schema 打补丁，纠正一下 schema 配置。
+   * @param schema
+   * @param renderer
+   * @param props
+   * @returns
+   */
+  patchSchema?: (
+    schema: Schema,
+    renderer: RendererConfig,
+    props?: any
+  ) => Schema | void;
 
   dispose?: () => void;
 }

--- a/packages/amis-editor-core/src/store/node.ts
+++ b/packages/amis-editor-core/src/store/node.ts
@@ -649,9 +649,19 @@ export const EditorNode = types
           );
         }
 
+        // 调用 amis 纠错补丁
         patched = filterSchema(patched, {
           component: info.renderer.component
         } as any);
+        // 调用插件上的补丁
+        patched =
+          info.plugin?.patchSchema?.(
+            patched,
+            {
+              component: info.renderer.component
+            },
+            component?.props
+          ) || patched;
         patched = JSONPipeIn(patched);
         if (patched !== schema) {
           root.changeValueById(info.id, patched, undefined, true, true);

--- a/packages/amis-editor/src/plugin/Dialog.tsx
+++ b/packages/amis-editor/src/plugin/Dialog.tsx
@@ -14,6 +14,7 @@ import {
 } from 'amis-editor-core';
 import {getEventControlConfig} from '../renderer/event-control/helper';
 import omit from 'lodash/omit';
+import type {RendererConfig, Schema} from 'amis-core';
 
 export class DialogPlugin extends BasePlugin {
   static id = 'DialogPlugin';
@@ -347,6 +348,35 @@ export class DialogPlugin extends BasePlugin {
       type: 'object',
       title: node.schema?.label || node.schema?.name,
       properties: dataSchema
+    };
+  }
+
+  /**
+   * 为了让 dialog 的按钮可以点击编辑
+   */
+  patchSchema(schema: Schema, info: RendererConfig, props?: any) {
+    if (Array.isArray(schema.actions)) {
+      return;
+    }
+
+    return {
+      ...schema,
+      actions: [
+        {
+          type: 'button',
+          actionType: 'cancel',
+          label: '取消'
+        },
+
+        props?.confirm
+          ? {
+              type: 'button',
+              actionType: 'confirm',
+              label: '确定',
+              primary: true
+            }
+          : null
+      ].filter((item: any) => item)
     };
   }
 }

--- a/packages/amis-editor/src/plugin/Form/Form.tsx
+++ b/packages/amis-editor/src/plugin/Form/Form.tsx
@@ -15,7 +15,7 @@ import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {jsonToJsonSchema} from 'amis-editor-core';
 import {EditorNodeType} from 'amis-editor-core';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
-import {setVariable, someTree} from 'amis-core';
+import {RendererConfig, Schema, setVariable, someTree} from 'amis-core';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 
 // 用于脚手架的常用表单控件
@@ -979,6 +979,40 @@ export class FormPlugin extends BasePlugin {
       scope?.removeSchema(jsonschema.$id);
       scope?.addSchema(jsonschema);
     }
+  }
+
+  /**
+   * 为了让 form 的按钮可以点击编辑
+   */
+  patchSchema(schema: Schema, info: RendererConfig, props: any) {
+    if (
+      Array.isArray(schema.actions) ||
+      schema.wrapWithPanel === false ||
+      (Array.isArray(schema.body) &&
+        schema.body.some(
+          (item: any) =>
+            item &&
+            !!~['submit', 'button', 'button-group', 'reset'].indexOf(
+              (item as any)?.body?.[0]?.type ||
+                (item as any)?.body?.type ||
+                (item as any).type
+            )
+        ))
+    ) {
+      return;
+    }
+
+    return {
+      ...schema,
+      actions: [
+        {
+          type: 'submit',
+          label:
+            props?.translate(props?.submitText) || schema.submitText || '提交',
+          primary: true
+        }
+      ]
+    };
   }
 }
 

--- a/packages/amis-editor/src/plugin/Form/InputDateRange.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputDateRange.tsx
@@ -325,6 +325,9 @@ export class DateRangeControlPlugin extends BasePlugin {
                 getSchemaTpl('formItemName', {
                   required: true
                 }),
+
+                getSchemaTpl('formItemExtraName'),
+
                 getSchemaTpl('label'),
                 getSchemaTpl('selectDateRangeType', {
                   value: this.scaffold.type,

--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -79,6 +79,28 @@ setSchemaTpl('formItemName', {
   // validateOnChange: false
 });
 
+setSchemaTpl('formItemExtraName', {
+  className: 'mb-3',
+  type: 'fieldset',
+  body: [
+    getSchemaTpl('formItemName', {
+      required: true,
+      label: '额外字段',
+      name: 'extraName',
+      visibleOn: 'typeof this.extraName === "string"'
+    }),
+
+    {
+      type: 'switch',
+      label: tipedLabel('存成两个字段', '开启后将选中范围分别存成两个字段'),
+      name: 'extraName',
+      pipeIn: (value: any) => typeof value === 'string',
+      pipeOut: (value: any) => (value ? '' : undefined),
+      inputClassName: 'is-inline'
+    }
+  ]
+});
+
 setSchemaTpl(
   'formItemMode',
   (config: {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bfb4335</samp>

This pull request adds a new plugin method `patchSchema` to customize renderer schemas in the editor. It also updates some existing plugins to use types from `amis-core` and to provide default actions for dialogs and forms. Additionally, it introduces a schema template for configuring an extra field name for date range inputs.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bfb4335</samp>

> _`patchSchema` method_
> _enhances editor plugins_
> _with autumnal hues_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bfb4335</samp>

*  Add `patchSchema` method to the plugin interface to allow plugins to modify the schema configuration of the renderer components ([link](https://github.com/baidu/amis/pull/7608/files?diff=unified&w=0#diff-2eb003bbc6f49ecb3f8b56411f1c1d02f055f595b7d9998f326a9c7ff41cc266L16-R16),[link](https://github.com/baidu/amis/pull/7608/files?diff=unified&w=0#diff-2eb003bbc6f49ecb3f8b56411f1c1d02f055f595b7d9998f326a9c7ff41cc266R929-R941))
*  Invoke `patchSchema` method in the `EditorNode` class to apply the plugin's schema patch to the current node's schema ([link](https://github.com/baidu/amis/pull/7608/files?diff=unified&w=0#diff-1a3d36eaf488e63b9e3aebc1811961232c7753524abb132e24d8ab51952e9fb6L652-R664))
*  Implement `patchSchema` method in the `Dialog` and `Form` plugin classes to add default actions to the dialog and form schemas if they are not specified ([link](https://github.com/baidu/amis/pull/7608/files?diff=unified&w=0#diff-d3bebdf8ee046a9260ff973d8fc59a35ef327db18d55902021b571b045359e1aR17),[link](https://github.com/baidu/amis/pull/7608/files?diff=unified&w=0#diff-d3bebdf8ee046a9260ff973d8fc59a35ef327db18d55902021b571b045359e1aR353-R381),[link](https://github.com/baidu/amis/pull/7608/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL18-R18),[link](https://github.com/baidu/amis/pull/7608/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dR983-R1015))
*  Use `formItemExtraName` schema template in the `InputDateRange` plugin class to allow the user to configure an extra field name for the date range input ([link](https://github.com/baidu/amis/pull/7608/files?diff=unified&w=0#diff-57750c096cc98f331f2101f229a6afcb6c830bba8f0b5cdcdc0bf130286c6961R328-R330))
*  Define `formItemExtraName` schema template in the `common.tsx` file to be reused by different plugins that need to support an extra field name option ([link](https://github.com/baidu/amis/pull/7608/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05R82-R103))
