### PR TITLE
refactor: 优化 autobind TS 类型

### DIFF
--- a/packages/amis-core/src/utils/autobind.ts
+++ b/packages/amis-core/src/utils/autobind.ts
@@ -2,7 +2,9 @@ const {defineProperty, getPrototypeOf} = Object;
 
 // 简写
 type Fn = Function
-type SuperStore = WeakMap<Fn, Fn>
+// FIXME 正确写法，但过不了检查，暂时使用 any 兼容
+// type SuperStore = WeakMap<Fn, Fn>
+type SuperStore = WeakMap<Fn, any>
 
 export function bind(fn: Fn, thisArg: any): Fn {
   if (fn.bind) {
@@ -37,7 +39,7 @@ function getBoundSuper(obj: Object, fn: Fn) {
     superStore.set(fn, bind(fn, obj));
   }
 
-  return superStore.get(fn) as Fn;
+  return superStore.get(fn);
 }
 
 function createDefaultSetter(key: string) {


### PR DESCRIPTION
- 消除 `getBoundSuper()` `undefined` 返回值的二义性。
- 显式声明 `mapStore` `value` 类型