### PR TITLE
chore: 增加 word 拼写检查的说明

### DIFF
--- a/docs/zh-CN/components/office-viewer.md
+++ b/docs/zh-CN/components/office-viewer.md
@@ -185,7 +185,7 @@ Word 渲染支持以下功能：
 
 目前变量使用的写法是 `{{name}}`，其中 `name` 代表变量名，另外这里可以是 amis 表达式，比如前面示例的 `{{DATETOSTR(TODAY(), 'YYYY-MM-DD')}}`
 
-> 为了避免 Word 自作主张添加额外标签，对于复杂的变量建议先在记事本之类的纯文本编辑器里编辑，再粘贴进 Word 里。
+**Word 经常会自作主张进行语法检查，生成无关的标签导致变量替换出错，解决办法是参考这个[文档](https://support.microsoft.com/zh-cn/office/%E5%9C%A8-word-%E4%B8%AD%E6%A3%80%E6%9F%A5%E8%AF%AD%E6%B3%95-%E6%8B%BC%E5%86%99%E7%AD%89-0f43bf32-ccde-40c5-b16a-c6a282c0d251?ui=zh-cn&rs=zh-cn&ad=cn)，将所有语法检查都忽略掉，也就是文档里不再有飘红的文字**
 
 ### 表格行循环
 

--- a/packages/office-viewer/__tests__/OpenXML.test.ts
+++ b/packages/office-viewer/__tests__/OpenXML.test.ts
@@ -87,3 +87,276 @@ test('space', async () => {
 
   expect(xmlDoc.getElementsByTagName('w:t')[0]?.innerHTML).toBe('Custom');
 });
+
+test('multi_proofErr', async () => {
+  const xmlDoc = parseXML(
+    `
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:body>
+        <w:p w:rsidR="00EA74AA" w:rsidRDefault="001F5EBE" w:rsidP="003D533A">
+          <w:pPr>
+            <w:spacing w:line="560" w:lineRule="exact"/>
+            <w:jc w:val="center"/>
+            <w:rPr>
+              <w:rFonts w:ascii="SimSun" w:eastAsia="SimSun" w:hAnsi="SimSun" w:cs="Times New Roman"/>
+              <w:color w:val="FF0000"/>
+              <w:sz w:val="18"/>
+              <w:szCs w:val="18"/>
+            </w:rPr>
+          </w:pPr>
+          <w:r w:rsidRPr="001F5EBE">
+            <w:rPr>
+              <w:rFonts w:ascii="SimSun" w:eastAsia="SimSun" w:hAnsi="SimSun" w:cs="Times New Roman"/>
+              <w:color w:val="000000" w:themeColor="text1"/>
+              <w:sz w:val="18"/>
+              <w:szCs w:val="18"/>
+            </w:rPr>
+            <w:t>{{</w:t>
+          </w:r>
+          <w:proofErr w:type="spellStart"/>
+          <w:r w:rsidRPr="001F5EBE">
+            <w:rPr>
+              <w:rFonts w:ascii="SimSun" w:eastAsia="SimSun" w:hAnsi="SimSun" w:cs="Times New Roman"/>
+              <w:color w:val="000000" w:themeColor="text1"/>
+              <w:sz w:val="18"/>
+              <w:szCs w:val="18"/>
+            </w:rPr>
+            <w:t>operate_</w:t>
+          </w:r>
+          <w:proofErr w:type="gramStart"/>
+          <w:r w:rsidRPr="001F5EBE">
+            <w:rPr>
+              <w:rFonts w:ascii="SimSun" w:eastAsia="SimSun" w:hAnsi="SimSun" w:cs="Times New Roman"/>
+              <w:color w:val="000000" w:themeColor="text1"/>
+              <w:sz w:val="18"/>
+              <w:szCs w:val="18"/>
+            </w:rPr>
+            <w:t>applicant.label</w:t>
+          </w:r>
+          <w:proofErr w:type="spellEnd"/>
+          <w:proofErr w:type="gramEnd"/>
+          <w:r w:rsidRPr="001F5EBE">
+            <w:rPr>
+              <w:rFonts w:ascii="SimSun" w:eastAsia="SimSun" w:hAnsi="SimSun" w:cs="Times New Roman"/>
+              <w:color w:val="000000" w:themeColor="text1"/>
+              <w:sz w:val="18"/>
+              <w:szCs w:val="18"/>
+            </w:rPr>
+            <w:t>}}</w:t>
+          </w:r>
+        </w:p>
+      </w:body>
+    </w:document>
+      `.trim()
+  );
+
+  const word = createWord();
+
+  mergeRun(word, xmlDoc);
+
+  expect(xmlDoc.getElementsByTagName('w:t')[0]?.innerHTML).toBe(
+    '{{operate_applicant.label}}'
+  );
+});
+
+test('multi_run', async () => {
+  const xmlDoc = parseXML(
+    `
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:body>
+        <w:p w:rsidR="00EA74AA" w:rsidRDefault="0089111F" w:rsidP="003D533A">
+        <w:pPr>
+          <w:spacing w:line="560" w:lineRule="exact"/>
+          <w:jc w:val="center"/>
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman"/>
+            <w:color w:val="FF0000"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+        </w:pPr>
+        <w:r w:rsidRPr="003826F8">
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman" w:hint="eastAsia"/>
+            <w:color w:val="000000" w:themeColor="text1"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+          <w:t>{</w:t>
+        </w:r>
+        <w:r w:rsidRPr="003826F8">
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman"/>
+            <w:color w:val="000000" w:themeColor="text1"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+          <w:t>{</w:t>
+        </w:r>
+        <w:r w:rsidR="00887A64" w:rsidRPr="00D1772D">
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman"/>
+            <w:color w:val="000000" w:themeColor="text1"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+          <w:t>operate</w:t>
+        </w:r>
+        <w:r w:rsidR="00636549">
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman"/>
+            <w:color w:val="000000" w:themeColor="text1"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+          <w:t>_</w:t>
+        </w:r>
+        <w:r w:rsidR="00636549">
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman" w:hint="eastAsia"/>
+            <w:color w:val="000000" w:themeColor="text1"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+          <w:t>a</w:t>
+        </w:r>
+        <w:r w:rsidR="00887A64" w:rsidRPr="00D1772D">
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman"/>
+            <w:color w:val="000000" w:themeColor="text1"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+          <w:t>pplicate</w:t>
+        </w:r>
+        <w:r w:rsidR="00636549">
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman"/>
+            <w:color w:val="000000" w:themeColor="text1"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+          <w:t>_u</w:t>
+        </w:r>
+        <w:r w:rsidR="00887A64" w:rsidRPr="00D1772D">
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman"/>
+            <w:color w:val="000000" w:themeColor="text1"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+          <w:t>nit</w:t>
+        </w:r>
+        <w:r w:rsidR="00343289">
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman"/>
+            <w:color w:val="000000" w:themeColor="text1"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+          <w:t>.label</w:t>
+        </w:r>
+        <w:r w:rsidRPr="003826F8">
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman"/>
+            <w:color w:val="000000" w:themeColor="text1"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+          <w:t>}}</w:t>
+        </w:r>
+      </w:p>
+      </w:body>
+    </w:document>
+      `.trim()
+  );
+
+  const word = createWord();
+
+  mergeRun(word, xmlDoc);
+
+  expect(xmlDoc.getElementsByTagName('w:t')[0]?.innerHTML).toBe(
+    '{{operate_applicate_unit.label}}'
+  );
+});
+
+test('error_proof', async () => {
+  const xmlDoc = parseXML(
+    `
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:body>
+        <w:p w:rsidR="00EA74AA" w:rsidRPr="00343289" w:rsidRDefault="00D06055" w:rsidP="00D06055">
+        <w:pPr>
+          <w:spacing w:line="560" w:lineRule="exact"/>
+          <w:jc w:val="center"/>
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman"/>
+            <w:color w:val="000000" w:themeColor="text1"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+        </w:pPr>
+        <w:r>
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman"/>
+            <w:color w:val="000000" w:themeColor="text1"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+          <w:t>{{</w:t>
+        </w:r>
+        <w:proofErr w:type="spellStart"/>
+        <w:r w:rsidRPr="00D06055">
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman"/>
+            <w:color w:val="000000" w:themeColor="text1"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+          <w:t>operate_work_type</w:t>
+        </w:r>
+        <w:r w:rsidR="00942520">
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman"/>
+            <w:color w:val="000000" w:themeColor="text1"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+          <w:t>.</w:t>
+        </w:r>
+        <w:r w:rsidR="00942520">
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman"/>
+            <w:color w:val="000000" w:themeColor="text1"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+          <w:t>label</w:t>
+        </w:r>
+        <w:proofErr w:type="spellEnd"/>
+        <w:r>
+          <w:rPr>
+            <w:rFonts w:ascii="宋体" w:eastAsia="宋体" w:hAnsi="宋体" w:cs="Times New Roman"/>
+            <w:color w:val="000000" w:themeColor="text1"/>
+            <w:sz w:val="18"/>
+            <w:szCs w:val="18"/>
+          </w:rPr>
+          <w:t>}}</w:t>
+        </w:r>
+      </w:p>
+      </w:body>
+    </w:document>
+      `.trim()
+  );
+
+  const word = createWord();
+
+  mergeRun(word, xmlDoc);
+
+  expect(xmlDoc.getElementsByTagName('w:t')[0]?.innerHTML).toBe(
+    '{{operate_work_type.label}}'
+  );
+});

--- a/scripts/get-all-docs.js
+++ b/scripts/get-all-docs.js
@@ -1,0 +1,36 @@
+/**
+ * 获取所有文档和 json 示例，生成到一个文件里，用于继续预训练
+ */
+
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+
+const docs = path.resolve(__dirname, '..', 'docs');
+
+const examples = path.resolve(__dirname, '..', 'examples');
+
+const outputFile = 'amis_docs.txt';
+
+glob(docs + '/**/*.md', {}, (err, files) => {
+  for (const file of files) {
+    const data = fs.readFileSync(file, {encoding: 'utf8', flag: 'r'});
+    fs.appendFileSync(outputFile, data + '\n\n');
+  }
+});
+
+// glob(examples + '/**/*.jsx', {}, (err, files) => {
+//   for (const file of files) {
+//     try {
+//       const content = fs.readFileSync(file, {encoding: 'utf8', flag: 'r'});
+//       if (content.indexOf('export default') !== -1) {
+//         const schema = Function(content.replace('export default', 'return'))();
+//         const json = JSON.stringify(schema, null, 2);
+//         console.log(file);
+//         fs.appendFileSync(outputFile, json + '\n\n');
+//       }
+//     } catch (e) {
+//       // console.log(e);
+//     }
+//   }
+// });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5929a06</samp>

This pull request updates the documentation and tests of the office viewer component, and adds a new script to collect all the documentation and JSON examples for natural language model pre-training. Specifically, it:

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5929a06</samp>

> _`office-viewer` docs_
> _Link to Microsoft support_
> _Winter of errors_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5929a06</samp>

*  Add a script to collect documentation and examples for natural language model pre-training (`[link](https://github.com/baidu/amis/pull/7807/files?diff=unified&w=0#diff-040ba6870c3a405b056928cbeee9da9c5d6562cbf744296f08d45d111b2bdd6bR1-R36)`)
