### PR TITLE
fix: nav popOverContainer兼容env不存在的情况

### DIFF
--- a/packages/amis/src/renderers/Nav.tsx
+++ b/packages/amis/src/renderers/Nav.tsx
@@ -672,7 +672,7 @@ export class Navigation extends React.Component<
                 data: createObject(data, link),
                 popOverContainer: popOverContainer
                   ? popOverContainer
-                  : env.getModalContainer
+                  : env && env.getModalContainer
                   ? env.getModalContainer
                   : () => document.body,
                 // 点击操作之后 就关闭 因为close方法里执行了preventDefault
@@ -821,7 +821,7 @@ export class Navigation extends React.Component<
               popOverContainer={
                 popOverContainer
                   ? popOverContainer
-                  : env.getModalContainer
+                  : env && env.getModalContainer
                   ? env.getModalContainer
                   : () => document.body
               }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4cf85c0</samp>

This pull request fixes potential null pointer errors in `Nav.tsx` by adding null checks for `env` in the `Navigation` class. This improves the robustness of rendering navigation components and links.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4cf85c0</samp>

> _Oh, we're the crew of the Navigation class_
> _And we sail the web with style and sass_
> _But we don't want errors to spoil our fun_
> _So we check for `env` before we run_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4cf85c0</samp>

*  Add null checks for `env` before accessing its `getModalContainer` property in the `Navigation` class ([link](https://github.com/baidu/amis/pull/7726/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL675-R675), [link](https://github.com/baidu/amis/pull/7726/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL824-R824))
