### PR TITLE
fix:ajax/dialog相关动作args中存在非预期配置时导致数据映射失败

### DIFF
--- a/packages/amis-core/src/actions/Action.ts
+++ b/packages/amis-core/src/actions/Action.ts
@@ -311,7 +311,11 @@ export const runAction = async (
       : afterMappingData;
 
   // 默认为当前数据域
-  const data = actionData !== undefined ? actionData : mergeData;
+  const data =
+    actionData !== undefined &&
+    !['ajax', 'download', 'dialog', 'drawer'].includes(action.actionType) // 避免非法配置影响对actionData的判断，导致动作配置中的数据映射失败
+      ? actionData
+      : mergeData;
 
   console.group?.(`run action ${action.actionType}`);
   console.debug(`[${action.actionType}] action args, data`, args, data);

--- a/packages/amis/__tests__/event-action/ajax.test.tsx
+++ b/packages/amis/__tests__/event-action/ajax.test.tsx
@@ -283,6 +283,22 @@ test('EventAction:ajax data1', async () => {
                         }
                       }
                     }
+                  },
+                  {
+                    actionType: 'ajax',
+                    args: {
+                      api: {
+                        url: '/api/xxx?name=${event.data.name}',
+                        method: 'post',
+                        data: {
+                          myname1: '${name}',
+                          myname2: '\\${name}',
+                          myname3: '${text}',
+                          myname4: '\\${text}'
+                        }
+                      },
+                      other: '${name}'
+                    }
                   }
                 ]
               }
@@ -308,7 +324,7 @@ test('EventAction:ajax data1', async () => {
   fireEvent.click(getByText(/发送请求/));
 
   await waitFor(() => {
-    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher).toHaveBeenCalledTimes(3);
     expect(fetcher.mock.calls[0][0].url).toEqual('/api/xxx?name=lll');
     expect(fetcher.mock.calls[0][0].data).toMatchObject({
       myname1: 'lll',
@@ -322,6 +338,14 @@ test('EventAction:ajax data1', async () => {
       param2: 'amis',
       param3: 'amis',
       param4: 'amis'
+    });
+    // 测试干扰配置
+    expect(fetcher.mock.calls[0][0].url).toEqual('/api/xxx?name=lll');
+    expect(fetcher.mock.calls[0][0].data).toMatchObject({
+      myname1: 'lll',
+      myname2: '${name}',
+      myname3: '${lll}',
+      myname4: '${text}'
     });
   });
 });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a180bfb</samp>

This pull request improves the testing and handling of the `ajax` action in `amis-core`. It adds a new test case for variable interpolation and escaping, and prevents invalid data sources for the action.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a180bfb</samp>

> _To avoid some invalid configs_
> _We check the action type in `ajax`_
> _If it's not a data source_
> _We skip the data course_
> _And use variables with escaping tricks_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a180bfb</samp>

* Add a condition to check the action type before using the action data as the data source ([link](https://github.com/baidu/amis/pull/7872/files?diff=unified&w=0#diff-76194a8e7381ab13d0958f281dedc42c1e9aa25aef256cc80f6eb98c041816f3L314-R318)). This prevents invalid configurations that may affect the data mapping for the action, such as using undefined variables.
