### PR TITLE
fix: InputFile组件限制选择文件上限后重新上传无效问题

### DIFF
--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -39,6 +39,7 @@ import {filter} from 'amis-core';
 import isPlainObject from 'lodash/isPlainObject';
 import merge from 'lodash/merge';
 import omit from 'lodash/omit';
+import isNil from 'lodash/isNil';
 import {TplSchema} from '../Tpl';
 import Sortable from 'sortablejs';
 
@@ -639,7 +640,7 @@ export default class ImageControl extends React.Component<
       currentFiles = [];
     }
 
-    const allowed = this.reuploadIndex
+    const allowed = !isNil(this.reuploadIndex)
       ? reFiles.length
       : (multiple
           ? maxLength
@@ -1116,7 +1117,7 @@ export default class ImageControl extends React.Component<
       currentFiles = [];
     }
 
-    const allowed = this.reuploadIndex
+    const allowed = !isNil(this.reuploadIndex)
       ? files.length
       : (multiple
           ? maxLength

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -639,12 +639,13 @@ export default class ImageControl extends React.Component<
       currentFiles = [];
     }
 
-    const allowed =
-      (multiple
-        ? maxLength
+    const allowed = this.reuploadIndex
+      ? reFiles.length
+      : (multiple
           ? maxLength
-          : reFiles.length + currentFiles.length
-        : 1) - currentFiles.length;
+            ? maxLength
+            : reFiles.length + currentFiles.length
+          : 1) - currentFiles.length;
 
     // 限制过多的错误文件
     if (allowed <= 0) {
@@ -1115,12 +1116,13 @@ export default class ImageControl extends React.Component<
       currentFiles = [];
     }
 
-    const allowed =
-      (multiple
-        ? maxLength
+    const allowed = this.reuploadIndex
+      ? files.length
+      : (multiple
           ? maxLength
-          : files.length + currentFiles.length
-        : 1) - currentFiles.length;
+            ? maxLength
+            : files.length + currentFiles.length
+          : 1) - currentFiles.length;
     const inputFiles: Array<FileX> = [];
 
     [].slice.call(files, 0, allowed).forEach((file: FileX) => {
@@ -1676,7 +1678,7 @@ export default class ImageControl extends React.Component<
                       <div className={cx('ImageControl-itemList')}>
                         {files.map((file, key) => (
                           <div
-                            key={this.getFileKey(file)}
+                            key={`${this.getFileKey(file)}-${key}`}
                             className={cx(
                               'ImageControl-item',
                               {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3488a22</samp>

Fix file limit and key conflict issues in `InputImage` component. Update the logic and attributes for reuploading files in `packages/amis/src/renderers/Form/InputImage.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3488a22</samp>

> _You thought you could escape the file limit doom_
> _But we fixed the bug in the `InputImage` tomb_
> _Now we use the `reuploadIndex` and `reFiles` to seal your fate_
> _And add the file index to the `key` to avoid the conflict hate_

### Why
当设置多选时点击重新上传，如果已经上传的图片数量等于maxLength，那么allowed为0，重新上传无效
![image](https://github.com/baidu/amis/assets/28388261/8fa95475-f663-4940-b4d0-03c5352614dc)


### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3488a22</samp>

*  Import `isNil` function to check for null or undefined values ([link](https://github.com/baidu/amis/pull/7783/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R42))
*  Fix file limit bug when reuploading a single file by using `reuploadIndex` and `reFiles` properties ([link](https://github.com/baidu/amis/pull/7783/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L642-R649), [link](https://github.com/baidu/amis/pull/7783/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1118-R1126))
*  Avoid key conflicts when rendering files by appending file index to `key` attribute ([link](https://github.com/baidu/amis/pull/7783/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1679-R1682))
