### PR TITLE
fix: 修复 static 属性嵌套影响问题 Close: #7088

### DIFF
--- a/packages/amis-core/src/SchemaRenderer.tsx
+++ b/packages/amis-core/src/SchemaRenderer.tsx
@@ -48,6 +48,8 @@ export const RENDERER_TRANSMISSION_OMIT_PROPS = [
   'hiddenOn',
   'disabled',
   'disabledOn',
+  'static',
+  'staticOn',
   'component',
   'detectField',
   'defaultValue',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c2bf700</samp>

Add `static` and `staticOn` to the list of props that are omitted when transmitting renderer props. This prevents conflicts with the `Form` component's `static` prop, which controls form editability.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c2bf700</samp>

> _`static` prop clashes_
> _Omit from transmission_
> _Form bug fixed in fall_

### Why

Close: #7088

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c2bf700</samp>

*  Add `static` and `staticOn` props to the list of omitted props when transmitting renderer props to child components, to avoid conflicts with the `Form` component's `static` prop ([link](https://github.com/baidu/amis/pull/7643/files?diff=unified&w=0#diff-337f9a56707dbfa5917084f1e2048555a5ade95f13df3f685076114867426347R51-R52))
