### PR TITLE
fix: 修复download 动作执行报错问题

### DIFF
--- a/packages/amis-core/src/actions/Action.ts
+++ b/packages/amis-core/src/actions/Action.ts
@@ -97,6 +97,7 @@ const getOmitActionProp = (type: string) => {
       omitList = ['msg', 'title'];
       break;
     case 'ajax':
+    case 'download':
       omitList = ['api', 'messages', 'options'];
       break;
     case 'setValue':
@@ -263,7 +264,7 @@ export const runAction = async (
   } else if (action.actionType === 'drawer') {
     action.drawer = {...(action.drawer ?? action.args?.drawer)};
     delete action.args?.drawer;
-  } else if (action.actionType === 'ajax') {
+  } else if (['ajax', 'download'].includes(action.actionType)) {
     const api = action.api ?? action.args?.api;
     action.api = typeof api === 'string' ? api : {...api};
     action.options = {...(action.options ?? action.args?.options)};

--- a/packages/amis-editor/src/renderer/event-control/index.tsx
+++ b/packages/amis-editor/src/renderer/event-control/index.tsx
@@ -480,6 +480,7 @@ export class EventControl extends React.Component<
         this.setState({
           onEvent: onEventConfig
         });
+        this.props.onChange && this.props.onChange(onEventConfig);
       }
     });
   }


### PR DESCRIPTION
### What
- 修复download 动作执行报错问题
- 修复页面设计器配置面板对事件列表进行排序后未保存到schema的问题

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d5ad027</samp>

*  Add support for downloading files from the server using an action of type 'download' ([link](https://github.com/baidu/amis/pull/7868/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3R100), [link](https://github.com/baidu/amis/pull/7868/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L266-R267))
  * In `Action.ts`, omit the 'download' action properties from the button rendering ([link](https://github.com/baidu/amis/pull/7868/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3R100))
  * In `Action.ts`, use the same logic as 'ajax' actions to handle the api property for 'download' actions ([link](https://github.com/baidu/amis/pull/7868/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L266-R267))
* Fix the bug of event configuration not syncing with the parent component ([link](https://github.com/baidu/amis/pull/7868/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754R483))
  * In `event-control/index.tsx`, call the onChange prop whenever the onEventConfig state changes ([link](https://github.com/baidu/amis/pull/7868/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754R483))
