### PR TITLE
chore: 允许 api 配置相对路径 Close: #7815

### DIFF
--- a/packages/amis-core/src/utils/api.ts
+++ b/packages/amis-core/src/utils/api.ts
@@ -756,15 +756,14 @@ export function isValidApi(api: string) {
   }
   const idx = api.indexOf('://');
 
-  // 不允许直接相对路径写 api
   // 不允许 :// 结尾
-  if ((!~idx && api[0] !== '/') || (~idx && idx + 3 === api.length)) {
+  if (~idx && idx + 3 === api.length) {
     return false;
   }
 
   try {
     // 不补一个协议，URL 判断为 false
-    api = (~idx ? '' : 'schema://domain') + api;
+    api = (~idx ? '' : `schema://domain${api[0] === '/' ? '' : '/'}`) + api;
     new URL(api);
   } catch (error) {
     return false;

--- a/packages/amis/__tests__/utils/api.test.ts
+++ b/packages/amis/__tests__/utils/api.test.ts
@@ -324,8 +324,8 @@ test('api:cache', async () => {
 });
 
 test('api:isvalidapi', () => {
-  expect(isValidApi('api/xxx')).toBeFalsy();
-  expect(isValidApi('api/xxx?a=1')).toBeFalsy();
+  expect(isValidApi('api/xxx')).toBeTruthy();
+  expect(isValidApi('api/xxx?a=1')).toBeTruthy();
   expect(isValidApi('/x')).toBeTruthy();
   expect(isValidApi('/api/xxx?a=1&b=2&c=3')).toBeTruthy();
   expect(isValidApi('http://xxxdomain')).toBeTruthy();


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca8a1bf</samp>

This pull request improves the handling of relative paths as APIs and fixes a URL construction bug in `api.ts`. It also updates the test cases in `api.test.ts` to match the new logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ca8a1bf</samp>

> _`isValidApi` has changed its rules_
> _No more slash to start the path_
> _But beware of the URL bug_
> _Or you'll face the domain's wrath_

### Why

Close: #7815

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca8a1bf</samp>

*  Allow relative paths without a leading slash as valid APIs ([link](https://github.com/baidu/amis/pull/7822/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL759-R760))
*  Add a slash between the domain and the path if the path does not start with a slash, when constructing a URL for validation ([link](https://github.com/baidu/amis/pull/7822/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cL767-R766))
