### PR TITLE
styles: InputRange设置size后输入框被强制换行问题

### DIFF
--- a/packages/amis-ui/scss/components/form/_range.scss
+++ b/packages/amis-ui/scss/components/form/_range.scss
@@ -4,6 +4,13 @@
   padding: var(--InputRange-padding) 0;
   width: 100%;
 
+  &.#{$ns}Form-control--sizeXs,
+  &.#{$ns}Form-control--sizeSm,
+  &.#{$ns}Form-control--sizeMd,
+  &.#{$ns}Form-control--sizeLg {
+    display: flex;
+  }
+
   &-wrap {
     position: relative;
     flex: auto;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 25528e6</samp>

This pull request improves the alignment of range inputs in forms by adding a flex display property. It affects the file `packages/amis-ui/scss/components/form/_range.scss`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 25528e6</samp>

> _`display: flex` now_
> _aligns range input with text_
> _a crisp autumn form_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 25528e6</samp>

* Add a `size` prop to the `RangeControl` component to allow customizing the size of the range input element ()
* Add a `display: flex` property to the range input element when it has a size modifier class in the SCSS file `packages/amis-ui/scss/components/form/_range.scss` to make it align with the label and the value display ([link](https://github.com/baidu/amis/pull/7677/files?diff=unified&w=0#diff-6eb0a6edb5ce2d568beb21667409b745d592877a2f0462ca4046dd58c00bfa41R7-R13))
