### PR TITLE
Revert "fix: InputText组件autoComplete标签显示错误问题 (#7869)"

### DIFF
--- a/packages/amis-core/src/store/formItem.ts
+++ b/packages/amis-core/src/store/formItem.ts
@@ -701,7 +701,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
       options = normalizeOptions(options as any, undefined, self.valueField);
 
       if (config?.extendsOptions && self.selectedOptions.length > 0) {
-        self.filteredOptions.forEach((item: any) => {
+        self.selectedOptions.forEach((item: any) => {
           const exited = findTree(
             options as any,
             optionValueCompare(item, self.valueField || 'value'),


### PR DESCRIPTION
This reverts commit d9b750516a824815bc64918078772a823dc815ed.

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b51d1c2</samp>

Fix a bug in `FormItemStore` that caused select options to be extended incorrectly. Use `selectedOptions` instead of `filteredOptions` in `packages/amis-core/src/store/formItem.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b51d1c2</samp>

> _`filteredOptions`_
> _wrongly used for select field_
> _bug fixed in autumn_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b51d1c2</samp>

* Fix a bug in `FormItemStore` that caused wrong options to be displayed for select fields ([link](https://github.com/baidu/amis/pull/7883/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L704-R704))
