### PR TITLE
fix: table2 rowClassName兼容数据替换场景

### DIFF
--- a/packages/amis-core/src/store/table2.ts
+++ b/packages/amis-core/src/store/table2.ts
@@ -442,7 +442,7 @@ export const TableStore2 = ServiceStore.named('TableStore2')
     function exchange(fromIndex: number, toIndex: number, item?: IRow2) {
       item = item || self.rows[fromIndex];
 
-      if (item.parentId) {
+      if (item?.parentId) {
         const parent: IRow2 = self.getRowById(item.parentId) as any;
         const offset = parent.children.indexOf(item) - fromIndex;
         toIndex += offset;

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -1591,11 +1591,13 @@ export default class Table2 extends React.Component<Table2Props, object> {
       if (rowClassNameExpr) {
         classnames.push(filter(rowClassNameExpr, {record, rowIndex}));
       }
+      // row可能不存在
+      // 比如初始化给了10条数据，异步接口又替换成4条
       const row = store.getRowByIndex(rowIndex);
-      if (row.modified) {
+      if (row?.modified) {
         classnames.push('is-modified');
       }
-      if (row.moved) {
+      if (row?.moved) {
         classnames.push('is-moved');
       }
       return classnames.join(' ');


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1916339</samp>

This pull request fixes a bug that caused errors and rendering issues when using nested data in a table. It adds optional chaining operators to safely access properties of `item` and `row` in `table2.ts` and `Table2/index.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1916339</samp>

> _`item` and `row`?_
> _Check with `?.` operator_
> _Autumn bug is fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1916339</samp>

*  Prevent errors when accessing properties of possibly null or undefined items or rows in table with nested data ([link](https://github.com/baidu/amis/pull/7678/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292L445-R445), [link](https://github.com/baidu/amis/pull/7678/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1594-R1600))
