### PR TITLE
fix(amis-ui): chart组件剔除默认最小宽高样式限制，支持特小宽高设置

### DIFF
--- a/packages/amis-ui/scss/components/_chart.scss
+++ b/packages/amis-ui/scss/components/_chart.scss
@@ -1,6 +1,4 @@
 .#{$ns}Chart {
-  min-width: 300px;
-  min-height: 300px;
   position: relative;
 
   &-placeholder {

--- a/packages/amis/src/renderers/Chart.tsx
+++ b/packages/amis/src/renderers/Chart.tsx
@@ -596,9 +596,8 @@ export class Chart extends React.Component<ChartProps> {
       data
     } = this.props;
     let style = this.props.style || {};
-
-    width && (style.width = width);
-    height && (style.height = height);
+    style.width = style.width || width || '300px';
+    style.height = style.width || height || '300px';
     const styleVar = buildStyle(style, data);
 
     return (

--- a/packages/amis/src/renderers/Chart.tsx
+++ b/packages/amis/src/renderers/Chart.tsx
@@ -596,7 +596,7 @@ export class Chart extends React.Component<ChartProps> {
       data
     } = this.props;
     let style = this.props.style || {};
-    style.width = style.width || width || '300px';
+    style.width = style.width || width || '100%';
     style.height = style.width || height || '300px';
     const styleVar = buildStyle(style, data);
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1cada5c</samp>

Removed min-width and min-height from chart component style and improved width and height logic. This makes the chart component more adaptable to different sizes and layouts.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1cada5c</samp>

> _Chart component style_
> _`width` and `height` props used_
> _Or defaults in fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1cada5c</samp>

*  Removed min-width and min-height from chart component style to allow more flexibility ([link](https://github.com/baidu/amis/pull/7764/files?diff=unified&w=0#diff-14359075ba7d806363c2851ae72e5671e7d17a40dfcd5c825ee9409f457e1d76L2-L3))
*  Changed logic for setting width and height of chart component to use style object, props, or default values ([link](https://github.com/baidu/amis/pull/7764/files?diff=unified&w=0#diff-b835aa79eebadb985fbc93069bbd1973522b0a1d125adbbe7b2300a154647acdL599-R600))
