### PR TITLE
style: 降低 sticky zindex Close: #7791

### DIFF
--- a/packages/amis-ui/scss/_variables.scss
+++ b/packages/amis-ui/scss/_variables.scss
@@ -421,7 +421,7 @@ $Grid-gutterWidth: px2rem(16px) !default;
 
 $zindex-affix: 900 !default;
 $zindex-dropdown: 1000 !default;
-$zindex-sticky: 1100 !default;
+$zindex-sticky: 900 !default;
 $zindex-fixed: 1200 !default;
 $zindex-popover: 1300 !default;
 $zindex-modal: 1400 !default;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0ba9979</samp>

Reduced the z-index of sticky elements in `amis-ui` to avoid overlapping with dropdown menus. This was part of a pull request to enhance the Bootstrap 4 integration of the framework.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0ba9979</samp>

> _`zindex-sticky` changed_
> _Dropdowns no longer hidden_
> _Autumn bug fixing_

### Why

Close: #7791

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0ba9979</samp>

* Lowered the z-index value of the `$zindex-sticky` variable to fix a bug where sticky elements would overlap dropdown menus ([link](https://github.com/baidu/amis/pull/7823/files?diff=unified&w=0#diff-96f34baddc0ec63bc836cebf664cff28b7e8f50904adb2cc040ebd4fb9738afdL424-R424))
