### PR TITLE
fix:import错误

### DIFF
--- a/packages/amis-editor/src/renderer/NavSourceControl.tsx
+++ b/packages/amis-editor/src/renderer/NavSourceControl.tsx
@@ -18,7 +18,7 @@ import {getSchemaTpl} from 'amis-editor';
 
 import {autobind} from 'amis-editor-core';
 import type {FormControlProps} from 'amis-core';
-import {SchemaApi} from 'amis';
+import type {SchemaApi} from 'amis';
 
 export type SourceType = 'custom' | 'api' | '';
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1b101d6</samp>

Refactored `NavSourceControl.tsx` to use type-only import for `SchemaApi`. This improves code quality and performance by avoiding runtime code and enhancing type checking.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1b101d6</samp>

> _`SchemaApi` import_
> _Only for type checking now_
> _Winter code pruning_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1b101d6</samp>

*  Refactor codebase to use type-only imports for types and interfaces ([link](https://github.com/baidu/amis/pull/7875/files?diff=unified&w=0#diff-1057424f764f4271aefe8c270b89628708d62eb1839348271752b8642114e102L21-R21),                             F29L
