### PR TITLE
chore(amis-editor): 调整编辑器的 debug 数据查看,去掉修改当前层数据功能(此功能貌似无用)

### DIFF
--- a/packages/amis-editor-core/src/plugin/DataDebug.tsx
+++ b/packages/amis-editor-core/src/plugin/DataDebug.tsx
@@ -1,7 +1,6 @@
 import {registerEditorPlugin} from '../manager';
 import {BaseEventContext, BasePlugin, BasicToolbarItem} from '../plugin';
 import React from 'react';
-import {InteractionProps} from 'react-json-view';
 export const JsonView = React.lazy(() => import('react-json-view'));
 
 /**
@@ -36,13 +35,7 @@ export class DataDebugPlugin extends BasePlugin {
       order: -1000,
       placement: 'bottom',
       tooltip: '上下文数据',
-      onClick: () =>
-        this.openDebugForm(
-          comp.props.data,
-          store.updateData && store.data === comp.props.data
-            ? values => store.updateData(values)
-            : undefined
-        )
+      onClick: () => this.openDebugForm(comp.props.data)
     });
   }
 
@@ -51,15 +44,7 @@ export class DataDebugPlugin extends BasePlugin {
     name: 'ctx',
     asFormItem: true,
     className: 'm-b-none',
-    component: ({
-      value,
-      onChange,
-      readOnly
-    }: {
-      value: any;
-      onChange: (value: any) => void;
-      readOnly?: boolean;
-    }) => {
+    component: ({value}: {value: any}) => {
       const [index, setIndex] = React.useState(0);
       let start = value || {};
       const stacks = [start];
@@ -73,14 +58,6 @@ export class DataDebugPlugin extends BasePlugin {
 
         stacks.push(superData);
         start = superData;
-      }
-
-      function emitChange(e: InteractionProps) {
-        const obj = Object.create(stacks[1] || Object.prototype);
-        Object.keys(e.updated_src).forEach(
-          key => (obj[key] = (e.updated_src as any)[key])
-        );
-        onChange(obj);
       }
 
       return (
@@ -105,9 +82,6 @@ export class DataDebugPlugin extends BasePlugin {
                 src={stacks[index]}
                 enableClipboard={false}
                 iconStyle="square"
-                onAdd={index === 0 && !readOnly ? emitChange : false}
-                onEdit={index === 0 && !readOnly ? emitChange : false}
-                onDelete={index === 0 && !readOnly ? emitChange : false}
                 collapsed={2}
               />
             </React.Suspense>
@@ -117,14 +91,13 @@ export class DataDebugPlugin extends BasePlugin {
     }
   };
 
-  async openDebugForm(data: any, callback?: (values: any) => void) {
-    const result = await this.manager.scaffold(
+  async openDebugForm(data: any) {
+    await this.manager.scaffold(
       {
         title: '上下文数据',
         body: [
           {
-            ...this.dataViewer,
-            readOnly: callback ? false : true
+            ...this.dataViewer
           }
         ]
       },
@@ -132,8 +105,6 @@ export class DataDebugPlugin extends BasePlugin {
         ctx: data
       }
     );
-
-    callback?.((result as any).ctx);
   }
 }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b30adda</samp>

Removed data editing features from the `DataDebugPlugin` in `amis-editor-core`. Simplified and cleaned up the code for the debug form, which now only displays the store data in a read-only mode.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b30adda</samp>

> _No more editing the store data_
> _You lost the power to manipulate_
> _The `DataDebugPlugin` is now read-only_
> _Simplified and stripped of all complexity_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b30adda</samp>

*  Remove unused import of `InteractionProps` from `react-json-view` ([link](https://github.com/baidu/amis/pull/7817/files?diff=unified&w=0#diff-5a7853178be0e5a8cd7d50d902b972c676cd0d01a063fb1a46c6e99382e9642dL4))
*  Simplify `onClick` handler of `DataDebugPlugin` to only pass data to `openDebugForm` ([link](https://github.com/baidu/amis/pull/7817/files?diff=unified&w=0#diff-5a7853178be0e5a8cd7d50d902b972c676cd0d01a063fb1a46c6e99382e9642dL39-R38))
*  Remove `onChange` and `readOnly` props from `component` function of `dataViewer` ([link](https://github.com/baidu/amis/pull/7817/files?diff=unified&w=0#diff-5a7853178be0e5a8cd7d50d902b972c676cd0d01a063fb1a46c6e99382e9642dL54-R47))
*  Remove `emitChange` function and its references from `DataDebug.tsx` ([link](https://github.com/baidu/amis/pull/7817/files?diff=unified&w=0#diff-5a7853178be0e5a8cd7d50d902b972c676cd0d01a063fb1a46c6e99382e9642dL78-L85), [link](https://github.com/baidu/amis/pull/7817/files?diff=unified&w=0#diff-5a7853178be0e5a8cd7d50d902b972c676cd0d01a063fb1a46c6e99382e9642dL108-L110), [link](https://github.com/baidu/amis/pull/7817/files?diff=unified&w=0#diff-5a7853178be0e5a8cd7d50d902b972c676cd0d01a063fb1a46c6e99382e9642dL135-L136))
*  Remove `onAdd`, `onEdit`, and `onDelete` props from `react-json-view` component ([link](https://github.com/baidu/amis/pull/7817/files?diff=unified&w=0#diff-5a7853178be0e5a8cd7d50d902b972c676cd0d01a063fb1a46c6e99382e9642dL108-L110))
*  Remove `callback` parameter and `readOnly` prop from `openDebugForm` method ([link](https://github.com/baidu/amis/pull/7817/files?diff=unified&w=0#diff-5a7853178be0e5a8cd7d50d902b972c676cd0d01a063fb1a46c6e99382e9642dL120-R100))
