### PR TITLE
chore: 调整 table 宽度同步逻辑, 解决可能出现异常滚动条问题

### DIFF
--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -824,6 +824,12 @@ export const TableStore = iRendererStore
     };
   })
   .actions(self => {
+    let tableRef: HTMLElement | null = null;
+
+    function setTable(ref: HTMLElement | null) {
+      tableRef = ref;
+    }
+
     function update(
       config: Partial<STableStore> & {tableLayout?: 'fixed' | 'auto'}
     ) {
@@ -952,6 +958,82 @@ export const TableStore = iRendererStore
           column => column.pristine.width
         );
       }
+    }
+
+    function syncTableWidth() {
+      const table = tableRef;
+      if (!table) {
+        return;
+      }
+      // 自动将 table-layout: auto 改成 fixed
+      const ths = (
+        [].slice.call(
+          table.querySelectorAll(':scope>thead>tr>th[data-index]')
+        ) as HTMLTableCellElement[]
+      ).filter((th, index, arr) => {
+        return (
+          arr.findIndex(
+            item =>
+              item.getAttribute('data-index') === th.getAttribute('data-index')
+          ) === index
+        );
+      });
+      const tbodyTr = table.querySelector(':scope>tbody>tr:first-child');
+
+      const div = document.createElement('div');
+      div.className = 'amis-scope'; // jssdk 里面 css 会在这一层
+      div.style.cssText = `position:absolute;top:0;left:0;pointer-events:none;visibility: hidden;`;
+      div.innerHTML = `<table style="table-layout:auto!important;width:0!important;min-width:0!important;" class="${
+        table.className
+      }"><thead><tr>${ths
+        .map(
+          th =>
+            `<th style="width:0" data-index="${th.getAttribute(
+              'data-index'
+            )}" class="${th.className}">${th.innerHTML}</th>`
+        )
+        .join('')}</tr></thead>${
+        tbodyTr ? `<tbody>${tbodyTr.outerHTML}</tbody>` : ''
+      }</table>`;
+      document.body.appendChild(div);
+      const minWidths: {
+        [propName: string]: number;
+      } = {};
+      [].slice
+        .call(div.querySelectorAll(':scope>table>thead>tr>th[data-index]'))
+        .forEach((th: HTMLTableCellElement) => {
+          minWidths[th.getAttribute('data-index')!] = th.clientWidth;
+        });
+      document.body.removeChild(div);
+      const cols = [].slice.call(
+        table.querySelectorAll(':scope>colgroup>col')
+      ) as Array<HTMLElement>;
+
+      if (self.useFixedLayout) {
+        table.style.cssText += `table-layout:fixed;`;
+        cols.forEach(col => {
+          const index = parseInt(col.getAttribute('data-index')!, 10);
+          const column = self.columns[index];
+          col.style.cssText += `width:${
+            typeof column.pristine.width === 'number'
+              ? column.pristine.width
+              : minWidths[index]
+          }px;`;
+        });
+      }
+      cols.forEach((col: HTMLElement) => {
+        const index = parseInt(col.getAttribute('data-index')!, 10);
+        const column = self.columns[index];
+        column.setWidth(
+          Math.max(
+            typeof column.pristine.width === 'number'
+              ? column.pristine.width
+              : col.clientWidth - 2,
+            minWidths[index]
+          ),
+          minWidths[index]
+        );
+      });
     }
 
     function invalidTableColumnWidth() {
@@ -1153,7 +1235,6 @@ export const TableStore = iRendererStore
       }
 
       self.dragging = false;
-      invalidTableColumnWidth(); // 更新内容需要重新计算表格布局
     }
 
     // 获取所有层级的子节点id
@@ -1515,8 +1596,10 @@ export const TableStore = iRendererStore
     }
 
     return {
+      setTable,
       update,
       updateColumns,
+      syncTableWidth,
       invalidTableColumnWidth,
       initRows,
       updateSelected,

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
@@ -562,6 +562,7 @@ exports[`Renderer:input table add 1`] = `
                 >
                   <table
                     class="cxd-Table-table"
+                    style="table-layout: fixed;"
                   >
                     <colgroup>
                       <col
@@ -572,7 +573,7 @@ exports[`Renderer:input table add 1`] = `
                       />
                       <col
                         data-index="5"
-                        style="width: 1%;"
+                        style="width: 100px;"
                       />
                     </colgroup>
                     <thead>

--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -1229,7 +1229,7 @@ export default class FormTable extends React.Component<TableProps, TableState> {
           label: __('Table.operation'),
           className: 'v-middle nowrap',
           fixed: 'right',
-          width: '1%',
+          width: 100,
           innerClassName: 'm-n'
         };
         columns.push(operation);
@@ -1248,7 +1248,7 @@ export default class FormTable extends React.Component<TableProps, TableState> {
     if (showIndex) {
       columns.unshift({
         label: __('Table.index'),
-        width: '1%',
+        width: 50,
         children: (props: any) => {
           return <td>{props.offset + props.data.index + 1}</td>;
         }

--- a/packages/amis/src/renderers/Table/TableBody.tsx
+++ b/packages/amis/src/renderers/Table/TableBody.tsx
@@ -64,6 +64,10 @@ export interface TableBodyProps extends LocaleProps {
 
 @observer
 export class TableBody extends React.Component<TableBodyProps> {
+  componentDidMount(): void {
+    this.props.store.syncTableWidth();
+  }
+
   renderRows(
     rows: Array<any>,
     columns = this.props.columns,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9bc43ca</samp>

This pull request improves the table column width handling in `Table` and `InputTable` renderers. It reduces unnecessary DOM operations, fixes a resizing bug, and respects the user or schema preferences.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9bc43ca</samp>

> _The `Table` renderer had a flaw_
> _The index column width was too small_
> _So they fixed it with ease_
> _By setting pixels, not percents_
> _And optimized the code for speed and all_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9bc43ca</samp>

* Fix index column width bug in InputTable renderer ([link](https://github.com/baidu/amis/pull/7735/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1251-R1251))
* Refactor and improve column width logic in Table renderer ([link](https://github.com/baidu/amis/pull/7735/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1171-R1180), [link](https://github.com/baidu/amis/pull/7735/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1184-R1199))
