### PR TITLE
fix: crud批量操作勾选和取消勾选项时selectedItems数据结构不一样

### DIFF
--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -864,9 +864,13 @@ export default class Table extends React.Component<TableProps, object> {
 
     const selectedItems = value
       ? [...store.selectedRows.map(row => row.data), item.data]
-      : store.selectedRows.filter(row => row.id !== item.id);
+      : store.selectedRows
+          .filter(row => row.id !== item.id)
+          .map(row => row.data);
     const unSelectedItems = value
-      ? store.unSelectedRows.filter(row => row.id !== item.id)
+      ? store.unSelectedRows
+          .filter(row => row.id !== item.id)
+          .map(row => row.data)
       : [...store.unSelectedRows.map(row => row.data), item.data];
 
     const rendererEvent = await dispatchEvent(


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f9ab93a</samp>

Fix a bug in the table component where `onBulkChange` would receive different types of values. Ensure that `selectedItems` and `unSelectedItems` always return data objects in `packages/amis/src/renderers/Table/index.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f9ab93a</samp>

> _`selectedItems`_
> _Always data, not row objects_
> _A bug fixed in fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f9ab93a</samp>

* Fix a bug where the `onBulkChange` callback would receive inconsistent types of values when selecting or deselecting rows in the table ([link](https://github.com/baidu/amis/pull/7733/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL867-R873))
* Ensure that the `selectedItems` and `unSelectedItems` variables always return an array of data objects, instead of a mix of data objects and row objects ([link](https://github.com/baidu/amis/pull/7733/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL867-R873))
* Update the `packages/amis/src/renderers/Table/index.tsx` file to reflect the changes ([link](https://github.com/baidu/amis/pull/7733/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL867-R873))
