### PR TITLE
fix(amis-editor): chart支持宽高可视化配置

### DIFF
--- a/packages/amis-editor/src/plugin/Chart.tsx
+++ b/packages/amis-editor/src/plugin/Chart.tsx
@@ -252,7 +252,6 @@ export class ChartPlugin extends BasePlugin {
                     visibleOn: 'data.api.url',
                     pipeIn: defaultValue(true)
                   }),
-
                   {
                     name: 'interval',
                     label: tipedLabel(
@@ -265,6 +264,15 @@ export class ChartPlugin extends BasePlugin {
                     visibleOn: 'data.api.url',
                     unitOptions: ['ms']
                   },
+                  getSchemaTpl('expressionFormulaControl', {
+                    evalMode: false,
+                    label: tipedLabel(
+                      '跟踪表达式',
+                      '如果这个表达式的值有变化时会更新图表，当 config 中用了数据映射时有用'
+                    ),
+                    name: 'trackExpression',
+                    placeholder: '\\${xxx}'
+                  }),
                   {
                     name: 'config',
                     asFormItem: true,
@@ -303,15 +311,6 @@ export class ChartPlugin extends BasePlugin {
                       '默认为追加模式，新的配置会跟旧的配置合并，如果勾选将直接完全覆盖'
                     ),
                     name: 'replaceChartOption'
-                  }),
-                  getSchemaTpl('expressionFormulaControl', {
-                    evalMode: false,
-                    label: tipedLabel(
-                      '跟踪表达式',
-                      '如果这个表达式的值有变化时会更新图表，当 config 中用了数据映射时有用'
-                    ),
-                    name: 'trackExpression',
-                    placeholder: '\\${xxx}'
                   })
                 ]
               },
@@ -354,6 +353,27 @@ export class ChartPlugin extends BasePlugin {
         {
           title: '外观',
           body: getSchemaTpl('collapseGroup', [
+            {
+              title: '宽高设置',
+              body: [
+                getSchemaTpl('style:widthHeight', {
+                  widthSchema: {
+                    label: tipedLabel(
+                      '宽度',
+                      '默认宽度为父容器宽度，值单位默认为 px，也支持百分比等单位 ，如：100%'
+                    ),
+                    pipeIn: defaultValue('100%')
+                  },
+                  heightSchema: {
+                    label: tipedLabel(
+                      '高度',
+                      '默认高度为300px，值单位默认为 px，也支持百分比等单位 ，如：100%'
+                    ),
+                    pipeIn: defaultValue('300px')
+                  }
+                })
+              ]
+            },
             ...getSchemaTpl('theme:common', {exclude: ['layout']})
           ])
         },

--- a/packages/amis/src/renderers/Chart.tsx
+++ b/packages/amis/src/renderers/Chart.tsx
@@ -94,12 +94,12 @@ export interface ChartSchema extends BaseSchema {
   /**
    * 宽度设置
    */
-  width?: number;
+  width?: number | string;
 
   /**
    * 高度设置
    */
-  height?: number;
+  height?: number | string;
 
   /**
    * 刷新时间


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e7b1be0</samp>

This pull request enhances the chart plugin and renderer for the amis-editor and amis library, by adding schema templates and supporting different units for width and height. It affects the files `Chart.tsx` in both `packages/amis-editor/src/plugin` and `packages/amis/src/renderers`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e7b1be0</samp>

> _To make charts more flexible and nice_
> _We changed `width` and `height` to string or slice_
> _We added some schema templates_
> _For `trackExpression` and dimensions_
> _And cleaned up the code with some spice_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e7b1be0</samp>

*  Allow users to specify width and height values with different units for charts ([link](https://github.com/baidu/amis/pull/7846/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0R356-R376), [link](https://github.com/baidu/amis/pull/7846/files?diff=unified&w=0#diff-b835aa79eebadb985fbc93069bbd1973522b0a1d125adbbe7b2300a154647acdL97-R102))
* Add a new schema template for the `trackExpression` property in the `ChartPlugin` class ([link](https://github.com/baidu/amis/pull/7846/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0R267-R275), [link](https://github.com/baidu/amis/pull/7846/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L306-L314))
* Remove an empty line from the `ChartPlugin` class ([link](https://github.com/baidu/amis/pull/7846/files?diff=unified&w=0#diff-92e2dff029222169328d9669f8f4806b472564461a594687e90b8adfb81333a0L255))
