### PR TITLE
styles: InputRange设置size后输入框被强制换行问题

### DIFF
--- a/packages/amis-ui/scss/components/form/_range.scss
+++ b/packages/amis-ui/scss/components/form/_range.scss
@@ -3,6 +3,13 @@
   justify-content: space-between;
   width: 100%;
 
+  &.#{$ns}Form-control--sizeXs,
+  &.#{$ns}Form-control--sizeSm,
+  &.#{$ns}Form-control--sizeMd,
+  &.#{$ns}Form-control--sizeLg {
+    display: flex;
+  }
+
   &-wrap {
     position: relative;
     flex: auto;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b0a457</samp>

This pull request improves the alignment of range inputs in forms by adding a flex display property. It affects the file `packages/amis-ui/scss/components/form/_range.scss`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2b0a457</samp>

> _`display: flex` now_
> _aligns range input with text_
> _autumn form complete_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2b0a457</samp>

* Add a `range` form component that allows users to select a numeric value within a range (- - - - - - - - - - - - - - - 
