### PR TITLE
docs: 去掉tpl组件快速编辑部分的说明

### DIFF
--- a/docs/zh-CN/components/tpl.md
+++ b/docs/zh-CN/components/tpl.md
@@ -27,29 +27,6 @@ order: 70
 
 更多模板相关配置请看[模板文档](../../docs/concepts/template)
 
-## 快速编辑
-
-通过 `quickEdit` 开启快速编辑功能，比如
-
-```schema: scope="body"
-{
-    "type": "form",
-    "body": [
-        {
-            "name": "static",
-            "type": "static",
-            "label": "静态展示",
-            "value": "123",
-            "quickEdit": {
-                "type": "number"
-            }
-        }
-    ]
-}
-```
-
-其他配置项参考 [快速编辑](crud#快速编辑)
-
 ## 属性表
 
 | 属性名          | 类型                                 | 默认值  | 说明                                         |


### PR DESCRIPTION
- 删除了文档中tpl组件说明里的快速编辑部分，因为这部分的示例代码里没有使用tpl类型组件，和页面主题无关
