### PR TITLE
feat: tinymce 支持扩充插件 Close: #7801

### DIFF
--- a/docs/zh-CN/components/form/input-rich-text.md
+++ b/docs/zh-CN/components/form/input-rich-text.md
@@ -142,6 +142,36 @@ table tr {
 }
 ```
 
+## 扩充 tinymce 插件
+
+需要在调用 amis 的时候，通过 `env.loadTinymcePlugin` 来加载自定义插件，可以查考： [examples/components/SchemaRender.jsx](https://github.com/baidu/amis/blob/master/examples/components/SchemaRender.jsx) 文件中的示例。
+
+```schema
+{
+  "type": "page",
+  "body": {
+    "type": "form",
+    "debug": true,
+    "body": [
+      {
+        "type": "input-rich-text",
+        "name": "rich",
+        "label": "Rich Text",
+        "options": {
+          "menubar": false,
+          "height": 200,
+          "plugins": [
+
+            "example"
+          ],
+          "toolbar": "undo redo | example"
+        }
+      }
+    ]
+  }
+}
+```
+
 ## 使用 froala 编辑器
 
 只需要加一行 `"vendor": "froala"` 配置就行，froala 是付费产品，需要设置 [richTextToken](../../start/getting-started#richtexttoken-string) 才能去掉水印。

--- a/docs/zh-CN/start/getting-started.md
+++ b/docs/zh-CN/start/getting-started.md
@@ -782,3 +782,11 @@ Toast 提示弹出位置，默认为`'top-center'`。
 ```
 'top-right' | 'top-center' | 'top-left' | 'bottom-center' | 'bottom-left' | 'bottom-right' | 'center'
 ```
+
+#### loadChartExtends
+
+可以用来加载 echarts 插件，首次加载 echarts 完毕后调用，支持异步返回一个 promise 即可。
+
+#### loadTinymcePlugin
+
+可以用来加载 tinymce 插件，每次渲染 tinymce 的时候执行，可以用来加载 tinymce 插件。

--- a/examples/components/Play.jsx
+++ b/examples/components/Play.jsx
@@ -247,6 +247,73 @@ export default class PlayGround extends React.Component {
       },
       replaceText: {
         AMIS_HOST: 'https://baidu.gitee.io/amis'
+      },
+      loadTinymcePlugin: async tinymce => {
+        // 参考：https://www.tiny.cloud/docs/advanced/creating-a-plugin/
+        /*
+          Note: We have included the plugin in the same JavaScript file as the TinyMCE
+          instance for display purposes only. Tiny recommends not maintaining the plugin
+          with the TinyMCE instance and using the `external_plugins` option.
+        */
+        tinymce.PluginManager.add('example', function (editor, url) {
+          var openDialog = function () {
+            return editor.windowManager.open({
+              title: 'Example plugin',
+              body: {
+                type: 'panel',
+                items: [
+                  {
+                    type: 'input',
+                    name: 'title',
+                    label: 'Title'
+                  }
+                ]
+              },
+              buttons: [
+                {
+                  type: 'cancel',
+                  text: 'Close'
+                },
+                {
+                  type: 'submit',
+                  text: 'Save',
+                  primary: true
+                }
+              ],
+              onSubmit: function (api) {
+                var data = api.getData();
+                /* Insert content when the window form is submitted */
+                editor.insertContent('Title: ' + data.title);
+                api.close();
+              }
+            });
+          };
+          /* Add a button that opens a window */
+          editor.ui.registry.addButton('example', {
+            text: 'My button',
+            onAction: function () {
+              /* Open window */
+              openDialog();
+            }
+          });
+          /* Adds a menu item, which can then be included in any menu via the menu/menubar configuration */
+          editor.ui.registry.addMenuItem('example', {
+            text: 'Example plugin',
+            onAction: function () {
+              /* Open window */
+              openDialog();
+            }
+          });
+          /* Return the metadata for the help plugin */
+          return {
+            getMetadata: function () {
+              return {
+                name: 'Example plugin',
+                url: 'http://exampleplugindocsurl.com'
+              };
+            }
+          };
+        });
       }
     };
 

--- a/examples/components/SchemaRender.jsx
+++ b/examples/components/SchemaRender.jsx
@@ -153,6 +153,73 @@ export default function (schema, schemaProps, showCode, envOverrides) {
             console.debug('eventTrack', eventTrack);
           },
           affixOffsetTop: 50,
+          loadTinymcePlugin: async tinymce => {
+            // 参考：https://www.tiny.cloud/docs/advanced/creating-a-plugin/
+            /*
+              Note: We have included the plugin in the same JavaScript file as the TinyMCE
+              instance for display purposes only. Tiny recommends not maintaining the plugin
+              with the TinyMCE instance and using the `external_plugins` option.
+            */
+            tinymce.PluginManager.add('example', function (editor, url) {
+              var openDialog = function () {
+                return editor.windowManager.open({
+                  title: 'Example plugin',
+                  body: {
+                    type: 'panel',
+                    items: [
+                      {
+                        type: 'input',
+                        name: 'title',
+                        label: 'Title'
+                      }
+                    ]
+                  },
+                  buttons: [
+                    {
+                      type: 'cancel',
+                      text: 'Close'
+                    },
+                    {
+                      type: 'submit',
+                      text: 'Save',
+                      primary: true
+                    }
+                  ],
+                  onSubmit: function (api) {
+                    var data = api.getData();
+                    /* Insert content when the window form is submitted */
+                    editor.insertContent('Title: ' + data.title);
+                    api.close();
+                  }
+                });
+              };
+              /* Add a button that opens a window */
+              editor.ui.registry.addButton('example', {
+                text: 'My button',
+                onAction: function () {
+                  /* Open window */
+                  openDialog();
+                }
+              });
+              /* Adds a menu item, which can then be included in any menu via the menu/menubar configuration */
+              editor.ui.registry.addMenuItem('example', {
+                text: 'Example plugin',
+                onAction: function () {
+                  /* Open window */
+                  openDialog();
+                }
+              });
+              /* Return the metadata for the help plugin */
+              return {
+                getMetadata: function () {
+                  return {
+                    name: 'Example plugin',
+                    url: 'http://exampleplugindocsurl.com'
+                  };
+                }
+              };
+            });
+          },
           ...envOverrides
         };
 

--- a/packages/amis-core/src/env.tsx
+++ b/packages/amis-core/src/env.tsx
@@ -82,6 +82,7 @@ export interface RendererEnv {
     reRender: Function
   ) => Promise<React.ElementType> | React.ElementType | JSX.Element | void;
   loadChartExtends?: () => void | Promise<void>;
+  loadTinymcePlugin?: (tinymce: any) => void | Promise<void>;
   useMobileUI?: boolean;
   /**
    * 过滤 html 标签，可用来添加 xss 保护逻辑

--- a/packages/amis/src/renderers/Form/InputRichText.tsx
+++ b/packages/amis/src/renderers/Form/InputRichText.tsx
@@ -4,7 +4,8 @@ import {
   FormControlProps,
   FormBaseControl,
   buildApi,
-  qsstringify
+  qsstringify,
+  autobind
 } from 'amis-core';
 import cx from 'classnames';
 import {LazyComponent} from 'amis-core';
@@ -182,6 +183,7 @@ export default class RichTextControl extends React.Component<
       const fetcher = props.env.fetcher;
       this.config = {
         ...props.options,
+        onLoaded: this.handleTinyMceLoaded,
         images_upload_handler: (blobInfo: any, progress: any) =>
           new Promise(async (resolve, reject) => {
             const formData = new FormData();
@@ -262,6 +264,12 @@ export default class RichTextControl extends React.Component<
     }
 
     onChange?.(value, submitOnChange, changeImmediately);
+  }
+
+  @autobind
+  handleTinyMceLoaded(tinymce: any) {
+    const env = this.props.env;
+    return env?.loadTinymcePlugin?.(tinymce);
   }
 
   render() {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 61c90ba</samp>

This pull request adds the ability to extend the tinymce editor with custom plugins in the input-rich-text component. It also enhances the Tinymce component with the onLoaded prop and fixes a potential bug. It updates the documentation and the examples to reflect these changes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 61c90ba</samp>

> _We are the masters of the rich text_
> _We extend the editor with our plugins_
> _We load them dynamically with `env`_
> _We unleash the power of `tinymce`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 61c90ba</samp>

*  Add the loadTinymcePlugin property to the RendererEnv interface and document its usage ([link](https://github.com/baidu/amis/pull/7821/files?diff=unified&w=0#diff-cecdf20aaa84e6464093def72aee232955ad9649b13e7187284dfb7176b3cdacR785-R792), [link](https://github.com/baidu/amis/pull/7821/files?diff=unified&w=0#diff-62f2e14b837dfa7b7f5f94ee2a856825f211639ddf0f85d783c666dbcd7f8d0dR85))
*  Modify the Tinymce component to accept an onLoaded prop and call it with the tinymce object when loaded ( [link](https://github.com/baidu/amis/pull/7821/files?diff=unified&w=0#diff-d6c65c2dcd820338178339a1d3f5272f5f7d2cfb02ba4977bdb04516544de8fbR66), [link](https://github.com/baidu/amis/pull/7821/files?diff=unified&w=0#diff-d6c65c2dcd820338178339a1d3f5272f5f7d2cfb02ba4977bdb04516544de8fbL142-R152), [link](https://github.com/baidu/amis/pull/7821/files?diff=unified&w=0#diff-d6c65c2dcd820338178339a1d3f5272f5f7d2cfb02ba4977bdb04516544de8fbL156-R167), [link](https://github.com/baidu/amis/pull/7821/files?diff=unified&w=0#diff-d6c65c2dcd820338178339a1d3f5272f5f7d2cfb02ba4977bdb04516544de8fbR183))
*  Pass the handleTinyMceLoaded method to the Tinymce component in the InputRichText component and call the loadTinymcePlugin function from the env object ([link](https://github.com/baidu/amis/pull/7821/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15L7-R8), [link](https://github.com/baidu/amis/pull/7821/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15R186), [link](https://github.com/baidu/amis/pull/7821/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15R269-R274))
*  Import the i18n keynav files for the help plugin of the tinymce editor ([link](https://github.com/baidu/amis/pull/7821/files?diff=unified&w=0#diff-d6c65c2dcd820338178339a1d3f5272f5f7d2cfb02ba4977bdb04516544de8fbR39-R43))
*  Add a new section to the documentation of the input-rich-text component with a schema example of using a custom plugin ([link](https://github.com/baidu/amis/pull/7821/files?diff=unified&w=0#diff-5763a9c8be2add40d5fb4ab942d81bd41c7206e75257284d7fbac17f9248cec8R145-R174))
*  Define an example tinymce plugin in the Play.jsx and SchemaRender.jsx files and load it by passing the loadTinymcePlugin property to the env object ([link](https://github.com/baidu/amis/pull/7821/files?diff=unified&w=0#diff-5137ffd3ac5c47279bb5615cf832b9123f909d763e58ba367327e65d738eeab8R250-R316), [link](https://github.com/baidu/amis/pull/7821/files?diff=unified&w=0#diff-ac1a60d172a301e9d64fda64e449666942e49e0d61ebfae939cb54dab34f887dR156-R222))
