### PR TITLE
inputFile filename hover展示优化

### DIFF
--- a/packages/amis-ui/scss/components/form/_file.scss
+++ b/packages/amis-ui/scss/components/form/_file.scss
@@ -79,9 +79,15 @@
       }
     }
 
-    &-tooltip span {
-      font-size: var(--fontSizeSm);
-      color: var(--FileControl-danger-color);
+    &-tooltip {
+      span {
+        font-size: var(--fontSizeSm);
+      }
+      &.is-invalid {
+        span {
+          color: var(--FileControl-danger-color);
+        }
+      }
     }
   }
 

--- a/packages/amis/src/renderers/Form/InputFile.tsx
+++ b/packages/amis/src/renderers/Form/InputFile.tsx
@@ -1500,7 +1500,11 @@ export default class FileControl extends React.Component<FileProps, FileState> {
                   <TooltipWrapper
                     placement="bottom"
                     container={container || env?.getModalContainer}
-                    tooltipClassName={cx('FileControl-list-tooltip')}
+                    tooltipClassName={cx(
+                      'FileControl-list-tooltip',
+                      (file.state === 'invalid' || file.state === 'error') &&
+                        'is-invalid'
+                    )}
                     tooltip={
                       file.state === 'invalid' || file.state === 'error'
                         ? (file as FileValue).error ||
@@ -1511,7 +1515,7 @@ export default class FileControl extends React.Component<FileProps, FileState> {
                                 maxSize: prettyBytes(maxSize, 1024)
                               })
                             : '')
-                        : ''
+                        : filename
                     }
                   >
                     <div


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6837490</samp>

This pull request enhances the file control component in `amis` by adding style and class name for invalid files, and by showing the file name in the tooltip. These changes improve the user experience and feedback when uploading files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6837490</samp>

> _Oh we are the coders of the file control_
> _We make it look good and we make it work well_
> _We add a `class` and a `style` for the bad_
> _And show the file name in the tooltip, me lad_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6837490</samp>

* Make the file control tooltip text color red when the file state is invalid or error ([link](https://github.com/baidu/amis/pull/7714/files?diff=unified&w=0#diff-75b0706a3eaeb3d5632debc03411197abc6641be9e6ea620664ea57885697096L82-R90), [link](https://github.com/baidu/amis/pull/7714/files?diff=unified&w=0#diff-5797b78d8d3f6d8899dfdb4fdebd4cf26bfb055b5b98c285726d6b8cad948b33L1503-R1507))
* Show the file name in the tooltip when the file state is not invalid or error ([link](https://github.com/baidu/amis/pull/7714/files?diff=unified&w=0#diff-5797b78d8d3f6d8899dfdb4fdebd4cf26bfb055b5b98c285726d6b8cad948b33L1514-R1518))
* Remove the redundant `tooltipClassName` prop from the `TooltipWrapper` component in `InputFile.tsx` ([link](https://github.com/baidu/amis/pull/7714/files?diff=unified&w=0#diff-5797b78d8d3f6d8899dfdb4fdebd4cf26bfb055b5b98c285726d6b8cad948b33L1503-R1507))
