### PR TITLE
fix: 【配置面板】grid组件布局方式&button角标配置样式

### DIFF
--- a/packages/amis-editor/src/plugin/Grid.tsx
+++ b/packages/amis-editor/src/plugin/Grid.tsx
@@ -313,6 +313,7 @@ export class GridPlugin extends BasePlugin {
                     label: '水平对齐',
                     tiled: true,
                     pipeIn: defaultValue('left'),
+                    inputClassName: 'flex-nowrap',
                     options: [
                       {
                         value: 'left',
@@ -339,6 +340,7 @@ export class GridPlugin extends BasePlugin {
                     label: '垂直对齐',
                     tiled: true,
                     pipeIn: defaultValue('top'),
+                    inputClassName: 'flex-nowrap',
                     options: [
                       {
                         value: 'top',
@@ -522,6 +524,7 @@ export class GridPlugin extends BasePlugin {
                       label: false,
                       tiled: true,
                       clearable: true,
+                      inputClassName: 'flex-nowrap',
                       options: [
                         {
                           value: 'top',

--- a/packages/amis-editor/src/renderer/BadgeControl.tsx
+++ b/packages/amis-editor/src/renderer/BadgeControl.tsx
@@ -217,6 +217,7 @@ export default class BadgeControl extends React.Component<
             mode: 'row',
             tiled: true,
             className: 'ae-BadgeControl-buttonGroup',
+            inputClassName: 'flex-nowrap',
             options: [
               {label: '点', value: 'dot', icon: 'fa fa-circle'},
               {label: '文字', value: 'text', icon: 'fa fa-font'},
@@ -237,13 +238,14 @@ export default class BadgeControl extends React.Component<
             }
           },
           {
-            label: '角标主题',
+            label: '主题',
             name: 'level',
             type: 'button-group-select',
             size: 'sm',
             mode: 'row',
             tiled: true,
             className: 'ae-BadgeControl-buttonGroup',
+            inputClassName: 'flex-nowrap',
             options: [
               {label: '成功', value: 'success'},
               {label: '警告', value: 'warning'},
@@ -253,13 +255,14 @@ export default class BadgeControl extends React.Component<
             pipeIn: defaultValue('danger')
           },
           {
-            label: '角标位置',
+            label: '位置',
             name: 'position',
             type: 'button-group-select',
             size: 'sm',
             mode: 'row',
             tiled: true,
             className: 'ae-BadgeControl-buttonGroup',
+            inputClassName: 'flex-nowrap',
             options: [
               {
                 label: '',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fc611d2</samp>

This pull request enhances the grid and badge editors in `amis-editor` by adding the `inputClassName` prop to various components and schemas, and adjusting some labels and styles. These changes improve the layout and usability of the editors.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fc611d2</samp>

> _To make the grid inputs look nice_
> _We added a new prop `inputClassName`_
> _And for the badge editor we did the same_
> _And also some labels we did rename_
> _To improve the layout and usability_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fc611d2</samp>

*  Add `inputClassName` prop with value `flex-nowrap` to various schemas and props of `Grid` and `BadgeControl` components to prevent input elements from wrapping in editors ([link](https://github.com/baidu/amis/pull/7874/files?diff=unified&w=0#diff-6b88ed8a424c23a5c4a325a588ad11b08b74b612361999c5cab0558215bd8eeeR316), [link](https://github.com/baidu/amis/pull/7874/files?diff=unified&w=0#diff-6b88ed8a424c23a5c4a325a588ad11b08b74b612361999c5cab0558215bd8eeeR343), [link](https://github.com/baidu/amis/pull/7874/files?diff=unified&w=0#diff-6b88ed8a424c23a5c4a325a588ad11b08b74b612361999c5cab0558215bd8eeeR527), [link](https://github.com/baidu/amis/pull/7874/files?diff=unified&w=0#diff-0b369f629bed4543e48417752907f56d3ffd004a01e21a6143f18641c43be5d0R220), [link](https://github.com/baidu/amis/pull/7874/files?diff=unified&w=0#diff-0b369f629bed4543e48417752907f56d3ffd004a01e21a6143f18641c43be5d0R248), [link](https://github.com/baidu/amis/pull/7874/files?diff=unified&w=0#diff-0b369f629bed4543e48417752907f56d3ffd004a01e21a6143f18641c43be5d0R265))
* Simplify labels of `level` and `position` props of `BadgeControl` component to make them more consistent with other components ([link](https://github.com/baidu/amis/pull/7874/files?diff=unified&w=0#diff-0b369f629bed4543e48417752907f56d3ffd004a01e21a6143f18641c43be5d0L240-R241), [link](https://github.com/baidu/amis/pull/7874/files?diff=unified&w=0#diff-0b369f629bed4543e48417752907f56d3ffd004a01e21a6143f18641c43be5d0L256-R258))
