### PR TITLE
fix: nav面板css

### DIFF
--- a/packages/amis-editor-core/scss/control/_nav-control.scss
+++ b/packages/amis-editor-core/scss/control/_nav-control.scss
@@ -1,3 +1,102 @@
+.ae-NavControl {
+  &-header {
+    @include flexBox();
+    width: 100%;
+    height: #{px2rem(24px)};
+    margin-bottom: #{px2rem(12px)};
+  }
+
+  &-content {
+    @include flexBox(column, flex-start);
+    margin: 0;
+    padding: 0;
+
+    .ae-OptionControlItem {
+      display: block;
+      width: 100%;
+      border: 1px dashed #999;
+      padding: 15px;
+      margin-bottom: 10px;
+      position: relative;
+
+      .ae-closeBtn {
+        position: absolute;
+        top: 0;
+        right: 0;
+        width: 20px;
+        height: 20px;
+        font-size: 18px;
+        text-align: center;
+        line-height: 20px;
+        cursor: pointer;
+      }
+
+      .ae-navControlLinks {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        height: 40px;
+
+        input {
+          width: 120px;
+        }
+      }
+    }
+  }
+
+  &-placeholder {
+    display: none;
+    color: #999;
+    line-height: #{px2rem(24px)};
+    text-align: center;
+    vertical-align: middle;
+    width: 100%;
+    padding: #{px2rem(10px)};
+  }
+
+  &-footer {
+    margin-top: 10px;
+  }
+
+  &-footer > * {
+    width: calc(50% - #{px2rem(6px)});
+
+    &:first-child {
+      margin-right: px2rem(12px);
+    }
+  }
+}
+
+.nav-mode-gif {
+  width: 160px;
+  height: 120px;
+  background: url('../static/nav-mode.gif');
+  background-repeat: no-repeat;
+  background-size: 100%;
+  margin: 10px auto 0;
+}
+
+.ae-BadgeControl {
+  .cxd-Form-groupColumn:nth-child(1) {
+    padding-right: 4px;
+  }
+  .cxd-Form-groupColumn:nth-child(2) {
+    padding-left: 4px;
+  }
+  .cxd-TextControl.is-focused > .cxd-TextControl-input {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    padding-left: 4px;
+  }
+  .cxd-TextControl-addOn:first-child {
+    border-left-width: 0.0625rem;
+  }
+  .cxd-TextControl-input {
+    padding: 4px;
+  }
+}
+
+// 自定义数据样式
 .ae-NavControl-header {
   display: flex;
   flex-flow: row nowrap;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3dc8f9d</samp>

Added a new SCSS file for the NavControl component, which is a navigation bar for the AMIS editor. The file defines the styles for the component and its subcomponents, such as the OptionControlItem and the BadgeControl. The file also includes a nav-mode-gif to demonstrate the component's functionality.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3dc8f9d</samp>

> _`NavControl` styles_
> _A new SCSS file added_
> _Winter of custom_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3dc8f9d</samp>

*  Add a new NavControl component and its subcomponents to the AMIS editor ([link](https://github.com/baidu/amis/pull/7878/files?diff=unified&w=0#diff-8092fd34cf7c7eef8f0e4c90fe2c32e29fcc9843df6aa0070160ffbcfcef7ae6R1-R99),                             F
