### PR TITLE
fix: 修复特殊字符串被当成操作符的问题 Close: #7492

### DIFF
--- a/packages/amis-formula/__tests__/evalute.test.ts
+++ b/packages/amis-formula/__tests__/evalute.test.ts
@@ -117,6 +117,10 @@ test('evalute:filter4', () => {
   ).toBe('a is 1,2,3,7');
 });
 
+test('evalute:keywords', () => {
+  expect(evaluate('a is ${JOIN([1, 2, 3], "|")}', {})).toBe('a is 1|2|3');
+});
+
 test('evalute:oldVariable', () => {
   expect(
     evaluate('a is $a', {

--- a/packages/amis-formula/src/lexer.ts
+++ b/packages/amis-formula/src/lexer.ts
@@ -336,9 +336,9 @@ export function lexer(input: string, options?: LexerOptions) {
       punctuator() ||
       char();
 
-    if (token?.value === '{') {
+    if (token?.value === '{' && token.type == 'Punctuator') {
       pushState(mainStates.BLOCK);
-    } else if (token?.value === '}') {
+    } else if (token?.value === '}' && token.type == 'Punctuator') {
       if (mainState === mainStates.Filter) {
         popState();
       }
@@ -366,7 +366,8 @@ export function lexer(input: string, options?: LexerOptions) {
     // filter 过滤器部分需要特殊处理
     if (
       mainState === mainStates.SCRIPT &&
-      token?.value === '|' &&
+      token?.type == 'Punctuator' &&
+      token.value === '|' &&
       allowFilter
     ) {
       pushState(mainStates.Filter);
@@ -376,7 +377,11 @@ export function lexer(input: string, options?: LexerOptions) {
         start: position(),
         end: position('|')
       };
-    } else if (mainState === mainStates.Filter && token?.value === '|') {
+    } else if (
+      mainState === mainStates.Filter &&
+      token?.value === '|' &&
+      token.type == 'Punctuator'
+    ) {
       return {
         type: TokenName[TokenEnum.OpenFilter],
         value: '|',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7558757</samp>

This pull request improves the formula lexer and evaluator in `amis-formula`. It fixes some parsing issues with curly braces, pipe symbols, and string literals, and adds support for array manipulation keywords like `JOIN`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7558757</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A cunning test for the `evaluate` function, and tried_
> _To make it handle `JOIN` and other keywords wise_
> _That manipulate arrays and strings with pipes applied._

### Why

Close: #7492

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7558757</samp>

*  Add a condition to check token type and value for curly braces and pipe symbols in `expression` function to avoid parsing errors ([link](https://github.com/baidu/amis/pull/7635/files?diff=unified&w=0#diff-df5c016047fe12131380e19914112903120d0ba7ae0a6baabe19927a039328b4L339-R341), [link](https://github.com/baidu/amis/pull/7635/files?diff=unified&w=0#diff-df5c016047fe12131380e19914112903120d0ba7ae0a6baabe19927a039328b4L369-R370), [link](https://github.com/baidu/amis/pull/7635/files?diff=unified&w=0#diff-df5c016047fe12131380e19914112903120d0ba7ae0a6baabe19927a039328b4L379-R384))
*  Add a test case for `evaluate` function to check array manipulation with `JOIN` keyword ([link](https://github.com/baidu/amis/pull/7635/files?diff=unified&w=0#diff-12afc0d8fc19329d900d849d7b791da51b3e399126e9e38059c4a30ba33e9c9dR120-R123))
