### PR TITLE
fix: 解决transfer\tree等options组件渲染大量节点时页面卡死崩溃的问题

### DIFF
--- a/packages/amis-core/src/utils/optionValueCompare.ts
+++ b/packages/amis-core/src/utils/optionValueCompare.ts
@@ -2,16 +2,28 @@ import {OptionValue, Option} from '../types';
 import {isObject} from './helper';
 import isEqual from 'lodash/isEqual';
 
+export function getOptionValue(
+  value: OptionValue,
+  valueField: string = 'value'
+) {
+  return isObject(value) &&
+    value &&
+    (value as Option).hasOwnProperty(valueField)
+    ? (value as Option)[valueField]
+    : value;
+}
+
+export function getOptionValueBindField(valueField: string = 'value') {
+  return (value: OptionValue) => getOptionValue(value, valueField);
+}
+
 export function matchOptionValue(
   a: OptionValue,
   b: Option,
   valueField: string = 'value'
 ) {
   // a 可能为 Option, 此时需要取其value
-  const aValue =
-    isObject(a) && a && (a as Option).hasOwnProperty(valueField)
-      ? (a as Option)[valueField]
-      : a;
+  const aValue = getOptionValue(a, valueField);
   const bValue = b[valueField || 'value'];
   return isObject(aValue)
     ? isEqual(aValue, bValue)

--- a/packages/amis-ui/src/components/ResultTableList.tsx
+++ b/packages/amis-ui/src/components/ResultTableList.tsx
@@ -69,8 +69,13 @@ export class BaseResultTableSelection extends BaseSelection<
   };
 
   static getDerivedStateFromProps(props: ResultTableSelectionProps) {
-    const {options, value, option2value} = props;
-    const valueArray = BaseSelection.value2array(value, options, option2value);
+    const {options, value, option2value, valueField} = props;
+    const valueArray = BaseSelection.value2array(
+      value,
+      options,
+      option2value,
+      valueField
+    );
     return {
       tableOptions: valueArray
     };
@@ -78,7 +83,8 @@ export class BaseResultTableSelection extends BaseSelection<
 
   @autobind
   handleCloseItem(option: Option) {
-    const {value, onChange, option2value, options, disabled} = this.props;
+    const {value, onChange, option2value, options, disabled, valueField} =
+      this.props;
 
     const {searching, searchTableOptions} = this.state;
 
@@ -87,7 +93,12 @@ export class BaseResultTableSelection extends BaseSelection<
     }
 
     // 删除普通值
-    let valueArray = BaseSelection.value2array(value, options, option2value);
+    let valueArray = BaseSelection.value2array(
+      value,
+      options,
+      option2value,
+      valueField
+    );
 
     let idx = valueArray.indexOf(option);
     valueArray.splice(idx, 1);
@@ -100,7 +111,8 @@ export class BaseResultTableSelection extends BaseSelection<
       const searchArray = BaseSelection.value2array(
         searchTableOptions,
         options,
-        option2value
+        option2value,
+        valueField
       );
       const searchIdx = searchArray.indexOf(option);
       searchTableOptions.splice(searchIdx, 1);

--- a/packages/amis-ui/src/components/Select.tsx
+++ b/packages/amis-ui/src/components/Select.tsx
@@ -5,7 +5,11 @@
  * @date 2017-11-07
  */
 
-import {uncontrollable} from 'amis-core';
+import {
+  getOptionValue,
+  getOptionValueBindField,
+  uncontrollable
+} from 'amis-core';
 import React from 'react';
 import isInteger from 'lodash/isInteger';
 import omit from 'lodash/omit';
@@ -108,20 +112,29 @@ export function value2array(
   >,
   enableNodePath: boolean = false
 ): Array<Option> {
+  const {
+    labelField,
+    valueField = 'value',
+    pathSeparator,
+    delimiter,
+    options,
+    multi,
+    multiple
+  } = props;
   if (enableNodePath) {
     value = normalizeNodePath(
       value,
       enableNodePath,
-      props.labelField,
-      props.valueField,
-      props.pathSeparator,
-      props.delimiter
+      labelField,
+      valueField,
+      pathSeparator,
+      delimiter
     ).nodeValueArray;
   }
 
-  if (props.multi || props.multiple) {
+  if (multi || multiple) {
     if (typeof value === 'string') {
-      value = value.split(props.delimiter || ',');
+      value = value.split(delimiter || ',');
     }
 
     if (!Array.isArray(value)) {
@@ -133,27 +146,21 @@ export function value2array(
     }
 
     return value
-      .map(
-        (value: any) =>
-          expandValue(value, props.options, props.valueField) ||
-          (isObject(value) && value.hasOwnProperty(props.valueField || 'value')
-            ? value
-            : undefined)
+      .map((value: any) =>
+        expandValue(value, options, valueField) ||
+        (isObject(value) && value.hasOwnProperty(valueField))
+          ? value
+          : undefined
       )
       .filter((item: any) => item) as Array<Option>;
   } else if (Array.isArray(value)) {
     value = value[0];
   }
 
-  let expandedValue = expandValue(
-    value as OptionValue,
-    props.options,
-    props.valueField
-  );
+  let expandedValue = expandValue(value as OptionValue, options, valueField);
   return expandedValue
     ? [expandedValue]
-    : isObject(value) &&
-      (value as Option).hasOwnProperty(props.valueField || 'value')
+    : isObject(value) && (value as Option).hasOwnProperty(valueField || 'value')
     ? [value as Option]
     : [];
 }
@@ -186,10 +193,10 @@ export function expandValue(
     value = (value as Option)[valueField || 'value'] ?? '';
   }
 
-  return findTree(
-    options,
-    optionValueCompare(value, valueField || 'value')
-  ) as Option;
+  return findTree(options, optionValueCompare(value, valueField || 'value'), {
+    resolve: getOptionValueBindField(valueField),
+    value: getOptionValue(value, valueField)
+  }) as Option;
 }
 
 export function matchOptionValue(

--- a/packages/amis-ui/src/components/Selection.tsx
+++ b/packages/amis-ui/src/components/Selection.tsx
@@ -15,7 +15,9 @@ import {
   ThemeProps,
   autobind,
   findTree,
-  flattenTree
+  flattenTree,
+  getOptionValue,
+  getOptionValueBindField
 } from 'amis-core';
 import Checkbox from './Checkbox';
 import {Option, Options} from './Select';
@@ -81,7 +83,8 @@ export class BaseSelection<
   static value2array(
     value: any,
     options: Options,
-    option2value: (option: Option) => any = (option: Option) => option
+    option2value: (option: Option) => any = (option: Option) => option,
+    valueField?: string
   ): Options {
     if (value === void 0) {
       return [];
@@ -92,8 +95,15 @@ export class BaseSelection<
     }
 
     return value.map((value: any) => {
-      const option = findTree(options, option =>
-        isEqual(option2value(option), value)
+      const option = findTree(
+        options,
+        option => isEqual(option2value(option), value),
+        valueField
+          ? {
+              value: getOptionValue(value, valueField),
+              resolve: getOptionValueBindField(valueField)
+            }
+          : undefined
       );
       return option || value;
     });
@@ -132,14 +142,20 @@ export class BaseSelection<
       options,
       disabled,
       multiple,
-      clearable
+      clearable,
+      valueField
     } = this.props;
 
     if (disabled || option.disabled) {
       return;
     }
 
-    let valueArray = BaseSelection.value2array(value, options, option2value);
+    let valueArray = BaseSelection.value2array(
+      value,
+      options,
+      option2value,
+      valueField
+    );
     let idx = valueArray.indexOf(option);
 
     if (~idx && (multiple || clearable)) {
@@ -207,12 +223,18 @@ export class BaseSelection<
       itemRender,
       multiple,
       labelField,
+      valueField,
       onClick
     } = this.props;
 
     const __ = this.props.translate;
 
-    let valueArray = BaseSelection.value2array(value, options, option2value);
+    let valueArray = BaseSelection.value2array(
+      value,
+      options,
+      option2value,
+      valueField
+    );
     let body: Array<React.ReactNode> = [];
 
     if (Array.isArray(options) && options.length) {

--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -155,6 +155,7 @@ interface TreeSelectorProps extends ThemeProps, LocaleProps, SpinnerExtraProps {
 
 interface TreeSelectorState {
   value: Array<any>;
+  valueSet: Set<any>;
   inputValue: string;
   addingParent: Option | null;
   isAdding: boolean;
@@ -227,19 +228,21 @@ export class TreeSelector extends React.Component<
 
   constructor(props: TreeSelectorProps) {
     super(props);
+    const value = value2array(
+      props.value,
+      {
+        multiple: props.multiple,
+        delimiter: props.delimiter,
+        valueField: props.valueField,
+        labelField: props.labelField,
+        options: props.options,
+        pathSeparator: props.pathSeparator
+      },
+      props.enableNodePath
+    );
     this.state = {
-      value: value2array(
-        props.value,
-        {
-          multiple: props.multiple,
-          delimiter: props.delimiter,
-          valueField: props.valueField,
-          labelField: props.labelField,
-          options: props.options,
-          pathSeparator: props.pathSeparator
-        },
-        props.enableNodePath
-      ),
+      value,
+      valueSet: new Set(value),
       flattenedOptions: [],
       inputValue: '',
       addingParent: null,
@@ -273,19 +276,21 @@ export class TreeSelector extends React.Component<
       prevProps.value !== props.value ||
       prevProps.options !== props.options
     ) {
+      const newValue = value2array(
+        props.value,
+        {
+          multiple: props.multiple,
+          delimiter: props.delimiter,
+          valueField: props.valueField,
+          pathSeparator: props.pathSeparator,
+          options: props.options,
+          labelField: props.labelField
+        },
+        props.enableNodePath
+      );
       this.setState({
-        value: value2array(
-          props.value,
-          {
-            multiple: props.multiple,
-            delimiter: props.delimiter,
-            valueField: props.valueField,
-            pathSeparator: props.pathSeparator,
-            options: props.options,
-            labelField: props.labelField
-          },
-          props.enableNodePath
-        )
+        value: newValue,
+        valueSet: new Set(newValue)
       });
     }
   }
@@ -481,28 +486,29 @@ export class TreeSelector extends React.Component<
   handleCheck(item: any, checked: boolean) {
     // TODO: 重新梳理这里的逻辑
     const props = this.props;
-    const value = this.state.value.concat();
-    const idx = value.indexOf(item);
+    const value = this.state.valueSet;
     const {onlyChildren, withChildren, cascade, autoCheckChildren} = props;
     if (checked) {
-      ~idx || value.push(item);
+      if (!value.has(item)) {
+        value.add(item);
+      }
       // cascade 为 true 表示父节点跟子节点没有级联关系。
       if (autoCheckChildren) {
-        const children = item.children ? item.children.concat([]) : [];
+        const children = item.children ? [...item.children] : [];
         const hasDisabled = flattenTree(children).some(item => item?.disabled);
 
         if (onlyChildren) {
-          // 父级选中的时候，子节点也都选中，但是自己不选中
-          !~idx && children.length && value.pop();
-
           // 这个 isAllChecked 主要是判断如果有disabled的item项，这时父节点还是选中的话，针对性的处理逻辑
           const isAllChecked = flattenTreeWithLeafNodes(children)
             .filter(item => !item?.disabled)
-            .every(v => ~value.indexOf(v));
+            .every(v => value.has(v));
+          // 父级选中的时候，子节点也都选中，但是自己不选中
+          if (value.has(item) && children.length) {
+            value.delete(item);
+          }
 
           while (children.length) {
             let child = children.shift();
-            let index = value.indexOf(child);
 
             if (child.children && child.children.length) {
               children.push.apply(children, child.children);
@@ -511,43 +517,48 @@ export class TreeSelector extends React.Component<
 
             if (hasDisabled && isAllChecked) {
               if (
-                ~index &&
-                children.value !== 'undefined' &&
+                value.has(child) &&
+                child.value !== 'undefined' &&
                 !child?.disabled
               ) {
-                value.splice(index, 1);
+                value.delete(child);
               }
               continue;
             }
 
-            if (!~index && child.value !== 'undefined' && !child?.disabled) {
-              value.push(child);
+            if (
+              !value.has(child) &&
+              child.value !== 'undefined' &&
+              !child?.disabled
+            ) {
+              value.add(child);
             }
           }
         } else {
           // 这个 isAllChecked 主要是判断如果有disabled的item项，这时父节点还是选中的话，针对性的处理逻辑
           const isAllChecked = flattenTree(children)
             .filter(item => !item?.disabled)
-            .every(v => ~value.indexOf(v));
+            .every(v => value.has(v));
 
           // 只要父节点选择了,子节点就不需要了,全部去掉勾选.  withChildren时相反
           while (children.length) {
             let child = children.shift();
-            let index = value.indexOf(child);
 
-            if (!child?.disabled) {
-              // 判断下下面是否有禁用项
-              if (!hasDisabled) {
-                if (~index) {
-                  value.splice(index, 1);
-                }
+            if (child?.disabled) {
+              continue;
+            }
 
-                if (withChildren || cascade) {
-                  value.push(child);
-                }
-              } else {
-                isAllChecked ? value.splice(index, 1) : value.push(child);
+            // 判断下下面是否有禁用项
+            if (!hasDisabled) {
+              if (value.has(child)) {
+                value.delete(child);
               }
+
+              if (withChildren || cascade) {
+                value.add(child);
+              }
+            } else {
+              isAllChecked ? value.delete(child) : value.add(child);
             }
 
             if (child.children && child.children.length) {
@@ -560,21 +571,18 @@ export class TreeSelector extends React.Component<
           while (true) {
             const parent = getTreeParent(props.options, toCheck);
             // 判断 parent 节点是否已经勾选，避免重复值
-            if (parent?.value && !~value.indexOf(parent)) {
+            if (parent?.value && !value.has(parent)) {
               // 如果所有孩子节点都勾选了，应该自动勾选父级。
 
-              if (
-                parent.children.every((child: any) => ~value.indexOf(child))
-              ) {
+              if (parent.children.every((child: any) => value.has(child))) {
                 if (!cascade && !withChildren) {
                   parent.children.forEach((child: any) => {
-                    const index = value.indexOf(child);
-                    if (~index) {
-                      value.splice(index, 1);
+                    if (value.has(child)) {
+                      value.delete(child);
                     }
                   });
                 }
-                value.push(parent);
+                value.add(parent);
                 toCheck = parent;
                 continue;
               }
@@ -584,15 +592,14 @@ export class TreeSelector extends React.Component<
         }
       }
     } else {
-      ~idx && value.splice(idx, 1);
+      value.has(item) && value.delete(item);
       if (autoCheckChildren) {
         if (cascade || withChildren || onlyChildren) {
-          const children = item.children ? item.children.concat([]) : [];
+          const children = item.children ? [...item.children] : [];
           while (children.length) {
             let child = children.shift();
-            let index = value.indexOf(child);
-            if (~index && !child?.disabled) {
-              value.splice(index, 1);
+            if (value.has(child) && !child?.disabled) {
+              value.delete(child);
             }
             if (child.children && child.children.length) {
               children.push.apply(children, child.children);
@@ -604,9 +611,9 @@ export class TreeSelector extends React.Component<
 
     this.setState(
       {
-        value
+        value: [...value]
       },
-      () => this.fireChange(value)
+      () => this.fireChange([...value])
     );
   }
 
@@ -952,11 +959,21 @@ export class TreeSelector extends React.Component<
     if (!item || !this.relations.get(item)) {
       return false;
     }
-    const itemParent = this.relations.get(item);
-    const {value} = this.state;
-    const checked = !!~value.indexOf(itemParent);
 
-    return checked || this.isParentChecked(itemParent);
+    const {valueSet} = this.state;
+    let currentItem = item;
+    while (currentItem) {
+      const itemParent = this.relations.get(currentItem);
+      if (!itemParent) {
+        return false;
+      }
+      if (valueSet.has(itemParent)) {
+        return true;
+      }
+      currentItem = itemParent;
+    }
+
+    return false;
   }
 
   /**
@@ -999,30 +1016,25 @@ export class TreeSelector extends React.Component<
 
     const {autoCheckChildren, onlyChildren, multiple, withChildren, cascade} =
       this.props;
-    const {value} = this.state;
-    const checked = !!~value.indexOf(item);
+    const {valueSet} = this.state;
+    const checked = valueSet.has(item);
 
     if (checked) {
       return true;
     }
 
     if (item.children?.length) {
-      if (
-        onlyChildren &&
-        autoCheckChildren &&
-        this.isItemChildrenChecked(item) // TODO: 优化这个逻辑
-      ) {
-        // 当前元素没有在 value 中，但是子组件全部勾选了
-        return true;
+      if (onlyChildren && autoCheckChildren) {
+        if (this.isItemChildrenChecked(item)) {
+          // 当前元素没有在 value 中，但是子组件全部勾选了
+          return true;
+        }
       }
     }
     const itemParent = this.relations.get(item);
     if (itemParent && multiple && autoCheckChildren) {
       // 当前节点为子节点
-      if (withChildren) {
-        return false;
-      }
-      if (cascade) {
+      if (withChildren || cascade) {
         return false;
       }
       return this.isParentChecked(item);
@@ -1069,13 +1081,10 @@ export class TreeSelector extends React.Component<
 
     const itemParent = this.relations.get(item);
 
-    if (
-      autoCheckChildren &&
-      multiple &&
-      checked &&
-      itemParent &&
-      this.isItemChecked(itemParent)
-    ) {
+    if (autoCheckChildren && multiple && checked && itemParent) {
+      if (!this.isItemChecked(itemParent)) {
+        return false;
+      }
       // 子节点
       if (onlyChildren) {
         return false;

--- a/packages/amis-ui/src/components/TreeSelection.tsx
+++ b/packages/amis-ui/src/components/TreeSelection.tsx
@@ -85,7 +85,8 @@ export class TreeSelection extends BaseSelection<
       onDeferLoad,
       disabled,
       multiple,
-      clearable
+      clearable,
+      valueField
     } = this.props;
 
     if (disabled || option.disabled) {
@@ -95,7 +96,12 @@ export class TreeSelection extends BaseSelection<
       return;
     }
 
-    let valueArray = BaseSelection.value2array(value, options, option2value);
+    let valueArray = BaseSelection.value2array(
+      value,
+      options,
+      option2value,
+      valueField
+    );
 
     if (
       option.value === void 0 &&
@@ -289,10 +295,16 @@ export class TreeSelection extends BaseSelection<
       classnames: cx,
       option2value,
       placeholderRender,
+      valueField,
       translate: __
     } = this.props;
 
-    this.valueArray = BaseSelection.value2array(value, options, option2value);
+    this.valueArray = BaseSelection.value2array(
+      value,
+      options,
+      option2value,
+      valueField
+    );
     let body: Array<React.ReactNode> = [];
 
     if (Array.isArray(options) && options.length) {

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -6,7 +6,8 @@ import {
   OptionsControl,
   FormOptionsControl,
   resolveEventData,
-  str2function
+  str2function,
+  getOptionValueBindField
 } from 'amis-core';
 import {SpinnerExtraProps, Transfer} from 'amis-ui';
 import type {Option} from 'amis-core';
@@ -233,7 +234,11 @@ export class BaseTransferRenderer<
           optionValueCompare(
             item[(valueField as string) || 'value'],
             (valueField as string) || 'value'
-          )
+          ),
+          {
+            resolve: getOptionValueBindField(valueField),
+            value: item[valueField as string] || 'value'
+          }
         );
 
         if (!indexes) {


### PR DESCRIPTION
What
- Transfer、Tree 等Options 类型组件在source超过一定数量时，页面会崩溃
- 本次主要针对 Transfer、Tree组件以及相关公共函数进行优化
- 主要原因是 
  - 数组在循环调用 findTree、findTreeIndex 等函数, 
  - 调用lodash的differenceWith数来计算两个数组之间的差异，时间复杂度会达到 O(n^2)
  - 在react render时重复计算上面的耗时计算，执行栈被卡死

How
- 主要优化思路是：缓存部分计算结果予以复用，使用Map、Set避免数组双循环将复杂度从 O(n^2) 降到 O(n)
- 优化`findTree和findTreeIndex`函数，以及使用缓存映射来提高从同一棵树中反复查找值的性能
- 优化`value2array`,`getSelectedOptions` 等通用耗时函数
- 优化`everyTree`，使用堆栈（stack）代替递归
- 添加并使用`valueSet`属性到`TreeSelectorState接口和TreeSelector`组件，使用`Set`而不是`Array`来存储和检查选定的值
- 改变`Transfer.tsx`中检查是否选择了所有可用选项的逻辑，使用集合代替数组来提高性能
- 改变`Tree.tsx`中检查父节点或子节点是否被选中的逻辑，使用while循环代替递归函数，并基于valueSet属性添加或简化条件
- 内敛部分函数的 if 判断条件，减少计算次数
- 其他简单优化

遗留问题
- amis-ui/Transfer 组件中使用的 `lodash.intersectionWith` 和 `lodash.unionWith` 被大数据调用时，仍然会有性能崩溃问题
- 与之相关的 `isAvailableOptionsAllSelected` 本身逻辑不完善，其他人已经在修复中

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ea99602</samp>

*  Add and use `getOptionValue` and `getOptionValueBindField` functions to handle different types of values in option components ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L34-R41), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L184-R250), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L666-R708), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L827-R874), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L1123-R1188), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L1142-R1200), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L1149-R1214), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-4b99b40978ec3331959241a3bf68215586177fbdf0374f4a4da33d0d0d083c2aR5-R19), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-4b99b40978ec3331959241a3bf68215586177fbdf0374f4a4da33d0d0d083c2aL11-R26), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL136-R153), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL148-R163), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL181-R191), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-ba63d39ad70a1c34ad20fbabdac0ec1361040e7e45d3abe4d7c7e19d6f133384L95-R106), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-ba63d39ad70a1c34ad20fbabdac0ec1361040e7e45d3abe4d7c7e19d6f133384L142-R158), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L217-R237), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L333-R353), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L388-R418), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L484-R511), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L514-R534), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L531-R561), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L563-R585), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L587-R602), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L955-R976), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1002-R1020), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1010-R1031), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1022-R1039), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1072-R1087), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-07debd2e776c043c2635a6714d9622ad216538a5d1a7d75a982e41f30e711e71L236-R241))
* Add and use `differenceFromAll` function to calculate the difference between two arrays based on a value function, and improve performance with a cache mechanism ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aR2000-R2032), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L3), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L9-R8), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L207-R223))
* Add and use `valueField` prop to pass the value field name to the option components and the `value2array` function ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-99f14dfb8d73cbb9b262d2b12e07f896a9dbc514de6c3f97ca2d156f90133758L72-R78), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-99f14dfb8d73cbb9b262d2b12e07f896a9dbc514de6c3f97ca2d156f90133758L81-R87), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-99f14dfb8d73cbb9b262d2b12e07f896a9dbc514de6c3f97ca2d156f90133758L90-R101), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-99f14dfb8d73cbb9b262d2b12e07f896a9dbc514de6c3f97ca2d156f90133758L103-R115), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL111-R137), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-ba63d39ad70a1c34ad20fbabdac0ec1361040e7e45d3abe4d7c7e19d6f133384L84-R87), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-ba63d39ad70a1c34ad20fbabdac0ec1361040e7e45d3abe4d7c7e19d6f133384L135-R146), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-ba63d39ad70a1c34ad20fbabdac0ec1361040e7e45d3abe4d7c7e19d6f133384R226), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-ba63d39ad70a1c34ad20fbabdac0ec1361040e7e45d3abe4d7c7e19d6f133384L215-R237), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L373-R391), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L833-R857), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L230-R245), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L276-R293), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L607-R616), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-fff9b9be7690e3e3ea14b9b498c7bb96ce12ec48bb58bf7e29c275aebd45057aL88-R89), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-fff9b9be7690e3e3ea14b9b498c7bb96ce12ec48bb58bf7e29c275aebd45057aL98-R104), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-fff9b9be7690e3e3ea14b9b498c7bb96ce12ec48bb58bf7e29c275aebd45057aL292-R307))
* Add and use `getSelectedOptionsCache` variable to cache the result of the `getSelectedOptions` function in `formItem.ts` ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9R58-R66), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L161-R192), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L184-R250))
* Add and use `withCache` parameter to the `findTree` and `findTreeIndex` functions in `helper.ts`, and use a cache map to improve performance when finding values from the same tree repeatedly ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL841-R901), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL884-R988))
* Add and use `valueSet` property to the `TreeSelectorState` interface and the `TreeSelector` component, and use a set instead of an array to store and check the selected values ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7R158), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L230-R245), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L276-R293), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L484-R511), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L514-R534), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L531-R561), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L563-R585), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L587-R602), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L607-R616), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L955-R976), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1002-R1020), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1010-R1031), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1022-R1039), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1072-R1087))
* Change the logic of iterating over the tree in `helper.ts`, using a for loop or a stack instead of a map or a recursive function, and allowing the iterator to return 'break', 'continue', or a boolean value to control the loop flow ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL828-R842), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1005-R1126))
* Change the logic of creating a new item with disabled state in `formItem.ts`, using the previous filtered option if the disabled state is the same, or creating a new object with the disabled property otherwise ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L1110-R1160))
* Change the logic of finding the tree index in `helper.ts`, using the `foundEffect` function to leverage the index calculation logic from the `findTree` function ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL884-R988))
* Change the logic of expanding the value to the option in `Select.tsx`, using the `expandValue` function or the `isObject` check to handle different types of values ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL136-R153), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL148-R163))
* Change the logic of normalizing the node path in `Select.tsx`, using the `enableNodePath` parameter to control the behavior ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL111-R137))
* Change the logic of checking if all available options are selected in `Transfer.tsx`, using a set instead of an array to improve performance ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L388-R418))
* Change the logic of checking if the parent or the children are checked in `Tree.tsx`, using a while loop instead of a recursive function, and adding or simplifying conditions based on the `valueSet` property ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L955-R976), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1002-R1020), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1010-R1031), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1022-R1039), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1072-R1087))
* Simplify the logic of getting the value array from the value argument in `formItem.ts`, and use the destructured variables from `self` ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L170-R203))
* Simplify the logic of creating an unmatched option in `formItem.ts`, using the `valueField` and `labelField` variables instead of hard-coded strings ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L1142-R1200), [link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L1149-R1214))
* Remove an empty line in `formItem.ts` ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9R1245))
* Add a new import of `eachTree` from `../utils/helper` in `formItem.ts` ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L25-R26))
* Add a new import of `uncontrollable` from `amis-core` in `Select.tsx` ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL8-R12))
* Add new imports of `isNumber` and `isString` from `lodash` in `helper.ts` ([link](https://github.com/baidu/amis/pull/7679/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aR30))
