### PR TITLE
fix: 过滤已执行事件监听

### DIFF
--- a/packages/amis-core/src/utils/renderer-event.ts
+++ b/packages/amis-core/src/utils/renderer-event.ts
@@ -136,7 +136,7 @@ export const bindEvent = (renderer: any) => {
       // eventName用来避免过滤广播事件
       rendererEventListeners = rendererEventListeners.filter(
         (item: RendererEventListener) =>
-          item.renderer !== renderer && eventName !== undefined
+          item.renderer === renderer && eventName !== undefined
             ? item.type !== eventName
             : true
       );


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a2c741</samp>

Fixed a bug in `bindEvent` that caused renderer event listeners to be removed incorrectly. This improved the performance and stability of the renderer system.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4a2c741</samp>

> _`bindEvent` fixed_
> _Listeners stay on unmount_
> _Winter bugs no more_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4a2c741</samp>

* Fix a bug that caused renderer event listeners to be removed incorrectly when unmounting a component ([link](https://github.com/baidu/amis/pull/7730/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6L139-R139))
