### PR TITLE
chore: 调整事件动作找不到组件时报错策略，默认只是 warning

### DIFF
--- a/packages/amis-core/src/actions/CmptAction.ts
+++ b/packages/amis-core/src/actions/CmptAction.ts
@@ -43,9 +43,13 @@ export class CmptAction implements RendererAction {
       : null;
 
     if (key && !component) {
-      throw Error(
-        '尝试执行一个不存在的目标组件动作，请检查目标组件非隐藏状态，且正确指定了componentId或componentName'
-      );
+      const msg =
+        '尝试执行一个不存在的目标组件动作，请检查目标组件非隐藏状态，且正确指定了componentId或componentName';
+      if (action.ignoreError === false) {
+        throw Error(msg);
+      } else {
+        console.warn(msg);
+      }
     }
 
     if (action.actionType === 'setValue') {

--- a/packages/amis-editor/src/renderer/event-control/action-config-dialog.tsx
+++ b/packages/amis-editor/src/renderer/event-control/action-config-dialog.tsx
@@ -6,7 +6,8 @@ import {
   PluginActions,
   RendererPluginAction,
   tipedLabel,
-  getSchemaTpl
+  getSchemaTpl,
+  defaultValue
 } from 'amis-editor-core';
 import React from 'react';
 import {ActionConfig, ComponentInfo} from './types';
@@ -141,7 +142,8 @@ export default class ActionDialog extends React.Component<ActionDialogProp> {
           __subActions: actionNode?.actions,
           __cmptTreeSource: actionNode?.supportComponents
             ? getComponents?.(actionNode) ?? []
-            : []
+            : [],
+          ignoreError: false
         });
       }
     };
@@ -286,6 +288,44 @@ export default class ActionDialog extends React.Component<ActionDialogProp> {
                             inline: false,
                             className: 'action-panel-title',
                             visibleOn: 'data.actionType'
+                          },
+                          {
+                            type: 'button-group-select',
+                            name: 'ignoreError',
+                            visibleOn: 'data.actionType',
+                            label: tipedLabel(
+                              '错误忽略',
+                              '动作发生错误时，是否忽略错误继续执行'
+                            ),
+                            mode: 'horizontal',
+                            pipeIn: (value: any, data: any) =>
+                              value === true
+                                ? '1'
+                                : value === false
+                                ? '2'
+                                : '3',
+                            pipeOut: (value: any) =>
+                              value === '1'
+                                ? true
+                                : value === '2'
+                                ? false
+                                : undefined,
+                            options: [
+                              {
+                                label: '忽略',
+                                value: '1'
+                              },
+                              {
+                                label: '不忽略',
+                                value: '2'
+                              },
+                              {
+                                label: '预设',
+                                value: '3'
+                              }
+                            ],
+                            description:
+                              '<%= data.ignoreError === false ? "找不到组件和动作执行失败都中断" : typeof data.ignoreError === "undefined" ? "找不到组件容忍，动作执行失败才中断" : ""%>'
                           },
                           getSchemaTpl('expressionFormulaControl', {
                             name: 'stopPropagation',


### PR DESCRIPTION


### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f42127f</samp>

This pull request adds a new option `ignoreError` to the component action schema, which lets the user decide how to handle the error when the target component is not found. This option is supported by the action config dialog in `amis-editor` and the `CmptAction` class in `amis-core`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f42127f</samp>

> _Sing, O Muse, of the skillful `amis-editor`_
> _That lets the mortal users craft their actions_
> _And choose to heed or spurn the direful errors_
> _When they invoke the powers of the components_

### Why

考虑到历史配置中存在大量指定错误组件的用法，降低错误提示级别

* ignoreError 没有配置时，找不到组件只是 warning，动作执行错误才中断
* ignoreError  配置成 true 时，凡是错误都直接忽略，继续后续动作
* ignoreError 配置为 false 时，找不到组件也会中断

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f42127f</samp>

*  Add `ignoreError` property to component action schema and config dialog ([link](https://github.com/baidu/amis/pull/7865/files?diff=unified&w=0#diff-3d7b0c5e5c5515b4c22895cf1ee4f3be874c4fd89fa5b5445bfcf8e55523e919L9-R10), [link](https://github.com/baidu/amis/pull/7865/files?diff=unified&w=0#diff-3d7b0c5e5c5515b4c22895cf1ee4f3be874c4fd89fa5b5445bfcf8e55523e919L144-R146), [link](https://github.com/baidu/amis/pull/7865/files?diff=unified&w=0#diff-3d7b0c5e5c5515b4c22895cf1ee4f3be874c4fd89fa5b5445bfcf8e55523e919R292-R329))
* Add condition to check `ignoreError` property in component action handler ([link](https://github.com/baidu/amis/pull/7865/files?diff=unified&w=0#diff-9fcca25fc37554994f4168d09ade3ba52487964b8f897e0a9de38442dc6b1ceaL46-R54))
