### PR TITLE
feat: 条件组件作为表单项配置面板隐藏极小宽度 & 增加必选校验

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Item.tsx
+++ b/packages/amis-editor/src/plugin/Form/Item.tsx
@@ -132,7 +132,28 @@ export class ItemPlugin extends BasePlugin {
             }),
 
             renderer.sizeMutable !== false
-              ? getSchemaTpl('formItemSize')
+              ? getSchemaTpl('formItemSize', {
+                  options: [
+                    {
+                      label: '小',
+                      value: 'sm'
+                    },
+
+                    {
+                      label: '中',
+                      value: 'md'
+                    },
+
+                    {
+                      label: '大',
+                      value: 'lg'
+                    },
+                    {
+                      label: '默认（占满）',
+                      value: 'full'
+                    }
+                  ]
+                })
               : null,
             getSchemaTpl('formItemInline'),
 

--- a/packages/amis-ui/src/locale/de-DE.ts
+++ b/packages/amis-ui/src/locale/de-DE.ts
@@ -375,6 +375,7 @@ register('de-DE', {
   'Condition.formula_placeholder': 'Bitte geben Sie eine Formel ein',
   'Condition.fun_error': 'Funktion ist undefiniert',
   'Condition.configured': 'Konfiguriert',
+  'Condition.isRequired': 'Bedingung kann nicht leer sein',
   'InputTable.uniqueError': 'Column `{{label}}` unique validate failed',
   'Timeline.collapseText': 'Falten',
   'Timeline.expandText': 'Entfalten',

--- a/packages/amis-ui/src/locale/en-US.ts
+++ b/packages/amis-ui/src/locale/en-US.ts
@@ -363,6 +363,7 @@ register('en-US', {
   'Condition.formula_placeholder': 'Please enter a formula',
   'Condition.fun_error': 'Function is undefined',
   'Condition.configured': 'Configured',
+  'Condition.isRequired': 'Condition is required',
   'InputTable.uniqueError': 'Column `{{label}}` unique validate failed',
   'Timeline.collapseText': 'Unfold',
   'Timeline.expandText': 'Fold',

--- a/packages/amis-ui/src/locale/zh-CN.ts
+++ b/packages/amis-ui/src/locale/zh-CN.ts
@@ -356,6 +356,7 @@ register('zh-CN', {
   'Condition.formula_placeholder': '请输入公式',
   'Condition.fun_error': '方法未定义',
   'Condition.configured': '已配置',
+  'Condition.isRequired': '条件不可为空',
   'InputTable.uniqueError': '列`{{label}}`没有通过唯一验证',
   'Timeline.collapseText': '收起',
   'Timeline.expandText': '展开',

--- a/packages/amis/src/renderers/Form/ConditionBuilder.tsx
+++ b/packages/amis/src/renderers/Form/ConditionBuilder.tsx
@@ -7,7 +7,8 @@ import {
   isPureVariable,
   resolveVariableAndFilter,
   createObject,
-  evalExpression
+  evalExpression,
+  ConditionRule
 } from 'amis-core';
 import {
   FormBaseControlSchema,
@@ -138,6 +139,33 @@ export default class ConditionBuilderControl extends React.PureComponent<Conditi
       return evalExpression(addGroupBtnVisibleOn, createObject(data, param));
     }
     return true;
+  }
+
+  validate(): any {
+    const {value, required, translate: __} = this.props;
+    // 校验必填
+    // 只要存在不为空条件即可通过校验
+    if (required) {
+      if (!value || !value.children) {
+        return __('Condition.isRequired');
+      }
+
+      let isEmpty = true;
+      const allowRightEmpty = ['is_empty', 'is_not_empty'];
+      value?.children?.forEach((item: ConditionRule) => {
+        // 如果左侧、操作符为空，必填不通过
+        if (
+          item.op &&
+          (item.right || !!~allowRightEmpty.indexOf(item.op as string))
+        ) {
+          isEmpty = false;
+          return;
+        }
+      });
+      return isEmpty ? __('Condition.isRequired') : null;
+    }
+
+    return;
   }
 
   render() {


### PR DESCRIPTION
修改内容：
1、perf：
条件组件作为表单项使用时禁止配置面板配置《控件宽度》为极小

2、feat：
条件组件作为表单项进行《必选》校验时支持 拦截**无完整条件的配置**
