### PR TITLE
fix:ajax动作不配置data时不应该发送数据

### DIFF
--- a/docs/zh-CN/concepts/event-action.md
+++ b/docs/zh-CN/concepts/event-action.md
@@ -281,7 +281,22 @@ run action ajax
           ]
         }
       }
-    },
+    }
+  ]
+}
+```
+
+#### 静默模式
+
+当配置`options.silent: true`时，请求完成后不会弹出提示信息。
+
+```schema
+{
+  type: 'page',
+  data: {
+    name: 'lll'
+  },
+  body: [
     {
       type: 'button',
       id: 'b_001',
@@ -321,6 +336,106 @@ run action ajax
       }
     }
   ]
+}
+```
+
+#### 可读取的数据
+
+请求配置中可读取的数据包含事件源所在数据域和动作执行产生的数据。可以通过`api.data`配置数据映射来读取所需数据。例如：
+
+- 取所在数据域的数据：通过`"name": "${name}", "email": "${email}"`来映射表单校验数据（只适用于事件源在表单内的情况）
+- 取动作产生的数据：通过`"name": "${event.data.validateResult.payload.name}", "email": "${event.data.validateResult.payload.email}"`来映射表单校验数据，这种是获取前面表单校验动作的校验结果数据。通过`"&": "${event.data.validateResult.payload}"`展开表单校验数据，结果相同，这是一个数据映射小技巧
+
+```schema
+{
+  "type": "page",
+  "body": [
+    {
+      "type": "button",
+      "label": "表单外的校验按钮",
+      "className": "mb-2",
+      level: 'primary',
+      "onEvent": {
+        "click": {
+          "actions": [
+            {
+              "componentId": "form_validate",
+              "outputVar": "validateResult",
+              "actionType": "validate"
+            },
+            {
+              "outputVar": "responseResult",
+              "actionType": "ajax",
+              "api": {
+                "method": "post",
+                "url": "https://3xsw4ap8wah59.cfc-execute.bj.baidubce.com/api/amis-mock/mock2/form/saveForm",
+                "data": {
+                  "name": "${name}",
+                  "email": "${email}"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "id": "u:bd7adb583ec8"
+    },
+    {
+      "type": "form",
+      "id": "form_validate",
+      "body": [
+        {
+          "type": "input-text",
+          "name": "name",
+          "label": "姓名：",
+          "required": true,
+          "id": "u:fbbc02500df6"
+        },
+        {
+          "name": "email",
+          "type": "input-text",
+          "label": "邮箱：",
+          "required": true,
+          "validations": {
+            "isEmail": true
+          },
+          "id": "u:830d0bad3e6a"
+        }
+      ],
+      "actions": [
+        {
+          "type": "button",
+          "label": "表单内的校验按钮",
+          level: 'primary',
+          "onEvent": {
+            "click": {
+              "actions": [
+                {
+                  "componentId": "form_validate",
+                  "outputVar": "validateResult",
+                  "actionType": "validate"
+                },
+                {
+                  "outputVar": "responseResult",
+                  "actionType": "ajax",
+                  "api": {
+                    "method": "post",
+                    "url": "https://3xsw4ap8wah59.cfc-execute.bj.baidubce.com/api/amis-mock/mock2/form/saveForm",
+                    "data": {
+                      "name": "${name}",
+                      "email": "${email}"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "id": "u:bd7adb583ec8"
+        }
+      ]
+    }
+  ],
+  "id": "u:d79af3431de1"
 }
 ```
 

--- a/packages/amis/__tests__/event-action/ajax.test.tsx
+++ b/packages/amis/__tests__/event-action/ajax.test.tsx
@@ -422,3 +422,190 @@ test('EventAction:ajax data2', async () => {
     });
   });
 });
+
+test('EventAction:ajax data3', async () => {
+  const fetcher = jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      data: {
+        status: 0,
+        msg: 'ok',
+        data: {
+          name: 'amis',
+          age: 18
+        }
+      }
+    })
+  );
+  const {getByText, container}: any = render(
+    amisRender(
+      {
+        type: 'page',
+        body: [
+          {
+            type: 'button',
+            label: '表单外的校验按钮',
+            className: 'mb-2',
+            level: 'primary',
+            onEvent: {
+              click: {
+                actions: [
+                  {
+                    componentId: 'form_validate',
+                    outputVar: 'validateResult',
+                    actionType: 'validate'
+                  },
+                  {
+                    outputVar: 'responseResult',
+                    actionType: 'ajax',
+                    api: {
+                      method: 'post',
+                      url: '/api/xxx1',
+                      data: {
+                        name: '${name}',
+                        email: '${email}'
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            type: 'form',
+            id: 'form_validate',
+            data: {
+              name: 'amis',
+              email: 'amis@baidu.com'
+            },
+            body: [
+              {
+                type: 'input-text',
+                name: 'name',
+                label: '姓名：',
+                required: true
+              },
+              {
+                name: 'email',
+                type: 'input-text',
+                label: '邮箱：',
+                required: true,
+                validations: {
+                  isEmail: true
+                }
+              }
+            ],
+            actions: [
+              {
+                type: 'button',
+                label: '表单内的校验按钮',
+                level: 'primary',
+                onEvent: {
+                  click: {
+                    actions: [
+                      {
+                        componentId: 'form_validate',
+                        outputVar: 'validateResult',
+                        actionType: 'validate'
+                      },
+                      {
+                        outputVar: 'responseResult',
+                        actionType: 'ajax',
+                        api: {
+                          method: 'post',
+                          url: '/api/xxx2',
+                          data: {
+                            name: '${name}',
+                            email: '${email}'
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                type: 'button',
+                label: '无data',
+                level: 'primary',
+                onEvent: {
+                  click: {
+                    actions: [
+                      {
+                        componentId: 'form_validate',
+                        outputVar: 'validateResult',
+                        actionType: 'validate'
+                      },
+                      {
+                        outputVar: 'responseResult',
+                        actionType: 'ajax',
+                        api: {
+                          method: 'post',
+                          url: '/api/xxx3'
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                type: 'button',
+                label: '字符串api无参数',
+                level: 'primary',
+                onEvent: {
+                  click: {
+                    actions: [
+                      {
+                        componentId: 'form_validate',
+                        outputVar: 'validateResult',
+                        actionType: 'validate'
+                      },
+                      {
+                        outputVar: 'responseResult',
+                        actionType: 'ajax',
+                        api: 'post:/api/xxx4'
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {},
+      makeEnv({
+        fetcher
+      })
+    )
+  );
+
+  await waitFor(() => {
+    expect(getByText('表单外的校验按钮')).toBeInTheDocument();
+    expect(getByText('表单内的校验按钮')).toBeInTheDocument();
+    expect(getByText('无data')).toBeInTheDocument();
+    expect(getByText('字符串api无参数')).toBeInTheDocument();
+  });
+
+  fireEvent.click(getByText(/表单外的校验按钮/));
+  fireEvent.click(getByText(/表单内的校验按钮/));
+  fireEvent.click(getByText(/无data/));
+  fireEvent.click(getByText(/字符串api无参数/));
+
+  await waitFor(() => {
+    expect(fetcher).toHaveBeenCalledTimes(4);
+    expect(fetcher.mock.calls[0][0].url).toEqual('/api/xxx1');
+    expect(fetcher.mock.calls[0][0].data).toMatchObject({
+      name: '',
+      email: ''
+    });
+    expect(fetcher.mock.calls[1][0].url).toEqual('/api/xxx2');
+    expect(fetcher.mock.calls[1][0].data).toMatchObject({
+      name: 'amis',
+      email: 'amis@baidu.com'
+    });
+    expect(fetcher.mock.calls[2][0].url).toEqual('/api/xxx3');
+    expect(fetcher.mock.calls[2][0].data).toMatchObject({});
+    expect(fetcher.mock.calls[3][0].url).toEqual('/api/xxx4');
+    expect(fetcher.mock.calls[3][0].data).toMatchObject({});
+  });
+});


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3232063</samp>

This pull request enhances the event-action mechanism in `amis` by fixing a documentation error, adding a new silent mode feature, and preventing unwanted data transmission. It also updates the `AjaxAction` class and adds a new test case to verify the changes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3232063</samp>

> _`AjaxAction` is the master of your fate_
> _Don't let the data domain seal your doom_
> _Control the parameters that you create_
> _With silent mode and data mapping tools_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3232063</samp>

* Fix a syntax error and add a section about silent mode in the schema code example for sending http requests ([link](https://github.com/baidu/amis/pull/7728/files?diff=unified&w=0#diff-9802ca5a2390dc6e213b3d844669c50fb10948dad8ad72a0d360c886731fbd3dL284-R299))
* Add a section and a schema code example to illustrate the concept of readable data and how to use the `api.data` configuration to map data from the event source domain and the action execution result ([link](https://github.com/baidu/amis/pull/7728/files?diff=unified&w=0#diff-9802ca5a2390dc6e213b3d844669c50fb10948dad8ad72a0d360c886731fbd3dR342-R441))
* Modify the `AjaxAction` class in `packages/amis-core/src/actions/AjaxAction.ts` to check if the `api` configuration has a `data` property and assign an empty object if not, to avoid sending the current data domain as the request parameters ([link](https://github.com/baidu/amis/pull/7728/files?diff=unified&w=0#diff-c85a51364485b453adba3a7d4d6cfc4ed76d74ffadc05dd7daf7b386e120c8b6L54-R66))
* Add a test case in `packages/amis/__tests__/event-action/ajax.test.tsx` to verify the behavior of the `AjaxAction` class after the modification, by rendering the same schema code example as the documentation, mocking a fetcher function, simulating clicking the buttons, and checking the fetcher function arguments ([link](https://github.com/baidu/amis/pull/7728/files?diff=unified&w=0#diff-8dd27b935bfdaa3bd00b58e4ca95436585071c4ba796dde88cf5bb5caec1fe6dR425-R586))
