### PR TITLE
chore: 优化 input-kv 在编辑过程中不更换顺序 Close: #7201

### DIFF
--- a/packages/amis-core/src/renderers/wrapControl.tsx
+++ b/packages/amis-core/src/renderers/wrapControl.tsx
@@ -648,7 +648,7 @@ export function wrapControl<
 
             if (pipeOut) {
               const oldValue = this.model.value;
-              value = pipeOut(value, oldValue, data);
+              value = pipeOut.call(this, value, oldValue, data);
             }
 
             this.model.changeTmpValue(value, 'input');
@@ -767,7 +767,7 @@ export function wrapControl<
             } = this.props;
 
             if (pipeOut) {
-              value = pipeOut(value, oldValue, data);
+              value = pipeOut.call(this, value, oldValue, data);
             }
 
             if (model.extraName) {
@@ -784,7 +784,7 @@ export function wrapControl<
             let value: any = this.model ? this.model.tmpValue : control.value;
 
             if (control.pipeIn) {
-              value = control.pipeIn(value, data);
+              value = control.pipeIn.call(this, value, data);
             }
 
             return value;

--- a/packages/amis/src/schemaExtend.ts
+++ b/packages/amis/src/schemaExtend.ts
@@ -14,9 +14,12 @@ addSchemaFilter(function (schema: Schema, renderer, props?: any) {
       draggable: true,
       ...schema,
       multiple: true,
-      pipeIn: (value: any) => {
+      pipeIn: function (this: any, value: any) {
         if (!isObject(value)) {
           return [];
+        }
+        if (isEqual(value, this.cachedValue)) {
+          return this.cachedValueArray;
         }
         const arr: Array<any> = [];
         Object.keys(value).forEach(key => {
@@ -33,7 +36,7 @@ addSchemaFilter(function (schema: Schema, renderer, props?: any) {
         });
         return arr;
       },
-      pipeOut: (value: any) => {
+      pipeOut: function (this: any, value: any) {
         if (!Array.isArray(value)) {
           return value;
         }
@@ -53,6 +56,8 @@ addSchemaFilter(function (schema: Schema, renderer, props?: any) {
 
           obj[key] = value;
         });
+        this.cachedValue = obj;
+        this.cachedValueArray = value;
         return obj;
       },
       items: [


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0c80b82</samp>

Enhance the `pipeIn` and `pipeOut` functions for wrapped controls and schema extensions. These functions can now access the component instance as `this` and use the state to store and retrieve values. This allows more customization and optimization for rendering complex forms with `amis`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0c80b82</samp>

> _Sing, O Muse, of the clever code review_
> _That enhanced the component's power and scope_
> _By using `this` as the instance, they knew_
> _How to pipe in and out with skill and hope_

### Why

Close: #7201

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0c80b82</samp>

*  Call `pipeIn` and `pipeOut` functions with `this` as the current component instance in `wrapControl.tsx` and `schemaExtend.ts`, to allow access to props and state ([link](https://github.com/baidu/amis/pull/7642/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL651-R651), [link](https://github.com/baidu/amis/pull/7642/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL770-R770), [link](https://github.com/baidu/amis/pull/7642/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL787-R787), [link](https://github.com/baidu/amis/pull/7642/files?diff=unified&w=0#diff-8c4d1dcae8d1a050e267684d07324d2da3a74514de066caf0a0a3f858d35cbd8L17-R23), [link](https://github.com/baidu/amis/pull/7642/files?diff=unified&w=0#diff-8c4d1dcae8d1a050e267684d07324d2da3a74514de066caf0a0a3f858d35cbd8L36-R39))
*  Optimize `pipeIn` function in `schemaExtend.ts` by checking and returning cached value and value array from state, to avoid unnecessary computation and rendering ([link](https://github.com/baidu/amis/pull/7642/files?diff=unified&w=0#diff-8c4d1dcae8d1a050e267684d07324d2da3a74514de066caf0a0a3f858d35cbd8L17-R23), [link](https://github.com/baidu/amis/pull/7642/files?diff=unified&w=0#diff-8c4d1dcae8d1a050e267684d07324d2da3a74514de066caf0a0a3f858d35cbd8R59-R60))
