### PR TITLE
feat(amis-editor): 配置面板只配置一个颜色时无需校验必填

### DIFF
--- a/packages/amis-editor/src/plugin/Progress.tsx
+++ b/packages/amis-editor/src/plugin/Progress.tsx
@@ -246,25 +246,24 @@ export class ProgressPlugin extends BasePlugin {
                 multiple: true,
                 label: tipedLabel(
                   '颜色',
-                  '分配不同的值段，用不同的颜色提示用户'
+                  '分配不同的值段，用不同的颜色提示用户。若只配置一个颜色不配置value，默认value为100'
                 ),
                 items: [
+                  {
+                    placeholder: 'color',
+                    type: 'input-color',
+                    name: 'color'
+                  },
                   {
                     type: 'input-number',
                     name: 'value',
                     placeholder: 'value',
-                    required: true,
                     columnClassName: 'w-xs',
                     unique: true,
+                    requiredOn: 'data.map?.length > 1',
                     min: 0,
                     step: 10,
                     precision: 0
-                  },
-                  {
-                    placeholder: 'color',
-                    type: 'input-color',
-                    name: 'color',
-                    required: true
                   }
                 ],
                 value: [
@@ -272,8 +271,30 @@ export class ProgressPlugin extends BasePlugin {
                   {color: '#fad733', value: 60},
                   {color: '#28a745', value: 100}
                 ],
-                pipeIn: (value: any) => {
-                  return Array.isArray(value) ? value : [];
+                pipeIn: (mapItem: any) => {
+                  // schema传入
+                  if (Array.isArray(mapItem) && mapItem.length) {
+                    return typeof mapItem[0] === 'string'
+                      ? mapItem.map((item: string, index: number) => {
+                          const span = 100 / mapItem.length;
+                          return {value: (index + 1) * span, color: item};
+                        })
+                      : mapItem.length === 1 && !mapItem[0].value
+                      ? [{color: mapItem[0].color, value: 100}]
+                      : mapItem;
+                  } else {
+                    return mapItem ? [mapItem] : [];
+                  }
+                },
+
+                pipeOut: (mapItem: any, origin: any, data: any) => {
+                  // 传入schema
+                  if (mapItem.length === 1 && !mapItem[0].value) {
+                    // 只有一个颜色且value未设置时默认为100
+                    return [{color: mapItem[0].color, value: 100}];
+                  } else {
+                    return mapItem;
+                  }
                 }
               })
             ]


### PR DESCRIPTION
改动点：
1、value必填校验触发条件修改：配置大于1个颜色时，校验必填 （设置requiredOn）
2、只设置一个颜色且value不设置时，schema的value设置为100 （pipeOut中处理）
3、shcema的map数据结构为string[]时，转换为Record<{color: string, value: string}>在配置面板回显 （pipeIn中处理）