### PR TITLE
fix: 事件动作中ajax和download的兼容问题

### DIFF
--- a/packages/amis-core/src/actions/Action.ts
+++ b/packages/amis-core/src/actions/Action.ts
@@ -97,6 +97,7 @@ const getOmitActionProp = (type: string) => {
       omitList = ['msg', 'title'];
       break;
     case 'ajax':
+    case 'download':
       omitList = ['api', 'messages', 'options'];
       break;
     case 'setValue':
@@ -263,7 +264,7 @@ export const runAction = async (
   } else if (action.actionType === 'drawer') {
     action.drawer = {...(action.drawer ?? action.args?.drawer)};
     delete action.args?.drawer;
-  } else if (action.actionType === 'ajax') {
+  } else if (['ajax', 'download'].includes(action.actionType)) {
     const api = action.api ?? action.args?.api;
     action.api = typeof api === 'string' ? api : {...api};
     action.options = {...(action.options ?? action.args?.options)};
@@ -298,7 +299,10 @@ export const runAction = async (
       : afterMappingData;
 
   // 默认为当前数据域
-  const data = actionData !== undefined ? actionData : mergeData;
+  const data =
+    actionData !== undefined && action.data !== undefined
+      ? actionData
+      : mergeData;
 
   console.group?.(`run action ${action.actionType}`);
   console.debug(`[${action.actionType}] action args, data`, args, data);

--- a/packages/amis-editor/src/renderer/event-control/index.tsx
+++ b/packages/amis-editor/src/renderer/event-control/index.tsx
@@ -480,6 +480,7 @@ export class EventControl extends React.Component<
         this.setState({
           onEvent: onEventConfig
         });
+        this.props.onChange && this.props.onChange(onEventConfig);
       }
     });
   }


### PR DESCRIPTION
### What

1. 修复download 动作执行报错问题
2. 兼容ajax 动作历史数据：在ajax动作中 如果args中存在除api、message、options之外其他的属性时，无法获取上下作用域数据
3. 修复页面设计器配置面板对事件列表进行排序后未保存到schema的问题
### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8c7071d</samp>

*  Add support for 'download' action type that allows users to download files from an API using an action button ([link](https://github.com/baidu/amis/pull/7866/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3R100), [link](https://github.com/baidu/amis/pull/7866/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L266-R267))
   *  Omit 'download' action properties when cloning an action in `getOmitActionProp` function in `Action.ts` ([link](https://github.com/baidu/amis/pull/7866/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3R100))
   *  Handle 'download' action type in `runAction` function in `Action.ts` and ensure that action.api is set to a string or an object ([link](https://github.com/baidu/amis/pull/7866/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L266-R267))
*  Fix bug that caused action.data to be ignored when actionData parameter was undefined in `runAction` function in `Action.ts` ([link](https://github.com/baidu/amis/pull/7866/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L301-R305))
   *  Set data variable to action.data if both actionData and action.data are defined, otherwise use mergeData variable ([link](https://github.com/baidu/amis/pull/7866/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L301-R305))
