### PR TITLE
style: 解决页面设计器预览 table 的 sticky 表头显示元素会重叠的问题

### DIFF
--- a/packages/amis-editor-core/scss/editor.scss
+++ b/packages/amis-editor-core/scss/editor.scss
@@ -158,10 +158,19 @@
     position: relative;
     height: 100%;
     width: 100%;
-    padding: 24px 16px 16px;
+    padding: 0 16px 16px;
     min-width: 300px;
     background-color: $default-bg-color;
     overflow: auto;
+
+    // 因为如果成员里面有 position:sticky 的内容
+    // 用 padding 会导致位置不正确
+    // 所以改成这种写法
+    &:before {
+      content: '';
+      display: block;
+      height: 24px;
+    }
 
     @include minScrollBar();
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b3d897</samp>

Fixed a layout issue with sticky elements in the editor by using a pseudo-element instead of padding. Updated the `editor.scss` file with the new CSS rule and a comment.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5b3d897</samp>

> _`padding-top` gone_
> _`.editor:before` fills space_
> _sticky autumn leaves_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5b3d897</samp>

* Add a pseudo-element `:before` to the `.editor` class to replace the padding-top and fix the position of sticky children elements ([link](https://github.com/baidu/amis/pull/7650/files?diff=unified&w=0#diff-a655efcb1bba154f0bdcbcff35544de6ac126ba2ace65f57c008e0d1eb4c1fc9L161-R174))
