### PR TITLE
fix: nav配置reload动作发送无效请求的问题

### DIFF
--- a/packages/amis/__tests__/renderers/Nav.test.tsx
+++ b/packages/amis/__tests__/renderers/Nav.test.tsx
@@ -695,3 +695,167 @@ test('Renderer:Nav with Dialog', async () => {
     ).toBeInTheDocument();
   });
 });
+
+// 10.Nav配置reload动作
+test('Renderer:Nav with reload1', async () => {
+  const fetcher = jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      data: {
+        status: 0,
+        msg: 'ok',
+        data: ''
+      }
+    })
+  );
+  const {container}: any = render(
+    amisRender(
+      {
+        type: 'page',
+        data: {
+          nav: [
+            {
+              label: 'Nav 1',
+              to: '/docs/index',
+              icon: 'fa fa-user'
+            },
+            {
+              label: 'Nav 2',
+              to: '/docs/api'
+            },
+            {
+              label: 'Nav 3',
+              to: '/docs/renderers'
+            }
+          ]
+        },
+        body: [
+          {
+            type: 'nav',
+            stacked: true,
+            id: 'xxNav',
+            source: '${nav}'
+          },
+          {
+            type: 'button',
+            level: 'primary',
+            className: 'mr-4',
+            label: 'reload',
+            onEvent: {
+              click: {
+                actions: [
+                  {
+                    componentId: 'xxNav',
+                    actionType: 'reload'
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {},
+      makeEnv({
+        session: 'test-case-action-no',
+        fetcher
+      })
+    )
+  );
+  fireEvent.click(container.querySelector('.cxd-Button'));
+  await wait(500);
+  expect(fetcher).not.toBeCalled();
+});
+
+// 11.Nav配置reload动作
+test('Renderer:Nav with reload2', async () => {
+  const fetcher = jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      data: {
+        status: 0,
+        msg: 'ok',
+        data: {
+          links: [
+            {
+              label: 'Nav 1',
+              to: '?cat=1',
+              value: '1',
+              icon: 'fa fa-user'
+            },
+            {
+              label: 'Nav 2',
+              unfolded: true,
+              children: [
+                {
+                  label: 'Nav 2-1',
+                  children: [
+                    {
+                      label: 'Nav 2-1-1',
+                      to: '?cat=2-1',
+                      value: '2-1'
+                    }
+                  ]
+                },
+                {
+                  label: 'Nav 2-2',
+                  to: '?cat=2-2',
+                  value: '2-2'
+                }
+              ]
+            },
+            {
+              label: 'Nav 3',
+              to: '?cat=3',
+              value: '3',
+              defer: true
+            }
+          ],
+          value: '?cat=1'
+        }
+      }
+    })
+  );
+  const {container}: any = render(
+    amisRender(
+      {
+        type: 'page',
+        data: {
+          url: '/api/options/nav'
+        },
+        body: [
+          {
+            type: 'nav',
+            stacked: true,
+            id: 'xxNav',
+            source: '${url}'
+          },
+          {
+            type: 'button',
+            level: 'primary',
+            className: 'mr-4',
+            label: 'reload',
+            onEvent: {
+              click: {
+                actions: [
+                  {
+                    componentId: 'xxNav',
+                    actionType: 'reload'
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {},
+      makeEnv({
+        session: 'test-case-action-no',
+        fetcher
+      })
+    )
+  );
+  await wait(500);
+  const navItem = container.querySelector('.cxd-Nav-Menu-item');
+  expect(navItem).toBeInTheDocument();
+  fireEvent.click(container.querySelector('.cxd-Button'));
+  await wait(500);
+  expect(fetcher).toBeCalled();
+});


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8eb3253</samp>

Fix a bug that causes invalid requests when using pure variables as source props in `WithRemoteConfig` component. Add a condition and a comment to handle this case in `packages/amis-ui/src/components/WithRemoteConfig.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8eb3253</samp>

> _`source` may be pure_
> _avoid invalid requests_
> _comment for clarity_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8eb3253</samp>

*  Add a condition to skip loading remote config when source is a pure variable ([link](https://github.com/baidu/amis/pull/7851/files?diff=unified&w=0#diff-602aa42ab34a4a248db44b9b79423e2b319cf4a1b6c8de867a96b4fee67546c1L288-R289))
