### PR TITLE
chore: input-sub-form 表单项默认改成不可读取上层数据 Close: #7715

### DIFF
--- a/packages/amis/__tests__/renderers/Form/inputSubForm.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/inputSubForm.test.tsx
@@ -338,3 +338,100 @@ test('Renderer:InputSubForm with addButtonClassName & itemsClassName & itemClass
     '自定义的新增'
   );
 });
+
+test('Renderer:InputSubForm-can-access-superdata-1', async () => {
+  const onChange = jest.fn();
+  const {getByText, container, baseElement} = render(
+    amisRender({
+      type: 'form',
+      data: {
+        a: '123',
+        b: '233'
+      },
+      body: [
+        {
+          type: 'input-sub-form',
+          name: 'form',
+          label: '子Form',
+          btnLabel: '设置子表单',
+          onChange,
+          form: {
+            title: '配置子表单',
+            body: [
+              {
+                name: 'a',
+                label: 'A',
+                type: 'input-text'
+              },
+              {
+                name: 'b',
+                label: 'B',
+                type: 'input-text'
+              }
+            ]
+          }
+        }
+      ]
+    })
+  );
+
+  fireEvent.click(getByText('设置子表单'));
+
+  expect(baseElement.querySelector('.cxd-Modal .cxd-Form')).toBeInTheDocument();
+
+  const inputs = baseElement.querySelectorAll(
+    '.cxd-Modal .cxd-Form .cxd-TextControl-input input'
+  );
+  expect(inputs!.length).toBe(2);
+  expect((inputs[0] as HTMLInputElement).value).toBe('');
+  expect((inputs[1] as HTMLInputElement).value).toBe('');
+});
+
+test('Renderer:InputSubForm-can-access-superdata-2', async () => {
+  const onChange = jest.fn();
+  const {getByText, container, baseElement} = render(
+    amisRender({
+      type: 'form',
+      data: {
+        a: '123',
+        b: '233'
+      },
+      body: [
+        {
+          type: 'input-sub-form',
+          name: 'form',
+          label: '子Form',
+          btnLabel: '设置子表单',
+          onChange,
+          form: {
+            canAccessSuperData: true,
+            title: '配置子表单',
+            body: [
+              {
+                name: 'a',
+                label: 'A',
+                type: 'input-text'
+              },
+              {
+                name: 'b',
+                label: 'B',
+                type: 'input-text'
+              }
+            ]
+          }
+        }
+      ]
+    })
+  );
+
+  fireEvent.click(getByText('设置子表单'));
+
+  expect(baseElement.querySelector('.cxd-Modal .cxd-Form')).toBeInTheDocument();
+
+  const inputs = baseElement.querySelectorAll(
+    '.cxd-Modal .cxd-Form .cxd-TextControl-input input'
+  );
+  expect(inputs!.length).toBe(2);
+  expect((inputs[0] as HTMLInputElement).value).toBe('123');
+  expect((inputs[1] as HTMLInputElement).value).toBe('233');
+});

--- a/packages/amis/src/renderers/Dialog.tsx
+++ b/packages/amis/src/renderers/Dialog.tsx
@@ -465,10 +465,6 @@ export default class Dialog extends React.Component<DialogProps> {
       syncLocation: false // 弹框中的 crud 一般不需要同步地址栏
     };
 
-    if (this.props.size === 'full') {
-      subProps.affixOffsetTop = 0;
-    }
-
     if (!(body as Schema).type) {
       return render(`body${key ? `/${key}` : ''}`, body, subProps);
     }

--- a/packages/amis/src/renderers/Form/InputSubForm.tsx
+++ b/packages/amis/src/renderers/Form/InputSubForm.tsx
@@ -362,7 +362,9 @@ export default class SubFormControl extends React.PureComponent<
       type: 'dialog',
       body: {
         type: 'form',
-        ...omit(form, dialogProps)
+        canAccessSuperData: false,
+        ...omit(form, dialogProps),
+        inheritData: false
       }
     };
   }
@@ -385,7 +387,9 @@ export default class SubFormControl extends React.PureComponent<
 
     return {
       type: 'form',
-      ...omit(form, dialogProps)
+      canAccessSuperData: false,
+      ...omit(form, dialogProps),
+      inheritData: false
     };
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 70db742</samp>

This pull request adds a new feature to the `InputSubForm` renderer component, which allows users to control the data access between the sub-form and the super-form. It also updates the TypeScript interface and the test cases for the component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 70db742</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A test for the `InputSubForm`, a wondrous component_
> _That opens a modal dialog for the user, and hides_
> _Or shows the super-form data, as the prop `canAccessSuperData` meant._

### Why

Close: #7715

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 70db742</samp>

*  Add `canAccessSuperData` prop to `InputSubForm` renderer component and its configuration interface ([link](https://github.com/baidu/amis/pull/7808/files?diff=unified&w=0#diff-2c4ae5b25ab00009bb38d0723797124a995223ee12f048e29e9724ab2173527aR365), [link](https://github.com/baidu/amis/pull/7808/files?diff=unified&w=0#diff-2c4ae5b25ab00009bb38d0723797124a995223ee12f048e29e9724ab2173527aR389))
* Add test cases for `InputSubForm` renderer component in `inputSubForm.test.tsx` ([link](https://github.com/baidu/amis/pull/7808/files?diff=unified&w=0#diff-f45803a0cbe5977125847db6ff169d6aee82bcd7c30cefb90b80c6c9e978cd6eR341-R437))
