### PR TITLE
feat: nav支持开通页配置不跳转属性

### DIFF
--- a/packages/amis-ui/scss/components/_nav.scss
+++ b/packages/amis-ui/scss/components/_nav.scss
@@ -16,3 +16,7 @@
     height: 2px;
   }
 }
+
+.#{$ns}Nav-disable-jump {
+  cursor: text;
+}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b9ee3a9</samp>

This pull request adds a new feature to the `Nav` component that allows disabling the navigation functionality. It introduces a new prop `disableJump` and a new CSS class `.Nav-disable-jump` to control the behavior and appearance of the component. This feature can be useful for scenarios where the navigation links are only for display purposes and not for actual navigation.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b9ee3a9</samp>

> _Oh, we're the crew of the `Nav` component_
> _And we sail the web with skill and intent_
> _But sometimes we need to `disableJump`_
> _And make our cursor a text lump_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b9ee3a9</samp>

*  Add a new prop `disableJump` to the `Nav` renderer component to control whether the navigation links are clickable or not ([link](https://github.com/baidu/amis/pull/7648/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bR268-R272))
*  Pass the `disableJump` prop to the `Navigation` sub-component that renders the navigation links and handles the select events ([link](https://github.com/baidu/amis/pull/7648/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bR702))
*  Add a new CSS class `.Nav-disable-jump` that sets the cursor to text for the navigation component when the `disableJump` prop is true ([link](https://github.com/baidu/amis/pull/7648/files?diff=unified&w=0#diff-3a1304ef934e1033e1f1d935ce1eee2ed355d7b693312b46ab1408f37ccd113aR19-R22), [link](https://github.com/baidu/amis/pull/7648/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL746-R753))
  *  When the navigation link has a `source` attribute that fetches the link target from a remote API ([link](https://github.com/baidu/amis/pull/7648/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL851-R861), [link](https://github.com/baidu/amis/pull/7648/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL871-R881), [link](https://github.com/baidu/amis/pull/7648/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bR888-R890))
  *  When the navigation link is clicked and dispatches a renderer event ([link](https://github.com/baidu/amis/pull/7648/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL1204-R1226), [link](https://github.com/baidu/amis/pull/7648/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bR1265-R1268))
  *  When the component is mounted and there are children navigation links that match the current URL ([link](https://github.com/baidu/amis/pull/7648/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL1353-R1385))
