### PR TITLE
fix: table2支持批量编辑功能

### DIFF
--- a/packages/amis-core/src/store/table2.ts
+++ b/packages/amis-core/src/store/table2.ts
@@ -24,11 +24,13 @@ import {
   immutableExtends,
   isEmpty,
   extendObject,
-  findTree
+  findTree,
+  difference
 } from '../utils/helper';
 import {normalizeApiResponseData} from '../utils/api';
 import {Api, Payload, fetchOptions, ApiObject} from '../types';
 import {ServiceStore} from './service';
+import {IFormStore} from './form';
 
 class ServerError extends Error {
   type = 'ServerError';
@@ -211,7 +213,8 @@ export const TableStore2 = ServiceStore.named('TableStore2')
     pageNo: 1,
     pageSize: 10,
     dragging: false,
-    rowSelectionKeyField: 'id'
+    rowSelectionKeyField: 'id',
+    formsRef: types.optional(types.array(types.frozen()), [])
   })
   .views(self => {
     function getToggable() {
@@ -297,6 +300,25 @@ export const TableStore2 = ServiceStore.named('TableStore2')
       return getMovedRows().length;
     }
 
+    function getModifiedRows(rows: IRow2[] = [], modifiedRows: IRow2[] = []) {
+      rows = rows && rows.length ? rows : self.rows;
+      rows.forEach((item: IRow2) => {
+        if (item.children && item.children.length) {
+          getModifiedRows(item.children, modifiedRows);
+        }
+        let diff = difference(item.data, item.pristine);
+        let hasDifference = Object.keys(diff).length;
+        if (hasDifference) {
+          modifiedRows.push(item);
+        }
+      });
+      return modifiedRows;
+    }
+
+    function getModified() {
+      return getModifiedRows().length;
+    }
+
     return {
       get toggable() {
         return getToggable();
@@ -366,6 +388,14 @@ export const TableStore2 = ServiceStore.named('TableStore2')
 
       get keyField() {
         return self.rowSelectionKeyField;
+      },
+
+      get modified() {
+        return getModified();
+      },
+
+      get modifiedRows() {
+        return getModifiedRows();
       }
     };
   })
@@ -735,6 +765,13 @@ export const TableStore2 = ServiceStore.named('TableStore2')
       self.dragging = false;
     }
 
+    function addForm(form: IFormStore, rowIndex: number) {
+      self.formsRef.push({
+        id: form.id,
+        rowIndex
+      });
+    }
+
     return {
       update,
       persistSaveToggledColumns,
@@ -769,7 +806,8 @@ export const TableStore2 = ServiceStore.named('TableStore2')
           }
         }, 200);
       },
-      saveRemote
+      saveRemote,
+      addForm
     };
   });
 

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -3,6 +3,7 @@ import {findDOMNode} from 'react-dom';
 import {isAlive} from 'mobx-state-tree';
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
+import intersection from 'lodash/intersection';
 
 import {
   ScopedContext,
@@ -47,6 +48,7 @@ import {HeadCellSearchDropDown} from './HeadCellSearchDropdown';
 import './TableCell';
 import './ColumnToggler';
 import {Action} from '../../types';
+import {SchemaQuickEdit} from '../QuickEdit';
 
 /**
  * Table 表格2渲染器。
@@ -145,6 +147,11 @@ export interface ColumnSchema {
    * 单元格样式
    */
   classNameExpr?: string;
+
+  /**
+   * 配置快速编辑功能
+   */
+  quickEdit?: SchemaQuickEdit;
 }
 
 export interface RowSelectionOptionsSchema {
@@ -430,6 +437,7 @@ export default class Table2 extends React.Component<Table2Props, object> {
 
   renderedToolbars: Array<string> = [];
   tableRef?: any;
+  subForms: any = {};
 
   static defaultProps: Partial<Table2Props> = {
     keyField: 'id'
@@ -628,6 +636,28 @@ export default class Table2 extends React.Component<Table2Props, object> {
     return findDOMNode(this);
   }
 
+  @autobind
+  subFormRef(form: any, x: number, y: number) {
+    const {quickEditFormRef} = this.props;
+
+    quickEditFormRef && quickEditFormRef(form, x, y);
+    this.subForms[`${x}-${y}`] = form;
+    form && this.props.store.addForm(form.props.store, y);
+  }
+
+  @autobind
+  reset() {
+    const {store} = this.props;
+
+    store.reset();
+
+    const subForms: Array<any> = [];
+    Object.keys(this.subForms).forEach(
+      key => this.subForms[key] && subForms.push(this.subForms[key])
+    );
+    subForms.forEach(item => item.clearErrors());
+  }
+
   renderCellSchema(schema: any, props: any) {
     const {render} = this.props;
 
@@ -646,7 +676,7 @@ export default class Table2 extends React.Component<Table2Props, object> {
         'cell-field',
         {
           ...rest,
-          title,
+          title: title || rest.label,
           type: 'cell-field',
           column: rest,
           data: props.data,
@@ -687,7 +717,6 @@ export default class Table2 extends React.Component<Table2Props, object> {
   // editor传来的处理过的column 还可能包含其他字段
   buildColumns(columns: Array<any>) {
     const {
-      env,
       render,
       store,
       popOverContainer,
@@ -708,11 +737,14 @@ export default class Table2 extends React.Component<Table2Props, object> {
         let titleSchema: any = null;
         const titleProps = {
           popOverContainer: popOverContainer || this.getPopOverContainer,
-          value: column.title
+          value: column.title || column.label
         };
         if (isObject(column.title)) {
           titleSchema = cloneDeep(column.title);
-        } else if (typeof column.title === 'string') {
+        } else if (
+          typeof column.title === 'string' ||
+          typeof column.label === 'string'
+        ) {
           titleSchema = {type: 'plain'};
         }
 
@@ -769,9 +801,10 @@ export default class Table2 extends React.Component<Table2Props, object> {
                     : column.name,
                   popOverContainer:
                     popOverContainer || this.getPopOverContainer,
+                  quickEditFormRef: this.subFormRef,
                   onQuickChange: (
                     values: object,
-                    saveImmediately?: boolean,
+                    saveImmediately?: boolean | any,
                     savePristine?: boolean,
                     options?: {
                       resetOnFailed?: boolean;
@@ -918,7 +951,56 @@ export default class Table2 extends React.Component<Table2Props, object> {
   }
 
   @autobind
-  handleSave(
+  async handleSave() {
+    const {store, onSave, primaryField, keyField} = this.props;
+
+    if (!store.modifiedRows.length) {
+      return;
+    }
+
+    // 验证所有表单项，没有错误才继续
+    const subForms: Array<any> = [];
+    Object.keys(this.subForms).forEach(
+      key => this.subForms[key] && subForms.push(this.subForms[key])
+    );
+    if (subForms.length) {
+      const result = await Promise.all(subForms.map(item => item.validate()));
+      if (~result.indexOf(false)) {
+        return;
+      }
+    }
+
+    const rows = store.modifiedRows.map(item => item.data);
+    const rowIndexes = store.modifiedRows.map(item => item.path);
+    const diff = store.modifiedRows.map(item =>
+      difference(item.data, item.pristine, [keyField, primaryField!])
+    );
+    const unModifiedRows = store.rows
+      .filter(item => !item.modified)
+      .map(item => item.data);
+    if (!onSave) {
+      this.handleQuickSave(
+        rows,
+        diff,
+        rowIndexes,
+        unModifiedRows,
+        store.modifiedRows.map(item => item.pristine)
+      );
+      return;
+    }
+    onSave(
+      rows,
+      diff,
+      rowIndexes,
+      unModifiedRows,
+      store.modifiedRows.map(item => item.pristine)
+    );
+  }
+
+  // 方法同CRUD2里的handleSave
+  // 目的是为了让table2不依赖crud2可以支持快速编辑
+  @autobind
+  handleQuickSave(
     rows: Array<object> | object,
     diff: Array<object> | object,
     indexes: Array<string>,
@@ -1009,8 +1091,14 @@ export default class Table2 extends React.Component<Table2Props, object> {
       return;
     }
 
-    const {onSave, onPristineChange, primaryField, keyField, quickSaveItemApi} =
-      this.props;
+    const {
+      onSave,
+      onPristineChange,
+      saveImmediately: propsSaveImmediately,
+      primaryField,
+      keyField,
+      quickSaveItemApi
+    } = this.props;
 
     item.change(values, savePristine);
 
@@ -1019,6 +1107,9 @@ export default class Table2 extends React.Component<Table2Props, object> {
 
     if (savePristine) {
       onPristineChange?.(item.data, item.path);
+      return;
+    }
+    if (!saveImmediately && !propsSaveImmediately) {
       return;
     }
 
@@ -1036,23 +1127,26 @@ export default class Table2 extends React.Component<Table2Props, object> {
       return;
     }
 
-    onSave
-      ? onSave(
-          item.data,
-          difference(item.data, item.pristine, [keyField, primaryField!]),
-          item.path,
-          undefined,
-          item.pristine,
-          options
-        )
-      : this.handleSave(
-          quickSaveItemApi ? item.data : [item.data],
-          difference(item.data, item.pristine, [keyField, primaryField!]),
-          [item.path],
-          undefined,
-          item.pristine,
-          options
-        );
+    if (!onSave) {
+      this.handleQuickSave(
+        quickSaveItemApi ? item.data : [item.data],
+        difference(item.data, item.pristine, [keyField, primaryField!]),
+        [item.path],
+        undefined,
+        item.pristine,
+        options
+      );
+      return;
+    }
+
+    onSave(
+      item.data,
+      difference(item.data, item.pristine, [keyField, primaryField!]),
+      item.path,
+      undefined,
+      item.pristine,
+      options
+    );
   }
 
   @autobind
@@ -1285,13 +1379,6 @@ export default class Table2 extends React.Component<Table2Props, object> {
     onSaveOrder(movedItems, items);
   }
 
-  @autobind
-  reset() {
-    const {store} = this.props;
-
-    store.reset();
-  }
-
   doAction(action: ActionObject, args: any, throwErrors: boolean): any {
     const {store, data, keyField: key, expandable, primaryField} = this.props;
 
@@ -1499,13 +1586,20 @@ export default class Table2 extends React.Component<Table2Props, object> {
       };
     }
 
-    let rowClassName = undefined;
-    // 设置了行样式
-    if (rowClassNameExpr) {
-      rowClassName = (record: any, rowIndex: number) => {
-        return filter(rowClassNameExpr, {record, rowIndex});
-      };
-    }
+    const rowClassName = (record: any, rowIndex: number) => {
+      const classnames = [];
+      if (rowClassNameExpr) {
+        classnames.push(filter(rowClassNameExpr, {record, rowIndex}));
+      }
+      const row = store.getRowByIndex(rowIndex);
+      if (row.modified) {
+        classnames.push('is-modified');
+      }
+      if (row.moved) {
+        classnames.push('is-moved');
+      }
+      return classnames.join(' ');
+    };
 
     let itemActionsConfig = undefined;
     if (itemActions) {
@@ -1573,12 +1667,73 @@ export default class Table2 extends React.Component<Table2Props, object> {
   }
 
   renderHeading() {
-    let {store, classnames: cx, headingClassName, translate: __} = this.props;
+    let {
+      title,
+      store,
+      hideQuickSaveBtn,
+      data,
+      classnames: cx,
+      headingClassName,
+      saveImmediately,
+      quickSaveApi,
+      translate: __,
+      columns
+    } = this.props;
 
-    if (store.moved) {
+    // 当被修改列的 column 开启 quickEdit.saveImmediately 时，不展示提交、放弃按钮
+    let isModifiedColumnSaveImmediately = false;
+    if (store.modifiedRows.length === 1) {
+      const saveImmediatelyColumnNames: string[] =
+        columns
+          ?.map((column: any) =>
+            column?.quickEdit?.saveImmediately ? column?.name : ''
+          )
+          .filter(a => a) || [];
+
+      const item = store.modifiedRows[0];
+      const diff = difference(item.data, item.pristine);
+      if (intersection(saveImmediatelyColumnNames, Object.keys(diff)).length) {
+        isModifiedColumnSaveImmediately = true;
+      }
+    }
+
+    if (
+      title ||
+      (quickSaveApi &&
+        !saveImmediately &&
+        !isModifiedColumnSaveImmediately &&
+        store.modified &&
+        !hideQuickSaveBtn) ||
+      store.moved
+    ) {
       return (
         <div className={cx('Table-heading', headingClassName)} key="heading">
-          {store.moved ? (
+          {!saveImmediately &&
+          store.modified &&
+          !hideQuickSaveBtn &&
+          !isModifiedColumnSaveImmediately ? (
+            <span>
+              {__('Table.modified', {
+                modified: store.modified
+              })}
+              <button
+                type="button"
+                className={cx('Button Button--size-xs Button--success m-l-sm')}
+                onClick={this.handleSave}
+              >
+                <Icon icon="check" className="icon m-r-xs" />
+                {__('Form.submit')}
+              </button>
+              <button
+                type="button"
+                className={cx('Button Button--size-xs Button--danger m-l-sm')}
+                onClick={this.reset}
+              >
+                <Icon icon="close" className="icon m-r-xs" />
+                {__('Table.discard')}
+              </button>
+            </span>
+          ) : store.moved ? (
             <span>
               {__('Table.moved', {
                 moved: store.moved
@@ -1600,7 +1755,11 @@ export default class Table2 extends React.Component<Table2Props, object> {
                 {__('Table.discard')}
               </button>
             </span>
-          ) : null}
+          ) : title ? (
+            filter(title, data)
+          ) : (
+            ''
+          )}
         </div>
       );
     }
@@ -1609,14 +1768,25 @@ export default class Table2 extends React.Component<Table2Props, object> {
   }
 
   render() {
-    const {classnames: cx, style, loading = false, loadingConfig} = this.props;
+    const {
+      classnames: cx,
+      style,
+      loading = false,
+      loadingConfig,
+      store
+    } = this.props;
 
     this.renderedToolbars = []; // 用来记录哪些 toolbar 已经渲染了
 
     const heading = this.renderHeading();
 
     return (
-      <div className={cx('Table-render-wrapper')} style={style}>
+      <div
+        className={cx('Table-render-wrapper', {
+          'Table--unsaved': !!store.modified || !!store.moved
+        })}
+        style={style}
+      >
         {this.renderActions('header')}
         {heading}
         {this.renderTable()}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fd32d58</samp>

This pull request implements quick editing for table rows in `amis`, using the enhanced `TableStore2` model in `amis-core`. It allows users to modify data in place and save the changes individually or in batch, with visual feedback on the table renderer.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fd32d58</samp>

> _To edit the tables with ease_
> _They enhanced the `TableStore2` model, please_
> _With new props and functions_
> _And some views and actions_
> _And a utility to compare the data with keys_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fd32d58</samp>

*  Add quick editing functionality to table columns and rows ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292L214-R216), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292R767-R773), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292L772-R809), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R6), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R150-R154), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L404-R411), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R440), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R639-R660), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L649-R679), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L690), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L711-R747), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L772-R807), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L921-R1003), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1012-R1101), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R1112-R1114), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1039-R1149), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1576-R1737))
  * Import `difference` and `intersection` functions from helper modules to compare and filter data ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292L27-R28), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R6))
  * Add `formsRef` property to `TableStore2` model to store references to sub forms ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292L214-R216))
  * Add `addForm` action to `TableStore2` model to push sub form and row index to `formsRef` ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292R767-R773), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292L772-R809))
  * Add `quickEdit` property to `ColumnSchema` interface to configure quick editing options ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R150-R154))
  * Add `subForms` property to `Table2` class to store references to sub forms by coordinates ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R440))
  * Add `subFormRef` method to `Table2` class to pass sub form and coordinates to `quickEditFormRef` prop and `addForm` action ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R639-R660))
  * Add `title` and `label` properties to `columnSchema` and `titleProps` objects to render column titles and labels ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L649-R679), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L711-R747))
  * Remove `env` property from `columnSchema` object as it is not needed for rendering cell fields ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L690))
  * Add `quickEditFormRef` property to `cellProps` object to pass `subFormRef` method to cell fields ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L772-R807))
  * Add `handleQuickSave` method to `Table2` class to save changes when there is no `onSave` prop ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L921-R1003))
  * Add `saveImmediately` property to `handleQuickChange` method to check if changes should be saved immediately or not ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1012-R1101), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R1112-R1114))
  * Change `handleQuickChange` method to call `handleQuickSave` method instead of `handleSave` method when there is no `onSave` prop ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1039-R1149))
  * Change `handleSave` method to use `store.modifiedRows` property and validate sub forms before saving ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L921-R1003))
  * Change `renderHeading` method to render modified count and submit and discard buttons when there are modified rows and `saveImmediately` and `hideQuickSaveBtn` props are not true ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1576-R1737))
  * Change `renderHeading` method to check if modified columns have `saveImmediately` property and if so, do not render buttons ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1576-R1737))
* Add logic to track and display modified and moved rows in table store and renderer ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292R302-R320), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292R390-R397), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1502-R1602), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1612-R1777), [link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1619-R1789))
  * Add `getModifiedRows` and `getModified` functions to `TableStore2` model to recursively collect and count modified rows ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292R302-R320))
  * Add `modified` and `modifiedRows` views to `TableStore2` model to compute modified rows and count from functions ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292R390-R397))
  * Change `rowClassName` function in `renderTable` method to add `is-modified` and `is-moved` classes to modified and moved rows ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1502-R1602))
  * Add `store` property to `render` method to access modified and moved rows ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1612-R1777))
  * Add `Table--unsaved` class to wrapper div in `render` method when there are modified or moved rows ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1619-R1789))
* Add logic to render table title from `title` prop and filter it with `data` prop ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1603-R1762))
  * Change `renderHeading` method to render `title` prop if defined and filter it with `data` prop ([link](https://github.com/baidu/amis/pull/7616/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1603-R1762))
