### PR TITLE
style: 还原label为空串时margin问题

### DIFF
--- a/packages/amis-ui/scss/components/form/_form.scss
+++ b/packages/amis-ui/scss/components/form/_form.scss
@@ -274,10 +274,6 @@
         margin-right: var(--Form--horizontal-label-gap);
         flex-shrink: 0;
 
-        &-noLabel {
-          margin-right: 0;
-        }
-
         .#{$ns}Form-star {
           position: absolute;
           left: px2rem(-6px);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 689c086</samp>

Removed unused CSS class for form items without labels. This class was redundant after the form layout was improved and could cause style issues.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 689c086</samp>

> _`&-noLabel` gone_
> _Form items breathe in spring air_
> _Simpler, cleaner code_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 689c086</samp>

* Remove unused modifier class `.form-item-noLabel` from `.form-item` selector in `_form.scss` ([link](https://github.com/baidu/amis/pull/7829/files?diff=unified&w=0#diff-f325489c306f0106cb368664288efa079f007a051f746e29ad32d88cde2abb4dL277-L280))
