### PR TITLE
feat: nav配置面板自定义数据模块更新,与平台交互一致

### DIFF
--- a/packages/amis-editor-core/scss/control/_nav-control.scss
+++ b/packages/amis-editor-core/scss/control/_nav-control.scss
@@ -1,97 +1,85 @@
-.ae-NavControl {
-  &-header {
-    @include flexBox();
-    width: 100%;
-    height: #{px2rem(24px)};
-    margin-bottom: #{px2rem(12px)};
-  }
-
-  &-content {
-    @include flexBox(column, flex-start);
-    margin: 0;
-    padding: 0;
-
-    .ae-OptionControlItem {
-      display: block;
+.ae-NavControl-header {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+.ae-NavControl-wrapper {
+  .nav-links {
+    &-parent {
       width: 100%;
-      border: 1px dashed #999;
-      padding: 15px;
-      margin-bottom: 10px;
-      position: relative;
+    }
+    &-item {
+      height: 32px;
+      margin-bottom: 8px;
+      padding: 0 10px 0 8px;
+      border-radius: 2px;
+      background-color: #f7f7f9;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-family: PingFangSC-Regular;
+      font-size: 12px;
+      color: #151b26;
 
-      .ae-closeBtn {
-        position: absolute;
-        top: 0;
-        right: 0;
-        width: 20px;
-        height: 20px;
-        font-size: 18px;
-        text-align: center;
-        line-height: 20px;
-        cursor: pointer;
+      &-icon {
+        margin: 0 -2px 0 8px;
+        color: #151b26;
+      }
+      &-dragBar {
+        color: #151b26;
+
+        &:hover {
+          color: #2468f2;
+        }
       }
 
-      .ae-navControlLinks {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        height: 40px;
+      &-label {
+        flex: 1;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: #151b26;
+        margin-left: 8px;
+      }
 
-        input {
-          width: 120px;
+      &-actions {
+        width: auto;
+
+        .icon {
+          color: #84868c;
+          font-size: 14px;
+          cursor: pointer;
+
+          &:hover {
+            color: #2468f2;
+          }
+        }
+        .icon-edit {
+          margin-left: 12px;
+        }
+        .icon-delete {
+          margin-left: 13px;
         }
       }
     }
-  }
 
-  &-placeholder {
-    display: none;
-    color: #999;
-    line-height: #{px2rem(24px)};
-    text-align: center;
-    vertical-align: middle;
-    width: 100%;
-    padding: #{px2rem(10px)};
-  }
-
-  &-footer {
-    margin-top: 10px;
-  }
-
-  &-footer > * {
-    width: calc(50% - #{px2rem(6px)});
-
-    &:first-child {
-      margin-right: px2rem(12px);
+    &-children {
+      margin-left: 24px;
     }
   }
 }
 
-.nav-mode-gif {
-  width: 160px;
-  height: 120px;
-  background: url('../static/nav-mode.gif');
-  background-repeat: no-repeat;
-  background-size: 100%;
-  margin: 10px auto 0;
+.ae-NavControl-footer {
+  button {
+    width: 100%;
+  }
 }
-
-.ae-BadgeControl {
-  .cxd-Form-groupColumn:nth-child(1) {
-    padding-right: 4px;
-  }
-  .cxd-Form-groupColumn:nth-child(2) {
-    padding-left: 4px;
-  }
-  .cxd-TextControl.is-focused > .cxd-TextControl-input {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-    padding-left: 4px;
-  }
-  .cxd-TextControl-addOn:first-child {
-    border-left-width: 0.0625rem;
-  }
-  .cxd-TextControl-input {
-    padding: 4px;
+.ae-NavControl-dialog {
+  .cxd-IconPickerControl-valueWrap {
+    display: flex;
   }
 }

--- a/packages/amis-editor/src/plugin/Nav.tsx
+++ b/packages/amis-editor/src/plugin/Nav.tsx
@@ -32,11 +32,13 @@ export class NavPlugin extends BasePlugin {
       {
         label: '页面1',
         to: '?id=1',
+        target: '_self',
         id: '0'
       },
       {
         label: '页面2',
         to: '?id=2',
+        target: '_self',
         id: '1'
       }
     ]

--- a/packages/amis-editor/src/renderer/NavSourceControl.tsx
+++ b/packages/amis-editor/src/renderer/NavSourceControl.tsx
@@ -3,80 +3,87 @@
  */
 
 import React from 'react';
+
 import cx from 'classnames';
+import Sortable from 'sortablejs';
 import set from 'lodash/set';
 import get from 'lodash/get';
-import Sortable from 'sortablejs';
-import {FormItem, Button, InputBox, Switch, Radios} from 'amis';
+import cloneDeep from 'lodash/cloneDeep';
+import {render as renderAmis} from 'amis-core';
+
+import {FormItem, Button, InputBox, Icon, Modal, toast} from 'amis';
+import {TooltipWrapper} from 'amis-ui';
+
+import {getSchemaTpl} from 'amis-editor';
 
 import {autobind} from 'amis-editor-core';
-import {getSchemaTpl} from 'amis-editor-core';
 import type {FormControlProps} from 'amis-core';
-import type {SchemaApi} from 'amis';
+import {SchemaApi} from 'amis';
 
-export type valueType = 'text' | 'boolean' | 'number';
+export type SourceType = 'custom' | 'api';
 
 export type NavControlItem = {
+  id?: string;
   label: string;
-  to: string;
-  target: string;
-  icon?: string;
-  unfolded?: boolean;
-  active?: boolean;
-  activeOn?: string;
-  overflow?: {
-    enable: boolean;
-    overflowLabel: string;
-    overflowIndicator: string;
-    maxVisibleCount: number;
-  };
-  // todo any
-  children?: Array<any>;
+  to?: string;
+  target?: string;
+  icon?: string | {id: string; name: string; svg: string};
+  badge?: string;
+  children?: Array<NavControlItem>;
 };
 
 export interface NavControlProps extends FormControlProps {}
 
-export interface OptionControlState {
+export interface NavControlState {
   links: Array<NavControlItem>;
   api: SchemaApi;
-  source: 'custom' | 'api' | 'apicenter';
+  source: SourceType;
+  showDialog: boolean;
+  isEdit: boolean;
+  modalName: string;
+  modalParent: string;
+  modalIcon: string;
+  modalTarget: string;
+  modalBadge: string;
+  modalUrl: string;
+  currentIndex: string;
+  previousModalParent: string;
 }
 
-type IconType = {id: string; name: string};
-
-export default class NavSourceControl extends React.Component<
+export class NavSourceControl extends React.Component<
   NavControlProps,
-  OptionControlState
+  NavControlState
 > {
-  sortable?: Sortable;
+  sortables: Sortable[];
   drag?: HTMLElement | null;
-  target: HTMLElement | null;
-  $comp: string; // 记录一下路径，不再从外部同步内部，只从内部同步外部
-
-  internalProps = ['checked', 'editing'];
 
   constructor(props: NavControlProps) {
     super(props);
 
-    let source: 'custom' | 'api' | 'apicenter' = 'custom';
-
-    if (props.data.hasOwnProperty('source') && props.data.source) {
-      const api = props.data.source;
-      const url =
-        typeof api === 'string'
-          ? api
-          : typeof api === 'object'
-          ? api.url || ''
-          : '';
-
-      source = !url.indexOf('api://') ? 'apicenter' : 'api';
-    }
-
     this.state = {
       links: this.transformOptions(props),
       api: props.data.source,
-      source
+      source: this.transformSource(props.data.source),
+      showDialog: false,
+      isEdit: false,
+      modalName: '',
+      modalParent: '',
+      modalIcon: '',
+      modalTarget: '_self',
+      modalBadge: '',
+      modalUrl: '',
+      currentIndex: '',
+      previousModalParent: ''
     };
+
+    this.sortables = [];
+  }
+
+  transformSource(source: SchemaApi) {
+    if (source) {
+      return 'api';
+    }
+    return 'custom';
   }
 
   transformOptions(props: NavControlProps) {
@@ -85,7 +92,7 @@ export default class NavSourceControl extends React.Component<
   }
 
   /**
-   * 更新options字段的统一出口
+   * 更新统一出口
    */
   onChange() {
     const {onBulkChange} = this.props;
@@ -94,94 +101,390 @@ export default class NavSourceControl extends React.Component<
       source: undefined,
       links: undefined
     };
-
     if (source === 'custom') {
       const {links} = this.state;
+      this.handleSetNavId(links, '');
       data.links = links;
-    }
-
-    if (source === 'api' || source === 'apicenter') {
+    } else {
       const {api} = this.state;
       data.source = api;
     }
     onBulkChange && onBulkChange(data);
-    return;
   }
 
   /**
    * 切换选项类型
    */
   @autobind
-  handleSourceChange(source: 'custom' | 'api' | 'apicenter') {
-    this.setState({source: source}, this.onChange);
+  handleSourceChange(source: SourceType) {
+    this.setState({api: '', source}, this.onChange);
   }
 
+  @autobind
+  dragRef(ref: any) {
+    if (!this.drag && ref) {
+      this.drag = ref;
+      this.initDragging();
+    } else if (this.drag && !ref) {
+      this.destroyDragging(true);
+    }
+  }
+
+  initDragging() {
+    const rootSortable = new Sortable(this.drag as HTMLElement, {
+      group: 'NavSourceControlGroup',
+      animation: 150,
+      handle: '.nav-links-item-dragBar',
+      onEnd: (e: Sortable.SortableEvent) => {
+        this.handleDragging(e);
+      }
+    });
+    this.sortables.push(rootSortable);
+    const parents = this.drag?.querySelectorAll('.nav-links-children');
+    if (!parents) {
+      return;
+    }
+    Array.from(parents).forEach((parent: HTMLElement) => {
+      const sortable = new Sortable(parent, {
+        group: 'NavSourceControlGroup',
+        animation: 150,
+        handle: '.nav-links-item-dragBar',
+        onEnd: (e: Sortable.SortableEvent) => {
+          this.handleDragging(e);
+        }
+      });
+      this.sortables.push(sortable);
+    });
+  }
+
+  @autobind
+  handleDragging(e: Sortable.SortableEvent) {
+    const {oldIndex, newIndex, from, to} = e;
+
+    const nodeOldIndex = from.dataset.level
+      ? `${from.dataset.level}_${oldIndex}`
+      : `${oldIndex}`;
+    const nodeNewIndex = to.dataset.level
+      ? `${to.dataset.level}_${newIndex}`
+      : `${newIndex}`;
+    const links = cloneDeep(this.state.links);
+    if (!nodeOldIndex || !nodeNewIndex) {
+      return;
+    }
+
+    const {path: oldPath, parentPath: oldParentPath} =
+      this.getNodePath(nodeOldIndex);
+
+    const activeDraggingItem = get(links, `${oldPath}`);
+    if (oldParentPath) {
+      const oldParent = get(links, `${oldParentPath}.children`, []);
+      oldParent.splice(oldIndex, 1);
+      set(links, `${oldParentPath}.children`, oldParent);
+    } else {
+      links.splice(oldIndex, 1);
+    }
+
+    const {parentPath: newParentPath} = this.getNodePath(nodeNewIndex);
+
+    if (newParentPath) {
+      const newParent = get(links, `${newParentPath}.children`, []);
+      newParent.splice(newIndex, 0, activeDraggingItem);
+      set(links, `${newParentPath}.children`, newParent);
+    } else {
+      links.splice(newIndex, 0, activeDraggingItem);
+    }
+    // 数据diff时会使得dom结构出bug，多个相同节点，先置空再重新赋值
+    this.setState({source: ''}, () => {
+      this.setState({links, source: 'custom'}, () => {
+        this.refreshBindDrag();
+        this.onChange();
+      });
+    });
+  }
+
+  @autobind
+  getNodePath(pathStr: string) {
+    let pathArr = pathStr.split('_');
+    if (pathArr.length === 1) {
+      return {
+        path: pathArr,
+        parentPath: ''
+      };
+    }
+    const path = `[${pathArr.join('].children[')}]`;
+    pathArr = pathArr.slice(0, pathArr.length - 1);
+    const parentPath = `[${pathArr.join('].children[')}]`;
+    return {
+      path,
+      parentPath
+    };
+  }
+
+  refreshBindDrag() {
+    if (this.drag) {
+      this.destroyDragging();
+      this.initDragging();
+    }
+  }
+
+  @autobind
+  destroyDragging(destroyRoot?: boolean) {
+    this.sortables.forEach(sortable => {
+      sortable?.destroy();
+    });
+    this.sortables = [];
+    destroyRoot && (this.drag = null);
+  }
   /**
    * 删除选项
    */
   @autobind
   handleDelete(index: string) {
-    const links = this.state.links.concat();
-    const indexArr = typeof index === 'string' ? index.split('_') : [index];
-    let str = '';
-    for (let i = 1; i < indexArr.length; i++) {
-      let id = indexArr[i];
-      if (i === indexArr.length - 1) {
-        str += `children`;
-      } else {
-        str += `children[${id}].`;
-      }
-    }
-    const originChildren = get(links[parseInt(indexArr[0])], str);
-    originChildren.splice(indexArr[indexArr.length - 1], 1);
-    this.setState({links}, () => this.onChange());
+    return new Promise(resolve => {
+      const links = this.state.links.concat();
+      const pathArr = index.split('_');
+
+      const parentPathArr = pathArr.slice(0, pathArr.length - 1);
+      const parentPath = `[${parentPathArr.join('].children[')}]`;
+      const deleteItemParent =
+        parentPathArr.length > 0
+          ? get(links, `${parentPath}.children`, [])
+          : links;
+      deleteItemParent.splice(parseInt(pathArr[pathArr.length - 1]), 1);
+      this.setState({links}, () => this.onChange());
+      resolve('');
+    });
   }
 
   @autobind
-  handleAdd() {
+  handleUpdate(index: string) {
     const {links} = this.state;
-    links.push({
-      label: '',
-      to: '',
-      target: '',
-      icon: '',
-      unfolded: false,
-      active: false,
-      children: []
-    });
-    this.setState({links}, () => {
-      this.onChange();
+    const pathArr = index.split('_');
+    const path = `[${pathArr.join('].children[')}]`;
+
+    const updateItem = get(links, path);
+
+    // find parent id
+    const parentPathArr = pathArr.slice(0, pathArr.length - 1);
+    let parentPath = `[${parentPathArr.join('].children[')}]`;
+    if (parentPathArr.length > 0) {
+      parentPath += 'id';
+    }
+    const parentId = parentPathArr.length > 0 ? get(links, parentPath) : '';
+    this.setState({
+      modalName: updateItem.label,
+      modalBadge: updateItem.badge,
+      modalIcon: updateItem.icon,
+      modalParent: parentId,
+      previousModalParent: parentId,
+      modalTarget: updateItem.target,
+      modalUrl: updateItem.to,
+      showDialog: true,
+      isEdit: true,
+      currentIndex: index
     });
   }
 
-  renderHeader() {
+  @autobind
+  getChildren() {
+    const {currentIndex, links} = this.state;
+    if (!currentIndex) {
+      return [];
+    }
+    const pathArr = currentIndex.split('_');
+    const path = `[${pathArr.join('].children[')}]`;
+    const item = get(links, path);
+    if (item && item.children) {
+      return item.children;
+    } else {
+      return [];
+    }
+  }
+
+  @autobind
+  async handleSubmit() {
     const {
-      render,
-      label,
-      labelRemark,
-      useMobileUI,
-      env,
-      popOverContainer,
-      hasApiCenter
-    } = this.props;
+      isEdit,
+      modalBadge,
+      modalIcon,
+      modalName,
+      modalParent,
+      modalTarget,
+      modalUrl,
+      currentIndex,
+      previousModalParent
+    } = this.state;
+    if (!modalName) {
+      toast.error('菜单名称必填');
+      return;
+    }
+    if (isEdit && currentIndex === modalParent) {
+      toast.error('不能将菜单拖入其自身内部');
+      return;
+    }
+    const activeLink = {
+      label: modalName,
+      to: modalUrl,
+      icon: modalIcon,
+      target: modalTarget,
+      badge: modalBadge,
+      children: this.getChildren()
+    };
+
+    if (isEdit && previousModalParent === modalParent) {
+      // 编辑状态，但是没有改层级结构
+      const links = cloneDeep(this.state.links);
+      const pathArr = currentIndex.split('_');
+      const path = `[${pathArr.join('].children[')}]`;
+      if (pathArr.length > 0) {
+        // 多层级下
+        set(links, path, activeLink);
+      } else {
+        // 一级菜单
+        links[parseInt(currentIndex)] = activeLink;
+      }
+      this.setState({links}, () => this.onChange());
+      this.closeModal();
+    } else {
+      const links = cloneDeep(this.state.links);
+      if (modalParent) {
+        const parentPathArr = modalParent.split('_');
+        const parentPath = `[${parentPathArr.join('].children[')}].children`;
+
+        let originChildren = get(links, parentPath) || [];
+        originChildren.push(activeLink);
+
+        set(links, parentPath, originChildren);
+      } else {
+        links.push(activeLink);
+      }
+      this.setState({links}, async () => {
+        this.onChange();
+        if (isEdit) {
+          // 更新完新的数据层级，再删除原来的节点
+          await this.handleDelete(currentIndex);
+        }
+      });
+
+      this.closeModal();
+    }
+  }
+
+  @autobind
+  handleSetNavId(data: NavControlItem[], index: string) {
+    for (let i = 0; i < data.length; i++) {
+      const item = data[i];
+      const newIndex = index ? `${index}_${i}` : `${i}`;
+      item.id = newIndex;
+      if (item.children) {
+        this.handleSetNavId(item.children, newIndex);
+      }
+    }
+  }
+
+  @autobind
+  handleDeleteNavId(data: NavControlItem[] | NavControlItem) {
+    if (Array.isArray(data)) {
+      for (let item of data) {
+        delete item.id;
+        if (item.children) {
+          this.handleDeleteNavId(item.children);
+        }
+      }
+    } else {
+      delete data.id;
+      if (data.children) {
+        this.handleDeleteNavId(data.children);
+      }
+    }
+  }
+
+  @autobind
+  handleFilterTreeData(data: NavControlItem[]) {
+    const {currentIndex} = this.state;
+    for (let item of data) {
+      if (item.id === currentIndex) {
+        this.handleDeleteNavId(item);
+        break;
+      } else if (item.children) {
+        this.handleFilterTreeData(item.children);
+      }
+    }
+  }
+
+  @autobind
+  openModal() {
+    this.setState({
+      showDialog: true
+    });
+  }
+
+  @autobind
+  closeModal() {
+    this.setState({
+      showDialog: false,
+      isEdit: false,
+      modalParent: '',
+      modalName: '',
+      modalUrl: '',
+      modalIcon: '',
+      modalBadge: '',
+      modalTarget: '_self',
+      currentIndex: ''
+    });
+  }
+
+  @autobind
+  handleChange(options: any) {
+    this.setState(options, this.onChange);
+  }
+
+  @autobind
+  handleAPIChange(source: SchemaApi) {
+    this.setState({api: source}, this.onChange);
+  }
+
+  renderApiPanel() {
+    const {render} = this.props;
+    const {source, api} = this.state;
+    if (source === 'api') {
+      return render(
+        'nav-' + source,
+        getSchemaTpl('apiControl', {
+          label: '接口',
+          name: 'source',
+          mode: 'normal',
+          className: 'ae-ExtendMore',
+          value: api,
+          onChange: this.handleAPIChange,
+          sourceType: source
+        })
+      );
+    }
+    return null;
+  }
+
+  renderHeader() {
+    const {render, label, labelRemark, useMobileUI, env, popOverContainer} =
+      this.props;
     const classPrefix = env?.theme?.classPrefix;
     const {source} = this.state;
     const optionSourceList = (
       [
         {
-          label: '自定义选项',
+          label: '自定义菜单',
           value: 'custom'
         },
         {
           label: '外部接口',
           value: 'api'
-        },
-        ...(hasApiCenter ? [{label: 'API中心', value: 'apicenter'}] : [])
+        }
       ] as Array<{
         label: string;
-        value: 'custom' | 'api' | 'apicenter';
+        value: SourceType;
       }>
     ).map(item => ({
+      key: item.value,
       ...item,
       onClick: () => this.handleSourceChange(item.value)
     }));
@@ -221,8 +524,8 @@ export default class NavSourceControl extends React.Component<
             {
               popOverContainer: null,
               data: {
-                selected: optionSourceList.find(item => item.value === source)!
-                  .label
+                selected: optionSourceList.find(item => item.value === source)
+                  ?.label
               }
             }
           )}
@@ -231,220 +534,213 @@ export default class NavSourceControl extends React.Component<
     );
   }
 
-  @autobind
-  handleEditLabel(
-    index: string,
-    value: string | boolean | IconType,
-    key: string
-  ) {
-    const links = this.state.links.concat();
-    const indexArr = typeof index === 'string' ? index.split('_') : [index];
-    let str = '';
-    for (let i = 1; i < indexArr.length; i++) {
-      let id = indexArr[i];
-      str += `children[${id}].`;
-    }
-    str += key;
-
-    set(links[parseInt(indexArr[0])], str, value);
-
-    this.setState({links}, () => this.onChange());
-  }
-
-  @autobind
-  handleAddChildren(index: string, value: boolean) {
-    const links = this.state.links.concat();
-    const indexArr = typeof index === 'string' ? index.split('_') : [index];
-
-    let str = '';
-    for (let i = 1; i < indexArr.length; i++) {
-      let id = indexArr[i];
-      str += `children[${id}].`;
-    }
-    str += 'children';
-
-    let originChildren = get(links[parseInt(indexArr[0])], str) || [];
-    originChildren.push({
-      label: '',
-      to: '',
-      target: '',
-      icon: '',
-      unfolded: false,
-      active: false,
-      children: []
-    });
-
-    if (value) {
-      set(links[parseInt(indexArr[0])], str, originChildren);
-    } else {
-      set(links[parseInt(indexArr[0])], str, []);
-    }
-    this.setState({links}, () => this.onChange());
-  }
-
-  renderNav(props: any) {
-    const {index} = props;
-    const render = this.props.render;
+  renderNav(dataSource: NavControlItem[], index?: string) {
+    const {render} = this.props;
     return (
-      <div key={index}>
-        <div
-          className="ae-closeBtn"
-          onClick={() => {
-            this.handleDelete(index);
-          }}
-        >
-          ×
-        </div>
-        <div className="ae-navControlLinks">
-          菜单名称:
-          <InputBox
-            className="ae-OptionControlItem-input"
-            value={props.label}
-            placeholder="请输入菜单名称"
-            onChange={(value: string) =>
-              this.handleEditLabel(index, value, 'label')
-            }
-          />
-        </div>
-        <div className="ae-navControlLinks">
-          跳转地址:
-          <InputBox
-            className="ae-OptionControlItem-input"
-            value={props.to}
-            placeholder="请输入跳转地址"
-            onChange={(value: string) =>
-              this.handleEditLabel(index, value, 'to')
-            }
-          />
-        </div>
-        <div className="ae-navControlLinks">
-          是否需要新开页面:
-          <Switch
-            value={props.target === '_parent'}
-            onChange={(value: boolean) =>
-              this.handleEditLabel(
-                index,
-                value ? '_parent' : '_blank',
-                'target'
-              )
-            }
-          />
-        </div>
+      <>
+        {dataSource.map((nav, i: number) => {
+          return (
+            <div
+              className={'nav-links-parent'}
+              key={nav.id || index ? `${index}_${i}` : `${i}`}
+              data-path={index ? `${index}_${i}` : `${i}`}
+            >
+              <div className="nav-links-item">
+                <a className="nav-links-item-dragBar">
+                  <Icon icon="drag-bar" className="icon" />
+                </a>
+                {nav.icon &&
+                  render(`render-icon-${nav.icon.id}`, {
+                    type: 'icon',
+                    icon: nav.icon,
+                    className: 'nav-links-item-icon'
+                  })}
+                <TooltipWrapper tooltip={nav.label} placement="left">
+                  <div className="nav-links-item-label">{nav.label}</div>
+                </TooltipWrapper>
 
-        <div style={{height: 40}}>
-          {render(
-            'container',
-            getSchemaTpl('icon', {
-              name: 'icon',
-              label: '图标',
+                <div className="nav-links-item-actions">
+                  <TooltipWrapper tooltip="编辑" placement="left">
+                    <Icon
+                      icon="edit"
+                      className="icon icon-edit"
+                      onClick={() =>
+                        this.handleUpdate(index ? `${index}_${i}` : `${i}`)
+                      }
+                    />
+                  </TooltipWrapper>
+                  <TooltipWrapper tooltip="删除" placement="left">
+                    <Icon
+                      icon="delete-btn"
+                      className="icon icon-delete"
+                      onClick={() =>
+                        this.handleDelete(index ? `${index}_${i}` : `${i}`)
+                      }
+                    />
+                  </TooltipWrapper>
+                </div>
+              </div>
+              {nav.children && nav.children.length > 0 && (
+                <div
+                  className="nav-links-children"
+                  data-level={index ? `${index}_${i}` : `${i}`}
+                >
+                  {this.renderNav(
+                    nav.children,
+                    index ? `${index}_${i}` : `${i}`
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </>
+    );
+  }
+
+  renderDialog() {
+    const {
+      links,
+      modalBadge,
+      modalIcon,
+      modalName,
+      modalParent,
+      modalUrl,
+      modalTarget,
+      isEdit
+    } = this.state;
+    const treeData = cloneDeep(links);
+    this.handleFilterTreeData(treeData);
+    return renderAmis(
+      {
+        type: 'dialog',
+        title: isEdit ? '编辑菜单项' : '添加菜单项',
+        bodyClassName: 'ae-NavControl-dialog',
+        body: {
+          type: 'form',
+          mode: 'horizontal',
+          wrapperComponent: 'div',
+          actions: [],
+          body: [
+            {
+              type: 'input-text',
+              label: '菜单名称',
+              name: 'modalName',
+              placeholder: '请输入菜单名称',
               mode: 'horizontal',
-              onChange: (icon: IconType) => {
-                this.handleEditLabel(index, icon, 'icon');
-              },
+              required: true,
               horizontal: {
                 justify: true,
-                left: 4
+                left: 2
+              },
+              onChange: (value: string) => {
+                this.setState({modalName: value});
               }
-            })
-          )}
-        </div>
-        <div className="ae-navControlLinks">
-          初始是否折叠:
-          <Switch
-            value={props.unfolded}
-            onChange={(value: boolean) =>
-              this.handleEditLabel(index, value, 'unfolded')
-            }
-          />
-        </div>
-        {/* <div className="ae-navControlLinks">
-          是否高亮:
-          <Radios
-            value={props.active}
-            options={[
-              {label: '是', value: true},
-              {label: '否', value: false},
-              {label: '表达式', value: ''}
-            ]}
-            onChange={(item: {label: string; value: boolean | string}) =>
-              this.handleEditLabel(index, item.value, 'active')
-            }
-          />
-        </div>
-        {props.active === '' && (
-          <div className="ae-navControlLinks">
-            表达式:
-            <InputBox
-              value={props.activeOn}
-              placeholder="留空将自动分析菜单地址"
-              onChange={(value: string) =>
-                this.handleEditLabel(index, value, 'activeOn')
+            },
+            {
+              type: 'tree-select',
+              label: '父级菜单',
+              name: 'modalParent',
+              initiallyOpen: false,
+              placeholder: '请选择，不选择默认为一级菜单',
+              searchable: true,
+              multiple: false,
+              valueField: 'id',
+              options: treeData,
+              mode: 'horizontal',
+              horizontal: {
+                justify: true,
+                left: 2
+              },
+              onChange: (value: string) => {
+                this.setState({modalParent: value});
               }
-            />
-          </div>
-        )} */}
-      </div>
-    );
-  }
-
-  renderOption(props: any) {
-    const {index, children} = props;
-
-    return (
-      <div className="ae-OptionControlItem" key={index}>
-        {this.renderNav(props)}
-        <div className="ae-navControlLinks">
-          包含子菜单:
-          <Switch
-            value={!!(children && children.length)}
-            onChange={(value: boolean) => this.handleAddChildren(index, value)}
-          />
-        </div>
-        {children && children.length ? (
-          <>
-            {children.map((item: any, id: number) => {
-              return this.renderOption({...item, index: `${index}_${id}`});
-            })}
-            <Button onClick={() => this.handleAddChildren(index, true)}>
-              新增子菜单
-            </Button>
-          </>
-        ) : null}
-      </div>
-    );
-  }
-
-  @autobind
-  handleAPIChange(source: SchemaApi) {
-    this.setState({api: source}, this.onChange);
-  }
-
-  renderApiPanel() {
-    const {render} = this.props;
-    const {source, api} = this.state;
-    if (source === 'custom') {
-      return null;
-    }
-
-    return render(
-      'api',
-      getSchemaTpl('apiControl', {
-        label: '接口',
-        name: 'source',
-        mode: 'normal',
-        className: 'ae-ExtendMore',
-        visibleOn: 'data.autoComplete !== false',
-        value: api,
-        onChange: this.handleAPIChange,
-        sourceType: source
-      })
+            },
+            getSchemaTpl('icon', {
+              name: 'modalIcon',
+              label: '菜单图标',
+              mode: 'horizontal',
+              horizontal: {
+                justify: true,
+                left: 2
+              },
+              onChange: (value: string) => {
+                this.setState({modalIcon: value});
+              }
+            }),
+            {
+              type: 'input-text',
+              label: '跳转地址',
+              placeholder: '请输入地址',
+              mode: 'horizontal',
+              name: 'modalUrl',
+              horizontal: {
+                justify: true,
+                left: 2
+              },
+              onChange: (value: string) => {
+                this.setState({modalUrl: value});
+              }
+            },
+            {
+              type: 'radios',
+              name: 'modalTarget',
+              label: '跳转方式',
+              inline: true,
+              options: [
+                {
+                  label: '当前页展开',
+                  value: '_self'
+                },
+                {
+                  label: '新标签页打开',
+                  value: '_blank'
+                }
+              ],
+              mode: 'horizontal',
+              horizontal: {
+                justify: true,
+                left: 2
+              },
+              onChange: (value: string) => {
+                this.setState({modalTarget: value});
+              }
+            },
+            {
+              type: 'input-text',
+              label: '角标内容',
+              placeholder: '若为空则不展示角标',
+              mode: 'horizontal',
+              name: 'modalBadge',
+              horizontal: {
+                justify: true,
+                left: 2
+              },
+              onChange: (value: string) => {
+                this.setState({modalBadge: value});
+              }
+            }
+          ]
+        }
+      },
+      {
+        data: {
+          modalBadge,
+          modalIcon,
+          modalName,
+          modalParent,
+          modalUrl,
+          modalTarget
+        },
+        onClose: this.closeModal,
+        onConfirm: this.handleSubmit
+      }
     );
   }
 
   render() {
-    const {links, source} = this.state;
+    const {links, source, showDialog} = this.state;
     const {className} = this.props;
-
     return (
       <div className={cx('ae-NavControl', className)}>
         {this.renderHeader()}
@@ -452,23 +748,23 @@ export default class NavSourceControl extends React.Component<
         {source === 'custom' ? (
           <div className="ae-NavControl-wrapper">
             {Array.isArray(links) && links.length ? (
-              <div className="ae-NavControl-content">
-                {links.map((option, index) =>
-                  this.renderOption({...option, index})
-                )}
+              <div className="ae-NavControl-content" ref={this.dragRef}>
+                {this.renderNav(links)}
               </div>
             ) : (
               <div className="ae-NavControl-placeholder">无选项</div>
             )}
             <div className="ae-NavControl-footer">
-              <Button level="enhance" onClick={this.handleAdd}>
+              <Button level="enhance" onClick={this.openModal}>
                 添加菜单
               </Button>
             </div>
           </div>
-        ) : null}
+        ) : (
+          this.renderApiPanel()
+        )}
 
-        {this.renderApiPanel()}
+        {showDialog && this.renderDialog()}
       </div>
     );
   }

--- a/packages/amis-editor/src/renderer/NavSourceControl.tsx
+++ b/packages/amis-editor/src/renderer/NavSourceControl.tsx
@@ -20,7 +20,7 @@ import {autobind} from 'amis-editor-core';
 import type {FormControlProps} from 'amis-core';
 import {SchemaApi} from 'amis';
 
-export type SourceType = 'custom' | 'api';
+export type SourceType = 'custom' | 'api' | '';
 
 export type NavControlItem = {
   id?: string;
@@ -178,20 +178,26 @@ export class NavSourceControl extends React.Component<
     const activeDraggingItem = get(links, `${oldPath}`);
     if (oldParentPath) {
       const oldParent = get(links, `${oldParentPath}.children`, []);
-      oldParent.splice(oldIndex, 1);
+      typeof oldIndex === 'number' && oldParent.splice(oldIndex, 1);
       set(links, `${oldParentPath}.children`, oldParent);
     } else {
-      links.splice(oldIndex, 1);
+      typeof oldIndex === 'number' && links.splice(oldIndex, 1);
     }
 
     const {parentPath: newParentPath} = this.getNodePath(nodeNewIndex);
 
     if (newParentPath) {
-      const newParent = get(links, `${newParentPath}.children`, []);
-      newParent.splice(newIndex, 0, activeDraggingItem);
+      const newParent: Array<NavControlItem> = get(
+        links,
+        `${newParentPath}.children`,
+        []
+      );
+      typeof newIndex === 'number' &&
+        newParent.splice(newIndex, 0, activeDraggingItem);
       set(links, `${newParentPath}.children`, newParent);
     } else {
-      links.splice(newIndex, 0, activeDraggingItem);
+      typeof newIndex === 'number' &&
+        links.splice(newIndex, 0, activeDraggingItem);
     }
     // 数据diff时会使得dom结构出bug，多个相同节点，先置空再重新赋值
     this.setState({source: ''}, () => {
@@ -550,11 +556,16 @@ export class NavSourceControl extends React.Component<
                   <Icon icon="drag-bar" className="icon" />
                 </a>
                 {nav.icon &&
-                  render(`render-icon-${nav.icon.id}`, {
-                    type: 'icon',
-                    icon: nav.icon,
-                    className: 'nav-links-item-icon'
-                  })}
+                  render(
+                    `render-icon-${
+                      typeof nav.icon !== 'string' ? nav.icon.id : nav.icon
+                    }`,
+                    {
+                      type: 'icon',
+                      icon: nav.icon,
+                      className: 'nav-links-item-icon'
+                    }
+                  )}
                 <TooltipWrapper tooltip={nav.label} placement="left">
                   <div className="nav-links-item-label">{nav.label}</div>
                 </TooltipWrapper>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6e33b8</samp>

This pull request updates the `NavPlugin` and the `NavControl` component in the AMIS editor to support custom link opening behavior and a new design and layout. It adds a `target` property to the `link` schema of the `NavPlugin` and rewrites the SCSS code for the `.ae-NavControl` class and its sub-classes in `packages/amis-editor-core/scss/control/_nav-control.scss`. It also removes the old SCSS code that was no longer needed.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b6e33b8</samp>

> _`NavControl` changes_
> _Flexbox, variables, links_
> _Autumn leaves old code_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b6e33b8</samp>

* Rewrite the SCSS code for the navigation control component to match the new design and layout using flexbox, variables, and nested selectors ([link](https://github.com/baidu/amis/pull/7836/files?diff=unified&w=0#diff-8092fd34cf7c7eef8f0e4c90fe2c32e29fcc9843df6aa0070160ffbcfcef7ae6L1-R84))
* Add the `target` property to the `link` schema of the `NavPlugin` class in `Nav.tsx` to allow the user to configure how the link should be opened when clicked ([link](https://github.com/baidu/amis/pull/7836/files?diff=unified&w=0#diff-09783eec140bf3c70e8dd5932d5b8108bd6777cd334ea0a27322d0f09586de29R35), [link](https://github.com/baidu/amis/pull/7836/files?diff=unified&w=0#diff-09783eec140bf3c70e8dd5932d5b8108bd6777cd334ea0a27322d0f09586de29R41))
