### PR TITLE
fix: chart配置面板去除自定义class & 添加trackExpression配置项

### DIFF
--- a/packages/amis-editor/src/plugin/Chart.tsx
+++ b/packages/amis-editor/src/plugin/Chart.tsx
@@ -192,6 +192,7 @@ export class ChartPlugin extends BasePlugin {
   ];
 
   panelTitle = '图表';
+  panelJustify = true;
   panelBodyCreator = (context: BaseEventContext) => {
     return [
       getSchemaTpl('tabs', [
@@ -236,34 +237,40 @@ export class ChartPlugin extends BasePlugin {
                   },
                   */
                   getSchemaTpl('apiControl', {
-                    label: '数据接口',
-                    // visibleOn: 'chartDataType === "dataApi"',
-                    description:
+                    label: tipedLabel(
+                      '数据接口',
                       '接口可以返回echart图表完整配置，或者图表数据，建议返回图表数据映射到 Echarts 配置中'
+                    ),
+                    mode: 'normal'
+                    // visibleOn: 'chartDataType === "dataApi"'
                   }),
 
                   getSchemaTpl('switch', {
                     label: '初始是否拉取',
                     name: 'initFetch',
                     // visibleOn: 'chartDataType === "dataApi" && data.api',
-                    visibleOn: 'data.api',
+                    visibleOn: 'data.api.url',
                     pipeIn: defaultValue(true)
                   }),
 
                   {
                     name: 'interval',
-                    label: '定时刷新间隔',
+                    label: tipedLabel(
+                      '定时刷新间隔',
+                      '设置后将自动定时刷新，最小3000, 单位 ms'
+                    ),
                     type: 'input-number',
                     step: 500,
                     // visibleOn: 'chartDataType === "dataApi" && data.api',
-                    visibleOn: 'data.api',
-                    description: '设置后将自动定时刷新，最小3000, 单位 ms'
+                    visibleOn: 'data.api.url',
+                    unitOptions: ['ms']
                   },
                   {
                     name: 'config',
                     asFormItem: true,
                     // visibleOn: 'chartDataType === "json"',
                     component: ChartConfigEditor,
+                    mode: 'normal',
                     // type: 'json-editor',
                     label: tipedLabel(
                       'Echarts 配置',
@@ -274,6 +281,7 @@ export class ChartPlugin extends BasePlugin {
                     name: 'dataFilter',
                     type: 'js-editor',
                     allowFullscreen: true,
+                    mode: 'normal',
                     label: '数据映射（dataFilter）',
                     size: 'lg',
                     description: `
@@ -290,16 +298,20 @@ export class ChartPlugin extends BasePlugin {
                     `
                   },
                   getSchemaTpl('switch', {
-                    label: 'Chart 配置完全替换',
-                    name: 'replaceChartOption',
-                    labelRemark: {
-                      trigger: 'click',
-                      className: 'm-l-xs',
-                      rootClose: true,
-                      content:
-                        '默认为追加模式，新的配置会跟旧的配置合并，如果勾选将直接完全覆盖。',
-                      placement: 'left'
-                    }
+                    label: tipedLabel(
+                      'Chart 配置完全替换',
+                      '默认为追加模式，新的配置会跟旧的配置合并，如果勾选将直接完全覆盖'
+                    ),
+                    name: 'replaceChartOption'
+                  }),
+                  getSchemaTpl('expressionFormulaControl', {
+                    evalMode: false,
+                    label: tipedLabel(
+                      '跟踪表达式',
+                      '如果这个表达式的值有变化时会更新图表，当 config 中用了数据映射时有用'
+                    ),
+                    name: 'trackExpression',
+                    placeholder: '\\${xxx}'
                   })
                 ]
               },
@@ -309,6 +321,7 @@ export class ChartPlugin extends BasePlugin {
                   {
                     name: 'clickAction',
                     asFormItem: true,
+                    label: false,
                     children: ({onChange, value}: any) => (
                       <div className="m-b">
                         <Button
@@ -341,11 +354,7 @@ export class ChartPlugin extends BasePlugin {
         {
           title: '外观',
           body: getSchemaTpl('collapseGroup', [
-            ...getSchemaTpl('theme:common', {exclude: ['layout']}),
-            {
-              title: '自定义 CSS 类名',
-              body: [getSchemaTpl('className')]
-            }
+            ...getSchemaTpl('theme:common', {exclude: ['layout']})
           ])
         },
         {


### PR DESCRIPTION
### What

chart配置面板调整
- 去除自定义class类型配置 （已经有外观及style配置项，且自定义class中一些字体等配置不会生效，会给用户疑惑）
- 增加trackExpression配置项（在用到上层数据域中的变量时比较有用）


### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca3051d</samp>

*  Add a `panelJustify` property to the `ChartPlugin` class to support different chart panel layouts ([link](https://github.com/baidu/amis/pull/7832/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0R195))
*  Remove the redundant `数据设置` section from the chart schema and handle the data settings by the `数据接口` section ([link](https://github.com/baidu/amis/pull/7832/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L206-L211))
*  Replace the `description` properties of the `apiControl`, `interval`, and `replaceChartOption` schemas with `tipedLabel` functions to create informative and consistent labels with tooltips and popovers ([link](https://github.com/baidu/amis/pull/7832/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L239-R239), [link](https://github.com/baidu/amis/pull/7832/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L255-R260), [link](https://github.com/baidu/amis/pull/7832/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L293-R308))
*  Add a `unitOptions` property to the `interval` schema to provide a dropdown list of interval units ([link](https://github.com/baidu/amis/pull/7832/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L255-R260))
*  Modify the `visibleOn` condition of the `initFetch` schema to check for `data.api.url` instead of `data.api` to avoid errors ([link](https://github.com/baidu/amis/pull/7832/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L249-R246))
*  Add a `mode` property to the `chartOption` and `chartData` schemas to support different modes of editing the chart option and data, such as `normal`, `simple`, or `advanced` ([link](https://github.com/baidu/amis/pull/7832/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0R267), [link](https://github.com/baidu/amis/pull/7832/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0R278))
*  Add a `trackExpression` schema to allow the user to enter an expression that will trigger the chart update when its value changes, useful for data mapping scenarios ([link](https://github.com/baidu/amis/pull/7832/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L293-R308))
*  Add a `label` property to the `chartDataType` schema to hide the label of the radio group and reduce the clutter ([link](https://github.com/baidu/amis/pull/7832/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0R318))
*  Comment out the unused `className` schema ([link](https://github.com/baidu/amis/pull/7832/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L344-R355))
