### PR TITLE
fix: picker显隐勾选、value绑定上层数据变量等问题修复

### DIFF
--- a/docs/zh-CN/components/form/picker.md
+++ b/docs/zh-CN/components/form/picker.md
@@ -500,6 +500,190 @@ order: 35
 }
 ```
 
+可以配置`visibleOn`属性控制 picker 显隐来支持更复杂的表单场景。如果 picker 的初始值需要绑定上层数据域变量，可以通过配置事件动作来更新上层数据域变量。
+
+```schema: scope="body"
+{
+  "type": "page",
+  "body": [
+    {
+      "type": "form",
+      "api": "",
+      "id": "test",
+      "data": {
+        "selectedValue": [{id: 1}, {id: 53}]
+      },
+      "body": [
+        {
+          "type": "button-group-select",
+          "name": "buttonGroupSelect",
+          "label": "按钮点选",
+          "inline": false,
+          "options": [
+            {
+              "label": "大模型训练",
+              "value": "train"
+            },
+            {
+              "label": "预测服务",
+              "value": "service"
+            }
+          ],
+          "value": "train"
+        },
+        {
+          "type": "picker",
+          "name": "type4",
+          "joinValues": true,
+          "valueField": "id",
+          "labelField": "engine",
+          "label": "",
+          "embed": true,
+          "source": "${trainList}",
+          "size": "lg",
+          "multiple": true,
+          "pickerSchema": {
+            "mode": "table",
+            "name": "thelist",
+            "columns": [
+              {
+                "name": "engine",
+                "label": "Rendering engine",
+                "sortable": true,
+                "searchable": true,
+                "type": "text",
+                "toggled": true
+              },
+              {
+                "name": "browser",
+                "label": "Browser",
+                "sortable": true,
+                "type": "text",
+                "toggled": true
+              },
+              {
+                "name": "platform",
+                "label": "Platform(s)",
+                "sortable": true,
+                "type": "text",
+                "toggled": true
+              }
+            ],
+            "onEvent": {
+              "selectedChange": {
+                "actions": [
+                  {
+                    "actionType": "toast",
+                    "args": {
+                      "msg": "已选择${event.data.selectedItems.length}条记录"
+                    }
+                  },
+                  {
+                      "actionType": "setValue",
+                      "args": {
+                        "value": {
+                          "selectedValue": "${event.data.selectedItems}"
+                        }
+                      },
+                      "componentId": "test"
+                    }
+                ]
+              }
+            },
+            "itemCheckableOn": "${id !== 1 && id !== 53}"
+          },
+          "validateApiFromAPIHub": false,
+          "visibleOn": "${buttonGroupSelect === 'train'}",
+          "sourceFromAPIHub": false,
+          "modalMode": "dialog",
+          "value": "${selectedValue}",
+          "valueField": "id",
+          "joinValues": false
+        },
+        {
+          "type": "picker",
+          "name": "type5",
+          "joinValues": false,
+          "labelField": "engine",
+          "label": "",
+          "embed": true,
+          "source": "${serviceList}",
+          "size": "lg",
+          "multiple": true,
+          "pickerSchema": {
+            "mode": "table",
+            "name": "thelist",
+            "columns": [
+              {
+                "name": "engine",
+                "label": "Rendering engine",
+                "sortable": true,
+                "searchable": true,
+                "type": "text",
+                "toggled": true
+              },
+              {
+                "name": "browser",
+                "label": "Browser",
+                "sortable": true,
+                "type": "text",
+                "toggled": true
+              },
+              {
+                "name": "platform",
+                "label": "Platform(s)",
+                "sortable": true,
+                "type": "text",
+                "toggled": true
+              }
+            ],
+            "onEvent": {
+              "selectedChange": {
+                "actions": [
+                  {
+                    "actionType": "toast",
+                    "args": {
+                      "msg": "已选择${event.data.selectedItems.length}条记录"
+                    }
+                  }
+                ]
+              }
+            },
+            "itemCheckableOn": "${id !== 2 && id !== 50}"
+          },
+          "validateApiFromAPIHub": false,
+          "style": {
+            "boxShadow": "var(--shadows-shadow-none)"
+          },
+          "value": "2,50",
+          "valueField": "id",
+          "visibleOn": "${buttonGroupSelect === 'service'}",
+          "joinValues": false
+        }
+      ],
+      "debug": true
+    }
+  ],
+  "asideResizor": false,
+  "style": {
+    "boxShadow": "var(--shadows-shadow-none)"
+  },
+  "pullRefresh": {
+    "disabled": true
+  },
+  "regions": [
+    "body"
+  ],
+  "initApi": {
+    "method": "get",
+    "url": "/api/mock2/sample",
+    "dataType": "json",
+    "initFetch": true,
+    "adaptor": "const data = payload.data.rows || payload.result.rows;\nconsole.log(' data', data)\nconst trainList = data.filter(item => item.grade === 'X');\nconst serviceList = data.filter(item => item.grade === 'C');\nreturn {\n  allList: data,\n  trainList,\n  serviceList,\n};"
+  }
+}
+```
+
 ## 属性表
 
 当做选择器表单项使用时，除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置

--- a/packages/amis-core/src/store/formItem.ts
+++ b/packages/amis-core/src/store/formItem.ts
@@ -198,7 +198,8 @@ export const FormItemStore = StoreNode.named('FormItemStore')
           ? value
           : // 单选时不应该分割
           typeof value === 'string' && multiple
-          ? value.split(delimiter || ',')
+          ? // picker的value有可能value: "1, 2"，所以需要去掉一下空格
+            value.split(delimiter || ',').map((v: string) => v.trim())
           : [value];
 
         const selected = valueArray.map(item =>
@@ -257,7 +258,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
         const values = Array.isArray(value)
           ? value
           : typeof value === 'string'
-          ? value.split(delimiter || ',')
+          ? value.split(delimiter || ',').map((v: string) => v.trim())
           : [];
         return values;
       }
@@ -1121,7 +1122,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
             item && item.hasOwnProperty(valueField) ? item[valueField] : item
           )
         : typeof value === 'string'
-        ? value.split(self.delimiter || ',')
+        ? value.split(self.delimiter || ',').map((v: string) => v.trim())
         : value === void 0
         ? []
         : [
@@ -1178,7 +1179,6 @@ export const FormItemStore = StoreNode.named('FormItemStore')
         value != null && flattened.push(item);
       });
       const selectedOptions: Array<any> = [];
-
       selected.forEach((item, index) => {
         const value = getOptionValue(item, valueField);
         if (flattenedMap.get(value)) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1203b41</samp>

This pull request fixes some bugs and enhances some features related to the picker component in the `amis` framework. It improves the handling of spaces, check states, asynchronous values, and visibility conditions in the picker and its related components, such as `FormItemStore`, `Table`, and `CRUD`. It also updates the documentation and the formatting of some files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1203b41</samp>

> _Picker and table_
> _Enhanced, fixed, documented_
> _`CRUD` in springtime_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1203b41</samp>

*  Fix a bug in the picker component where the value was not properly split by the delimiter if there were spaces in the string, and update the documentation with a new example schema ([link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-ffb83afdb8b23606187f39ef74bb72d1b14ea78e3fd0c3f0d47e123c0ee17ef7R503-R686), [link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L201-R202), [link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L260-R261), [link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L1124-R1125))
*  Add a new parameter `checked` to the `toggle` function of the `Row` and `TableStore` classes, to explicitly set the check state of the rows instead of toggling it based on the previous state ([link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL259-R263), [link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1342-R1348))
*  Modify the logic of the `getSelectedRows` function of the `TableStore` class, to include the rows that are not checkable but are selected in the result ([link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1323-R1329))
*  Modify the logic of the `toggle` function of the `TableStore` class, to check the `checked` parameter before adding or removing the row from the selected rows, and to avoid adding or removing the row twice if the `checked` parameter is different from the previous state ([link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1348-R1362))
*  Modify the logic of the `componentDidUpdate` function of the `CRUD` component, to handle the case where the picker value is asynchronously loaded and may change from an unmatched value to a matched value, and to compare the value field of the value and the selected items, instead of the whole objects, to avoid unnecessary updates and selection errors ([link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L582-R598))
*  Add the `valueField` prop to the `renderSelected` function of the `CRUD` component, and use it as a fallback if the `labelField` or the `primaryField` are not available in the data object, to support the case where the value field is different from the label or the primary field ([link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R2240), [link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L2265-R2272))
*  Add the `value` parameter to the `handleCheck` function of the `Table` component, and pass it to the `toggle` function of the `Row` class, to support the case where the picker value is bound to an upper-level data variable, and the user can only update the variable through an event action, and to avoid the toggle error by explicitly setting the check state of the row ([link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL906-R911))
*  Modify the logic of the `handleCheckAll` function of the `Table` component, to handle the case where the selected change event may have already updated the selected rows through a `setValue` action, and to check the `allChecked` state before calling the `toggleAll` function of the `TableStore` class, to avoid toggling the rows twice, and to filter out the rows that are not checkable from the selected items, to avoid selecting the disabled rows ([link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL960-R988))
*  Remove some empty lines from the `FormItemStore`, `CRUD`, and `Table` classes, which are probably formatting or linting issues ([link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L1181), [link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1600-R1610), [link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR835), [link](https://github.com/baidu/amis/pull/7816/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1099))
