### PR TITLE
fix: CRUD组件列过滤重置时未触发 columnFilter 事件问题

### DIFF
--- a/docs/zh-CN/components/crud.md
+++ b/docs/zh-CN/components/crud.md
@@ -3149,7 +3149,7 @@ itemAction 里的 onClick 还能通过 `data` 参数拿到当前行的数据，�
 | -------------- | ----------------------------------------------------------------------- | -------------------- |
 | selectedChange | `selectedItems: item[]` 已选择行<br/>`unSelectedItems: item[]` 未选择行 | 手动选择表格项时触发 |
 | columnSort     | `orderBy: string` 列排序列名<br/>`orderDir: string` 列排序值            | 点击列排序时触发     |
-| columnFilter   | `filterName: string` 列筛选列名<br/>`filterValue: string` 列筛选值      | 点击列筛选时触发     |
+| columnFilter   | `filterName: string` 列筛选列名<br/>`filterValue: string \| undefined` 列筛选值      | 点击列筛选时触发，点击重置后事件参数`filterValue`为`undefined`     |
 | columnSearch   | `searchName: string` 列搜索列名<br/>`searchValue: object` 列搜索数据    | 点击列搜索时触发     |
 | orderChange    | `movedItems: item[]` 已排序数据                                         | 手动拖拽行排序时触发 |
 | columnToggled  | `columns: item[]` 当前显示的列配置数据                                  | 点击自定义列时触发   |

--- a/packages/amis/src/renderers/Table/HeadCellFilterDropdown.tsx
+++ b/packages/amis/src/renderers/Table/HeadCellFilterDropdown.tsx
@@ -255,8 +255,21 @@ export class HeadCellFilterDropDown extends React.Component<
     });
   }
 
-  handleReset() {
-    const {name, onQuery} = this.props;
+  async handleReset() {
+    const {name, dispatchEvent, data, onQuery} = this.props;
+
+    const rendererEvent = await dispatchEvent(
+      'columnFilter',
+      createObject(data, {
+        filterName: name,
+        filterValue: undefined
+      })
+    );
+
+    if (rendererEvent?.prevented) {
+      return;
+    }
+
     onQuery(
       {
         [name]: undefined


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5aabfef</samp>

This pull request enhances the `columnFilter` event of the `crud` component in amis. It allows the event to be dispatched with `undefined` values when the user resets the column filter, and to be prevented by the renderer if needed. It also updates the documentation of the event accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5aabfef</samp>

> _`columnFilter` event_
> _now can be undefined_
> _autumn of reset_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5aabfef</samp>

*  Update the `columnFilter` event documentation in `crud.md` to include the possibility of `undefined` `filterValue` ([link](https://github.com/baidu/amis/pull/7752/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653L3152-R3152))
*  Modify the `handleReset` method of the `HeadCellFilterDropDown` class in `HeadCellFilterDropdown.tsx` to dispatch the `columnFilter` event with `undefined` `filterName` and `filterValue` when the user clicks the reset button ([link](https://github.com/baidu/amis/pull/7752/files?diff=unified&w=0#diff-584f5d22b7c0b5689df20135e76477634c65ed1a0758591485cef1c40e5dd78cL258-R272))
*  Add a check for the `columnFilter` event prevention in the `handleReset` method before calling the `onQuery` method ([link](https://github.com/baidu/amis/pull/7752/files?diff=unified&w=0#diff-584f5d22b7c0b5689df20135e76477634c65ed1a0758591485cef1c40e5dd78cL258-R272))
