### PR TITLE
fix: 修复 itemAction 与行选中冲突问题

### DIFF
--- a/packages/amis-core/src/utils/helper.ts
+++ b/packages/amis-core/src/utils/helper.ts
@@ -1658,7 +1658,9 @@ export function isClickOnInput(e: React.MouseEvent<HTMLElement>) {
   if (
     !e.currentTarget.contains(target) ||
     ~['INPUT', 'TEXTAREA'].indexOf(target.tagName) ||
-    ((formItem = target.closest(`button, a, [data-role="form-item"]`)) &&
+    ((formItem = target.closest(
+      `button, a, [data-role="form-item"], label[data-role="checkbox"]`
+    )) &&
       e.currentTarget.contains(formItem))
   ) {
     return true;

--- a/packages/amis-ui/src/components/Checkbox.tsx
+++ b/packages/amis-ui/src/components/Checkbox.tsx
@@ -95,6 +95,7 @@ export class Checkbox extends React.Component<CheckboxProps, any> {
           'Checkbox--button--disabled--checked':
             optionType === 'button' && disabled && _checked
         })}
+        data-role="checkbox"
       >
         <input
           type={type}

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/checkbox.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/checkbox.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`Renderer:checkbox 1`] = `
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -172,6 +173,7 @@ exports[`Renderer:checkbox with checked 1`] = `
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 checked=""
@@ -291,6 +293,7 @@ exports[`Renderer:checkbox with optionType 1`] = `
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--button cxd-Checkbox--button--checked"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/checkboxes.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/checkboxes.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`Renderer:checkboxes 1`] = `
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -67,6 +68,7 @@ exports[`Renderer:checkboxes 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -80,6 +82,7 @@ exports[`Renderer:checkboxes 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -93,6 +96,7 @@ exports[`Renderer:checkboxes 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -240,6 +244,7 @@ exports[`Renderer:checkboxes 2`] = `
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -253,6 +258,7 @@ exports[`Renderer:checkboxes 2`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -266,6 +272,7 @@ exports[`Renderer:checkboxes 2`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -279,6 +286,7 @@ exports[`Renderer:checkboxes 2`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -422,6 +430,7 @@ exports[`Renderer:checkboxes with checkall: all selected 1`] = `
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 checked=""
@@ -444,6 +453,7 @@ exports[`Renderer:checkboxes with checkall: all selected 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -457,6 +467,7 @@ exports[`Renderer:checkboxes with checkall: all selected 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -470,6 +481,7 @@ exports[`Renderer:checkboxes with checkall: all selected 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   checked=""
@@ -484,6 +496,7 @@ exports[`Renderer:checkboxes with checkall: all selected 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -506,6 +519,7 @@ exports[`Renderer:checkboxes with checkall: all selected 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   checked=""
@@ -658,6 +672,7 @@ exports[`Renderer:checkboxes with checkall: default value 1`] = `
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox"
+              data-role="checkbox"
             >
               <input
                 checked=""
@@ -680,6 +695,7 @@ exports[`Renderer:checkboxes with checkall: default value 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -693,6 +709,7 @@ exports[`Renderer:checkboxes with checkall: default value 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -706,6 +723,7 @@ exports[`Renderer:checkboxes with checkall: default value 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   checked=""
@@ -720,6 +738,7 @@ exports[`Renderer:checkboxes with checkall: default value 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -742,6 +761,7 @@ exports[`Renderer:checkboxes with checkall: default value 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   checked=""
@@ -894,6 +914,7 @@ exports[`Renderer:checkboxes with checkall: no selected 1`] = `
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox"
+              data-role="checkbox"
             >
               <input
                 checked=""
@@ -916,6 +937,7 @@ exports[`Renderer:checkboxes with checkall: no selected 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -929,6 +951,7 @@ exports[`Renderer:checkboxes with checkall: no selected 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -942,6 +965,7 @@ exports[`Renderer:checkboxes with checkall: no selected 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   checked=""
@@ -956,6 +980,7 @@ exports[`Renderer:checkboxes with checkall: no selected 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -978,6 +1003,7 @@ exports[`Renderer:checkboxes with checkall: no selected 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   checked=""
@@ -1136,6 +1162,7 @@ exports[`Renderer:checkboxes with columnsCount 1`] = `
               >
                 <label
                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                  data-role="checkbox"
                 >
                   <input
                     type="checkbox"
@@ -1153,6 +1180,7 @@ exports[`Renderer:checkboxes with columnsCount 1`] = `
               >
                 <label
                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                  data-role="checkbox"
                 >
                   <input
                     type="checkbox"
@@ -1174,6 +1202,7 @@ exports[`Renderer:checkboxes with columnsCount 1`] = `
               >
                 <label
                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                  data-role="checkbox"
                 >
                   <input
                     type="checkbox"
@@ -1191,6 +1220,7 @@ exports[`Renderer:checkboxes with columnsCount 1`] = `
               >
                 <label
                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                  data-role="checkbox"
                 >
                   <input
                     type="checkbox"
@@ -1327,6 +1357,7 @@ exports[`Renderer:checkboxes with columnsCount 2`] = `
               >
                 <label
                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                  data-role="checkbox"
                 >
                   <input
                     type="checkbox"
@@ -1348,6 +1379,7 @@ exports[`Renderer:checkboxes with columnsCount 2`] = `
               >
                 <label
                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                  data-role="checkbox"
                 >
                   <input
                     type="checkbox"
@@ -1365,6 +1397,7 @@ exports[`Renderer:checkboxes with columnsCount 2`] = `
               >
                 <label
                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                  data-role="checkbox"
                 >
                   <input
                     type="checkbox"
@@ -1386,6 +1419,7 @@ exports[`Renderer:checkboxes with columnsCount 2`] = `
               >
                 <label
                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                  data-role="checkbox"
                 >
                   <input
                     type="checkbox"
@@ -1530,6 +1564,7 @@ exports[`Renderer:checkboxes with columnsCount 3`] = `
                 >
                   <label
                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                    data-role="checkbox"
                   >
                     <input
                       type="checkbox"
@@ -1547,6 +1582,7 @@ exports[`Renderer:checkboxes with columnsCount 3`] = `
                 >
                   <label
                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                    data-role="checkbox"
                   >
                     <input
                       type="checkbox"
@@ -1580,6 +1616,7 @@ exports[`Renderer:checkboxes with columnsCount 3`] = `
                 >
                   <label
                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                    data-role="checkbox"
                   >
                     <input
                       type="checkbox"
@@ -1597,6 +1634,7 @@ exports[`Renderer:checkboxes with columnsCount 3`] = `
                 >
                   <label
                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                    data-role="checkbox"
                   >
                     <input
                       type="checkbox"
@@ -1614,6 +1652,7 @@ exports[`Renderer:checkboxes with columnsCount 3`] = `
                 >
                   <label
                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                    data-role="checkbox"
                   >
                     <input
                       type="checkbox"
@@ -1635,6 +1674,7 @@ exports[`Renderer:checkboxes with columnsCount 3`] = `
                 >
                   <label
                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                    data-role="checkbox"
                   >
                     <input
                       type="checkbox"
@@ -1772,6 +1812,7 @@ exports[`Renderer:checkboxes with creatable & createBtnLabel & addControls & add
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -1785,6 +1826,7 @@ exports[`Renderer:checkboxes with creatable & createBtnLabel & addControls & add
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -1798,6 +1840,7 @@ exports[`Renderer:checkboxes with creatable & createBtnLabel & addControls & add
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -1811,6 +1854,7 @@ exports[`Renderer:checkboxes with creatable & createBtnLabel & addControls & add
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -1824,6 +1868,7 @@ exports[`Renderer:checkboxes with creatable & createBtnLabel & addControls & add
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -1965,6 +2010,7 @@ exports[`Renderer:checkboxes with creatable & createBtnLabel & addControls & add
             >
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -1978,6 +2024,7 @@ exports[`Renderer:checkboxes with creatable & createBtnLabel & addControls & add
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -1991,6 +2038,7 @@ exports[`Renderer:checkboxes with creatable & createBtnLabel & addControls & add
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -2004,6 +2052,7 @@ exports[`Renderer:checkboxes with creatable & createBtnLabel & addControls & add
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -2319,6 +2368,7 @@ exports[`Renderer:checkboxes with defaultCheckAll & inline 1`] = `
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 checked=""
@@ -2333,6 +2383,7 @@ exports[`Renderer:checkboxes with defaultCheckAll & inline 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -2346,6 +2397,7 @@ exports[`Renderer:checkboxes with defaultCheckAll & inline 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -2359,6 +2411,7 @@ exports[`Renderer:checkboxes with defaultCheckAll & inline 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -2394,6 +2447,7 @@ exports[`Renderer:checkboxes with defaultCheckAll & inline 1`] = `
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -2407,6 +2461,7 @@ exports[`Renderer:checkboxes with defaultCheckAll & inline 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -2420,6 +2475,7 @@ exports[`Renderer:checkboxes with defaultCheckAll & inline 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -2433,6 +2489,7 @@ exports[`Renderer:checkboxes with defaultCheckAll & inline 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -2565,6 +2622,7 @@ exports[`Renderer:checkboxes with editable & editControls & editApi: dialog open
             >
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -2587,6 +2645,7 @@ exports[`Renderer:checkboxes with editable & editControls & editApi: dialog open
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -2609,6 +2668,7 @@ exports[`Renderer:checkboxes with editable & editControls & editApi: dialog open
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -2631,6 +2691,7 @@ exports[`Renderer:checkboxes with editable & editControls & editApi: dialog open
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -2916,6 +2977,7 @@ exports[`Renderer:checkboxes with editable & editControls & editApi: edit succes
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -2938,6 +3000,7 @@ exports[`Renderer:checkboxes with editable & editControls & editApi: edit succes
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -2960,6 +3023,7 @@ exports[`Renderer:checkboxes with editable & editControls & editApi: edit succes
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -2982,6 +3046,7 @@ exports[`Renderer:checkboxes with editable & editControls & editApi: edit succes
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -3119,6 +3184,7 @@ exports[`Renderer:checkboxes with editable & editControls & editApi: hover edit 
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -3141,6 +3207,7 @@ exports[`Renderer:checkboxes with editable & editControls & editApi: hover edit 
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -3163,6 +3230,7 @@ exports[`Renderer:checkboxes with editable & editControls & editApi: hover edit 
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -3185,6 +3253,7 @@ exports[`Renderer:checkboxes with editable & editControls & editApi: hover edit 
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -3330,6 +3399,7 @@ exports[`Renderer:checkboxes with group 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -3343,6 +3413,7 @@ exports[`Renderer:checkboxes with group 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -3365,6 +3436,7 @@ exports[`Renderer:checkboxes with group 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -3378,6 +3450,7 @@ exports[`Renderer:checkboxes with group 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -3391,6 +3464,7 @@ exports[`Renderer:checkboxes with group 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -3404,6 +3478,7 @@ exports[`Renderer:checkboxes with group 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -3418,6 +3493,7 @@ exports[`Renderer:checkboxes with group 1`] = `
             </div>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -3546,6 +3622,7 @@ exports[`Renderer:checkboxes with menuTpl 1`] = `
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -3569,6 +3646,7 @@ exports[`Renderer:checkboxes with menuTpl 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -3592,6 +3670,7 @@ exports[`Renderer:checkboxes with menuTpl 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -3615,6 +3694,7 @@ exports[`Renderer:checkboxes with menuTpl 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -3753,6 +3833,7 @@ exports[`Renderer:checkboxes with optionType & labelClassName & itemClassName 1`
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox iamitem cxd-Checkbox--full cxd-Checkbox--button"
+              data-role="checkbox"
               style="border-radius: 4px 0 0 4px; border-left-width: 1px; border-top-width: 1px;"
             >
               <input
@@ -3767,6 +3848,7 @@ exports[`Renderer:checkboxes with optionType & labelClassName & itemClassName 1`
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox iamitem cxd-Checkbox--full cxd-Checkbox--button"
+              data-role="checkbox"
               style="border-radius: 0; border-left-width: 0; border-top-width: 1px;"
             >
               <input
@@ -3781,6 +3863,7 @@ exports[`Renderer:checkboxes with optionType & labelClassName & itemClassName 1`
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox iamitem cxd-Checkbox--full cxd-Checkbox--button cxd-Checkbox--button--checked"
+              data-role="checkbox"
               style="border-radius: 0; border-left-width: 0; border-top-width: 1px;"
             >
               <input
@@ -3796,6 +3879,7 @@ exports[`Renderer:checkboxes with optionType & labelClassName & itemClassName 1`
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox iamitem cxd-Checkbox--full cxd-Checkbox--button"
+              data-role="checkbox"
               style="border-radius: 0 4px 4px 0; border-left-width: 0; border-top-width: 1px;"
             >
               <input
@@ -3929,6 +4013,7 @@ exports[`Renderer:checkboxes with removable & deleteApi: dialog open 1`] = `
             >
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -3951,6 +4036,7 @@ exports[`Renderer:checkboxes with removable & deleteApi: dialog open 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -3973,6 +4059,7 @@ exports[`Renderer:checkboxes with removable & deleteApi: dialog open 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -3995,6 +4082,7 @@ exports[`Renderer:checkboxes with removable & deleteApi: dialog open 1`] = `
               </label>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -4180,6 +4268,7 @@ exports[`Renderer:checkboxes with removable & deleteApi: hover edit 1`] = `
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -4202,6 +4291,7 @@ exports[`Renderer:checkboxes with removable & deleteApi: hover edit 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -4224,6 +4314,7 @@ exports[`Renderer:checkboxes with removable & deleteApi: hover edit 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"
@@ -4246,6 +4337,7 @@ exports[`Renderer:checkboxes with removable & deleteApi: hover edit 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="checkbox"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/options.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/options.test.tsx.snap
@@ -85,6 +85,7 @@ exports[`options:linkage 1`] = `
       >
         <label
           class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+          data-role="checkbox"
         >
           <input
             type="radio"
@@ -98,6 +99,7 @@ exports[`options:linkage 1`] = `
         </label>
         <label
           class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+          data-role="checkbox"
         >
           <input
             type="radio"
@@ -200,6 +202,7 @@ exports[`options:linkage 2`] = `
       >
         <label
           class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+          data-role="checkbox"
         >
           <input
             disabled=""
@@ -214,6 +217,7 @@ exports[`options:linkage 2`] = `
         </label>
         <label
           class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+          data-role="checkbox"
         >
           <input
             type="radio"
@@ -316,6 +320,7 @@ exports[`options:linkage 3`] = `
       >
         <label
           class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+          data-role="checkbox"
         >
           <input
             type="radio"
@@ -418,6 +423,7 @@ exports[`options:linkage 4`] = `
       >
         <label
           class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+          data-role="checkbox"
         >
           <input
             type="radio"
@@ -431,6 +437,7 @@ exports[`options:linkage 4`] = `
         </label>
         <label
           class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+          data-role="checkbox"
         >
           <input
             type="radio"
@@ -444,6 +451,7 @@ exports[`options:linkage 4`] = `
         </label>
         <label
           class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+          data-role="checkbox"
         >
           <input
             type="radio"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/radios.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/radios.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`Renderer:radios 1`] = `
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="radio"
@@ -67,6 +68,7 @@ exports[`Renderer:radios 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="radio"
@@ -80,6 +82,7 @@ exports[`Renderer:radios 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="radio"
@@ -93,6 +96,7 @@ exports[`Renderer:radios 1`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="radio"
@@ -240,6 +244,7 @@ exports[`Renderer:radios 2`] = `
           >
             <label
               class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="radio"
@@ -253,6 +258,7 @@ exports[`Renderer:radios 2`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="radio"
@@ -266,6 +272,7 @@ exports[`Renderer:radios 2`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="radio"
@@ -279,6 +286,7 @@ exports[`Renderer:radios 2`] = `
             </label>
             <label
               class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+              data-role="checkbox"
             >
               <input
                 type="radio"
@@ -428,6 +436,7 @@ exports[`Renderer:radios source & autoFill 1`] = `
               >
                 <label
                   class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+                  data-role="checkbox"
                 >
                   <input
                     type="radio"
@@ -445,6 +454,7 @@ exports[`Renderer:radios source & autoFill 1`] = `
               >
                 <label
                   class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+                  data-role="checkbox"
                 >
                   <input
                     type="radio"
@@ -462,6 +472,7 @@ exports[`Renderer:radios source & autoFill 1`] = `
               >
                 <label
                   class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+                  data-role="checkbox"
                 >
                   <input
                     type="radio"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/select.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/select.test.tsx.snap
@@ -2864,6 +2864,7 @@ exports[`Renderer:select table with labelField & valueField 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -2891,6 +2892,7 @@ exports[`Renderer:select table with labelField & valueField 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -2920,6 +2922,7 @@ exports[`Renderer:select table with labelField & valueField 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -2949,6 +2952,7 @@ exports[`Renderer:select table with labelField & valueField 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -2978,6 +2982,7 @@ exports[`Renderer:select table with labelField & valueField 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -3007,6 +3012,7 @@ exports[`Renderer:select table with labelField & valueField 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -3036,6 +3042,7 @@ exports[`Renderer:select table with labelField & valueField 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/tabsTransfer.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/tabsTransfer.test.tsx.snap
@@ -196,6 +196,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                       </div>
                                       <label
                                         class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                        data-role="checkbox"
                                       >
                                         <input
                                           type="checkbox"
@@ -235,6 +236,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                       />
                                       <label
                                         class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                        data-role="checkbox"
                                       >
                                         <input
                                           type="checkbox"
@@ -279,6 +281,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                       </div>
                                       <label
                                         class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                        data-role="checkbox"
                                       >
                                         <input
                                           type="checkbox"
@@ -318,6 +321,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                       />
                                       <label
                                         class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                        data-role="checkbox"
                                       >
                                         <input
                                           type="checkbox"
@@ -357,6 +361,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                       />
                                       <label
                                         class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                        data-role="checkbox"
                                       >
                                         <input
                                           type="checkbox"
@@ -401,6 +406,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                       </div>
                                       <label
                                         class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                        data-role="checkbox"
                                       >
                                         <input
                                           type="checkbox"
@@ -440,6 +446,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                       />
                                       <label
                                         class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                        data-role="checkbox"
                                       >
                                         <input
                                           type="checkbox"
@@ -479,6 +486,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                       />
                                       <label
                                         class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                        data-role="checkbox"
                                       >
                                         <input
                                           type="checkbox"
@@ -518,6 +526,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                       />
                                       <label
                                         class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                        data-role="checkbox"
                                       >
                                         <input
                                           type="checkbox"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/tabsTransferPicker.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/tabsTransferPicker.test.tsx.snap
@@ -487,6 +487,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                           </div>
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -534,6 +535,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                           />
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -593,6 +595,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                           </div>
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -640,6 +643,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                           />
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -694,6 +698,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                           />
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -753,6 +758,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                           </div>
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -800,6 +806,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                           />
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -854,6 +861,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                           />
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -908,6 +916,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                           />
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -965,6 +974,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                     >
                       <label
                         class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                        data-role="checkbox"
                       >
                         <input
                           type="checkbox"
@@ -997,6 +1007,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                     >
                       <label
                         class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                        data-role="checkbox"
                       >
                         <input
                           type="checkbox"
@@ -1029,6 +1040,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                     >
                       <label
                         class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                        data-role="checkbox"
                       >
                         <input
                           type="checkbox"
@@ -1061,6 +1073,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                     >
                       <label
                         class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                        data-role="checkbox"
                       >
                         <input
                           type="checkbox"
@@ -1115,6 +1128,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                           </div>
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -1167,6 +1181,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                           </div>
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -1214,6 +1229,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                           />
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -1261,6 +1277,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                           />
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -1308,6 +1325,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                           />
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -1355,6 +1373,7 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                           />
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/transfer.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/transfer.test.tsx.snap
@@ -77,6 +77,7 @@ exports[`Renderer:transfer 1`] = `
                           <span>
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -104,6 +105,7 @@ exports[`Renderer:transfer 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -128,6 +130,7 @@ exports[`Renderer:transfer 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -152,6 +155,7 @@ exports[`Renderer:transfer 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -176,6 +180,7 @@ exports[`Renderer:transfer 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -200,6 +205,7 @@ exports[`Renderer:transfer 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -224,6 +230,7 @@ exports[`Renderer:transfer 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -648,6 +655,7 @@ exports[`Renderer:transfer associated mode with virtual 1`] = `
                             >
                               <label
                                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                data-role="checkbox"
                               >
                                 <input
                                   type="checkbox"
@@ -673,6 +681,7 @@ exports[`Renderer:transfer associated mode with virtual 1`] = `
                             >
                               <label
                                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                data-role="checkbox"
                               >
                                 <input
                                   type="checkbox"
@@ -698,6 +707,7 @@ exports[`Renderer:transfer associated mode with virtual 1`] = `
                             >
                               <label
                                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                data-role="checkbox"
                               >
                                 <input
                                   type="checkbox"
@@ -723,6 +733,7 @@ exports[`Renderer:transfer associated mode with virtual 1`] = `
                             >
                               <label
                                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                data-role="checkbox"
                               >
                                 <input
                                   type="checkbox"
@@ -1382,6 +1393,7 @@ exports[`Renderer:transfer chained mode with virtual 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -1407,6 +1419,7 @@ exports[`Renderer:transfer chained mode with virtual 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -1432,6 +1445,7 @@ exports[`Renderer:transfer chained mode with virtual 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -1457,6 +1471,7 @@ exports[`Renderer:transfer chained mode with virtual 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -1682,6 +1697,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                   <span>
                     <label
                       class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--sm"
+                      data-role="checkbox"
                     >
                       <input
                         type="checkbox"
@@ -1742,6 +1758,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                         </div>
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -1781,6 +1798,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                         />
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -1825,6 +1843,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                         </div>
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -1864,6 +1883,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                         />
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -1903,6 +1923,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                         />
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -1947,6 +1968,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                         </div>
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -1986,6 +2008,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                         />
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -2025,6 +2048,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                         />
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -2064,6 +2088,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                         />
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -2340,6 +2365,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                   <span>
                     <label
                       class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--sm"
+                      data-role="checkbox"
                     >
                       <input
                         type="checkbox"
@@ -2400,6 +2426,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                         </div>
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -2439,6 +2466,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                         />
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -2483,6 +2511,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                         </div>
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -2522,6 +2551,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                         />
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -2561,6 +2591,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                         />
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -2605,6 +2636,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                         </div>
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -2644,6 +2676,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                         />
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -2683,6 +2716,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                         />
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -2722,6 +2756,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                         />
                         <label
                           class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                          data-role="checkbox"
                         >
                           <input
                             type="checkbox"
@@ -3019,6 +3054,7 @@ exports[`Renderer:transfer group mode with virtual 1`] = `
                   <span>
                     <label
                       class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                      data-role="checkbox"
                     >
                       <input
                         type="checkbox"
@@ -3062,6 +3098,7 @@ exports[`Renderer:transfer group mode with virtual 1`] = `
                             >
                               <label
                                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                data-role="checkbox"
                               >
                                 <input
                                   type="checkbox"
@@ -3095,6 +3132,7 @@ exports[`Renderer:transfer group mode with virtual 1`] = `
                             >
                               <label
                                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                data-role="checkbox"
                               >
                                 <input
                                   type="checkbox"
@@ -3128,6 +3166,7 @@ exports[`Renderer:transfer group mode with virtual 1`] = `
                             >
                               <label
                                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                data-role="checkbox"
                               >
                                 <input
                                   type="checkbox"
@@ -3161,6 +3200,7 @@ exports[`Renderer:transfer group mode with virtual 1`] = `
                             >
                               <label
                                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                data-role="checkbox"
                               >
                                 <input
                                   type="checkbox"
@@ -3963,6 +4003,7 @@ exports[`Renderer:transfer table 1`] = `
                                   >
                                     <label
                                       class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                      data-role="checkbox"
                                     >
                                       <input
                                         type="checkbox"
@@ -3990,6 +4031,7 @@ exports[`Renderer:transfer table 1`] = `
                                   >
                                     <label
                                       class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                      data-role="checkbox"
                                     >
                                       <input
                                         type="checkbox"
@@ -4023,6 +4065,7 @@ exports[`Renderer:transfer table 1`] = `
                                   >
                                     <label
                                       class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                      data-role="checkbox"
                                     >
                                       <input
                                         type="checkbox"
@@ -4056,6 +4099,7 @@ exports[`Renderer:transfer table 1`] = `
                                   >
                                     <label
                                       class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                      data-role="checkbox"
                                     >
                                       <input
                                         type="checkbox"
@@ -4089,6 +4133,7 @@ exports[`Renderer:transfer table 1`] = `
                                   >
                                     <label
                                       class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                      data-role="checkbox"
                                     >
                                       <input
                                         type="checkbox"
@@ -4122,6 +4167,7 @@ exports[`Renderer:transfer table 1`] = `
                                   >
                                     <label
                                       class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                      data-role="checkbox"
                                     >
                                       <input
                                         type="checkbox"
@@ -4155,6 +4201,7 @@ exports[`Renderer:transfer table 1`] = `
                                   >
                                     <label
                                       class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                      data-role="checkbox"
                                     >
                                       <input
                                         type="checkbox"
@@ -4374,6 +4421,7 @@ exports[`Renderer:transfer table mode with virtual: result not virtual 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 checked=""
@@ -4428,6 +4476,7 @@ exports[`Renderer:transfer table mode with virtual: result not virtual 1`] = `
                                 >
                                   <label
                                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                    data-role="checkbox"
                                   >
                                     <input
                                       checked=""
@@ -4463,6 +4512,7 @@ exports[`Renderer:transfer table mode with virtual: result not virtual 1`] = `
                                 >
                                   <label
                                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                    data-role="checkbox"
                                   >
                                     <input
                                       type="checkbox"
@@ -4497,6 +4547,7 @@ exports[`Renderer:transfer table mode with virtual: result not virtual 1`] = `
                                 >
                                   <label
                                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                    data-role="checkbox"
                                   >
                                     <input
                                       checked=""
@@ -4532,6 +4583,7 @@ exports[`Renderer:transfer table mode with virtual: result not virtual 1`] = `
                                 >
                                   <label
                                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                    data-role="checkbox"
                                   >
                                     <input
                                       type="checkbox"
@@ -4566,6 +4618,7 @@ exports[`Renderer:transfer table mode with virtual: result not virtual 1`] = `
                                 >
                                   <label
                                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                    data-role="checkbox"
                                   >
                                     <input
                                       checked=""
@@ -4601,6 +4654,7 @@ exports[`Renderer:transfer table mode with virtual: result not virtual 1`] = `
                                 >
                                   <label
                                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                    data-role="checkbox"
                                   >
                                     <input
                                       type="checkbox"
@@ -4635,6 +4689,7 @@ exports[`Renderer:transfer table mode with virtual: result not virtual 1`] = `
                                 >
                                   <label
                                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                    data-role="checkbox"
                                   >
                                     <input
                                       checked=""
@@ -4670,6 +4725,7 @@ exports[`Renderer:transfer table mode with virtual: result not virtual 1`] = `
                                 >
                                   <label
                                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                    data-role="checkbox"
                                   >
                                     <input
                                       type="checkbox"
@@ -4704,6 +4760,7 @@ exports[`Renderer:transfer table mode with virtual: result not virtual 1`] = `
                                 >
                                   <label
                                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                    data-role="checkbox"
                                   >
                                     <input
                                       checked=""
@@ -4739,6 +4796,7 @@ exports[`Renderer:transfer table mode with virtual: result not virtual 1`] = `
                                 >
                                   <label
                                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                    data-role="checkbox"
                                   >
                                     <input
                                       type="checkbox"
@@ -4773,6 +4831,7 @@ exports[`Renderer:transfer table mode with virtual: result not virtual 1`] = `
                                 >
                                   <label
                                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                    data-role="checkbox"
                                   >
                                     <input
                                       checked=""
@@ -5233,6 +5292,7 @@ exports[`Renderer:transfer table mode with virtual: result virtual 1`] = `
                           >
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 checked=""
@@ -5287,6 +5347,7 @@ exports[`Renderer:transfer table mode with virtual: result virtual 1`] = `
                                 >
                                   <label
                                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                    data-role="checkbox"
                                   >
                                     <input
                                       checked=""
@@ -5322,6 +5383,7 @@ exports[`Renderer:transfer table mode with virtual: result virtual 1`] = `
                                 >
                                   <label
                                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                    data-role="checkbox"
                                   >
                                     <input
                                       type="checkbox"
@@ -5356,6 +5418,7 @@ exports[`Renderer:transfer table mode with virtual: result virtual 1`] = `
                                 >
                                   <label
                                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                    data-role="checkbox"
                                   >
                                     <input
                                       checked=""
@@ -5391,6 +5454,7 @@ exports[`Renderer:transfer table mode with virtual: result virtual 1`] = `
                                 >
                                   <label
                                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                    data-role="checkbox"
                                   >
                                     <input
                                       type="checkbox"
@@ -5774,6 +5838,7 @@ exports[`Renderer:transfer tree 1`] = `
                           <span>
                             <label
                               class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                              data-role="checkbox"
                             >
                               <input
                                 type="checkbox"
@@ -5815,6 +5880,7 @@ exports[`Renderer:transfer tree 1`] = `
                                 </div>
                                 <label
                                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                  data-role="checkbox"
                                 >
                                   <input
                                     type="checkbox"
@@ -5854,6 +5920,7 @@ exports[`Renderer:transfer tree 1`] = `
                                 />
                                 <label
                                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                  data-role="checkbox"
                                 >
                                   <input
                                     type="checkbox"
@@ -5898,6 +5965,7 @@ exports[`Renderer:transfer tree 1`] = `
                                 </div>
                                 <label
                                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                  data-role="checkbox"
                                 >
                                   <input
                                     type="checkbox"
@@ -5937,6 +6005,7 @@ exports[`Renderer:transfer tree 1`] = `
                                 />
                                 <label
                                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                  data-role="checkbox"
                                 >
                                   <input
                                     type="checkbox"
@@ -5976,6 +6045,7 @@ exports[`Renderer:transfer tree 1`] = `
                                 />
                                 <label
                                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                  data-role="checkbox"
                                 >
                                   <input
                                     type="checkbox"
@@ -6020,6 +6090,7 @@ exports[`Renderer:transfer tree 1`] = `
                                 </div>
                                 <label
                                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                  data-role="checkbox"
                                 >
                                   <input
                                     type="checkbox"
@@ -6059,6 +6130,7 @@ exports[`Renderer:transfer tree 1`] = `
                                 />
                                 <label
                                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                  data-role="checkbox"
                                 >
                                   <input
                                     type="checkbox"
@@ -6098,6 +6170,7 @@ exports[`Renderer:transfer tree 1`] = `
                                 />
                                 <label
                                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                  data-role="checkbox"
                                 >
                                   <input
                                     type="checkbox"
@@ -6137,6 +6210,7 @@ exports[`Renderer:transfer tree 1`] = `
                                 />
                                 <label
                                   class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                                  data-role="checkbox"
                                 >
                                   <input
                                     type="checkbox"
@@ -6303,6 +6377,7 @@ exports[`Renderer:transfer with showInvalidMatch & unmatched do not add 1`] = `
             <span>
               <label
                 class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                data-role="checkbox"
               >
                 <input
                   type="checkbox"
@@ -6339,6 +6414,7 @@ exports[`Renderer:transfer with showInvalidMatch & unmatched do not add 1`] = `
                   />
                   <label
                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                    data-role="checkbox"
                   >
                     <input
                       type="checkbox"
@@ -6378,6 +6454,7 @@ exports[`Renderer:transfer with showInvalidMatch & unmatched do not add 1`] = `
                   />
                   <label
                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                    data-role="checkbox"
                   >
                     <input
                       type="checkbox"
@@ -6417,6 +6494,7 @@ exports[`Renderer:transfer with showInvalidMatch & unmatched do not add 1`] = `
                   />
                   <label
                     class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full cxd-Checkbox--sm"
+                    data-role="checkbox"
                   >
                     <input
                       type="checkbox"

--- a/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox"
+                            data-role="checkbox"
                           >
                             <input
                               disabled=""
@@ -182,6 +183,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -203,6 +205,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -224,6 +227,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -245,6 +249,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -266,6 +271,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               disabled=""
@@ -288,6 +294,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               disabled=""
@@ -310,6 +317,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               disabled=""
@@ -332,6 +340,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               disabled=""
@@ -354,6 +363,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               disabled=""
@@ -376,6 +386,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               disabled=""
@@ -411,6 +422,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox"
+                            data-role="checkbox"
                           >
                             <input
                               disabled=""
@@ -502,6 +514,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -550,6 +563,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -598,6 +612,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -646,6 +661,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               type="checkbox"
@@ -694,6 +710,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               disabled=""
@@ -743,6 +760,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               disabled=""
@@ -792,6 +810,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               disabled=""
@@ -841,6 +860,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               disabled=""
@@ -890,6 +910,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               disabled=""
@@ -939,6 +960,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox cxd-Checkbox--full"
+                            data-role="checkbox"
                           >
                             <input
                               disabled=""
@@ -1065,6 +1087,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox"
+                            data-role="checkbox"
                           >
                             <input
                               disabled=""
@@ -1112,6 +1135,7 @@ exports[`Renderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
                         >
                           <label
                             class="cxd-Checkbox cxd-Checkbox--checkbox"
+                            data-role="checkbox"
                           >
                             <input
                               disabled=""

--- a/packages/amis/__tests__/renderers/__snapshots__/Picker.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Picker.test.tsx.snap
@@ -118,6 +118,7 @@ exports[`Renderer:Picker base 1`] = `
                 >
                   <label
                     class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+                    data-role="checkbox"
                   >
                     <input
                       type="radio"
@@ -146,6 +147,7 @@ exports[`Renderer:Picker base 1`] = `
                 >
                   <label
                     class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+                    data-role="checkbox"
                   >
                     <input
                       type="radio"
@@ -174,6 +176,7 @@ exports[`Renderer:Picker base 1`] = `
                 >
                   <label
                     class="cxd-Checkbox cxd-Checkbox--radio cxd-Checkbox--full"
+                    data-role="checkbox"
                   >
                     <input
                       type="radio"

--- a/packages/amis/src/renderers/Table/TableRow.tsx
+++ b/packages/amis/src/renderers/Table/TableRow.tsx
@@ -67,6 +67,9 @@ export class TableRow extends React.Component<TableRowProps> {
       return;
     }
 
+    e.preventDefault();
+    e.stopPropagation();
+
     const {
       itemAction,
       onAction,
@@ -92,7 +95,7 @@ export class TableRow extends React.Component<TableRowProps> {
 
     if (itemAction) {
       onAction && onAction(e, itemAction, item?.data);
-      item.toggle();
+      // item.toggle();
     } else {
       if (item.checkable && item.isCheckAvaiableOnClick) {
         onCheck?.(item);

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -2158,9 +2158,7 @@ export default class Table extends React.Component<TableProps, object> {
             type={multiple ? 'checkbox' : 'radio'}
             checked={item.checked}
             disabled={item.checkdisable || !item.checkable}
-            onChange={
-              checkOnItemClick ? noop : this.handleCheck.bind(this, item)
-            }
+            onChange={this.handleCheck.bind(this, item)}
           />
         </td>
       );


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 548d030</samp>

Fixed a bug in the table renderer that caused double toggling of items when using the `checkOnItemClick` feature. Improved the detection of clicks on checkbox labels and inputs by modifying the `isClickOnInput` function and the `Checkbox` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 548d030</samp>

> _Sing, O Muse, of the skillful code review_
> _That fixed the bug and made the table shine_
> _With checkboxes that respond to clicks on labels_
> _And `isClickOnInput` that works with `data-role`._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 548d030</samp>

*  Add `data-role="checkbox"` attribute to `Checkbox` component to support `checkOnItemClick` feature of `Table` renderer ([link](https://github.com/baidu/amis/pull/7732/files?diff=unified&w=0#diff-cf1d86b7b21bf30e5bccf38949c4bdeb51873626aeb06acac5395c8e3c9b91baR98))
*  Modify `isClickOnInput` function to detect clicks on checkbox labels as well as inputs and textareas ([link](https://github.com/baidu/amis/pull/7732/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1661-R1663))
*  Simplify `onChange` prop of `Checkbox` component in `Table` renderer to always call `handleCheck` method ([link](https://github.com/baidu/amis/pull/7732/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2161-R2161))
*  Prevent default and stop propagation of click event in `TableRow` component to avoid triggering other actions or handlers ([link](https://github.com/baidu/amis/pull/7732/files?diff=unified&w=0#diff-43b60bad2b0604663fde07452d82b7576c0d07c3fea6c0a0d6d24a1dd3b82f49R70-R72))
*  Comment out `item.toggle()` line in `TableRow` component to prevent double toggling when `checkOnItemClick` feature is enabled ([link](https://github.com/baidu/amis/pull/7732/files?diff=unified&w=0#diff-43b60bad2b0604663fde07452d82b7576c0d07c3fea6c0a0d6d24a1dd3b82f49L95-R98))
