### PR TITLE
fix: 修复tableCell canAccessSuperData默认使用table props

### DIFF
--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -53,6 +53,7 @@ export const Column = types
     searchable: types.maybe(types.frozen()),
     enableSearch: true,
     sortable: false,
+    canAccessSuperData: true,
     filterable: types.optional(types.frozen(), undefined),
     fixed: '',
     index: 0,

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -2203,9 +2203,9 @@ export default class Table extends React.Component<TableProps, object> {
       classnames: cx,
       checkOnItemClick,
       popOverContainer,
-      canAccessSuperData,
       itemBadge
     } = this.props;
+    const canAccessSuperData = column.canAccessSuperData;
 
     if (column.name && item.rowSpans[column.name] === 0) {
       return null;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 18fba2e</samp>

This pull request adds support for super data in table columns, which allows rendering dynamic values based on other data sources. It modifies the `Column` interface and the `TableStore` class to handle the new `canAccessSuperData` property, and updates the `Table` component accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 18fba2e</samp>

> _`canAccessSuperData`_
> _A new prop for columns_
> _Cutting through the table_

### Why

tableCell canAccessSuperData渲染时使用的是table的canAccessSuperData，但应该使用table column的canAccessSuperData，默认值为true

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 18fba2e</samp>

*  Add `canAccessSuperData` property to `Column` interface to indicate super data access ([link](https://github.com/baidu/amis/pull/7758/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR56))
*  Move `canAccessSuperData` prop assignment from `Table` component to `TableStore` class to pass it to column renderers ([link](https://github.com/baidu/amis/pull/7758/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2206-R2208))
