### PR TITLE
chore: 修复CRUDFilter UT 超时失败问题

### DIFF
--- a/packages/amis/__tests__/renderers/CRUDfilter.test.tsx
+++ b/packages/amis/__tests__/renderers/CRUDfilter.test.tsx
@@ -79,7 +79,7 @@ test('CRUD filter1', async () => {
       makeEnv({fetcher: mockFetcher})
     )
   );
-  await wait(200);
+  await wait(500);
   const a = container.querySelector('input[name="a"]')!;
   const b = container.querySelector('input[name="b"]')!;
   expect(a).toBeTruthy();
@@ -139,7 +139,7 @@ test('CRUD filter2', async () => {
       makeEnv({fetcher: mockFetcher})
     )
   );
-  await wait(200);
+  await wait(500);
   const a = container.querySelector('input[name="a"]')!;
   const b = container.querySelector('input[name="b"]')!;
   expect(a).toBeTruthy();


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 31f8788</samp>

Improved the stability of CRUD filter tests by increasing the wait time. This affects the file `packages/amis/__tests__/renderers/CRUDfilter.test.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 31f8788</samp>

> _We face the doom of failing tests_
> _We need more time to see the truth_
> _We raise the `wait` to pass the quest_
> _We use the CRUD to filter the ruth_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 31f8788</samp>

* Increase the wait time for two test cases that use the CRUD filter component to avoid flaky tests ([link](https://github.com/baidu/amis/pull/7705/files?diff=unified&w=0#diff-df72ec462a3722216949b80a4c8346a8d8a87fcf74e88cf39f45e7af1b5abc2aL82-R82), [link](https://github.com/baidu/amis/pull/7705/files?diff=unified&w=0#diff-df72ec462a3722216949b80a4c8346a8d8a87fcf74e88cf39f45e7af1b5abc2aL142-R142)). These tests are in the file `packages/amis/__tests__/renderers/CRUDfilter.test.tsx`.
