### PR TITLE
fix(amis): 修正chart的height设置

### DIFF
--- a/packages/amis/src/renderers/Chart.tsx
+++ b/packages/amis/src/renderers/Chart.tsx
@@ -597,7 +597,7 @@ export class Chart extends React.Component<ChartProps> {
     } = this.props;
     let style = this.props.style || {};
     style.width = style.width || width || '100%';
-    style.height = style.width || height || '300px';
+    style.height = style.height || height || '300px';
     const styleVar = buildStyle(style, data);
 
     return (


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eb0efdd</samp>

Fixed a bug in `Chart.tsx` that caused incorrect chart height. The bug was reported in issue #2499.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at eb0efdd</samp>

> _`style.height` fixed_
> _chart shows proper dimension_
> _autumn bug resolved_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eb0efdd</samp>

* Fix chart height assignment to use correct variable ([link](https://github.com/baidu/amis/pull/7809/files?diff=unified&w=0#diff-b835aa79eebadb985fbc93069bbd1973522b0a1d125adbbe7b2300a154647acdL600-R600))
