### PR TITLE
fix: 修改禁用和隐藏的schema配置面板不实时更新

### DIFF
--- a/packages/amis-editor/src/plugin/Card.tsx
+++ b/packages/amis-editor/src/plugin/Card.tsx
@@ -130,6 +130,11 @@ export class CardPlugin extends BasePlugin {
               label: '图片地址',
               description: '支持模板语法如： <code>\\${xxx}</code>'
             },
+            {
+              name: 'href',
+              type: 'input-text',
+              label: '打开外部链接'
+            },
             getSchemaTpl('cardDesc'),
             {
               name: 'header.highlight',

--- a/packages/amis-editor/src/plugin/Cards.tsx
+++ b/packages/amis-editor/src/plugin/Cards.tsx
@@ -106,11 +106,6 @@ export class CardsPlugin extends BasePlugin {
               type: 'divider'
             },
             getSchemaTpl('title'),
-            {
-              name: 'href',
-              type: 'input-text',
-              label: '打开外部链接'
-            },
 
             isCRUDBody
               ? null

--- a/packages/amis-editor/src/plugin/Form/Form.tsx
+++ b/packages/amis-editor/src/plugin/Form/Form.tsx
@@ -873,6 +873,25 @@ export class FormPlugin extends BasePlugin {
               ]
             },
 
+            {
+              name: 'labelAlign',
+              label: '标签对齐方式',
+              type: 'button-group-select',
+              size: 'sm',
+              visibleOn: "${mode === 'horizontal'}",
+              pipeIn: defaultValue('right', false),
+              options: [
+                {
+                  label: '左对齐',
+                  value: 'left'
+                },
+                {
+                  label: '右对齐',
+                  value: 'right'
+                }
+              ]
+            },
+
             getSchemaTpl('horizontal', {
               visibleOn: 'this.mode == "horizontal"'
             }),

--- a/packages/amis-editor/src/plugin/Form/Item.tsx
+++ b/packages/amis-editor/src/plugin/Form/Item.tsx
@@ -105,16 +105,7 @@ export class ItemPlugin extends BasePlugin {
                   label: '只读模式'
                 })
               : null,
-            getSchemaTpl('switch', {
-              name: 'disabled',
-              label: '禁用',
-              mode: 'horizontal',
-              horizontal: {
-                justify: true,
-                left: 8
-              },
-              inputClassName: 'is-inline '
-            }),
+            getSchemaTpl('disabled'),
             ignoreValidator ? null : getSchemaTpl('required'),
             getSchemaTpl('description'),
             getSchemaTpl('placeholder'),
@@ -173,8 +164,6 @@ export class ItemPlugin extends BasePlugin {
         {
           title: '显隐',
           body: [
-            // TODO: 有些表单项没有 disabled
-            getSchemaTpl('disabled'),
             getSchemaTpl('visible'),
             supportStatic ? getSchemaTpl('static') : null,
             getSchemaTpl('switch', {

--- a/packages/amis-editor/src/plugin/Form/Picker.tsx
+++ b/packages/amis-editor/src/plugin/Form/Picker.tsx
@@ -189,9 +189,6 @@ export class PickerControlPlugin extends BasePlugin {
 
               getSchemaTpl('strictMode'),
               getSchemaTpl('multiple'),
-              getSchemaTpl('joinValues'),
-              getSchemaTpl('delimiter'),
-              getSchemaTpl('extractValue'),
               getSchemaTpl('autoFillApi', {
                 visibleOn:
                   '!this.autoFill || this.autoFill.scene && this.autoFill.action'

--- a/packages/amis-editor/src/renderer/StatusControl.tsx
+++ b/packages/amis-editor/src/renderer/StatusControl.tsx
@@ -99,13 +99,13 @@ export class StatusControl extends React.Component<
         this.props;
 
       const newData: Record<string, any> = {
-        [name]: undefined,
+        [name]: value == falseValue ? falseValue : undefined,
         [expressionName]: undefined
       };
       if (value == trueValue) {
         switch (statusType) {
           case 1:
-            newData[name] = true;
+            newData[name] = trueValue;
             break;
           case 2:
             newData[expressionName] = expression;

--- a/packages/amis-editor/src/renderer/StatusControl.tsx
+++ b/packages/amis-editor/src/renderer/StatusControl.tsx
@@ -93,13 +93,25 @@ export class StatusControl extends React.Component<
   @autobind
   handleSwitch(value: boolean) {
     const {trueValue, falseValue} = this.props;
+    const {expression, statusType = 1} = this.state.formData || {};
     this.setState({checked: value == trueValue ? true : false}, () => {
       const {onBulkChange, noBulkChange, onDataChange, expressionName, name} =
         this.props;
-      const newData = {
-        [name]: value == trueValue ? trueValue : falseValue,
+
+      const newData: Record<string, any> = {
+        [name]: undefined,
         [expressionName]: undefined
       };
+      if (value == trueValue) {
+        switch (statusType) {
+          case 1:
+            newData[name] = true;
+            break;
+          case 2:
+            newData[expressionName] = expression;
+            break;
+        }
+      }
       !noBulkChange && onBulkChange && onBulkChange(newData);
       onDataChange && onDataChange(newData);
     });

--- a/packages/amis-ui/scss/components/form/_transfer.scss
+++ b/packages/amis-ui/scss/components/form/_transfer.scss
@@ -564,7 +564,7 @@
   }
 }
 .#{$ns}TransferDropDown-content {
-  min-width: px2rem(400px);
+  min-width: px2rem(40px);
   display: flex;
   flex-direction: column;
   padding: var(--gap-xs) 0;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a4a4de9</samp>

This pull request adds a new property `labelAlign` to the form plugin to control the label alignment, and fixes a bug in the status control that caused the expression to be lost when switching the status.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a4a4de9</samp>

> _`FormPlugin` adds_
> _`labelAlign` property_
> _Customize layout_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a4a4de9</samp>

*  Add `labelAlign` property to `FormPlugin` class to customize label alignment in horizontal form mode ([link](https://github.com/baidu/amis/pull/7690/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dR876-R894))
*  Fix expression loss bug in `StatusControl` class by adding `statusType` state variable and updating `newData` object in `handleSwitch` method ([link](https://github.com/baidu/amis/pull/7690/files?diff=unified&w=0#diff-04709e53c43bdedbb92ed32bd99c2d62584ca89aec4243a5fef10598148bae02L96-R114))
