### PR TITLE
fix: crud兼容cards使用场景

### DIFF
--- a/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
@@ -562,7 +562,6 @@ exports[`Renderer:input table add 1`] = `
                 >
                   <table
                     class="cxd-Table-table"
-                    style="table-layout: fixed;"
                   >
                     <colgroup>
                       <col

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -585,14 +585,15 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     // 显隐切换时，也会导致需要二次点击才能选中的问题
     let val: any;
     const valueField = props.valueField || props.primaryField;
+
     if (
       this.props.pickerMode &&
       isArrayChildrenModified(
-        (val = getPropValue(this.props)).map((item: any) => item[valueField]),
-        getPropValue(prevProps).map((item: any) => item[valueField])
+        (val = getPropValue(this.props))?.map((item: any) => item[valueField]),
+        getPropValue(prevProps)?.map((item: any) => item[valueField])
       ) &&
       !isEqual(
-        val.map((item: any) => item[valueField]),
+        val?.map((item: any) => item[valueField]),
         store.selectedItems.concat().map((item: any) => item[valueField])
       )
     ) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 846db93</samp>

Fixed a bug in `CRUD.tsx` that caused the component to crash when the data source was empty or returned an error. Added optional chaining operators to prevent errors when accessing properties of potentially null or undefined values.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 846db93</samp>

> _`?.` prevents crash_
> _when data source is empty_
> _autumn bug is fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 846db93</samp>

*  Prevent errors when data source is empty or error-prone in CRUD component ([link](https://github.com/baidu/amis/pull/7841/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L588-R597))
