### PR TITLE
fix: 修复 amis-editor 下拉框关闭可多选会自动干掉joinValues/delimiter/extractValue等相关…

### DIFF
--- a/packages/amis-core/src/renderers/Options.tsx
+++ b/packages/amis-core/src/renderers/Options.tsx
@@ -106,6 +106,11 @@ export interface FormOptionsControl extends FormBaseControl {
   delimiter?: string;
 
   /**
+   * 多选模式，值太多时是否避免折行
+   */
+  valuesNoWrap?: boolean;
+
+  /**
    * 开启后将选中的选项 value 的值封装为数组，作为当前表单项的值。
    */
   extractValue?: boolean;

--- a/packages/amis-editor/src/renderer/SwitchMoreControl.tsx
+++ b/packages/amis-editor/src/renderer/SwitchMoreControl.tsx
@@ -44,6 +44,7 @@ export interface SwitchMoreProps extends FormControlProps {
   bulk?: boolean; // 是否是一个综合object属性，若是，最终提交所有项覆盖到表单data，否则提交为 [name] 一项,
   onRemove?: (e: React.UIEvent<any> | void) => void;
   onClose: (e: React.UIEvent<any> | void) => void;
+  clearChildValuesOnOff?: boolean; // 关闭开关时，删除子表单字段，默认 true
   defaultData?: any; // 默认数据
 }
 
@@ -76,6 +77,7 @@ export default class SwitchMore extends React.Component<
     | 'falseValue'
     | 'formType'
     | 'bulk'
+    | 'clearChildValuesOnOff'
     // | 'editable'
   > = {
     // btnIcon: 'pencil',
@@ -88,7 +90,8 @@ export default class SwitchMore extends React.Component<
     trueValue: true,
     falseValue: false,
     formType: 'pop',
-    bulk: true
+    bulk: true,
+    clearChildValuesOnOff: true
     // editable: true
   };
 
@@ -178,7 +181,8 @@ export default class SwitchMore extends React.Component<
       defaultData,
       name,
       trueValue,
-      falseValue
+      falseValue,
+      clearChildValuesOnOff
     } = this.props;
 
     this.setState({checked});
@@ -191,11 +195,11 @@ export default class SwitchMore extends React.Component<
         name && (data[name] = trueValue);
         onBulkChange && onBulkChange(data);
       }
-      // 取消选中后，讲所有字段重置
+      // 取消选中后，将所有字段重置
       else {
-        const values = fromPairs(
-          this.getFormItemNames().map(i => [i, undefined])
-        );
+        const values = clearChildValuesOnOff
+          ? fromPairs(this.getFormItemNames().map(i => [i, undefined]))
+          : {};
         name && (values[name] = falseValue);
         onBulkChange && onBulkChange(values);
       }

--- a/packages/amis-editor/src/tpl/options.tsx
+++ b/packages/amis-editor/src/tpl/options.tsx
@@ -125,6 +125,7 @@ setSchemaTpl('multiple', (schema: any = {}) => {
     label: '可多选',
     value: false,
     hiddenOnDefault: true,
+    clearChildValuesOnOff: false,
     formType: 'extend',
     ...(schema.patch || {}),
     form: {


### PR DESCRIPTION
…选项的问题

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 40943ec</samp>

This pull request enhances the `SwitchMoreControl` and `FormOptionsControl` components with new props to control their display and behavior. It also updates the editor template for the `SwitchMoreControl` to expose the new prop.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 40943ec</samp>

> _We're coding up a storm, me hearties, coding up a storm_
> _We're adding props and options to the `SwitchMoreControl` form_
> _We'll let the user decide, me lads, decide to clear or not_
> _The values of the children when the switch is turned to off_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 40943ec</samp>

*  Add a new property `clearChildValuesOnOff` to the `SwitchMoreControl` component, which controls whether the child form fields are deleted or not when the switch is turned off ([link](https://github.com/baidu/amis/pull/7812/files?diff=unified&w=0#diff-c43d5ecc88b69a4ce979e8d1451eea6c5a822dce31c9a352e997442ae9d82c11R47), [link](https://github.com/baidu/amis/pull/7812/files?diff=unified&w=0#diff-c43d5ecc88b69a4ce979e8d1451eea6c5a822dce31c9a352e997442ae9d82c11R80), [link](https://github.com/baidu/amis/pull/7812/files?diff=unified&w=0#diff-c43d5ecc88b69a4ce979e8d1451eea6c5a822dce31c9a352e997442ae9d82c11L91-R94), [link](https://github.com/baidu/amis/pull/7812/files?diff=unified&w=0#diff-c43d5ecc88b69a4ce979e8d1451eea6c5a822dce31c9a352e997442ae9d82c11L181-R185), [link](https://github.com/baidu/amis/pull/7812/files?diff=unified&w=0#diff-c43d5ecc88b69a4ce979e8d1451eea6c5a822dce31c9a352e997442ae9d82c11L194-R202), [link](https://github.com/baidu/amis/pull/7812/files?diff=unified&w=0#diff-4ff8190ccb19edb2d788deb7ebf73420c1799a07d6061d2aeb89ab77e9e66b95R128))
*  Add a new property `valuesNoWrap` to the `FormOptionsControl` interface, which controls whether the values of multiple options are wrapped or not when displayed ([link](https://github.com/baidu/amis/pull/7812/files?diff=unified&w=0#diff-d9bf7707bf7ac9b7c40f2740fc783de7b5318386f02fd8348a8b7ef4b69717b2R109-R113))
