### PR TITLE
style: 还原容器边距

### DIFF
--- a/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
+++ b/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
@@ -33,7 +33,7 @@ export const defaultFlexColumnSchema = (title?: string) => {
 // 默认的布局容器Schema
 const defaultFlexContainerSchema = {
   type: 'flex',
-  className: '',
+  className: 'p-1',
   items: [
     defaultFlexColumnSchema('第一列'),
     defaultFlexColumnSchema('第二列'),

--- a/packages/amis-editor/src/plugin/Layout/Layout_sorption_container.tsx
+++ b/packages/amis-editor/src/plugin/Layout/Layout_sorption_container.tsx
@@ -14,7 +14,7 @@ export default class Layout_fixed_top extends FlexPluginBase {
     type: 'flex',
     isSorptionContainer: true,
     sorptionPosition: 'top',
-    className: '',
+    className: 'p-1',
     items: [
       defaultFlexColumnSchema(),
       defaultFlexColumnSchema(),

--- a/packages/amis-ui/scss/components/_wrapper.scss
+++ b/packages/amis-ui/scss/components/_wrapper.scss
@@ -1,22 +1,22 @@
 .#{$ns}Wrapper,
 .#{$ns}Container {
   &--xs {
-    // padding: var(--gap-xs);
+    padding: var(--gap-xs);
   }
 
   &--sm {
-    // padding: var(--gap-sm);
+    padding: var(--gap-sm);
   }
 
   &--md {
-    // padding: var(--gap-md);
+    padding: var(--gap-md);
   }
 
   &--lg {
-    // padding: var(--gap-lg);
+    padding: var(--gap-lg);
   }
 
   &--xl {
-    // padding: var(--gap-xl);
+    padding: var(--gap-xl);
   }
 }

--- a/packages/amis-ui/scss/layout/_grid.scss
+++ b/packages/amis-ui/scss/layout/_grid.scss
@@ -17,23 +17,23 @@
     min-height: 1px;
     max-width: 100%;
     width: 100%;
-    // padding-left: math.div($Grid-gutterWidth, 2);
-    // padding-right: math.div($Grid-gutterWidth, 2);
+    padding-left: math.div($Grid-gutterWidth, 2);
+    padding-right: math.div($Grid-gutterWidth, 2);
   }
 
   .#{$ns}Grid-col--#{$class}Auto {
     flex: 0 0 auto;
     width: auto;
     max-width: 100%;
-    // padding-left: math.div($Grid-gutterWidth, 2);
-    // padding-right: math.div($Grid-gutterWidth, 2);
+    padding-left: math.div($Grid-gutterWidth, 2);
+    padding-right: math.div($Grid-gutterWidth, 2);
   }
 }
 
 // Generate Grid row
 @mixin make-row($gutter: $Grid-gutterWidth) {
-  // margin-left: math.div($gutter, -2);
-  // margin-right: math.div($gutter, -2);
+  margin-left: math.div($gutter, -2);
+  margin-right: math.div($gutter, -2);
   display: flex;
   flex-wrap: wrap;
 }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ffaded7</samp>

This pull request improves the layout and spacing of various components in the `amis` UI and editor. It adds padding and negative margin to the grid system, adds padding classes to the flex and sorption containers, and enables the padding classes for the container component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ffaded7</samp>

> _We are the masters of the layout_
> _We bend the flex and grid to our will_
> _With `padding` and `margin` we create the space_
> _With `size` and `gap` we control the thrill_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ffaded7</samp>

*  Add padding to flex and sorption containers in the editor ([link](https://github.com/baidu/amis/pull/7820/files?diff=unified&w=0#diff-0c77368e9183efe6a72ad9cdc7339d1c15ab5f70f8518721c1bda55460262a07L36-R36), [link](https://github.com/baidu/amis/pull/7820/files?diff=unified&w=0#diff-2017ff4b4a1ae3f652ccffbe9eeeeac2fe380d009438d1ddeaf8225b0be65183L17-R17))
*  Enable padding classes for the container component based on `size` property ([link](https://github.com/baidu/amis/pull/7820/files?diff=unified&w=0#diff-733283b52cdf17256b725aa928c87ca86de7f0f5270af55f1d1a266254425b82L4-R20))
*  Enable padding and negative margin for the grid column and row components based on grid gutter width ([link](https://github.com/baidu/amis/pull/7820/files?diff=unified&w=0#diff-e4fada7e1a63d9c17e5ab079cca8b1c96c2452e69cbf9f6225180aa5b0746e4eL20-R21), [link](https://github.com/baidu/amis/pull/7820/files?diff=unified&w=0#diff-e4fada7e1a63d9c17e5ab079cca8b1c96c2452e69cbf9f6225180aa5b0746e4eL28-R29), [link](https://github.com/baidu/amis/pull/7820/files?diff=unified&w=0#diff-e4fada7e1a63d9c17e5ab079cca8b1c96c2452e69cbf9f6225180aa5b0746e4eL35-R36))
