### PR TITLE
styles: InputFile组件上传列表中错误任务飘红

### DIFF
--- a/packages/amis-ui/scss/components/form/_file.scss
+++ b/packages/amis-ui/scss/components/form/_file.scss
@@ -104,6 +104,11 @@
 
     &.is-invalid {
       color: var(--FileControl-danger-color);
+
+      .#{$ns}FileControl-itemInfoIcon,
+      .#{$ns}FileControl-itemInfoText {
+        color: var(--FileControl-danger-color);
+      }
     }
 
     > svg:not(:first-child) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 28dc80b</samp>

Improve file validation feedback in form component. Add danger color style for invalid or error file items in `form/_file.scss`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 28dc80b</samp>

> _`file-control` warns_
> _with danger color style rule_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 28dc80b</samp>

* Add a danger color style for invalid or error file items in the file control component ([link](https://github.com/baidu/amis/pull/7785/files?diff=unified&w=0#diff-75b0706a3eaeb3d5632debc03411197abc6641be9e6ea620664ea57885697096R107-R111))
