### PR TITLE
Fix: 修复配置面板样式问题 & 下掉page组件“组件静态数据”配置项

### DIFF
--- a/packages/amis-editor-core/scss/control/_switch-more-control.scss
+++ b/packages/amis-editor-core/scss/control/_switch-more-control.scss
@@ -9,6 +9,7 @@
     div {
       @include flexBox(row, flex-end);
       background-color: #fff !important;
+      flex: 1;
       hr {
         display: inline-block;
         border: 0;

--- a/packages/amis-editor-core/scss/control/_textarea-formula-control.scss
+++ b/packages/amis-editor-core/scss/control/_textarea-formula-control.scss
@@ -56,7 +56,6 @@
       font-size: 12px;
       color: var(--text--muted-color);
       pointer-events: none;
-      padding: 10px;
     }
 
     &-footer {

--- a/packages/amis-editor/src/plugin/Each.tsx
+++ b/packages/amis-editor/src/plugin/Each.tsx
@@ -58,7 +58,7 @@ export class EachPlugin extends BasePlugin {
         children: (
           <Button
             size="sm"
-            level="danger"
+            level="primary"
             className="m-b"
             block
             onClick={this.editDetail.bind(this, context.id)}

--- a/packages/amis-editor/src/plugin/Form/InputSubForm.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputSubForm.tsx
@@ -63,7 +63,7 @@ export class SubFormControlPlugin extends BasePlugin {
           return (
             <Button
               size="sm"
-              level="danger"
+              level="primary"
               className="m-b"
               block
               onClick={this.editDetail.bind(this, context.id)}

--- a/packages/amis-editor/src/plugin/List.tsx
+++ b/packages/amis-editor/src/plugin/List.tsx
@@ -81,7 +81,7 @@ export class ListPlugin extends BasePlugin {
                     block
                     onClick={this.editDetail.bind(this, context.id)}
                   >
-                    配置成员详情
+                    配置成员渲染器
                   </Button>
                 )
               },
@@ -290,7 +290,7 @@ export class ListPlugin extends BasePlugin {
     node &&
       value &&
       this.manager.openSubEditor({
-        title: '配置成员详情',
+        title: '配置成员渲染器',
         value: {
           ...value.listItem
         },
@@ -338,7 +338,7 @@ export class ListPlugin extends BasePlugin {
       (info.renderer.name === 'crud' && schema.mode === 'list')
     ) {
       menus.push('|', {
-        label: '配置成员详情',
+        label: '配置成员渲染器',
         onSelect: this.editDetail.bind(this, id)
       });
     }

--- a/packages/amis-editor/src/plugin/Page.tsx
+++ b/packages/amis-editor/src/plugin/Page.tsx
@@ -228,12 +228,13 @@ export class PagePlugin extends BasePlugin {
               {
                 title: '数据',
                 body: [
-                  getSchemaTpl('combo-container', {
-                    type: 'input-kv',
-                    mode: 'normal',
-                    name: 'data',
-                    label: '组件静态数据'
-                  }),
+                  // page组件下掉组件静态数据配置项，可通过页面变量来定义页面中的变量
+                  // getSchemaTpl('combo-container', {
+                  //   type: 'input-kv',
+                  //   mode: 'normal',
+                  //   name: 'data',
+                  //   label: '组件静态数据'
+                  // }),
                   getSchemaTpl('apiControl', {
                     name: 'initApi',
                     mode: 'row',


### PR DESCRIPTION
### What

- 页面设计器中 标题 展示样式异常
- page组件下掉“组件静态数据”配置项
- 统一组件配置面板成员渲染器名称及按钮颜色

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 53535e2</samp>

> _`Button` colors change_
> _Editor theme more consistent_
> _Autumn of red leaves_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 53535e2</samp>

*  Change the color of the edit buttons for each item and subform from red to blue to match the primary theme ([link](https://github.com/baidu/amis/pull/7886/files?diff=unified&w=0#diff-3a0279a7838f7675af297c48b02cc8e56f6db60530dc4293b6b0f1d09fb47185L61-R61), [link](https://github.com/baidu/amis/pull/7886/files?diff=unified&w=0#diff-dfad0eccb82ac974f318c1027bef76fd9ea72e1553fa63dc67cd30040247081eL66-R66))
*  Change the text and title of the edit buttons and menus for each item from "配置成员详情" to "配置成员渲器", which is more accurate and clear ([link](https://github.com/baidu/amis/pull/7886/files?diff=unified&w=0#diff-e9a6fb7232d913f01614a4f17f1c96594550c1f0dd3d41710d8a05a3b027ddf6L84-R84), [link](https://github.com/baidu/amis/pull/7886/files?diff=unified&w=0#diff-e9a6fb7232d913f01614a4f17f1c96594550c1f0dd3d41710d8a05a3b027ddf6L293-R293), [link](https://github.com/baidu/amis/pull/7886/files?diff=unified&w=0#diff-e9a6fb7232d913f01614a4f17f1c96594550c1f0dd3d41710d8a05a3b027ddf6L341-R341))
*  Add a flex property to the switch-more-control class to fill the available space in the container (`_switch-more-control.scss`, [link](https://github.com/baidu/amis/pull/7886/files?diff=unified&w=0#diff-6f46faa29a07ca2327bafa4c5f4099503330884f893ee7b072f41b6d15cd4a34R12))
*  Remove the padding property from the textarea-formula-control class, which is redundant (`_textarea-formula-control.scss`, [link](https://github.com/baidu/amis/pull/7886/files?diff=unified&w=0#diff-a866428d4b4889f641f7fa60f60ba4526c8b563159953b981a8a6306c72254c5L59))
*  Comment out the schema template for the data property of the page component, which is replaced by the page variables (`Page.tsx`, [link](https://github.com/baidu/amis/pull/7886/files?diff=unified&w=0#diff-4e3988acdee43b9a8f0c6fa2a99f1a94dc43fae57be0bffca0890574a1af5552L231-R237))
