### PR TITLE
fix: 修复树组件懒加载情况下，第一次点击节点展开后收起，再点击其他根节点懒加载时，第一次点击节点显示异常问题

### DIFF
--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -924,11 +924,11 @@ export class TreeSelector extends React.Component<
           return;
         }
         this.levels.set(item, level);
+        parent && this.relations.set(item, parent);
         if (paths.length === 0) {
           // 父节点
           flattenedOptions.push(item);
         } else if (this.isUnfolded(parent)) {
-          this.relations.set(item, parent);
           // 父节点是展开的状态
           flattenedOptions.push(item);
         }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f70630c</samp>

Simplify the logic of setting parent-child relations in `Tree.tsx`. Fix a bug with tree item selection when parents are collapsed or expanded.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f70630c</samp>

> _`relations.set` now_
> _outside of conditionals_
> _autumn leaves unfold_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f70630c</samp>

*  Simplify the logic of setting the relations between tree items and their parents by moving a common statement outside of conditional branches ([link](https://github.com/baidu/amis/pull/7793/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L927-R931))
