### PR TITLE
fix: flex布局容器,、表单等取消边距

### DIFF
--- a/packages/amis-core/src/renderers/Item.tsx
+++ b/packages/amis-core/src/renderers/Item.tsx
@@ -997,7 +997,8 @@ export class FormItemWrap extends React.Component<FormItemProps> {
                       : 'normal'
                   }`]: horizontal.leftFixed,
                   [`Form-itemColumn--${left}`]: !horizontal.leftFixed,
-                  'Form-label--left': labelAlign === 'left'
+                  'Form-label--left': labelAlign === 'left',
+                  'Form-label-noLabel': label === ''
                 },
                 getItemLabelClassName(props)
               )}

--- a/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
+++ b/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
@@ -33,7 +33,7 @@ export const defaultFlexColumnSchema = (title?: string) => {
 // 默认的布局容器Schema
 const defaultFlexContainerSchema = {
   type: 'flex',
-  className: 'p-1',
+  className: '',
   items: [
     defaultFlexColumnSchema('第一列'),
     defaultFlexColumnSchema('第二列'),

--- a/packages/amis-editor/src/plugin/Layout/Layout_sorption_container.tsx
+++ b/packages/amis-editor/src/plugin/Layout/Layout_sorption_container.tsx
@@ -14,7 +14,7 @@ export default class Layout_fixed_top extends FlexPluginBase {
     type: 'flex',
     isSorptionContainer: true,
     sorptionPosition: 'top',
-    className: 'p-1',
+    className: '',
     items: [
       defaultFlexColumnSchema(),
       defaultFlexColumnSchema(),

--- a/packages/amis-ui/scss/components/_wrapper.scss
+++ b/packages/amis-ui/scss/components/_wrapper.scss
@@ -1,22 +1,22 @@
 .#{$ns}Wrapper,
 .#{$ns}Container {
   &--xs {
-    padding: var(--gap-xs);
+    // padding: var(--gap-xs);
   }
 
   &--sm {
-    padding: var(--gap-sm);
+    // padding: var(--gap-sm);
   }
 
   &--md {
-    padding: var(--gap-md);
+    // padding: var(--gap-md);
   }
 
   &--lg {
-    padding: var(--gap-lg);
+    // padding: var(--gap-lg);
   }
 
   &--xl {
-    padding: var(--gap-xl);
+    // padding: var(--gap-xl);
   }
 }

--- a/packages/amis-ui/scss/components/form/_form.scss
+++ b/packages/amis-ui/scss/components/form/_form.scss
@@ -274,6 +274,10 @@
         margin-right: var(--Form--horizontal-label-gap);
         flex-shrink: 0;
 
+        &-noLabel {
+          margin-right: 0;
+        }
+
         .#{$ns}Form-star {
           position: absolute;
           left: px2rem(-6px);

--- a/packages/amis-ui/scss/layout/_grid.scss
+++ b/packages/amis-ui/scss/layout/_grid.scss
@@ -17,16 +17,16 @@
     min-height: 1px;
     max-width: 100%;
     width: 100%;
-    padding-left: math.div($Grid-gutterWidth, 2);
-    padding-right: math.div($Grid-gutterWidth, 2);
+    // padding-left: math.div($Grid-gutterWidth, 2);
+    // padding-right: math.div($Grid-gutterWidth, 2);
   }
 
   .#{$ns}Grid-col--#{$class}Auto {
     flex: 0 0 auto;
     width: auto;
     max-width: 100%;
-    padding-left: math.div($Grid-gutterWidth, 2);
-    padding-right: math.div($Grid-gutterWidth, 2);
+    // padding-left: math.div($Grid-gutterWidth, 2);
+    // padding-right: math.div($Grid-gutterWidth, 2);
   }
 }
 

--- a/packages/amis-ui/scss/layout/_grid.scss
+++ b/packages/amis-ui/scss/layout/_grid.scss
@@ -32,8 +32,8 @@
 
 // Generate Grid row
 @mixin make-row($gutter: $Grid-gutterWidth) {
-  margin-left: math.div($gutter, -2);
-  margin-right: math.div($gutter, -2);
+  // margin-left: math.div($gutter, -2);
+  // margin-right: math.div($gutter, -2);
   display: flex;
   flex-wrap: wrap;
 }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef33a41</samp>

This pull request removes or comments out some default padding rules for various layout and form components in `amis-ui` and `amis-editor`. This allows more flexibility and control for the user to customize the spacing and alignment of their elements. It also adds a new CSS class `Form-label-noLabel` to handle the case of form items with empty labels.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ef33a41</samp>

> _No more padding, no more space_
> _We control the layout of our fate_
> _`Form-label-noLabel` is our class_
> _We break the rules of the CSS_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ef33a41</samp>

*  Remove default padding from flex and sorption container schemas to give user more control over layout ([link](https://github.com/baidu/amis/pull/7681/files?diff=unified&w=0#diff-0c77368e9183efe6a72ad9cdc7339d1c15ab5f70f8518721c1bda55460262a07L36-R36), [link](https://github.com/baidu/amis/pull/7681/files?diff=unified&w=0#diff-2017ff4b4a1ae3f652ccffbe9eeeeac2fe380d009438d1ddeaf8225b0be65183L17-R17))
*  Add `Form-label-noLabel` class to label element of form item when label is empty and set its margin-right to zero to improve layout of form items with no labels ([link](https://github.com/baidu/amis/pull/7681/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1000-R1001), [link](https://github.com/baidu/amis/pull/7681/files?diff=unified&w=0#diff-f325489c306f0106cb368664288efa079f007a051f746e29ad32d88cde2abb4dR277-R280))
*  Comment out padding rules for container modifier classes and grid column elements in SCSS files to disable them by default and let user decide whether to use them or not ([link](https://github.com/baidu/amis/pull/7681/files?diff=unified&w=0#diff-733283b52cdf17256b725aa928c87ca86de7f0f5270af55f1d1a266254425b82L4-R20), [link](https://github.com/baidu/amis/pull/7681/files?diff=unified&w=0#diff-e4fada7e1a63d9c17e5ab079cca8b1c96c2452e69cbf9f6225180aa5b0746e4eL20-R21), [link](https://github.com/baidu/amis/pull/7681/files?diff=unified&w=0#diff-e4fada7e1a63d9c17e5ab079cca8b1c96c2452e69cbf9f6225180aa5b0746e4eL28-R29))
