### PR TITLE
chore: 调整 responseData 当接口返回错误但是有数据返回时也有用 Close: #7680

### DIFF
--- a/packages/amis-core/src/utils/api.ts
+++ b/packages/amis-core/src/utils/api.ts
@@ -14,7 +14,8 @@ import {
   extendObject,
   qsparse,
   uuid,
-  JSONTraverse
+  JSONTraverse,
+  isEmpty
 } from './helper';
 import isPlainObject from 'lodash/isPlainObject';
 import {debug, warning} from './debug';
@@ -432,19 +433,11 @@ export function responseAdaptor(ret: fetcherResult, api: ApiObject) {
 
   debug('api', 'response', payload);
 
-  if (payload.ok && api.responseData) {
+  if (api.responseData && (payload.ok || !isEmpty(payload.data))) {
     debug('api', 'before dataMapping', payload.data);
     const responseData = dataMapping(
       api.responseData,
-
-      createObject(
-        {api},
-        (Array.isArray(payload.data)
-          ? {
-              items: payload.data
-            }
-          : payload.data) || {}
-      ),
+      createObject({api}, normalizeApiResponseData(payload.data)),
       undefined,
       api.convertKeyToPath
     );

--- a/packages/amis/__tests__/utils/api.test.ts
+++ b/packages/amis/__tests__/utils/api.test.ts
@@ -509,3 +509,139 @@ test('api:requestAdaptor2', async () => {
   expect(container.querySelector('input[name="id"]')).toBeInTheDocument();
   expect((container.querySelector('input[name="id"]') as any).value).toBe('2');
 });
+
+test('api:responseData1', async () => {
+  const notify = jest.fn();
+  const fetcher = jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      data: {
+        status: 0,
+        msg: 'ok',
+        data: {
+          id: 1
+        }
+      }
+    })
+  );
+  const {container, getByText} = render(
+    amisRender(
+      {
+        type: 'page',
+        body: [
+          {
+            type: 'form',
+            id: 'form_submit',
+            submitText: '提交表单',
+            api: {
+              method: 'post',
+              url: '/api/mock2/form/saveForm',
+              responseData: {
+                id: '${id}',
+                id2: '${id + 1}'
+              }
+            },
+            body: [
+              {
+                type: 'input-text',
+                name: 'id',
+                label: 'Id'
+              },
+              {
+                type: 'input-text',
+                name: 'id2',
+                label: 'Id2'
+              }
+            ]
+          }
+        ]
+      },
+      {},
+      makeEnv({
+        notify,
+        fetcher
+      })
+    )
+  );
+
+  await waitFor(() => {
+    expect(getByText('提交表单')).toBeInTheDocument();
+  });
+
+  fireEvent.click(getByText(/提交表单/));
+  await wait(300);
+
+  expect(fetcher).toHaveBeenCalledTimes(1);
+  expect(container.querySelector('input[name="id"]')).toBeInTheDocument();
+  expect((container.querySelector('input[name="id"]') as any).value).toBe('1');
+
+  expect(container.querySelector('input[name="id2"]')).toBeInTheDocument();
+  expect((container.querySelector('input[name="id2"]') as any).value).toBe('2');
+});
+
+test('api:responseData2', async () => {
+  const notify = jest.fn();
+  const fetcher = jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      data: {
+        status: 500,
+        msg: 'ok',
+        data: {
+          id: 1
+        }
+      }
+    })
+  );
+  const {container, getByText} = render(
+    amisRender(
+      {
+        type: 'page',
+        body: [
+          {
+            type: 'form',
+            id: 'form_submit',
+            submitText: '提交表单',
+            api: {
+              method: 'post',
+              url: '/api/mock2/form/saveForm',
+              responseData: {
+                id: '${id}',
+                id2: '${id + 1}'
+              }
+            },
+            body: [
+              {
+                type: 'input-text',
+                name: 'id',
+                label: 'Id'
+              },
+              {
+                type: 'input-text',
+                name: 'id2',
+                label: 'Id2'
+              }
+            ]
+          }
+        ]
+      },
+      {},
+      makeEnv({
+        notify,
+        fetcher
+      })
+    )
+  );
+
+  await waitFor(() => {
+    expect(getByText('提交表单')).toBeInTheDocument();
+  });
+
+  fireEvent.click(getByText(/提交表单/));
+  await wait(300);
+
+  expect(fetcher).toHaveBeenCalledTimes(1);
+  expect(container.querySelector('input[name="id"]')).toBeInTheDocument();
+  expect((container.querySelector('input[name="id"]') as any).value).toBe('1');
+
+  expect(container.querySelector('input[name="id2"]')).toBeInTheDocument();
+  expect((container.querySelector('input[name="id2"]') as any).value).toBe('2');
+});


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9c1cb98</samp>

This pull request enhances the `responseAdaptor` function in `packages/amis-core/src/utils/api.ts` to handle different response data formats and apply the mapping option more consistently. It also adds two test cases in `packages/amis/__tests__/utils/api.test.ts` to verify the expected behavior of the function with a form component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9c1cb98</samp>

> _We render the form of doom_
> _With `amisRender` we seal our fate_
> _We adapt the response with skill_
> _With `responseAdaptor` we map our hate_

### Why

Close: #7680

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9c1cb98</samp>

* Import `isEmpty` function from `./helper` to check response data in `responseAdaptor` ([link](https://github.com/baidu/amis/pull/7684/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL17-R18))
* Modify `responseAdaptor` to handle different response data formats and apply `api.responseData` mapping if data is not empty ([link](https://github.com/baidu/amis/pull/7684/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL435-R440))
* Add test cases for `responseAdaptor` with different response data and status in `packages/amis/__tests__/utils/api.test.ts` ([link](https://github.com/baidu/amis/pull/7684/files?diff=unified&w=0#diff-42dba9595cf16673bf6fe7f237d7cf2ba3647c1fcbcf944118da8961e3460c44R512-R647))
