### PR TITLE
fix: 支持表达式多语言默认显示

### DIFF
--- a/packages/amis-core/src/locale.tsx
+++ b/packages/amis-core/src/locale.tsx
@@ -1,6 +1,7 @@
 // 多语言支持
 import React from 'react';
 import hoistNonReactStatic from 'hoist-non-react-statics';
+import moment from 'moment';
 import {resolveVariable} from './utils/tpl-builtin';
 
 export type TranslateFn<T = any> = (str: T, data?: object) => T;
@@ -10,6 +11,12 @@ interface LocaleConfig {
 }
 
 let defaultLocale: string = 'zh-CN';
+
+const momentLocaleMap: Record<string, string> = {
+  'zh-CN': 'zh-cn',
+  'en-US': 'en',
+  'de-DE': 'de'
+};
 
 const locales: {
   [propName: string]: LocaleConfig;
@@ -154,6 +161,7 @@ export function localeable<
           locale,
           translate: translate!
         };
+        moment.locale(momentLocaleMap?.[locale] ?? locale);
         const refConfig = ComposedComponent.prototype?.isReactComponent
           ? {ref: this.childRef}
           : {forwardedRef: this.childRef};


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d01f8e1</samp>

Fixed a bug in the calendar component that caused incorrect locale settings based on the user's language. Changed the order of the `moment` locales in `Calendar.tsx` to match the `getLang` function.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d01f8e1</samp>

> _`moment` locales_
> _reordered for calendars_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d01f8e1</samp>

* Changed the order of the moment locales to match the language order in `getLang` ([link](https://github.com/baidu/amis/pull/7805/files?diff=unified&w=0#diff-95af3120d1ccfbc45e4d5e68e1139a6a5da04bb3209049f4482822284aa46ad1L15-R16))
