### PR TITLE
fix: 「动作配置」组件赋值面板点【取消】关闭弹窗后，再次打开值被清空

### DIFF
--- a/packages/amis-editor/src/renderer/event-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/event-control/helper.tsx
@@ -3105,7 +3105,6 @@ export const getEventControlConfig = (
         delete action.__actionExpression;
         delete action.__statusType;
       }
-      console.log('hhhh', action);
 
       delete action.config;
 

--- a/packages/amis-editor/src/renderer/event-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/event-control/helper.tsx
@@ -2786,19 +2786,13 @@ export const getEventControlConfig = (
       if (['setValue'].includes(action.actionType) && action.args?.value) {
         !config.args && (config.args = {});
         if (Array.isArray(action.args?.value)) {
-          config.args.value = action.args?.value.reduce(
-            (arr: any, valueItem: any, index: number) => {
-              if (!arr[index]) {
-                arr[index] = {};
-              }
-              arr[index] = {
-                key: valueItem.key,
-                val: valueItem.val
-              };
-              return arr;
-            },
-            []
-          );
+          config.args.value = action.args?.value.map((valueItem: any) => {
+            valueItem = {
+              key: valueItem.key,
+              val: valueItem.val
+            };
+            return valueItem;
+          });
           // 目前只有给combo赋值会是数组，所以认为是全量的赋值方式
           config.args['__comboType'] = 'all';
         } else if (typeof action.args?.value === 'object') {

--- a/packages/amis-editor/src/renderer/event-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/event-control/helper.tsx
@@ -2791,7 +2791,10 @@ export const getEventControlConfig = (
               if (!arr[index]) {
                 arr[index] = {};
               }
-              arr[index].item = objectToComboArray(valueItem);
+              arr[index] = {
+                key: valueItem.key,
+                val: valueItem.val
+              };
               return arr;
             },
             []
@@ -3102,6 +3105,7 @@ export const getEventControlConfig = (
         delete action.__actionExpression;
         delete action.__statusType;
       }
+      console.log('hhhh', action);
 
       delete action.config;
 

--- a/packages/amis-editor/src/renderer/event-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/event-control/helper.tsx
@@ -2776,6 +2776,7 @@ export const getEventControlConfig = (
     },
     actionConfigInitFormatter: async (action: ActionConfig) => {
       let config = {...action};
+      config.args = {...action.args};
       if (['link', 'url'].includes(action.actionType) && action.args?.params) {
         config.args = {
           ...config.args,
@@ -2786,12 +2787,16 @@ export const getEventControlConfig = (
       if (['setValue'].includes(action.actionType) && action.args?.value) {
         !config.args && (config.args = {});
         if (Array.isArray(action.args?.value)) {
-          config.args.value = action.args?.value.map((valueItem: any) => {
-            return {
-              key: valueItem.key,
-              val: valueItem.val
-            };
-          });
+          config.args.value = action.args?.value.reduce(
+            (arr: any, valueItem: any, index: number) => {
+              if (!arr[index]) {
+                arr[index] = {};
+              }
+              arr[index].item = objectToComboArray(valueItem);
+              return arr;
+            },
+            []
+          );
           // 目前只有给combo赋值会是数组，所以认为是全量的赋值方式
           config.args['__comboType'] = 'all';
         } else if (typeof action.args?.value === 'object') {

--- a/packages/amis-editor/src/renderer/event-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/event-control/helper.tsx
@@ -2787,11 +2787,10 @@ export const getEventControlConfig = (
         !config.args && (config.args = {});
         if (Array.isArray(action.args?.value)) {
           config.args.value = action.args?.value.map((valueItem: any) => {
-            valueItem = {
+            return {
               key: valueItem.key,
               val: valueItem.val
             };
-            return valueItem;
           });
           // 目前只有给combo赋值会是数组，所以认为是全量的赋值方式
           config.args['__comboType'] = 'all';


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 061cf1b</samp>

Fix label bug and add debug log in event control component. Use `objToArr` instead of `objToArray` in `getEventControlConfig` function in `helper.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 061cf1b</samp>

> _The label bug is fixed, the event control is free_
> _We use the right method to convert the object to array_
> _We log the console, we trace the error's source_
> _We rock the code review, we show no remorse_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 061cf1b</samp>

* Fix bug in event control component that displayed wrong labels for keys ([link](https://github.com/baidu/amis/pull/7746/files?diff=unified&w=0#diff-f55d29e93a330da662e7a91960e5ed88c12f80e9e38564d3a4497ff543da26b8L2794-R2797))
* Add console log statement for debugging action object in event control component ([link](https://github.com/baidu/amis/pull/7746/files?diff=unified&w=0#diff-f55d29e93a330da662e7a91960e5ed88c12f80e9e38564d3a4497ff543da26b8R3108))
