### PR TITLE
chore: 调整 condition-builder 中 tooltip 实现,解决遮挡问题

### DIFF
--- a/packages/amis-ui/src/components/condition-builder/GroupOrItem.tsx
+++ b/packages/amis-ui/src/components/condition-builder/GroupOrItem.tsx
@@ -8,6 +8,7 @@ import ConditionItem from './Item';
 import FormulaPicker, {FormulaPickerProps} from '../formula/Picker';
 import Button from '../Button';
 import type {ConditionGroupValue, ConditionValue} from 'amis-core';
+import TooltipWrapper from '../TooltipWrapper';
 
 export interface CBGroupOrItemProps extends ThemeProps {
   builderMode?: 'simple' | 'full';
@@ -189,13 +190,20 @@ export class CBGroupOrItem extends React.Component<CBGroupOrItemProps> {
                   onChange={this.handleIfChange}
                 >
                   {({onClick}) => (
-                    <a
-                      className={cx('CBIf', value?.if ? 'is-active' : '')}
-                      onClick={onClick}
-                      data-tooltip="配置启动条件，当前规则只有在此条件成立时才会生效"
+                    <TooltipWrapper
+                      tooltip={
+                        '配置启动条件，当前规则只有在此条件成立时才会生效'
+                      }
+                      tooltipTheme="dark"
+                      container={popOverContainer}
                     >
-                      <Icon icon="if" className="icon" />
-                    </a>
+                      <a
+                        className={cx('CBIf', value?.if ? 'is-active' : '')}
+                        onClick={onClick}
+                      >
+                        <Icon icon="if" className="icon" />
+                      </a>
+                    </TooltipWrapper>
                   )}
                 </FormulaPicker>
               ) : null}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a15a02</samp>

Added tooltips to condition builder triggers. This improves the user experience and the visual style of the `if` condition trigger in the `condition-builder/GroupOrItem.tsx` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2a15a02</samp>

> _Sing, O Muse, of the skillful coder who enhanced the app_
> _With a tooltip of dark theme, a subtle and helpful trap_
> _For the curious user who clicks the `if` condition trigger_
> _And learns the logic of the builder, like a wise and ancient seer_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2a15a02</samp>

*  Add a tooltip to the `if` condition trigger in the condition builder (`[link](https://github.com/baidu/amis/pull/7856/files?diff=unified&w=0#diff-e739d54e710cb7e461bb442b0b438b9e44a2ce1f4492a64c16fe1afcd2f5d166R11)`, `[link](https://github.com/baidu/amis/pull/7856/files?diff=unified&w=0#diff-e739d54e710cb7e461bb442b0b438b9e44a2ce1f4492a64c16fe1afcd2f5d166L192-R206)`)
