### PR TITLE
fix: 修复transfer支持配置noResultsText

### DIFF
--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -545,7 +545,8 @@ export class BaseTransferRenderer<
       loadingConfig,
       showInvalidMatch,
       onlyChildren,
-      useMobileUI
+      useMobileUI,
+      noResultsText
     } = this.props;
 
     // 目前 LeftOptions 没有接口可以动态加载
@@ -607,6 +608,7 @@ export class BaseTransferRenderer<
           loadingConfig={loadingConfig}
           showInvalidMatch={showInvalidMatch}
           useMobileUI={useMobileUI}
+          noResultsText={noResultsText}
         />
 
         <Spinner


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a74178</samp>

Added a new feature to the transfer renderer to allow customizing the empty state message. Modified `Transfer.tsx` to accept and pass a new prop `noResultsText` to the `antd` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8a74178</samp>

> _Oh we are the coders of the `transfer` component_
> _We make it easy to move data from left to right_
> _And when there's nothing left to show, we have a message so_
> _We pass the `noResultsText` prop with all our might_

### Why

没有透传noResultsText

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a74178</samp>

* Add a new prop `noResultsText` to `BaseTransferRenderer` to customize the text for no matching items ([link](https://github.com/baidu/amis/pull/7804/files?diff=unified&w=0#diff-07debd2e776c043c2635a6714d9622ad216538a5d1a7d75a982e41f30e711e71L548-R549))
* Pass the `noResultsText` prop to the `Transfer` component from `antd` in `Transfer.tsx` to render the text in the UI ([link](https://github.com/baidu/amis/pull/7804/files?diff=unified&w=0#diff-07debd2e776c043c2635a6714d9622ad216538a5d1a7d75a982e41f30e711e71R611))
