### PR TITLE
style: 优化inputtext,textarea组件readonly状态样式

### DIFF
--- a/packages/amis-ui/src/components/Textarea.tsx
+++ b/packages/amis-ui/src/components/Textarea.tsx
@@ -195,7 +195,7 @@ export class Textarea extends React.Component<TextAreaProps, TextAreaState> {
           {
             [`TextareaControl--border${ucFirst(borderMode)}`]: borderMode,
             'is-focused': this.state.focused,
-            'is-disabled': disabled
+            'is-disabled': disabled || readOnly
           },
           className
         )}

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/textarea.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/textarea.test.tsx.snap
@@ -303,7 +303,7 @@ exports[`Renderer:textarea with readOnly 1`] = `
             </span>
           </label>
           <div
-            class="cxd-TextareaControl cxd-Form-control"
+            class="cxd-TextareaControl is-disabled cxd-Form-control"
           >
             <textarea
               autocomplete="off"

--- a/packages/amis/__tests__/renderers/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Wizard.test.tsx.snap
@@ -2717,7 +2717,7 @@ exports[`Renderer:Wizard readOnly 1`] = `
               </span>
             </label>
             <div
-              class="cxd-Form-control cxd-TextControl"
+              class="cxd-Form-control cxd-TextControl is-disabled"
             >
               <div
                 class="cxd-TextControl-input"

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -857,7 +857,7 @@ export default class TextControl extends React.PureComponent<
                             className: cx(`TextControl-sugItem`, {
                               'is-highlight':
                                 highlightedIndex === indices[value],
-                              'is-disabled': option.disabled
+                              'is-disabled': option.disabled || option.readOnly
                             })
                           })}
                           key={value}
@@ -1018,6 +1018,7 @@ export default class TextControl extends React.PureComponent<
       render,
       data,
       disabled,
+      readOnly,
       inputOnly,
       static: isStatic,
       addOnClassName
@@ -1058,7 +1059,7 @@ export default class TextControl extends React.PureComponent<
       ? cx(className, `${ns}TextControl`, {
           [`${ns}TextControl--withAddOn`]: !!addOnDom,
           'is-focused': this.state.isFocused,
-          'is-disabled': disabled
+          'is-disabled': disabled || readOnly
         })
       : cx(`${ns}TextControl`, {
           [`${ns}TextControl--withAddOn`]: !!addOnDom


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 61015ec</samp>

This pull request adds read-only mode for text inputs, select options, and textareas in `amis` renderers and UI components. It fixes issue #2379 by applying the `is-disabled` class to the relevant elements when the `readOnly` prop is true.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 61015ec</samp>

> _To make inputs look disabled when read-only_
> _We added a prop and a class, quite easy_
> _The `is-disabled` style_
> _Will apply for a while_
> _To `InputText`, `TextControl`, and `Select`, you see_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 61015ec</samp>

*  Add `readOnly` prop and `is-disabled` class to various components to support read-only mode for text inputs, textareas, and select options, as requested in issue #2379. ([link](https://github.com/baidu/amis/pull/7739/files?diff=unified&w=0#diff-4814feb9b8ef8a7c7d84419efa4154cdc0d620e75a0992de3fb158851913959aL198-R198), [link](https://github.com/baidu/amis/pull/7739/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L860-R860), [link](https://github.com/baidu/amis/pull/7739/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11R1021), [link](https://github.com/baidu/amis/pull/7739/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L1061-R1062))
*  Update `Textarea.tsx` to apply `is-disabled` class to `TextareaControl` component when `readOnly` prop is true. ([link](https://github.com/baidu/amis/pull/7739/files?diff=unified&w=0#diff-4814feb9b8ef8a7c7d84419efa4154cdc0d620e75a0992de3fb158851913959aL198-R198))
*  Update `InputText.tsx` to apply `is-disabled` class to `Select` option component when `readOnly` prop is true. ([link](https://github.com/baidu/amis/pull/7739/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L860-R860))
*  Update `InputText.tsx` to pass down `readOnly` prop from `TextControl` component to `InputText` component. ([link](https://github.com/baidu/amis/pull/7739/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11R1021))
*  Update `InputText.tsx` to apply `is-disabled` class to `TextControl` component when `readOnly` prop is true. ([link](https://github.com/baidu/amis/pull/7739/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L1061-R1062))
