### PR TITLE
fix: 修复input-image以及tree相关的一些问题

### DIFF
--- a/packages/amis-core/src/components/CustomStyle.tsx
+++ b/packages/amis-core/src/components/CustomStyle.tsx
@@ -1,0 +1,29 @@
+import {useEffect} from 'react';
+import type {RendererEnv} from '../env';
+import type {CustomStyleClassName} from '../utils/style-helper';
+import {insertCustomStyle} from '../utils/style-helper';
+
+interface CustomStyleProps {
+  config: {
+    themeCss: any;
+    classNames: CustomStyleClassName[];
+    id?: string;
+    defaultData?: any;
+  };
+  env: RendererEnv;
+}
+
+export default function (props: CustomStyleProps) {
+  const {themeCss, classNames, id, defaultData} = props.config;
+  useEffect(() => {
+    insertCustomStyle(
+      themeCss,
+      classNames,
+      id,
+      defaultData,
+      props.env?.customStyleClassPrefix
+    );
+  }, [props.config.themeCss]);
+
+  return null;
+}

--- a/packages/amis-core/src/index.tsx
+++ b/packages/amis-core/src/index.tsx
@@ -102,6 +102,7 @@ import type {OnEventProps} from './utils/index';
 import {valueMap as styleMap} from './utils/style-helper';
 import {RENDERER_TRANSMISSION_OMIT_PROPS} from './SchemaRenderer';
 import type {IItem} from './store/list';
+import CustomStyle from './components/CustomStyle';
 
 // @ts-ignore
 export const version = '__buildVersion';
@@ -189,7 +190,8 @@ export {
   IColumn2,
   IRow2,
   OnEventProps,
-  FormSchemaBase
+  FormSchemaBase,
+  CustomStyle
 };
 
 export function render(

--- a/packages/amis-core/src/utils/style-helper.ts
+++ b/packages/amis-core/src/utils/style-helper.ts
@@ -279,3 +279,14 @@ export function getValueByPath(path: string, data: any) {
     return null;
   }
 }
+
+export interface CustomStyleClassName {
+  key: string;
+  value?: string;
+  weights?: {
+    default?: extra;
+    hover?: extra;
+    active?: extra;
+    disabled?: extra;
+  };
+}

--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -906,11 +906,11 @@ export class TreeSelector extends React.Component<
         if (!isVisible(item)) {
           return;
         }
+        parent && this.relations.set(item, parent);
         if (paths.length === 1) {
           // 父节点
           flattenedOptions.push(item);
         } else if (this.isUnfolded(parent)) {
-          this.relations.set(item, parent);
           // 父节点是展开的状态
           item.level = level;
           flattenedOptions.push(item);

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -5,7 +5,7 @@ import {
   FormBaseControl,
   prettyBytes,
   resolveEventData,
-  insertCustomStyle
+  CustomStyle
 } from 'amis-core';
 // import 'cropperjs/dist/cropper.css';
 const Cropper = React.lazy(() => import('react-cropper'));
@@ -14,7 +14,13 @@ import {FileRejection, ErrorCode, DropEvent} from 'react-dropzone';
 import 'blueimp-canvastoblob';
 import find from 'lodash/find';
 import {Payload, ActionObject} from 'amis-core';
-import {buildApi} from 'amis-core';
+import {
+  buildApi,
+  isEffectiveApi,
+  normalizeApi,
+  isApiOutdated,
+  isApiOutdatedWithData
+} from 'amis-core';
 import {createObject, qsstringify, guid, isEmpty, qsparse} from 'amis-core';
 import {Icon, TooltipWrapper, Button} from 'amis-ui';
 import accepts from 'attr-accept';
@@ -34,10 +40,11 @@ import isPlainObject from 'lodash/isPlainObject';
 import merge from 'lodash/merge';
 import omit from 'lodash/omit';
 import {TplSchema} from '../Tpl';
+import Sortable from 'sortablejs';
 
 /**
  * Image 图片上传控件
- * 文档：https://baidu.gitee.io/amis/docs/components/form/image
+ * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/form/image
  */
 export interface ImageControlSchema extends FormBaseControlSchema {
   /**
@@ -278,6 +285,18 @@ export interface ImageControlSchema extends FormBaseControlSchema {
    * 固定尺寸的 CSS类名
    */
   fixedSizeClassName?: SchemaClassName;
+
+  /**
+   * 是否可拖拽排序
+   */
+  draggable?: boolean;
+
+  /**
+   * 可拖拽排序的提示信息。
+   *
+   * @default 可拖拽排序
+   */
+  draggableTip?: string;
 }
 
 let preventEvent = (e: any) => e.stopPropagation();
@@ -354,7 +373,8 @@ export default class ImageControl extends React.Component<
     delimiter: ',',
     autoUpload: true,
     multiple: false,
-    dropCrop: true
+    dropCrop: true,
+    initAutoFill: true
   };
 
   static valueToFile(
@@ -397,6 +417,7 @@ export default class ImageControl extends React.Component<
   };
 
   files: Array<FileValue | FileX> = [];
+  fileKeys: WeakMap<FileValue | FileX, string> = new WeakMap();
   fileUploadCancelExecutors: Array<{
     file: any;
     executor: () => void;
@@ -408,7 +429,7 @@ export default class ImageControl extends React.Component<
   resolve?: (value?: any) => void;
   emitValue: any;
   unmounted = false;
-  initAutoFill: boolean;
+  initedFilled = false;
   // 文件重新上传的位置标记，用以定位替换
   reuploadIndex: undefined | number = undefined;
 
@@ -419,7 +440,6 @@ export default class ImageControl extends React.Component<
     const joinValues = props.joinValues;
     const delimiter = props.delimiter as string;
     let files: Array<FileValue> = [];
-    this.initAutoFill = !!(props.initAutoFill ?? true);
 
     if (value) {
       // files = (multiple && Array.isArray(value) ? value : joinValues ? (value as string).split(delimiter) : [value])
@@ -464,14 +484,20 @@ export default class ImageControl extends React.Component<
     this.syncAutoFill = this.syncAutoFill.bind(this);
     this.handleReSelect = this.handleReSelect.bind(this);
     this.handleFileCancel = this.handleFileCancel.bind(this);
+    this.dragTipRef = this.dragTipRef.bind(this);
   }
 
   componentDidMount() {
-    if (this.initAutoFill) {
-      const {formInited, addHook} = this.props;
-      formInited || !addHook
-        ? this.syncAutoFill()
-        : addHook(this.syncAutoFill, 'init');
+    const {formInited, addHook} = this.props;
+
+    if (formInited || !addHook) {
+      this.initedFilled = true;
+      this.props.initAutoFill && this.syncAutoFill();
+    } else if (addHook) {
+      addHook(() => {
+        this.initedFilled = true;
+        this.props.initAutoFill && this.syncAutoFill();
+      }, 'init');
     }
 
     if (this.props.initCrop && this.files.length) {
@@ -511,7 +537,7 @@ export default class ImageControl extends React.Component<
               obj = {
                 ...org,
                 ...obj,
-                id: org.id || obj.id
+                id: org.id || obj.id || guid()
               };
             }
 
@@ -524,7 +550,9 @@ export default class ImageControl extends React.Component<
         {
           files: (this.files = files)
         },
-        this.initAutoFill ? this.syncAutoFill : () => {}
+        props.changeMotivation !== 'formInited' && this.initedFilled
+          ? this.syncAutoFill
+          : undefined
       );
     }
 
@@ -543,6 +571,20 @@ export default class ImageControl extends React.Component<
 
   componentWillUnmount() {
     this.unmounted = true;
+    this.fileKeys = new WeakMap();
+  }
+
+  getFileKey(file: FileValue | FileX) {
+    if (file.id) {
+      return file.id;
+    }
+    if (this.fileKeys.has(file)) {
+      return this.fileKeys.get(file);
+    }
+
+    const key = guid();
+    this.fileKeys.set(file, key);
+    return key;
   }
 
   buildCrop(props: ImageProps) {
@@ -626,7 +668,9 @@ export default class ImageControl extends React.Component<
             }
             // 文件太大
             else if (err.code === ErrorCode.FileTooLarge) {
-              return __('File.sizeLimit', {maxSize});
+              return __('File.sizeLimit', {
+                maxSize: prettyBytes(maxSize as number, 1024)
+              });
             }
           })
           .join('; ');
@@ -735,16 +779,16 @@ export default class ImageControl extends React.Component<
                 newFile.state =
                   file.state !== 'uploading' ? file.state : 'error';
                 newFile.error = error;
-                if (!multiple) {
-                  this.current = null;
-                  return this.setState(
-                    {
-                      files: (this.files = []),
-                      error
-                    },
-                    this.tick
-                  );
-                }
+
+                this.current = null;
+                files.splice(idx, 1);
+                return this.setState(
+                  {
+                    files: (this.files = files),
+                    error
+                  },
+                  this.tick
+                );
               } else {
                 newFile = {
                   name: file.name || this.state.cropFileName,
@@ -965,6 +1009,18 @@ export default class ImageControl extends React.Component<
   handleDrop(files: Array<FileX>, e?: any, event?: DropEvent) {
     const {multiple, crop, dropCrop} = this.props;
 
+    if (!files.length && Array.isArray(e)) {
+      const error = e
+        .reduce((errors: Array<string>, item) => {
+          errors = errors.concat(item.errors.map((e: any) => e.message));
+          return errors;
+        }, [])
+        .join('\n');
+
+      this.props.env.alert(error);
+      return;
+    }
+
     if (crop && !multiple && dropCrop) {
       const file = files[0] as any;
       if (!file.preview || !file.url) {
@@ -1071,7 +1127,7 @@ export default class ImageControl extends React.Component<
       if (maxSize && file.size > maxSize) {
         this.props.env.alert(
           __('File.maxSize', {
-            filename: file.name,
+            filename: file.name || __('File.imageAfterCrop'),
             actualSize: prettyBytes(file.size, 1024),
             maxSize: prettyBytes(maxSize, 1024)
           })
@@ -1331,7 +1387,7 @@ export default class ImageControl extends React.Component<
           },
           () => {
             if (!needUploading) {
-              this.onChange(false, true, this.initAutoFill);
+              this.onChange(false, true, this.props.initAutoFill);
             }
           }
         );
@@ -1430,6 +1486,56 @@ export default class ImageControl extends React.Component<
     );
   }
 
+  dragTip?: HTMLElement;
+  sortable?: Sortable;
+  id: string = guid();
+  dragTipRef(ref: any) {
+    if (!this.dragTip && ref) {
+      this.initDragging(ref.parentNode as HTMLElement);
+    } else if (this.dragTip && !ref) {
+      this.destroyDragging();
+    }
+
+    this.dragTip = ref;
+  }
+
+  initDragging(dom: HTMLElement) {
+    const ns = this.props.classPrefix;
+    this.sortable = new Sortable(dom, {
+      group: `inputimages-${this.id}`,
+      animation: 150,
+      handle: `.${ns}ImageControl-item [data-role="dragBar"]`,
+      ghostClass: `${ns}ImageControl-item--dragging`,
+      onEnd: (e: any) => {
+        // 没有移动
+        if (e.newIndex === e.oldIndex) {
+          return;
+        }
+
+        // 换回来
+        const parent = e.to as HTMLElement;
+        if (e.oldIndex < parent.childNodes.length - 1) {
+          parent.insertBefore(e.item, parent.childNodes[e.oldIndex]);
+        } else {
+          parent.appendChild(e.item);
+        }
+
+        const files = this.files.concat();
+        files.splice(e.newIndex, 0, files.splice(e.oldIndex, 1)[0]);
+        this.setState(
+          {
+            files: (this.files = files)
+          },
+          () => this.onChange(true)
+        );
+      }
+    });
+  }
+
+  destroyDragging() {
+    this.sortable && this.sortable.destroy();
+  }
+
   render() {
     const {
       className,
@@ -1454,57 +1560,11 @@ export default class ImageControl extends React.Component<
       addBtnControlClassName,
       iconControlClassName,
       id,
-      translate: __
+      translate: __,
+      draggable,
+      draggableTip,
+      env
     } = this.props;
-
-    insertCustomStyle(
-      themeCss,
-      [
-        {
-          key: 'inputImageControlClassName',
-          value: inputImageControlClassName
-        }
-      ],
-      id,
-      null
-    );
-
-    insertCustomStyle(
-      themeCss,
-      [
-        {
-          key: 'addBtnControlClassName',
-          value: addBtnControlClassName,
-          weights: {
-            hover: {
-              suf: ':not(:disabled):not(.is-disabled)'
-            },
-            active: {
-              suf: ':not(:disabled):not(.is-disabled)'
-            }
-          }
-        }
-      ],
-      id + '-addOn',
-      null
-    );
-
-    insertCustomStyle(
-      themeCss,
-      [
-        {
-          key: 'iconControlClassName',
-          value: iconControlClassName,
-          weights: {
-            default: {
-              suf: ' svg'
-            }
-          }
-        }
-      ],
-      id + '-icon',
-      null
-    );
 
     const {
       files,
@@ -1521,6 +1581,10 @@ export default class ImageControl extends React.Component<
     }
     const filterFrameImage = filter(frameImage, this.props.data, '| raw');
     const hasPending = files.some(file => file.state == 'pending');
+
+    const enableDraggable =
+      !!multiple && draggable && !disabled && !hasPending && files.length > 1;
+
     return (
       <div
         className={cx(`ImageControl`, className, inputImageControlClassName)}
@@ -1575,7 +1639,7 @@ export default class ImageControl extends React.Component<
             accept={accept}
             multiple={dropMultiple}
             disabled={disabled}
-            maxSize={maxSize}
+            maxSize={crop ? undefined : maxSize}
           >
             {({
               getRootProps,
@@ -1608,10 +1672,11 @@ export default class ImageControl extends React.Component<
                   </div>
                 ) : (
                   <>
-                    {files && files.length
-                      ? files.map((file, key) => (
+                    {files && files.length ? (
+                      <div className={cx('ImageControl-itemList')}>
+                        {files.map((file, key) => (
                           <div
-                            key={file.id || key}
+                            key={this.getFileKey(file)}
                             className={cx(
                               'ImageControl-item',
                               {
@@ -1747,6 +1812,22 @@ export default class ImageControl extends React.Component<
                                   thumbRatio={thumbRatio}
                                   overlays={
                                     <>
+                                      {enableDraggable ? (
+                                        <a
+                                          data-role="dragBar"
+                                          data-tooltip={__(
+                                            draggableTip || 'Image.dragTip'
+                                          )}
+                                          data-position="bottom"
+                                          target="_blank"
+                                          rel="noopener"
+                                        >
+                                          <Icon
+                                            icon="drag-bar"
+                                            className="icon"
+                                          />
+                                        </a>
+                                      ) : null}
                                       <a
                                         data-tooltip={__('Image.zoomIn')}
                                         data-position="bottom"
@@ -1812,23 +1893,27 @@ export default class ImageControl extends React.Component<
                                         </a>
                                       ) : null}
                                       {/* <a
-                                        data-tooltip={
-                                          file.name ||
-                                          getNameFromUrl(file.value || file.url)
-                                        }
-                                        data-position="bottom"
-                                        target="_blank"
-                                      >
-                                        <Icon icon="info" className="icon" />
-                                      </a> */}
+                                      data-tooltip={
+                                        file.name ||
+                                        getNameFromUrl(file.value || file.url)
+                                      }
+                                      data-position="bottom"
+                                      target="_blank"
+                                    >
+                                      <Icon icon="info" className="icon" />
+                                    </a> */}
                                     </>
                                   }
                                 />
                               </>
                             )}
                           </div>
-                        ))
-                      : null}
+                        ))}
+                        {enableDraggable ? (
+                          <span ref={this.dragTipRef} />
+                        ) : null}
+                      </div>
+                    ) : null}
 
                     {(multiple && (!maxLength || files.length < maxLength)) ||
                     (!multiple && !files.length) ? (
@@ -1906,6 +1991,58 @@ export default class ImageControl extends React.Component<
             )}
           </DropZone>
         )}
+        <CustomStyle
+          config={{
+            themeCss,
+            classNames: [
+              {
+                key: 'inputImageControlClassName',
+                value: inputImageControlClassName
+              }
+            ],
+            id
+          }}
+          env={env}
+        />
+        <CustomStyle
+          config={{
+            themeCss,
+            classNames: [
+              {
+                key: 'addBtnControlClassName',
+                value: addBtnControlClassName,
+                weights: {
+                  hover: {
+                    suf: ':not(:disabled):not(.is-disabled)'
+                  },
+                  active: {
+                    suf: ':not(:disabled):not(.is-disabled)'
+                  }
+                }
+              }
+            ],
+            id: id + '-addOn'
+          }}
+          env={env}
+        />
+        <CustomStyle
+          config={{
+            themeCss,
+            classNames: [
+              {
+                key: 'iconControlClassName',
+                value: iconControlClassName,
+                weights: {
+                  default: {
+                    suf: ' svg'
+                  }
+                }
+              }
+            ],
+            id: id + '-icon'
+          }}
+          env={env}
+        />
       </div>
     );
   }
@@ -1913,6 +2050,20 @@ export default class ImageControl extends React.Component<
 
 @FormItem({
   type: 'input-image',
-  sizeMutable: false
+  sizeMutable: false,
+  shouldComponentUpdate: (props: any, prevProps: any) =>
+    !!isEffectiveApi(props.receiver, props.data) &&
+    (isApiOutdated(
+      props.receiver,
+      prevProps.receiver,
+      props.data,
+      prevProps.data
+    ) ||
+      isApiOutdatedWithData(
+        props.receiver,
+        prevProps.receiver,
+        props.data,
+        prevProps.data
+      ))
 })
 export class ImageControlRenderer extends ImageControl {}

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -39,6 +39,7 @@ import {filter} from 'amis-core';
 import isPlainObject from 'lodash/isPlainObject';
 import merge from 'lodash/merge';
 import omit from 'lodash/omit';
+import isNil from 'lodash/isNil';
 import {TplSchema} from '../Tpl';
 import Sortable from 'sortablejs';
 
@@ -639,7 +640,7 @@ export default class ImageControl extends React.Component<
       currentFiles = [];
     }
 
-    const allowed = this.reuploadIndex
+    const allowed = !isNil(this.reuploadIndex)
       ? reFiles.length
       : (multiple
           ? maxLength
@@ -1116,7 +1117,7 @@ export default class ImageControl extends React.Component<
       currentFiles = [];
     }
 
-    const allowed = this.reuploadIndex
+    const allowed = !isNil(this.reuploadIndex)
       ? files.length
       : (multiple
           ? maxLength

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -639,12 +639,13 @@ export default class ImageControl extends React.Component<
       currentFiles = [];
     }
 
-    const allowed =
-      (multiple
-        ? maxLength
+    const allowed = this.reuploadIndex
+      ? reFiles.length
+      : (multiple
           ? maxLength
-          : reFiles.length + currentFiles.length
-        : 1) - currentFiles.length;
+            ? maxLength
+            : reFiles.length + currentFiles.length
+          : 1) - currentFiles.length;
 
     // 限制过多的错误文件
     if (allowed <= 0) {
@@ -1115,12 +1116,13 @@ export default class ImageControl extends React.Component<
       currentFiles = [];
     }
 
-    const allowed =
-      (multiple
-        ? maxLength
+    const allowed = this.reuploadIndex
+      ? files.length
+      : (multiple
           ? maxLength
-          : files.length + currentFiles.length
-        : 1) - currentFiles.length;
+            ? maxLength
+            : files.length + currentFiles.length
+          : 1) - currentFiles.length;
     const inputFiles: Array<FileX> = [];
 
     [].slice.call(files, 0, allowed).forEach((file: FileX) => {
@@ -1676,7 +1678,7 @@ export default class ImageControl extends React.Component<
                       <div className={cx('ImageControl-itemList')}>
                         {files.map((file, key) => (
                           <div
-                            key={this.getFileKey(file)}
+                            key={`${this.getFileKey(file)}-${key}`}
                             className={cx(
                               'ImageControl-item',
                               {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 11b106d</samp>

This pull request adds a new `CustomStyle` component that allows customizing the style of AMIS components based on the theme and class names. It also adds some features and fixes some bugs in the `InputImage` and `TreeSelector` components. It updates the `amis-core` and `amis-ui` packages accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 11b106d</samp>

> _`CustomStyle` adds_
> _CSS flexibility_
> _to AMIS components_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 11b106d</samp>

*  Add a new component `CustomStyle` that can insert custom CSS styles based on the theme and class names of the component ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-64f487ea8bb551e6157d95133fcf65572d6990b062dd31bf6502543a77ad9fb5R1-R29))
*  Import and export the `CustomStyle` component in the `amis-core` package index file ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-ed2759a19afd843ed555f6c368bef12e2d0dab8b1b113f0ff059a4575bad00c2R105),[link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-ed2759a19afd843ed555f6c368bef12e2d0dab8b1b113f0ff059a4575bad00c2L192-R194))
*  Add a new interface `CustomStyleClassName` that defines the type of the class names that can be passed to the `CustomStyle` component ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdR282-R292))
*  Fix a bug in the `TreeSelector` component that caused the parent-child relationship of the tree nodes to be incorrect when the node was a root node ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L909-R913))
*  Replace the import of the `insertCustomStyle` function with the import of the `CustomStyle` component, and add some imports of functions that can check the validity and freshness of an API configuration or response in the `InputImage` component ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L8-R8),[link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L17-R23))
*  Add some imports of functions that can check if a value is null or undefined, and a library that enables drag and drop sorting of elements in the `InputImage` component ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L36-R48))
*  Add some new properties to the `ImageControlSchema` interface that can configure the draggable sorting and the auto fill features of the `InputImage` component ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R289-R300))
*  Add a default value of `true` for the `initAutoFill` property in the `ImageControl` class ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L357-R378))
*  Add a new property `fileKeys` that stores the unique keys for each file object in the `ImageControl` class ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R421))
*  Rename the property `initAutoFill` to `initedFilled` and remove the assignment of the prop to the property in the `ImageControl` class ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L411-R433),[link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L422))
*  Modify the `componentDidMount` method to set the `initedFilled` property and call the `syncAutoFill` method when the form is initialized or the `addHook` prop is truthy, and to bind the `dragTipRef` method to the `this` context in the `ImageControl` class ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L467-R501))
*  Modify the `syncAutoFill` method to assign a `guid` to the file object if it does not have an `id` property, and to avoid calling the method twice when the component is initialized by the form in the `ImageControl` class ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L514-R541),[link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L527-R556))
*  Add a new method `getFileKey` that returns the corresponding key from the `fileKeys` property for a file object, or generates a new key and sets it to the property if it does not exist in the `ImageControl` class ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L546-R590))
*  Modify the `componentWillUnmount` method to reset the `fileKeys` property to a new `WeakMap` when the component is unmounted in the `ImageControl` class ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L546-R590))
*  Modify the `handleDrop` method to support the reupload feature, which allows the user to replace an existing image with a new one, and to format the file size limit in a human-readable format in the `ImageControl` class ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L600-R649),[link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L629-R675))
*  Modify the `uploadFile` method to fix a bug that caused the component to clear all the files when one file upload failed, and to ensure that the component only removes the failed file from the state in the `ImageControl` class ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L738-R793))
*  Modify the `handleSelect` method to handle the case when the user selects multiple files that are all invalid, to support the reupload feature, and to handle the case when the file object is created from the cropped image data in the `ImageControl` class ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R1014-R1025),[link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1062-R1126),[link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1074-R1133))
*  Modify the `setState` callback in the `handleSelect` method to use the `initAutoFill` prop instead of the property in the `ImageControl` class ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1334-R1393))
*  Add some new properties and methods that implement the draggable sorting feature, which allows the user to drag and drop the images to reorder them, and to create a drag tip element that acts as a placeholder for the drag handle in the `ImageControl` class ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R1492-R1541))
*  Modify the `render` method to use the `CustomStyle` component instead of the `insertCustomStyle` function, to avoid applying the file size limit to the cropped image data, to create a container element for the file elements, to render the drag handle and the drag tip elements, and to remove the unused code that renders an info element in the `ImageControl` class ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1457-R1571),[link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R1587-R1590),[link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1578-R1645),[link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R1818-R1833),[link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1815-R1907),[link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1830-R1919),[link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R1997-R2048))
*  Modify the `FormItem` decorator of the `ImageControlRenderer` class to add a `shouldComponentUpdate` prop that optimizes the performance of the component by avoiding unnecessary updates, and ensures that the component can update when the `receiver` prop changes or becomes outdated in the `InputImage` component ([link](https://github.com/baidu/amis/pull/7794/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1916-R2070))
