### PR TITLE
fix: table2兼容render方法不同返回值 Close:#7348

### DIFF
--- a/packages/amis-ui/src/components/table/index.tsx
+++ b/packages/amis-ui/src/components/table/index.tsx
@@ -38,7 +38,7 @@ export interface ColumnProps {
   name: string;
   className?: Function;
   children?: Array<ColumnProps>;
-  render: Function;
+  render?: Function;
   fixed?: boolean | string;
   width?: number | string;
   sorter?: (a: any, b: any) => number | boolean; // 设置为true时，执行onSort，否则执行前端排序
@@ -119,7 +119,7 @@ export interface SortProps {
 
 export interface TableProps extends ThemeProps, LocaleProps, SpinnerExtraProps {
   title: string | React.ReactNode | Function;
-  footer: string | React.ReactNode | Function;
+  footer?: string | React.ReactNode | Function;
   className?: string;
   dataSource: Array<any>;
   classnames: ClassNamesFn;
@@ -1459,14 +1459,18 @@ export class Table extends React.PureComponent<TableProps, TableState> {
       ) : null;
 
     const cells = tdColumns.map((item, i) => {
+      // 为了支持灵活合并单元格，renderers层的Table2传递的render方法，返回{children: <ReactElement>, props: {rowSpan, colSpan}}
+      // 但直接使用amis-ui的table，render方法一般直接返回ReactElement
       const render =
         item.render && typeof item.render === 'function'
           ? item.render(data[item.name], data, rowIndex, i)
           : null;
       let props = {rowSpan: 1, colSpan: 1};
       let children = render;
-      if (render && isObject(render)) {
-        props = render.props;
+      if (render && !React.isValidElement(render) && isObject(render)) {
+        if (render.props) {
+          props = render.props;
+        }
         children = render.children;
         // 如果合并行 且有展开行，那么合并行不生效
         if (props.rowSpan > 1 && isExpandableRow && hasChildrenRow) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 661672e</samp>

Improved table component in `amis-ui` by making some props optional and enhancing column rendering. Added code comments for clarity.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 661672e</samp>

> _`amis-ui` is the master of the tables_
> _Rendering columns with optional props_
> _No confusion in the code, only clarity_
> _Comments guide us through the logic hops_

### Why

Close: #7348

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 661672e</samp>

*  Make `render` and `footer` properties optional for table columns and table components respectively ([link](https://github.com/baidu/amis/pull/7722/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L41-R41), [link](https://github.com/baidu/amis/pull/7722/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L122-R122))
*  Add comment to explain how `render` property can return different types of values ([link](https://github.com/baidu/amis/pull/7722/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R1462-R1463))
*  Modify condition to check `render` property and handle edge cases for table cell rendering ([link](https://github.com/baidu/amis/pull/7722/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1468-R1473))
