### PR TITLE
fix:picker全选排除已禁用的行

### DIFF
--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -653,10 +653,9 @@ export const TableStore = iRendererStore
       },
 
       get allChecked(): boolean {
-        return !!(
-          self.selectedRows.length ===
-            (self as ITableStore).checkableRows.length &&
-          (self as ITableStore).checkableRows.length
+        // 只要selectedRows中包含checkableRows中的全部数据，就认为是全选
+        return (self as ITableStore).checkableRows.every(item =>
+          self.selectedRows.includes(item)
         );
       },
 
@@ -1246,7 +1245,11 @@ export const TableStore = iRendererStore
 
     function toggleAll() {
       if (self.allChecked) {
-        self.selectedRows.clear();
+        // 需要将不可选的row排除掉
+        // 不可选的 始终保持初始化的状态
+        self.selectedRows.replace(
+          self.selectedRows.filter(row => !row.checkable)
+        );
       } else {
         self.selectedRows.replace(getSelectedRows());
       }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0867798</samp>

Improved and fixed table row selection logic in `TableStore`. Non-checkable rows are now properly ignored when checking or unchecking rows.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0867798</samp>

> _`TableStore` fixed_
> _Non-checkable rows behave_
> _Autumn bug no more_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0867798</samp>

* Fix the logic of checking and unchecking all rows in the table store ([link](https://github.com/baidu/amis/pull/7736/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL656-R659), [link](https://github.com/baidu/amis/pull/7736/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1249-R1255))
