### PR TITLE
fix: nav图标增加默认间距、菜单项显隐问题修复

### DIFF
--- a/packages/amis-ui/scss/components/_menu.scss
+++ b/packages/amis-ui/scss/components/_menu.scss
@@ -225,8 +225,6 @@
   }
 
   &-item-icon {
-    margin-right: var(--gap-sm);
-
     &-collapsed {
       font-size: var(--Menu-fontSize--collapsed);
       margin: 0 auto;
@@ -238,12 +236,6 @@
         margin: 0 auto;
       }
     }
-  }
-
-  // 悬浮菜单是挂在body下面的
-  &-item-icon-after {
-    margin-right: 0;
-    margin-left: var(--gap-sm);
   }
 
   &-item-label {

--- a/packages/amis/__tests__/renderers/__snapshots__/Nav.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Nav.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`Renderer:Nav 1`] = `
                   class="cxd-Nav-Menu-item-icon"
                 >
                   <img
-                    class="cxd-Icon"
+                    class="cxd-Icon mr-2"
                     src="https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg"
                   />
                 </i>
@@ -288,7 +288,7 @@ exports[`Renderer:Nav with icons 1`] = `
                         class="cxd-Nav-Menu-item-icon"
                       >
                         <i
-                          class="fa fa-user fa fa-user"
+                          class="fa fa-user mr-2 fa fa-user"
                         />
                       </i>
                       <span
@@ -372,11 +372,11 @@ exports[`Renderer:Nav with icons 1`] = `
                             class="cxd-Nav-Menu-item-icon"
                           >
                             <icon-mock
-                              classname="icon-star"
+                              classname="mr-2 icon-star"
                               icon="star"
                             />
                             <icon-mock
-                              classname="icon-search"
+                              classname="mr-2 icon-search"
                               icon="search"
                             />
                           </i>
@@ -390,7 +390,7 @@ exports[`Renderer:Nav with icons 1`] = `
                             class="cxd-Nav-Menu-item-icon-after"
                           >
                             <img
-                              class="cxd-Icon"
+                              class="cxd-Icon ml-2"
                               src="https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg"
                             />
                           </i>
@@ -479,7 +479,7 @@ exports[`Renderer:Nav with itemActions 1`] = `
                         class="cxd-Nav-Menu-item-icon"
                       >
                         <i
-                          class="fa fa-user fa fa-user"
+                          class="fa fa-user mr-2 fa fa-user"
                         />
                       </i>
                       <span
@@ -820,7 +820,7 @@ exports[`Renderer:Nav with itemActions 2`] = `
                         class="cxd-Nav-Menu-item-icon"
                       >
                         <i
-                          class="fa fa-user fa fa-user"
+                          class="fa fa-user mr-2 fa fa-user"
                         />
                       </i>
                       <span
@@ -1196,7 +1196,7 @@ exports[`Renderer:Nav with multi-level 1`] = `
                 class="cxd-Nav-Menu-item-icon"
               >
                 <i
-                  class="fa fa-user fa fa-user"
+                  class="fa fa-user mr-2 fa fa-user"
                 />
               </i>
               <span
@@ -1584,7 +1584,7 @@ exports[`Renderer:Nav with source 1`] = `
                         class="cxd-Nav-Menu-item-icon"
                       >
                         <i
-                          class="fa fa-user fa fa-user"
+                          class="fa fa-user mr-2 fa fa-user"
                         />
                       </i>
                       <span
@@ -1722,7 +1722,7 @@ exports[`Renderer:Nav with stacked 1`] = `
                 class="cxd-Nav-Menu-item-icon"
               >
                 <i
-                  class="fa fa-user fa fa-user"
+                  class="fa fa-user mr-2 fa fa-user"
                 />
               </i>
               <span


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 288d679</samp>

This pull request enhances the `Navigation` component with a collapsible menu feature and a better icon style. It modifies the `Nav.tsx` file to implement the logic and behavior of the menu collapse and expand, and the `_menu.scss` file to adjust the icon style when the menu is collapsed.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 288d679</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The `Navigation` component with a clever mind,_
> _Who made the menu items shrink or grow at will,_
> _And trimmed the icon margins with a master's skill._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 288d679</samp>

*  Add a `collapsed` prop to the `Navigation` component to control the menu state ([link](https://github.com/baidu/amis/pull/7683/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL556-R557))
*  Adjust the menu item icon styles based on the `collapsed` prop, removing unnecessary margins and aligning the icons vertically ([link](https://github.com/baidu/amis/pull/7683/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL228-L229), [link](https://github.com/baidu/amis/pull/7683/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL243-L248), [link](https://github.com/baidu/amis/pull/7683/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL566-R688))
*  Filter out the hidden links from the navigation items to avoid rendering empty elements ([link](https://github.com/baidu/amis/pull/7683/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL566-R688))
