### PR TITLE
fix: 修改禁用和隐藏的schema配置面板不实时更新

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Form.tsx
+++ b/packages/amis-editor/src/plugin/Form/Form.tsx
@@ -873,6 +873,25 @@ export class FormPlugin extends BasePlugin {
               ]
             },
 
+            {
+              name: 'labelAlign',
+              label: '标签对齐方式',
+              type: 'button-group-select',
+              size: 'sm',
+              visibleOn: "${mode === 'horizontal'}",
+              pipeIn: defaultValue('right', false),
+              options: [
+                {
+                  label: '左对齐',
+                  value: 'left'
+                },
+                {
+                  label: '右对齐',
+                  value: 'right'
+                }
+              ]
+            },
+
             getSchemaTpl('horizontal', {
               visibleOn: 'this.mode == "horizontal"'
             }),

--- a/packages/amis-editor/src/renderer/StatusControl.tsx
+++ b/packages/amis-editor/src/renderer/StatusControl.tsx
@@ -93,13 +93,25 @@ export class StatusControl extends React.Component<
   @autobind
   handleSwitch(value: boolean) {
     const {trueValue, falseValue} = this.props;
+    const {expression, statusType = 1} = this.state.formData || {};
     this.setState({checked: value == trueValue ? true : false}, () => {
       const {onBulkChange, noBulkChange, onDataChange, expressionName, name} =
         this.props;
-      const newData = {
-        [name]: value == trueValue ? trueValue : falseValue,
+
+      const newData: Record<string, any> = {
+        [name]: undefined,
         [expressionName]: undefined
       };
+      if (value == trueValue) {
+        switch (statusType) {
+          case 1:
+            newData[name] = true;
+            break;
+          case 2:
+            newData[expressionName] = expression;
+            break;
+        }
+      }
       !noBulkChange && onBulkChange && onBulkChange(newData);
       onDataChange && onDataChange(newData);
     });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d507ab</samp>

This pull request adds a new feature to the amis-editor that allows the user to choose the label alignment in horizontal forms and to use expressions to control the status of form items. It modifies the `FormPlugin` and `StatusControl` classes in `Form.tsx` and `StatusControl.tsx` respectively.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1d507ab</samp>

> _Align form labels_
> _`handleSwitch` adds logic_
> _Autumn of expressions_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1d507ab</samp>

*  Add `labelAlign` property to `FormPlugin` class to allow choosing label alignment in horizontal form mode ([link](https://github.com/baidu/amis/pull/7687/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dR876-R894))
*  Modify `handleSwitch` method of `StatusControl` class to handle expression-based status control for form items ([link](https://github.com/baidu/amis/pull/7687/files?diff=unified&w=0#diff-04709e53c43bdedbb92ed32bd99c2d62584ca89aec4243a5fef10598148bae02L96-R114))
