### PR TITLE
fix: crud显隐切换未获取正确选中项

### DIFF
--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -536,11 +536,16 @@ export default class CRUD extends React.Component<CRUDProps, any> {
         items: []
       });
     }
+    // 如果picker用visibleOn来控制显隐，显隐切换时，constructor => handleSelect => componentDidMount的执行顺序
+    // 因此需要将componentDidMount中的设置选中项提前到constructor，否则handleSelect里拿不到的选中项
+    let val: any;
+    if (this.props.pickerMode && (val = getPropValue(this.props))) {
+      store.setSelectedItems(val);
+    }
   }
 
   componentDidMount() {
     const {store, autoGenerateFilter, columns} = this.props;
-
     if (this.props.perPage) {
       store.changePage(store.page, this.props.perPage);
     }
@@ -554,11 +559,6 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       (store.filterTogggable && !store.filterVisible)
     ) {
       this.handleFilterInit({});
-    }
-
-    let val: any;
-    if (this.props.pickerMode && (val = getPropValue(this.props))) {
-      store.setSelectedItems(val);
     }
 
     this.parentContainer = this.getClosestParentContainer();
@@ -1529,7 +1529,6 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     } = this.props;
     let newItems = items;
     let newUnSelectedItems = unSelectedItems;
-
     if (keepItemSelectionOnPageChange && store.selectedItems.length) {
       const oldItems = store.selectedItems.concat();
       const oldUnselectedItems = store.unSelectedItems.concat();


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a3a1472</samp>

Fix a bug in the `CRUD` component that affected the picker functionality. Refactor some code in `CRUD.tsx` to improve readability and performance.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a3a1472</samp>

> _`handleSelect` fixed_
> _Picker logic moved up high_
> _Redundant code gone_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a3a1472</samp>

* Move the logic of setting the selected items of the CRUD store from `componentDidMount` to the constructor to fix a bug with the picker visibility ([link](https://github.com/baidu/amis/pull/7745/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L539-R548), [link](https://github.com/baidu/amis/pull/7745/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L559-L563))
* Remove an empty line at the end of the file `packages/amis/src/renderers/CRUD.tsx` for formatting ([link](https://github.com/baidu/amis/pull/7745/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1532))
