### PR TITLE
fix: 修复 autoFillHeight 模式高度问题 Close: #7606, #6850, #5565, #5067, #493…

### DIFF
--- a/packages/amis-ui/scss/components/_table.scss
+++ b/packages/amis-ui/scss/components/_table.scss
@@ -152,7 +152,6 @@
 
   &-contentWrap {
     position: relative;
-    margin-bottom: var(--Table-toolbar-marginY);
   }
 
   &-actions {

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import {findDOMNode} from 'react-dom';
 import isEqual from 'lodash/isEqual';
-import {ScopedContext, IScopedContext, SchemaExpression} from 'amis-core';
+import {
+  ScopedContext,
+  IScopedContext,
+  SchemaExpression,
+  position
+} from 'amis-core';
 import {Renderer, RendererProps} from 'amis-core';
 import {SchemaNode, ActionObject, Schema} from 'amis-core';
 import forEach from 'lodash/forEach';
@@ -504,10 +509,10 @@ export default class Table extends React.Component<TableProps, object> {
   sortable?: Sortable;
   dragTip?: HTMLElement;
   affixedTable?: HTMLTableElement;
-  parentNode?: HTMLElement | Window;
   renderedToolbars: Array<string> = [];
   subForms: any = {};
   timer: ReturnType<typeof setTimeout>;
+  toDispose: Array<() => void> = [];
 
   constructor(props: TableProps, context: IScopedContext) {
     super(props);
@@ -645,21 +650,16 @@ export default class Table extends React.Component<TableProps, object> {
 
   componentDidMount() {
     const currentNode = findDOMNode(this) as HTMLElement;
-    let parent: HTMLElement | Window | null = getScrollParent(currentNode);
 
-    if (!parent || parent === document.body) {
-      parent = window;
+    if (this.props.autoFillHeight) {
+      let frame: number;
+      let fn = () => {
+        cancelAnimationFrame(frame);
+        frame = requestAnimationFrame(this.updateAutoFillHeight);
+      };
+      this.toDispose.push(resizeSensor(currentNode.parentElement!, fn));
+      this.updateAutoFillHeight();
     }
-
-    this.parentNode = parent;
-
-    const dom = findDOMNode(this) as HTMLElement;
-    if (dom.closest('.modal-body')) {
-      return;
-    }
-
-    this.updateAutoFillHeight();
-    window.addEventListener('resize', this.updateAutoFillHeight);
 
     const {store, autoGenerateFilter, onSearchableFromInit} = this.props;
 
@@ -684,47 +684,67 @@ export default class Table extends React.Component<TableProps, object> {
     if (!autoFillHeight) {
       return;
     }
-    const table = findDOMNode(this) as HTMLElement;
-    const tableContent = table.querySelector(
-      `.${ns}Table-content`
-    ) as HTMLElement;
-    const tableContentWrap = table.querySelector(
-      `.${ns}Table-contentWrap`
-    ) as HTMLElement;
-    const footToolbar = table.querySelector(
-      `.${ns}Table-footToolbar`
-    ) as HTMLElement;
+    const table = this.table!;
+    const tableContent = table.parentElement as HTMLElement;
 
     if (!tableContent) {
       return;
     }
 
-    // 计算 table-content 在 dom 中的位置
-    const tableContentTop = offset(tableContent).top;
-    const viewportHeight = window.innerHeight;
-    // 有时候会拿不到 footToolbar？
-    const footToolbarHeight = footToolbar ? offset(footToolbar).height : 0;
-    // 有时候会拿不到 footToolbar，等一下在执行
-    if (!footToolbarHeight && footerToolbar && footerToolbar.length) {
+    // 可能数据还没到，没有渲染 footer
+    // 也可能是弹窗中，弹窗还在动画中，等一下再执行
+    if (
+      !tableContent.offsetHeight ||
+      tableContent.getBoundingClientRect().height / tableContent.offsetHeight <
+        0.8
+    ) {
       this.timer = setTimeout(() => {
         this.updateAutoFillHeight();
       }, 100);
       return;
     }
-    const tableContentWrapMarginButtom = getStyleNumber(
-      tableContentWrap,
-      'margin-bottom'
-    );
 
-    // 循环计算父级节点的 pddding，这里不考虑父级节点还可能会有其它兄弟节点的情况了
-    let allParentPaddingButtom = 0;
-    let parentNode = tableContent.parentElement;
+    // 计算 table-content 在 dom 中的位置
+
+    let viewportHeight = window.innerHeight;
+    let tableContentTop = offset(tableContent).top;
+
+    const parent = getScrollParent(tableContent.parentElement as HTMLElement);
+    if (parent && parent !== document.body) {
+      viewportHeight = parent.clientHeight - 1;
+      tableContentTop = position(tableContent, parent).top;
+    }
+
+    let tableContentBottom = 0;
+    let selfNode = tableContent;
+    let parentNode = selfNode.parentElement;
     while (parentNode) {
-      const paddingButtom = getStyleNumber(parentNode, 'padding-bottom');
+      const paddingBottom = getStyleNumber(parentNode, 'padding-bottom');
       const borderBottom = getStyleNumber(parentNode, 'border-bottom-width');
-      allParentPaddingButtom =
-        allParentPaddingButtom + paddingButtom + borderBottom;
-      parentNode = parentNode.parentElement;
+
+      let nextSiblingHeight = 0;
+      let nextSibling = selfNode.nextElementSibling as HTMLElement;
+      while (nextSibling) {
+        const positon = getComputedStyle(nextSibling).position;
+        if (positon !== 'absolute' && positon !== 'fixed') {
+          nextSiblingHeight +=
+            nextSibling.offsetHeight +
+            getStyleNumber(nextSibling, 'margin-bottom');
+        }
+
+        nextSibling = nextSibling.nextElementSibling as HTMLElement;
+      }
+
+      const marginBottom = getStyleNumber(selfNode, 'margin-bottom');
+      tableContentBottom +=
+        paddingBottom + borderBottom + marginBottom + nextSiblingHeight;
+
+      selfNode = parentNode;
+      parentNode = selfNode.parentElement;
+
+      if (parent && parent !== document.body && parent === selfNode) {
+        break;
+      }
     }
 
     const heightField =
@@ -738,13 +758,7 @@ export default class Table extends React.Component<TableProps, object> {
 
     const tableContentHeight = heightValue
       ? `${heightValue}px`
-      : `${
-          viewportHeight -
-          tableContentTop -
-          tableContentWrapMarginButtom -
-          footToolbarHeight -
-          allParentPaddingButtom
-        }px`;
+      : `${viewportHeight - tableContentTop - tableContentBottom}px`;
 
     tableContent.style[heightField] = tableContentHeight;
   }
@@ -827,7 +841,8 @@ export default class Table extends React.Component<TableProps, object> {
   componentWillUnmount() {
     const {formItem} = this.props;
 
-    window.removeEventListener('resize', this.updateAutoFillHeight);
+    this.toDispose.forEach(fn => fn());
+    this.toDispose = [];
 
     formItem && isAlive(formItem) && formItem.setSubStore(null);
     clearTimeout(this.timer);
@@ -1616,6 +1631,7 @@ export default class Table extends React.Component<TableProps, object> {
           buttons: searchableColumns.map(column => {
             return {
               type: 'checkbox',
+              label: false,
               className: cx('Table-searchableForm-checkbox'),
               inputClassName: cx('Table-searchableForm-checkbox-inner'),
               name: `__search_${column.searchable?.name ?? column.name}`,


### PR DESCRIPTION
…5, #4481

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f35c89</samp>

This pull request enhances the Table component in `amis` by improving its auto fill height feature and removing some redundant styles. It uses some utilities from `amis-core` to calculate the table height more accurately and efficiently, and fixes some bugs and unnecessary elements in the table and toolbar renderers. It also updates the corresponding SCSS file to remove the margin-bottom style from the toolbar.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1f35c89</samp>

> _The table toolbar had some padding_
> _That made the layout look quite maddening_
> _So they removed the margin_
> _And used `position` and `resizeSensor`_
> _To make the auto fill height more fitting_

### Why

Close: #7606, #6850, #5565, #5067, #4935, #4481

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f35c89</samp>

*  Remove unnecessary margin-bottom from table toolbar ([link](https://github.com/baidu/amis/pull/7665/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dL155))
*  Import position function from amis-core to calculate relative position of table to scroll parent ([link](https://github.com/baidu/amis/pull/7665/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL4-R9))
*  Add toDispose property to Table component to store functions for disposing resources or listeners ([link](https://github.com/baidu/amis/pull/7665/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL507-R515))
*  Use resizeSensor function instead of window resize event to detect changes in scroll parent and table dimensions and update auto fill height ([link](https://github.com/baidu/amis/pull/7665/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL648-R665), [link](https://github.com/baidu/amis/pull/7665/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL830-R847))
*  Simplify selectors for table, tableContent and tableContentWrap elements using table and parentElement properties ([link](https://github.com/baidu/amis/pull/7665/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL687-R690))
*  Change condition for returning early from updateAutoFillHeight method to check tableContent offsetHeight and boundingClientRect height ([link](https://github.com/baidu/amis/pull/7665/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL702-R702))
*  Change logic for calculating tableContentHeight using position function and iterating over parent and sibling elements ([link](https://github.com/baidu/amis/pull/7665/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL714-R749), [link](https://github.com/baidu/amis/pull/7665/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL741-R763))
*  Add label: false property to toolbar renderer to prevent overlapping label element ([link](https://github.com/baidu/amis/pull/7665/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR1636))
