### PR TITLE
feat: transfer 树形搜索的时候支持高亮& feat: transfer 提供清空搜索的事件动作 & fix: transfer 穿梭器左上角的全选勾选时，没有处理 onlyChildren:true 的逻辑

### DIFF
--- a/docs/zh-CN/components/form/transfer.md
+++ b/docs/zh-CN/components/form/transfer.md
@@ -929,6 +929,6 @@ icon:
 | --------- | -------------------------------------- | --------------------------------------------------------------------------------------- |
 | clear     | -                                      | 清空                                                                                    |
 | reset     | -                                      | 将值重置为`resetValue`，若没有配置`resetValue`，则清空                                  |
-| clearSearch | `left: boolean` 左侧搜索、`right:boolean`右侧搜索                                     | 默认清除所有搜索态，可以单独配置`left`、`right`为`true`来清空对应左侧或者右侧面板                                                    |
+| clearSearch | `left: boolean` 左侧搜索、`right:boolean`右侧搜索                                     | 默认清除所有搜索态，可以单独配置`left`、`right`为`true`来清空对应左侧或者右侧面板(`3.4.0`及以上版本支持）                                                    |
 | selectAll | -                                      | 全选                                                                                    |
 | setValue  | `value: string` \| `string[]` 更新的值 | 更新数据，开启`multiple`支持设置多项，开启`joinValues`时，多值用`,`分隔，否则多值用数组 |

--- a/docs/zh-CN/components/form/transfer.md
+++ b/docs/zh-CN/components/form/transfer.md
@@ -929,5 +929,6 @@ icon:
 | --------- | -------------------------------------- | --------------------------------------------------------------------------------------- |
 | clear     | -                                      | 清空                                                                                    |
 | reset     | -                                      | 将值重置为`resetValue`，若没有配置`resetValue`，则清空                                  |
+| clearSearch | `left: boolean` 左侧搜索、`right:boolean`右侧搜索 Tab                                      | 默认清除所有搜索态，可以单独配置`left`、`right`为`true`来清空对应左侧或者右侧面板                                                    |
 | selectAll | -                                      | 全选                                                                                    |
 | setValue  | `value: string` \| `string[]` 更新的值 | 更新数据，开启`multiple`支持设置多项，开启`joinValues`时，多值用`,`分隔，否则多值用数组 |

--- a/docs/zh-CN/components/form/transfer.md
+++ b/docs/zh-CN/components/form/transfer.md
@@ -929,6 +929,6 @@ icon:
 | --------- | -------------------------------------- | --------------------------------------------------------------------------------------- |
 | clear     | -                                      | 清空                                                                                    |
 | reset     | -                                      | 将值重置为`resetValue`，若没有配置`resetValue`，则清空                                  |
-| clearSearch | `left: boolean` 左侧搜索、`right:boolean`右侧搜索 Tab                                      | 默认清除所有搜索态，可以单独配置`left`、`right`为`true`来清空对应左侧或者右侧面板                                                    |
+| clearSearch | `left: boolean` 左侧搜索、`right:boolean`右侧搜索                                     | 默认清除所有搜索态，可以单独配置`left`、`right`为`true`来清空对应左侧或者右侧面板                                                    |
 | selectAll | -                                      | 全选                                                                                    |
 | setValue  | `value: string` \| `string[]` 更新的值 | 更新数据，开启`multiple`支持设置多项，开启`joinValues`时，多值用`,`分隔，否则多值用数组 |

--- a/examples/components/EventAction/cmpt-event-action/TransferEvent.jsx
+++ b/examples/components/EventAction/cmpt-event-action/TransferEvent.jsx
@@ -56,6 +56,29 @@ export default {
           name: 'transferEvent2',
           id: 'transferEvent2',
           type: 'action',
+          label: '清空搜索',
+          level: 'primary',
+          className: 'mr-3 mb-3',
+          debugger: true,
+          onEvent: {
+            click: {
+              actions: [
+                {
+                  actionType: 'clearSearch',
+                  componentId: 'transfer-receiver',
+                  args: {
+                    left: true,
+                    right: true
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          name: 'transferEvent2',
+          id: 'transferEvent2',
+          type: 'action',
           label: '重置功能',
           level: 'primary',
           className: 'mr-3 mb-3',
@@ -84,6 +107,8 @@ export default {
           id: 'transfer-receiver',
           type: 'transfer',
           name: 'transfer',
+          searchable: true,
+          resultSearchable: true,
           debugger: true,
           resetValue: 'c',
           source: '/api/mock2/form/getTreeOptions',

--- a/packages/amis-core/src/types.ts
+++ b/packages/amis-core/src/types.ts
@@ -339,7 +339,8 @@ export interface ActionObject extends ButtonObject {
     | 'collapse'
     | 'step-submit'
     | 'selectAll'
-    | 'changeTabKey';
+    | 'changeTabKey'
+    | 'clearSearch';
   api?: BaseApiObject | string;
   asyncApi?: BaseApiObject | string;
   payload?: any;

--- a/packages/amis-ui/src/components/ResultList.tsx
+++ b/packages/amis-ui/src/components/ResultList.tsx
@@ -16,7 +16,6 @@ import TransferSearch from './TransferSearch';
 import VirtualList, {AutoSizer} from './virtual-list';
 
 export interface ResultListProps extends ThemeProps, LocaleProps {
-  onRef?: any;
   className?: string;
   value?: Array<Option>;
   onChange?: (value: Array<Option>, optionModified?: boolean) => void;
@@ -86,7 +85,6 @@ export class ResultList extends React.Component<
 
   componentDidMount() {
     this.props.sortable && this.initSortable();
-    this.props?.onRef?.(this);
   }
 
   componentDidUpdate() {
@@ -104,7 +102,9 @@ export class ResultList extends React.Component<
 
   @autobind
   domSearchRef(ref: any) {
-    console.log('domSearchRef', ref);
+    while (ref && ref.getWrappedInstance) {
+      ref = ref.getWrappedInstance();
+    }
     this.searchRef = ref;
   }
 
@@ -188,10 +188,6 @@ export class ResultList extends React.Component<
   @autobind
   clearSearch() {
     this.setState({searchResult: null});
-    const {searchable} = this.props;
-    if (searchable) {
-      this.searchRef?.clear?.();
-    }
   }
 
   @autobind
@@ -380,7 +376,7 @@ export class ResultList extends React.Component<
         {title ? <div className={cx('Selections-title')}>{title}</div> : null}
         {searchable ? (
           <TransferSearch
-            onRef={this.domSearchRef}
+            ref={this.domSearchRef}
             placeholder={searchPlaceholder}
             onSearch={this.search}
             onCancelSearch={this.clearSearch}

--- a/packages/amis-ui/src/components/ResultList.tsx
+++ b/packages/amis-ui/src/components/ResultList.tsx
@@ -16,6 +16,7 @@ import TransferSearch from './TransferSearch';
 import VirtualList, {AutoSizer} from './virtual-list';
 
 export interface ResultListProps extends ThemeProps, LocaleProps {
+  onRef?: any;
   className?: string;
   value?: Array<Option>;
   onChange?: (value: Array<Option>, optionModified?: boolean) => void;
@@ -81,9 +82,11 @@ export class ResultList extends React.Component<
   id = guid();
   sortable?: Sortable;
   unmounted = false;
+  searchRef?: any;
 
   componentDidMount() {
     this.props.sortable && this.initSortable();
+    this.props?.onRef?.(this);
   }
 
   componentDidUpdate() {
@@ -97,6 +100,12 @@ export class ResultList extends React.Component<
   componentWillUnmount() {
     this.desposeSortable();
     this.unmounted = true;
+  }
+
+  @autobind
+  domSearchRef(ref: any) {
+    console.log('domSearchRef', ref);
+    this.searchRef = ref;
   }
 
   initSortable() {
@@ -179,6 +188,18 @@ export class ResultList extends React.Component<
   @autobind
   clearSearch() {
     this.setState({searchResult: null});
+    const {searchable} = this.props;
+    if (searchable) {
+      this.searchRef?.clear?.();
+    }
+  }
+
+  @autobind
+  clearInput() {
+    if (this.props.searchable) {
+      this.searchRef?.clearInput?.();
+    }
+    this.clearSearch();
   }
 
   // 删除项
@@ -359,6 +380,7 @@ export class ResultList extends React.Component<
         {title ? <div className={cx('Selections-title')}>{title}</div> : null}
         {searchable ? (
           <TransferSearch
+            onRef={this.domSearchRef}
             placeholder={searchPlaceholder}
             onSearch={this.search}
             onCancelSearch={this.clearSearch}

--- a/packages/amis-ui/src/components/ResultTableList.tsx
+++ b/packages/amis-ui/src/components/ResultTableList.tsx
@@ -16,7 +16,6 @@ import {CloseIcon} from './icons';
 import TableSelection from './TableSelection';
 
 export interface ResultTableSelectionProps extends BaseSelectionProps {
-  onRef?: any;
   title?: string;
   searchPlaceholder?: string;
   placeholder?: string;
@@ -84,12 +83,11 @@ export class BaseResultTableSelection extends BaseSelection<
     };
   }
 
-  componentDidMount() {
-    this.props?.onRef?.(this);
-  }
-
   @autobind
   domSearchRef(ref: any) {
+    while (ref && ref.getWrappedInstance) {
+      ref = ref.getWrappedInstance();
+    }
     this.searchRef = ref;
   }
 
@@ -253,7 +251,7 @@ export class BaseResultTableSelection extends BaseSelection<
         {title ? <div className={cx('Selections-title')}>{title}</div> : null}
         {searchable ? (
           <TransferSearch
-            onRef={this.domSearchRef}
+            ref={this.domSearchRef}
             placeholder={searchPlaceholder}
             onSearch={this.search}
             onCancelSearch={this.clearSearch}

--- a/packages/amis-ui/src/components/ResultTableList.tsx
+++ b/packages/amis-ui/src/components/ResultTableList.tsx
@@ -16,6 +16,7 @@ import {CloseIcon} from './icons';
 import TableSelection from './TableSelection';
 
 export interface ResultTableSelectionProps extends BaseSelectionProps {
+  onRef?: any;
   title?: string;
   searchPlaceholder?: string;
   placeholder?: string;
@@ -68,6 +69,8 @@ export class BaseResultTableSelection extends BaseSelection<
     searchTableOptions: []
   };
 
+  searchRef?: any;
+
   static getDerivedStateFromProps(props: ResultTableSelectionProps) {
     const {options, value, option2value, valueField} = props;
     const valueArray = BaseSelection.value2array(
@@ -79,6 +82,15 @@ export class BaseResultTableSelection extends BaseSelection<
     return {
       tableOptions: valueArray
     };
+  }
+
+  componentDidMount() {
+    this.props?.onRef?.(this);
+  }
+
+  @autobind
+  domSearchRef(ref: any) {
+    this.searchRef = ref;
   }
 
   @autobind
@@ -145,6 +157,14 @@ export class BaseResultTableSelection extends BaseSelection<
       searching: false,
       searchTableOptions: []
     });
+  }
+
+  @autobind
+  clearInput() {
+    if (this.props.searchable) {
+      this.searchRef?.clearInput?.();
+    }
+    this.clearSearch();
   }
 
   renderTable() {
@@ -233,6 +253,7 @@ export class BaseResultTableSelection extends BaseSelection<
         {title ? <div className={cx('Selections-title')}>{title}</div> : null}
         {searchable ? (
           <TransferSearch
+            onRef={this.domSearchRef}
             placeholder={searchPlaceholder}
             onSearch={this.search}
             onCancelSearch={this.clearSearch}

--- a/packages/amis-ui/src/components/ResultTreeList.tsx
+++ b/packages/amis-ui/src/components/ResultTreeList.tsx
@@ -20,7 +20,6 @@ export interface ResultTreeListProps
     LocaleProps,
     BaseSelectionProps,
     SpinnerExtraProps {
-  onRef?: any;
   className?: string;
   title?: string;
   searchable?: boolean;
@@ -177,12 +176,11 @@ export class BaseResultTreeList extends React.Component<
     };
   }
 
-  componentDidMount() {
-    this.props?.onRef?.(this);
-  }
-
   @autobind
   domSearchRef(ref: any) {
+    while (ref && ref.getWrappedInstance) {
+      ref = ref.getWrappedInstance();
+    }
     this.searchRef = ref;
   }
 
@@ -334,7 +332,7 @@ export class BaseResultTreeList extends React.Component<
         {title ? <div className={cx('Selections-title')}>{title}</div> : null}
         {searchable ? (
           <TransferSearch
-            onRef={this.domSearchRef}
+            ref={this.domSearchRef}
             placeholder={searchPlaceholder}
             onSearch={this.search}
             onCancelSearch={this.clearSearch}

--- a/packages/amis-ui/src/components/ResultTreeList.tsx
+++ b/packages/amis-ui/src/components/ResultTreeList.tsx
@@ -20,6 +20,7 @@ export interface ResultTreeListProps
     LocaleProps,
     BaseSelectionProps,
     SpinnerExtraProps {
+  onRef?: any;
   className?: string;
   title?: string;
   searchable?: boolean;
@@ -163,6 +164,8 @@ export class BaseResultTreeList extends React.Component<
     searchTreeOptions: []
   };
 
+  searchRef?: any;
+
   static getDerivedStateFromProps(props: ResultTreeListProps) {
     const newOptions = getResultOptions(
       props.value,
@@ -172,6 +175,15 @@ export class BaseResultTreeList extends React.Component<
     return {
       treeOptions: cloneDeep(newOptions)
     };
+  }
+
+  componentDidMount() {
+    this.props?.onRef?.(this);
+  }
+
+  @autobind
+  domSearchRef(ref: any) {
+    this.searchRef = ref;
   }
 
   // 删除非选中节点
@@ -259,6 +271,14 @@ export class BaseResultTreeList extends React.Component<
     });
   }
 
+  @autobind
+  clearInput() {
+    if (this.props.searchable) {
+      this.searchRef?.clearInput?.();
+    }
+    this.clearSearch();
+  }
+
   renderTree() {
     const {
       className,
@@ -314,6 +334,7 @@ export class BaseResultTreeList extends React.Component<
         {title ? <div className={cx('Selections-title')}>{title}</div> : null}
         {searchable ? (
           <TransferSearch
+            onRef={this.domSearchRef}
             placeholder={searchPlaceholder}
             onSearch={this.search}
             onCancelSearch={this.clearSearch}

--- a/packages/amis-ui/src/components/Transfer.tsx
+++ b/packages/amis-ui/src/components/Transfer.tsx
@@ -197,11 +197,17 @@ export class Transfer<
 
   @autobind
   domRef(ref: any) {
+    while (ref && ref.getWrappedInstance) {
+      ref = ref.getWrappedInstance();
+    }
     this.treeRef = ref;
   }
 
   @autobind
   domResultRef(ref: any) {
+    while (ref && ref.getWrappedInstance) {
+      ref = ref.getWrappedInstance();
+    }
     this.resultRef = ref;
   }
 
@@ -590,7 +596,7 @@ export class Transfer<
       />
     ) : mode === 'tree' ? (
       <Tree
-        onRef={this.domRef}
+        ref={this.domRef}
         placeholder={noResultsText}
         className={cx('Transfer-selection')}
         options={options}
@@ -704,7 +710,7 @@ export class Transfer<
       />
     ) : selectMode === 'tree' ? (
       <Tree
-        onRef={this.domRef}
+        ref={this.domRef}
         placeholder={noResultsText}
         className={cx('Transfer-selection')}
         options={options}
@@ -822,7 +828,7 @@ export class Transfer<
       case 'table':
         return (
           <ResultTableList
-            onRef={this.domResultRef}
+            ref={this.domResultRef}
             classnames={cx}
             columns={columns!}
             options={options || []}
@@ -843,7 +849,7 @@ export class Transfer<
       case 'tree':
         return (
           <ResultTreeList
-            onRef={this.domResultRef}
+            ref={this.domResultRef}
             loadingConfig={loadingConfig}
             classnames={cx}
             className={cx('Transfer-value')}
@@ -864,7 +870,7 @@ export class Transfer<
       default:
         return (
           <ResultList
-            onRef={this.domResultRef}
+            ref={this.domResultRef}
             className={cx('Transfer-value')}
             sortable={sortable}
             disabled={disabled}

--- a/packages/amis-ui/src/components/TransferSearch.tsx
+++ b/packages/amis-ui/src/components/TransferSearch.tsx
@@ -11,7 +11,6 @@ import {LocaleProps, localeable} from 'amis-core';
 import InputBox from './InputBox';
 
 export interface TransferSearchProps extends ThemeProps, LocaleProps {
-  onRef?: any;
   className?: string;
   placeholder: string;
   onSearch: Function;
@@ -37,10 +36,6 @@ export class TransferSearch extends React.Component<
   };
 
   cancelSearch?: () => void;
-
-  componentDidMount() {
-    this.props?.onRef?.(this);
-  }
 
   componentWillUnmount() {
     this.lazySearch.cancel();

--- a/packages/amis-ui/src/components/TransferSearch.tsx
+++ b/packages/amis-ui/src/components/TransferSearch.tsx
@@ -11,6 +11,7 @@ import {LocaleProps, localeable} from 'amis-core';
 import InputBox from './InputBox';
 
 export interface TransferSearchProps extends ThemeProps, LocaleProps {
+  onRef?: any;
   className?: string;
   placeholder: string;
   onSearch: Function;
@@ -36,6 +37,10 @@ export class TransferSearch extends React.Component<
   };
 
   cancelSearch?: () => void;
+
+  componentDidMount() {
+    this.props?.onRef?.(this);
+  }
 
   componentWillUnmount() {
     this.lazySearch.cancel();
@@ -79,6 +84,13 @@ export class TransferSearch extends React.Component<
   @autobind
   handleSeachCancel() {
     this.props.onCancelSearch?.();
+    this.setState({
+      inputValue: ''
+    });
+  }
+
+  @autobind
+  clearInput() {
     this.setState({
       inputValue: ''
     });

--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -1355,6 +1355,19 @@ export class TreeSelector extends React.Component<
     );
   }
 
+  @autobind
+  handleToggle(bool?: boolean) {
+    const availableOptions = this.getAvailableOptions();
+    if (bool === undefined) {
+      const checkedAll = availableOptions.every(option =>
+        this.isItemChecked(option)
+      );
+      this.handleCheckAll(availableOptions, checkedAll);
+      return;
+    }
+    this.handleCheckAll(availableOptions, bool);
+  }
+
   renderCheckAll() {
     const {
       multiple,

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/transfer.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/transfer.test.tsx.snap
@@ -1775,11 +1775,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="法师"
                           >
-                            <span
-                              class=""
-                            >
-                              法师
-                            </span>
+                            法师
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -1815,11 +1811,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="诸葛亮"
                           >
-                            <span
-                              class=""
-                            >
-                              诸葛亮
-                            </span>
+                            诸葛亮
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -1860,11 +1852,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="战士"
                           >
-                            <span
-                              class=""
-                            >
-                              战士
-                            </span>
+                            战士
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -1900,11 +1888,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="曹操"
                           >
-                            <span
-                              class=""
-                            >
-                              曹操
-                            </span>
+                            曹操
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -1940,11 +1924,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="钟无艳"
                           >
-                            <span
-                              class=""
-                            >
-                              钟无艳
-                            </span>
+                            钟无艳
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -1985,11 +1965,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="打野"
                           >
-                            <span
-                              class=""
-                            >
-                              打野
-                            </span>
+                            打野
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2025,11 +2001,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="李白"
                           >
-                            <span
-                              class=""
-                            >
-                              李白
-                            </span>
+                            李白
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2065,11 +2037,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="韩信"
                           >
-                            <span
-                              class=""
-                            >
-                              韩信
-                            </span>
+                            韩信
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2105,11 +2073,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="云中君"
                           >
-                            <span
-                              class=""
-                            >
-                              云中君
-                            </span>
+                            云中君
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2443,11 +2407,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="法师"
                           >
-                            <span
-                              class=""
-                            >
-                              法师
-                            </span>
+                            法师
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2483,11 +2443,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="诸葛亮"
                           >
-                            <span
-                              class=""
-                            >
-                              诸葛亮
-                            </span>
+                            诸葛亮
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2528,11 +2484,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="战士"
                           >
-                            <span
-                              class=""
-                            >
-                              战士
-                            </span>
+                            战士
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2568,11 +2520,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="曹操"
                           >
-                            <span
-                              class=""
-                            >
-                              曹操
-                            </span>
+                            曹操
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2608,11 +2556,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="钟无艳"
                           >
-                            <span
-                              class=""
-                            >
-                              钟无艳
-                            </span>
+                            钟无艳
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2653,11 +2597,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="打野"
                           >
-                            <span
-                              class=""
-                            >
-                              打野
-                            </span>
+                            打野
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2693,11 +2633,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="李白"
                           >
-                            <span
-                              class=""
-                            >
-                              李白
-                            </span>
+                            李白
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2733,11 +2669,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="韩信"
                           >
-                            <span
-                              class=""
-                            >
-                              韩信
-                            </span>
+                            韩信
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2773,11 +2705,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="云中君"
                           >
-                            <span
-                              class=""
-                            >
-                              云中君
-                            </span>
+                            云中君
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -5897,11 +5825,7 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="法师"
                                   >
-                                    <span
-                                      class=""
-                                    >
-                                      法师
-                                    </span>
+                                    法师
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -5937,11 +5861,7 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="诸葛亮"
                                   >
-                                    <span
-                                      class=""
-                                    >
-                                      诸葛亮
-                                    </span>
+                                    诸葛亮
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -5982,11 +5902,7 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="战士"
                                   >
-                                    <span
-                                      class=""
-                                    >
-                                      战士
-                                    </span>
+                                    战士
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -6022,11 +5938,7 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="曹操"
                                   >
-                                    <span
-                                      class=""
-                                    >
-                                      曹操
-                                    </span>
+                                    曹操
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -6062,11 +5974,7 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="钟无艳"
                                   >
-                                    <span
-                                      class=""
-                                    >
-                                      钟无艳
-                                    </span>
+                                    钟无艳
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -6107,11 +6015,7 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="打野"
                                   >
-                                    <span
-                                      class=""
-                                    >
-                                      打野
-                                    </span>
+                                    打野
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -6147,11 +6051,7 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="李白"
                                   >
-                                    <span
-                                      class=""
-                                    >
-                                      李白
-                                    </span>
+                                    李白
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -6187,11 +6087,7 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="韩信"
                                   >
-                                    <span
-                                      class=""
-                                    >
-                                      韩信
-                                    </span>
+                                    韩信
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -6227,11 +6123,7 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="云中君"
                                   >
-                                    <span
-                                      class=""
-                                    >
-                                      云中君
-                                    </span>
+                                    云中君
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -6431,11 +6323,7 @@ exports[`Renderer:transfer with showInvalidMatch & unmatched do not add 1`] = `
                       class="cxd-Tree-itemText"
                       title="诸葛亮"
                     >
-                      <span
-                        class=""
-                      >
-                        诸葛亮
-                      </span>
+                      诸葛亮
                     </span>
                     <div
                       class="cxd-Tree-item-icons"
@@ -6471,11 +6359,7 @@ exports[`Renderer:transfer with showInvalidMatch & unmatched do not add 1`] = `
                       class="cxd-Tree-itemText"
                       title="曹操"
                     >
-                      <span
-                        class=""
-                      >
-                        曹操
-                      </span>
+                      曹操
                     </span>
                     <div
                       class="cxd-Tree-item-icons"
@@ -6511,11 +6395,7 @@ exports[`Renderer:transfer with showInvalidMatch & unmatched do not add 1`] = `
                       class="cxd-Tree-itemText"
                       title="钟无艳"
                     >
-                      <span
-                        class=""
-                      >
-                        钟无艳
-                      </span>
+                      钟无艳
                     </span>
                     <div
                       class="cxd-Tree-item-icons"

--- a/packages/amis/__tests__/renderers/Form/transfer.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/transfer.test.tsx
@@ -1230,3 +1230,84 @@ test('Renderer:transfer with searchApi', async () => {
   const caocao = container.querySelector('span[title=曹操]');
   expect(caocao).toBeNull();
 });
+
+test('Renderer:transfer tree onlyChildren true', async () => {
+  const onSubmit = jest.fn();
+  const schema = {
+    "type": "form",
+    "api": "/api/mock2/form/saveForm",
+    "debug": true,
+    "body": [
+      {
+        "label": "默认",
+        "type": "transfer",
+        "name": "transfer",
+        "value": "libai",
+        "selectMode": "tree",
+        "searchable": true,
+        "onlyChildren": true,
+        "options": [
+          {
+            "label": "法师",
+            "children": [
+              {
+                "label": "诸葛亮",
+                "value": "zhugeliang"
+              }
+            ]
+          },
+          {
+            "label": "战士",
+            "value": "战士",
+            "children": [
+              {
+                "label": "曹操",
+                "disabled": true,
+                "value": "caocao"
+              },
+              {
+                "label": "钟无艳",
+                "value": "zhongwuyan"
+              }
+            ]
+          },
+          {
+            "label": "打野",
+            "children": [
+              {
+                "label": "李白",
+                "value": "libai"
+              },
+              {
+                "label": "韩信",
+                "value": "hanxin"
+              },
+              {
+                "label": "云中君",
+                "value": "yunzhongjun"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  };
+
+  const {getByText, container} = render(
+    amisRender(schema, {onSubmit}, makeEnv({}))
+  );
+
+  const checkbox = container.querySelector('.cxd-Checkbox');
+  expect(checkbox).not.toBeNull();
+
+  checkbox && fireEvent.click(checkbox);
+
+  fireEvent.click(getByText('提交'));
+
+  await wait(100);
+  expect(onSubmit).toBeCalledTimes(1);
+
+  expect(onSubmit.mock.calls[0][0]).toEqual({
+    transfer: "zhugeliang,zhongwuyan,libai,hanxin,yunzhongjun"
+  });
+});

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -428,29 +428,21 @@ export class BaseTransferRenderer<
 
   @autobind
   optionItemRender(option: Option, states: ItemRenderStates) {
-    const {menuTpl, render, data, labelField = 'label'} = this.props;
+    const {menuTpl, render, data} = this.props;
 
-    if (menuTpl) {
-      return render(`item/${states.index}`, menuTpl, {
-        data: createObject(createObject(data, states), option)
-      });
-    }
-
-    return BaseSelection.itemRender(option, {labelField, ...states});
+    return render(`item/${states.index}`, menuTpl, {
+      data: createObject(createObject(data, states), option)
+    });
   }
 
   @autobind
   resultItemRender(option: Option, states: ItemRenderStates) {
     const {valueTpl, render, data} = this.props;
 
-    if (valueTpl) {
-      return render(`value/${states.index}`, valueTpl, {
-        onChange: states.onChange,
-        data: createObject(createObject(data, states), option)
-      });
-    }
-
-    return ResultList.itemRender(option, states);
+    return render(`value/${states.index}`, valueTpl, {
+      onChange: states.onChange,
+      data: createObject(createObject(data, states), option)
+    });
   }
 
   @autobind
@@ -508,6 +500,10 @@ export class BaseTransferRenderer<
       case 'selectAll':
         this.tranferRef?.selectAll();
         break;
+      case 'clearSearch': {
+        this.tranferRef?.clearSearch(data);
+        break;
+      }
     }
   }
 
@@ -533,6 +529,7 @@ export class BaseTransferRenderer<
       selectTitle,
       resultTitle,
       menuTpl,
+      valueTpl,
       searchPlaceholder,
       resultListModeFollowSelect = false,
       resultSearchPlaceholder,
@@ -597,8 +594,8 @@ export class BaseTransferRenderer<
           statistics={statistics}
           labelField={labelField}
           valueField={valueField}
-          optionItemRender={this.optionItemRender}
-          resultItemRender={this.resultItemRender}
+          optionItemRender={menuTpl ? this.optionItemRender : undefined}
+          resultItemRender={valueTpl ? this.resultItemRender : undefined}
           onSelectAll={this.onSelectAll}
           onRef={this.getRef}
           virtualThreshold={virtualThreshold}


### PR DESCRIPTION
feat: transfer 树形搜索的时候支持高亮
feat: transfer 提供清空搜索的事件动作 
fix: transfer 穿梭器左上角的全选勾选时，没有处理 onlyChildren:true 的逻辑