### PR TITLE
fix: 修复展示类组件 value 配置表达式可能会原样输出的问题 Close: #7662

### DIFF
--- a/packages/amis-core/src/utils/helper.ts
+++ b/packages/amis-core/src/utils/helper.ts
@@ -27,6 +27,7 @@ import {
 import {string2regExp} from './string2regExp';
 import {getVariable} from './getVariable';
 import {keyToPath} from './keyToPath';
+import {isExpression, replaceExpression} from './formula';
 
 export {
   createObject,
@@ -1615,7 +1616,9 @@ export function getPropValue<
     value ??
     getter?.(props) ??
     resolveValueByName(data, name, canAccessSuper) ??
-    defaultValue
+    (isExpression(defaultValue)
+      ? resolveVariableAndFilter(defaultValue, data)
+      : replaceExpression(defaultValue))
   );
 }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d5c6e8</samp>

Add support for expressions in props default values. Use `./formula` module to evaluate expressions based on data context.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6d5c6e8</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever way to make the props more versatile,_
> _By adding to their default values the power of expressions,_
> _Using the functions of the `formula` module, the gift of Hermes._

### Why

Close: #7662

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6d5c6e8</samp>

*  Add support for expressions in default values of props ([link](https://github.com/baidu/amis/pull/7688/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aR30), [link](https://github.com/baidu/amis/pull/7688/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1614-R1620))
