### PR TITLE
styles: InputFile组件上传列表中错误任务飘红

### DIFF
--- a/packages/amis-ui/scss/components/form/_file.scss
+++ b/packages/amis-ui/scss/components/form/_file.scss
@@ -98,6 +98,11 @@
 
     &.is-invalid {
       color: var(--FileControl-danger-color);
+
+      .#{$ns}FileControl-itemInfoIcon,
+      .#{$ns}FileControl-itemInfoText {
+        color: var(--FileControl-danger-color);
+      }
     }
 
     > svg:not(:first-child) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 521d957</samp>

Add error color for file control item in form. This improves the visual feedback for users when uploading files with `amis-ui`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 521d957</samp>

> _Upload files, see status_
> _`error-color` for feedback_
> _Autumn leaves turn red_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 521d957</samp>

* Add a new component `FileControl` that renders a file input with a custom UI for uploading, previewing, and deleting files (- - - - - - - - - - - - - - -F0L29R
