### PR TITLE
fix:复选框上下文单选情况

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Checkboxes.tsx
+++ b/packages/amis-editor/src/plugin/Form/Checkboxes.tsx
@@ -249,31 +249,42 @@ export class CheckboxesControlPlugin extends BasePlugin {
       originalValue: node.schema?.value // 记录原始值，循环引用检测需要
     };
 
-    if (node.schema?.extractValue) {
+    if (node.schema?.joinValues === false) {
       dataSchema = {
-        type: 'array',
-        title: node.schema?.label || node.schema?.name
-      };
-    } else if (node.schema?.joinValues === false) {
-      dataSchema = {
-        type: 'array',
+        ...dataSchema,
+        type: 'object',
         title: node.schema?.label || node.schema?.name,
-        items: {
-          type: 'object',
-          title: '成员',
-          properties: {
-            label: {
-              type: 'string',
-              title: '文本'
-            },
-            value: {
-              type,
-              title: '值'
-            }
+        properties: {
+          label: {
+            type: 'string',
+            title: '文本'
+          },
+          value: {
+            type,
+            title: '值'
           }
-        },
-        originalValue: dataSchema.originalValue
+        }
       };
+    }
+
+    if (node.schema?.multiple) {
+      if (node.schema?.extractValue) {
+        dataSchema = {
+          type: 'array',
+          title: node.schema?.label || node.schema?.name
+        };
+      } else if (node.schema?.joinValues === false) {
+        dataSchema = {
+          type: 'array',
+          title: node.schema?.label || node.schema?.name,
+          items: {
+            type: 'object',
+            title: '成员',
+            properties: dataSchema.properties
+          },
+          originalValue: dataSchema.originalValue
+        };
+      }
     }
 
     return dataSchema;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c8a4e5</samp>

Fix a bug in `Checkboxes.tsx` that causes the checkboxes control to lose the original value when `joinValues` is false and `multiple` is true. Modify the `getDataSchema` method to handle different cases of `joinValues` and `multiple` options.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3c8a4e5</samp>

> _`joinValues` false_
> _checkboxes keep original_
> _autumn bug is fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c8a4e5</samp>

* Fix a bug that causes the checkboxes control to lose the original value when the `joinValues` option is false and the `multiple` option is true ([link](https://github.com/baidu/amis/pull/7766/files?diff=unified&w=0#diff-4a3c5c6e5498b74e1254ee4f776efe0e8de65ee84a90f59472e29990f67e2978L252-R289))
