### PR TITLE
fix: transferPicker 弹窗位置错误

### DIFF
--- a/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
@@ -109,10 +109,8 @@ export class TabsTransferPickerRenderer extends BaseTabsTransferRenderer<TabsTra
       labelField = 'label',
       valueField = 'value',
       useMobileUI,
-      env,
-      popOverContainer
+      env
     } = this.props;
-    const mobileUI = useMobileUI && isMobile();
 
     return (
       <div className={cx('TabsTransferControl', className)}>
@@ -145,11 +143,7 @@ export class TabsTransferPickerRenderer extends BaseTabsTransferRenderer<TabsTra
           labelField={labelField}
           valueField={valueField}
           useMobileUI={useMobileUI}
-          popOverContainer={
-            mobileUI
-              ? env?.getModalContainer
-              : popOverContainer || env.getModalContainer
-          }
+          popOverContainer={env?.getModalContainer}
         />
 
         <Spinner

--- a/packages/amis/src/renderers/Form/TransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TransferPicker.tsx
@@ -88,10 +88,8 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
       labelField = 'label',
       valueField = 'value',
       useMobileUI,
-      env,
-      popOverContainer
+      env
     } = this.props;
-    const mobileUI = useMobileUI && isMobile();
 
     // 目前 LeftOptions 没有接口可以动态加载
     // 为了方便可以快速实现动态化，让选项的第一个成员携带
@@ -141,11 +139,7 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
           }
           virtualThreshold={virtualThreshold}
           useMobileUI={useMobileUI}
-          popOverContainer={
-            mobileUI
-              ? env?.getModalContainer
-              : popOverContainer || env.getModalContainer
-          }
+          popOverContainer={env?.getModalContainer}
         />
 
         <Spinner


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d52e79a</samp>

Removed the `popOverContainer` prop from several components related to the transfer picker feature, and improved the popover container logic. This change simplifies the code and makes the components more consistent with the environment.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d52e79a</samp>

> _No more `popOverContainer`, no more props of pain_
> _We simplify the logic, we break the chains_
> _We get the container from the dark abyss_
> _We reduce the complexity, we code like this_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d52e79a</samp>

*  Removed the `popOverContainer` prop from the `TabsTransferPickerRenderer` and `TransferPickerRenderer` classes, as it was redundant and unnecessary ([link](https://github.com/baidu/amis/pull/7619/files?diff=unified&w=0#diff-b3d9a4cde668e595a9e905f6d4ce38b014991a0a41b16a89c9297934d9ea5334L112-R113), [link](https://github.com/baidu/amis/pull/7619/files?diff=unified&w=0#diff-b5e07e34c62b71ba2aa268d6e62e8c9c6db92b4f3d71609f840bf806f3a41c15L91-R92))
* Simplified the logic for determining the container for the popover component in the `TransferPicker` component rendered by both classes, using the optional chaining operator to access the `env.getModalContainer` function ([link](https://github.com/baidu/amis/pull/7619/files?diff=unified&w=0#diff-b3d9a4cde668e595a9e905f6d4ce38b014991a0a41b16a89c9297934d9ea5334L148-R146), [link](https://github.com/baidu/amis/pull/7619/files?diff=unified&w=0#diff-b5e07e34c62b71ba2aa268d6e62e8c9c6db92b4f3d71609f840bf806f3a41c15L144-R142))
