### PR TITLE
feat:dropdownButton children buttons level & className

### DIFF
--- a/packages/amis/__tests__/renderers/DropDownButton.test.tsx
+++ b/packages/amis/__tests__/renderers/DropDownButton.test.tsx
@@ -10,6 +10,7 @@
  * 7. 默认展开 defaultIsOpened
  * 8. 对齐方式 align
  * 9. block & size
+ * 10. buttons level & className
  */
 
 import React from 'react';
@@ -395,4 +396,37 @@ test('Renderer:dropdown-button with block & size', async () => {
     'cxd-Button--size-lg'
   );
   expect(container).toMatchSnapshot();
+});
+
+test('Renderer:dropdown-button buttons with className & level', async () => {
+  const {container} = render(
+    amisRender({
+      type: "dropdown-button",
+      level: "success",
+      label: "下拉菜单",
+      buttons: [
+        {
+          type: "button",
+          label: "按钮1",
+          level: "success",
+          className: "custom-button-class"
+        },
+        {
+          type: "button",
+          label: "按钮2"
+        }
+      ]
+    })
+  );
+
+  const dropdownButton = document.querySelector('button.cxd-Button');
+  fireEvent.click(dropdownButton as HTMLDivElement);
+
+  expect(container.querySelectorAll('.cxd-DropDown-menu-root .cxd-DropDown-button')[0]!).toHaveClass(
+    'cxd-Button--success'
+  );
+
+  expect(container.querySelectorAll('.cxd-DropDown-menu-root .cxd-DropDown-button')[0]!).toHaveClass(
+    'custom-button-class'
+  );
 });

--- a/packages/amis/src/renderers/DropDownButton.tsx
+++ b/packages/amis/src/renderers/DropDownButton.tsx
@@ -279,15 +279,25 @@ export default class DropDownButton extends React.Component<
       return (
         <li
           key={index}
-          className={cx('DropDown-button', {
-            ['is-disabled']: isDisabled(button, data)
-          })}
+          className={cx(
+            'DropDown-button',
+            {
+              ['is-disabled']: isDisabled(button, data)
+            },
+            typeof button.level === 'undefined'
+              ? ''
+              : button.level
+              ? `Button--${button.level}`
+              : '',
+            button.className
+          )}
         >
           {render(
             `button/${index}`,
             {
               type: 'button',
-              ...(button as any)
+              ...(button as any),
+              className: ''
             },
             {
               isMenuItem: true,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8923ca5</samp>

This pull request enhances the dropdown-button renderer in `amis` by adding a test case, a comment, and some style adjustments. It ensures that the `className` and `level` props are rendered correctly and consistently for the buttons.
This pull request adds a new feature for dropDownButton children buttons, support buttons level and className option

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8923ca5</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _the dropdown-button renderer in amis, the noble framework._
> _He added a test case, wise and diligent, to verify_
> _the level and `className` props, the marks of beauty and distinction._

### Why

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8923ca5</samp>

*  Modify the dropdown-button renderer in `DropDownButton.tsx` to apply the button level and className props to the li element instead of the button element ([link](https://github.com/baidu/amis/pull/7777/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L282-R293), [link](https://github.com/baidu/amis/pull/7777/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L290-R300))
* Add a test case in `DropDownButton.test.tsx` to verify that the rendered button elements have the expected classes based on the level and className props ([link](https://github.com/baidu/amis/pull/7777/files?diff=unified&w=0#diff-96cf72b55e5e00a0962aa763752506eaa09f2e7d63c1daf43ed78a462f58272bR400-R432), [link](https://github.com/baidu/amis/pull/7777/files?diff=unified&w=0#diff-96cf72b55e5e00a0962aa763752506eaa09f2e7d63c1daf43ed78a462f58272bR13))
