### PR TITLE
chore:动作执行支持ignoreError，用于忽略执行错误继续执行动作列表

### DIFF
--- a/docs/zh-CN/concepts/event-action.md
+++ b/docs/zh-CN/concepts/event-action.md
@@ -3194,7 +3194,7 @@ http 请求动作执行结束后，后面的动作可以通过 `${responseResult
 | id     | 组件 ID，即组件的 id 属性的值 |
 | path   | 数据路径，即数据变量的路径    |
 
-# 事件动作干预
+# 干预动作执行
 
 事件动作干预是指执行完当前动作后，干预所监听事件默认处理逻辑和后续其他动作的执行。通过`preventDefault`、`stopPropagation`分别阻止监听事件默认行为和停止下一个动作执行。
 
@@ -3305,6 +3305,65 @@ http 请求动作执行结束后，后面的动作可以通过 `${responseResult
 }
 ```
 
+## 忽略动作报错继续执行
+
+> `3.3.1` 及以上版本
+
+默认情况下，尝试执行一个不存在的目标组件动作、JS 脚本执行错误等程序错误都会导致动作执行终止，可以通过`ignoreError: true`来忽略动作报错继续执行后面的动作。
+
+```schema
+{
+  "type": "page",
+  "title": "第一个按钮发生错误直接阻塞执行，第二个按钮发生错误后仍然执行",
+  "body": [
+    {
+      type: 'button',
+      label: '无法弹出提示',
+      level: 'primary',
+      className: 'mr-2',
+      onEvent: {
+        click: {
+          actions: [
+            {
+              actionType: 'reload',
+              componentId: 'notfound'
+            },
+            {
+              actionType: 'toast',
+              args: {
+                msg: 'okk'
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      type: 'button',
+      label: '可以弹出提示',
+      level: 'primary',
+      onEvent: {
+        click: {
+          actions: [
+            {
+              actionType: 'reload',
+              componentId: 'notfound',
+              ignoreError: true
+            },
+            {
+              actionType: 'toast',
+              args: {
+                msg: 'okk'
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
 # 自定义组件接入事件动作
 
 需求场景主要是想要自定义组件的内部事件暴露出去，能够通过对事件的监听来执行所需动作，并希望自定义组件自身的动作能够被其他组件调用。接入方法是通过`props.dispatchEvent`派发自身的各种事件，使其具备更灵活的交互设计能力；通过实现`doAction`方法实现其他组件对其专属动作的调用，需要注意的是，此处依赖内部的 `Scoped Context`来实现自身的注册，可以参考 [组件间通信](../../docs/extend/custom-react#组件间通信)。
@@ -3321,3 +3380,4 @@ http 请求动作执行结束后，后面的动作可以通过 `${responseResult
 | stopPropagation | `boolean`\|[表达式](../concepts/expression)\|[ConditionBuilder](../../components/form/condition-builder) | false   | 停止后续动作执行，`> 1.10.0 及以上版本支持表达式，> 2.9.0 及以上版本支持ConditionBuilder`                     |
 | expression      | `boolean`\|[表达式](../concepts/expression)\|[ConditionBuilder](../../components/form/condition-builder) | -       | 执行条件，不设置表示默认执行，`> 1.10.0 及以上版本支持表达式，> 2.9.0 及以上版本支持ConditionBuilder`         |
 | outputVar       | `string`                                                                                                 | -       | 输出数据变量名                                                                                                |
+| ignoreError     | `boolean`                                                                                                | false   | 当动作执行出错后，是否忽略错误继续执行。`3.3.1 及以上版本支持`                                                |

--- a/packages/amis-core/src/actions/CmptAction.ts
+++ b/packages/amis-core/src/actions/CmptAction.ts
@@ -43,7 +43,9 @@ export class CmptAction implements RendererAction {
       : null;
 
     if (key && !component) {
-      throw Error('目标组件没有找到，请检查componentId或componentName是否正确');
+      throw Error(
+        '尝试执行一个不存在的目标组件动作，请检查目标组件非隐藏状态，且正确指定了componentId或componentName'
+      );
     }
 
     if (action.actionType === 'setValue') {

--- a/packages/amis/__tests__/event-action/prevent.test.tsx
+++ b/packages/amis/__tests__/event-action/prevent.test.tsx
@@ -97,3 +97,70 @@ test('EventAction:prevent', async () => {
   expect(container).toMatchSnapshot();
   expect(fetcher).not.toHaveBeenCalled();
 });
+
+test('EventAction:ignoreError', async () => {
+  const notify = jest.fn();
+  const fetcher = jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      data: {
+        status: 0,
+        msg: 'ok',
+        data: {
+          age: 18
+        }
+      }
+    })
+  );
+  const {getByText, container}: any = render(
+    amisRender(
+      {
+        type: 'page',
+        body: [
+          {
+            type: 'button',
+            label: '按钮',
+            level: 'primary',
+            onEvent: {
+              click: {
+                actions: [
+                  {
+                    actionType: 'reload',
+                    componentId: 'notfound',
+                    ignoreError: true
+                  },
+                  {
+                    actionType: 'ajax',
+                    api: '/api/test3'
+                  },
+                  {
+                    actionType: 'custom',
+                    script:
+                      "const myMsg = '我是自定义JS';\nsdfsdfsdf();\ndoAction({\n  actionType: 'toast',\n  args: {\n    msg: myMsg\n  }\n});\n",
+                    ignoreError: true
+                  },
+                  {
+                    actionType: 'ajax',
+                    api: '/api/test4'
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {},
+      makeEnv({
+        getModalContainer: () => container,
+        notify,
+        fetcher
+      })
+    )
+  );
+
+  fireEvent.click(getByText('按钮'));
+  await waitFor(() => {
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher.mock.calls[0][0].url).toEqual('/api/test3');
+    expect(fetcher.mock.calls[1][0].url).toEqual('/api/test4');
+  });
+});

--- a/packages/amis/src/renderers/Table/ColGroup.tsx
+++ b/packages/amis/src/renderers/Table/ColGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {IColumn, ITableStore} from 'amis-core/lib/store/table';
+import type {IColumn, ITableStore} from 'amis-core';
 import {observer} from 'mobx-react';
 
 export function ColGroup({


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 68fe3e2</samp>

Added a new feature to allow users to ignore errors in action execution with the `ignoreError` property. Updated the documentation, the source code, and the test cases to support the feature. Improved the error messages and the import statements in some files.

copilot:poem

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 68fe3e2</samp>

* Add a new feature to optionally ignore errors in action execution and continue with the next actions ([link](https://github.com/baidu/amis/pull/7855/files?diff=unified&w=0#diff-9802ca5a2390dc6e213b3d844669c50fb10948dad8ad72a0d360c886731fbd3dR3308-R3366), [link](https://github.com/baidu/amis/pull/7855/files?diff=unified&w=0#diff-9802ca5a2390dc6e213b3d844669c50fb10948dad8ad72a0d360c886731fbd3dR3383), [link](https://github.com/baidu/amis/pull/7855/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3R27), [link](https://github.com/baidu/amis/pull/7855/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L184-R197), [link](https://github.com/baidu/amis/pull/7855/files?diff=unified&w=0#diff-1765d9b28c306f37b4a50dc7162c0e6f19488b0b3d2fd67c1e184214a70d3fceR100-R166))
  - Update the documentation of `event-action.md` to introduce the new feature and provide an example schema ([link](https://github.com/baidu/amis/pull/7855/files?diff=unified&w=0#diff-9802ca5a2390dc6e213b3d844669c50fb10948dad8ad72a0d360c886731fbd3dR3308-R3366), [link](https://github.com/baidu/amis/pull/7855/files?diff=unified&w=0#diff-9802ca5a2390dc6e213b3d844669c50fb10948dad8ad72a0d360c886731fbd3dR3383))
  - Add a new property `ignoreError` to the interface `ListenerAction` in the source code of `Action.ts` ([link](https://github.com/baidu/amis/pull/7855/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3R27))
  - Add a try-catch block to the `runActions` function in the source code of `Action.ts` to check the `ignoreError` property and handle errors accordingly ([link](https://github.com/baidu/amis/pull/7855/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L184-R197))
  - Add a new test case `EventAction:ignoreError` to the `prevent.test.tsx` file to test the functionality of the new feature ([link](https://github.com/baidu/amis/pull/7855/files?diff=unified&w=0#diff-1765d9b28c306f37b4a50dc7162c0e6f19488b0b3d2fd67c1e184214a70d3fceR100-R166))
* Modify the section title `事件动作干预` to `干预动作执行` in the documentation of `event-action.md` to make it more consistent with the content and the English version ([link](https://github.com/baidu/amis/pull/7855/files?diff=unified&w=0#diff-9802ca5a2390dc6e213b3d844669c50fb10948dad8ad72a0d360c886731fbd3dL3197-R3197))
* Modify the error message thrown by the `CmptAction` class in the source code of `CmptAction.ts` to be more informative and user-friendly ([link](https://github.com/baidu/amis/pull/7855/files?diff=unified&w=0#diff-9fcca25fc37554994f4168d09ade3ba52487964b8f897e0a9de38442dc6b1ceaL46-R48))
* Simplify the import statement of the `amis-core` package in the source code of `ColGroup.tsx` to use the default export instead of the sub-module ([link](https://github.com/baidu/amis/pull/7855/files?diff=unified&w=0#diff-b4960ad44934bf990cfc6e86973e87d97d8ae96dbfa69ee15cad4d013719feb5L2-R2))
