### PR TITLE
feat: Picker组件已选项支持限制最大展示数量

### DIFF
--- a/docs/zh-CN/components/form/picker.md
+++ b/docs/zh-CN/components/form/picker.md
@@ -684,12 +684,520 @@ order: 35
 }
 ```
 
+## 限制标签最大展示数量
+
+设置`overflowConfig`后可以限制标签的最大展示数量，该属性仅在多选模式开启后生效，包含以下几个配置项：
+- `maxTagCount`：最大展示数量，是范围为0 - 选项总数量的整数，超出数量的部分会收纳到 Popover 中。
+- `displayPosition`：收纳标签生效的位置，类型为字符串数组，未开启内嵌模式默认为**选择器**, 开启后默认为**选择器**和**CRUD 顶部**，可选值为`'select'`(选择器)、`'crud'`(增删改查)。
+- `overflowTagPopover`配置收纳标签 Popover 相关[属性](../tooltip#属性表)。
+- `overflowTagPopoverInCRUD`可以配置**CRUD 顶部**收纳标签的 Popover相关[属性](../tooltip#属性表)。
+
+> `3.4.0` 及以上版本
+
+```schema: scope="body"
+{
+  "type": "form",
+  "api": "/api/mock2/form/saveForm",
+  "debug": true,
+  "body": [
+    {
+      "type": "picker",
+      "overflowConfig": {
+        "maxTagCount": 3,
+      },
+      "name": "maxTagCount1",
+      "joinValues": true,
+      "valueField": "id",
+      "labelField": "engine",
+      "label": "多选",
+      "source": "/api/mock2/sample",
+      "size": "lg",
+      "value": "1,2,3,4,5,6,7",
+      "multiple": true,
+      "pickerSchema": {
+        "mode": "table",
+        "name": "thelist",
+        "quickSaveApi": "/api/mock2/sample/bulkUpdate",
+        "quickSaveItemApi": "/api/mock2/sample/$id",
+        "draggable": true,
+        "headerToolbar": {
+          "wrapWithPanel": false,
+          "type": "form",
+          "className": "text-right",
+          "target": "thelist",
+          "mode": "inline",
+          "body": [
+            {
+              "type": "input-text",
+              "name": "keywords",
+              "addOn": {
+                "type": "submit",
+                "label": "搜索",
+                "level": "primary",
+                "icon": "fa fa-search pull-left"
+              }
+            }
+          ]
+        },
+        "footerToolbar": [
+          "statistics",
+          {
+            "type": "pagination",
+            "showPageInput": true,
+            "layout": "perPage,pager,go"
+          }
+        ],
+        "columns": [
+          {
+            "name": "engine",
+            "label": "Rendering engine",
+            "sortable": true,
+            "searchable": true,
+            "type": "text",
+            "toggled": true
+          },
+          {
+            "name": "browser",
+            "label": "Browser",
+            "sortable": true,
+            "type": "text",
+            "toggled": true
+          },
+          {
+            "name": "platform",
+            "label": "Platform(s)",
+            "sortable": true,
+            "type": "text",
+            "toggled": true
+          },
+          {
+            "name": "version",
+            "label": "Engine version",
+            "quickEdit": true,
+            "type": "text",
+            "toggled": true
+          },
+          {
+            "name": "grade",
+            "label": "CSS grade",
+            "quickEdit": {
+              "mode": "inline",
+              "type": "select",
+              "options": [
+                "A",
+                "B",
+                "C",
+                "D",
+                "X"
+              ],
+              "saveImmediately": true
+            },
+            "type": "text",
+            "toggled": true
+          },
+          {
+            "type": "operation",
+            "label": "操作",
+            "width": 100,
+            "buttons": [
+              {
+                "type": "button",
+                "icon": "fa fa-eye",
+                "actionType": "dialog",
+                "dialog": {
+                  "title": "查看",
+                  "body": {
+                    "type": "form",
+                    "body": [
+                      {
+                        "type": "static",
+                        "name": "engine",
+                        "label": "Engine"
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "static",
+                        "name": "browser",
+                        "label": "Browser"
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "static",
+                        "name": "platform",
+                        "label": "Platform(s)"
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "static",
+                        "name": "version",
+                        "label": "Engine version"
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "static",
+                        "name": "grade",
+                        "label": "CSS grade"
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "html",
+                        "html": "<p>添加其他 <span>Html 片段</span> 需要支持变量替换（todo）.</p>"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "type": "button",
+                "icon": "fa fa-pencil",
+                "actionType": "dialog",
+                "dialog": {
+                  "position": "left",
+                  "size": "lg",
+                  "title": "编辑",
+                  "body": {
+                    "type": "form",
+                    "name": "sample-edit-form",
+                    "api": "/api/mock2/sample/$id",
+                    "body": [
+                      {
+                        "type": "input-text",
+                        "name": "engine",
+                        "label": "Engine",
+                        "required": true
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "input-text",
+                        "name": "browser",
+                        "label": "Browser",
+                        "required": true
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "input-text",
+                        "name": "platform",
+                        "label": "Platform(s)",
+                        "required": true
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "input-text",
+                        "name": "version",
+                        "label": "Engine version"
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "select",
+                        "name": "grade",
+                        "label": "CSS grade",
+                        "options": [
+                          "A",
+                          "B",
+                          "C",
+                          "D",
+                          "X"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "type": "button",
+                "icon": "fa fa-times text-danger",
+                "actionType": "ajax",
+                "confirmText": "您确认要删除?",
+                "api": "delete:/api/mock2/sample/$id"
+              }
+            ],
+            "toggled": true
+          }
+        ]
+      }
+    }
+
+  ]
+}
+```
+
+内嵌模式下
+
+```schema: scope="body"
+{
+  "type": "form",
+  "api": "/api/mock2/form/saveForm",
+  "debug": true,
+  "body": [
+    {
+      "type": "picker",
+      "overflowConfig": {
+        "maxTagCount": 3,
+        "overflowTagPopoverInCRUD": {
+          "placement": "top"
+        }
+      },
+      "embed": true,
+      "name": "maxTagCount2",
+      "joinValues": true,
+      "valueField": "id",
+      "labelField": "engine",
+      "label": "多选",
+      "source": "/api/mock2/sample",
+      "size": "lg",
+      "value": "1,2,3,4,5,6,7",
+      "multiple": true,
+      "pickerSchema": {
+        "mode": "table",
+        "name": "thelist",
+        "quickSaveApi": "/api/mock2/sample/bulkUpdate",
+        "quickSaveItemApi": "/api/mock2/sample/$id",
+        "draggable": true,
+        "headerToolbar": {
+          "wrapWithPanel": false,
+          "type": "form",
+          "className": "text-right",
+          "target": "thelist",
+          "mode": "inline",
+          "body": [
+            {
+              "type": "input-text",
+              "name": "keywords",
+              "addOn": {
+                "type": "submit",
+                "label": "搜索",
+                "level": "primary",
+                "icon": "fa fa-search pull-left"
+              }
+            }
+          ]
+        },
+        "footerToolbar": [
+          "statistics",
+          {
+            "type": "pagination",
+            "showPageInput": true,
+            "layout": "perPage,pager,go"
+          }
+        ],
+        "columns": [
+          {
+            "name": "engine",
+            "label": "Rendering engine",
+            "sortable": true,
+            "searchable": true,
+            "type": "text",
+            "toggled": true
+          },
+          {
+            "name": "browser",
+            "label": "Browser",
+            "sortable": true,
+            "type": "text",
+            "toggled": true
+          },
+          {
+            "name": "platform",
+            "label": "Platform(s)",
+            "sortable": true,
+            "type": "text",
+            "toggled": true
+          },
+          {
+            "name": "version",
+            "label": "Engine version",
+            "quickEdit": true,
+            "type": "text",
+            "toggled": true
+          },
+          {
+            "name": "grade",
+            "label": "CSS grade",
+            "quickEdit": {
+              "mode": "inline",
+              "type": "select",
+              "options": [
+                "A",
+                "B",
+                "C",
+                "D",
+                "X"
+              ],
+              "saveImmediately": true
+            },
+            "type": "text",
+            "toggled": true
+          },
+          {
+            "type": "operation",
+            "label": "操作",
+            "width": 100,
+            "buttons": [
+              {
+                "type": "button",
+                "icon": "fa fa-eye",
+                "actionType": "dialog",
+                "dialog": {
+                  "title": "查看",
+                  "body": {
+                    "type": "form",
+                    "body": [
+                      {
+                        "type": "static",
+                        "name": "engine",
+                        "label": "Engine"
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "static",
+                        "name": "browser",
+                        "label": "Browser"
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "static",
+                        "name": "platform",
+                        "label": "Platform(s)"
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "static",
+                        "name": "version",
+                        "label": "Engine version"
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "static",
+                        "name": "grade",
+                        "label": "CSS grade"
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "html",
+                        "html": "<p>添加其他 <span>Html 片段</span> 需要支持变量替换（todo）.</p>"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "type": "button",
+                "icon": "fa fa-pencil",
+                "actionType": "dialog",
+                "dialog": {
+                  "position": "left",
+                  "size": "lg",
+                  "title": "编辑",
+                  "body": {
+                    "type": "form",
+                    "name": "sample-edit-form",
+                    "api": "/api/mock2/sample/$id",
+                    "body": [
+                      {
+                        "type": "input-text",
+                        "name": "engine",
+                        "label": "Engine",
+                        "required": true
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "input-text",
+                        "name": "browser",
+                        "label": "Browser",
+                        "required": true
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "input-text",
+                        "name": "platform",
+                        "label": "Platform(s)",
+                        "required": true
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "input-text",
+                        "name": "version",
+                        "label": "Engine version"
+                      },
+                      {
+                        "type": "divider"
+                      },
+                      {
+                        "type": "select",
+                        "name": "grade",
+                        "label": "CSS grade",
+                        "options": [
+                          "A",
+                          "B",
+                          "C",
+                          "D",
+                          "X"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "type": "button",
+                "icon": "fa fa-times text-danger",
+                "actionType": "ajax",
+                "confirmText": "您确认要删除?",
+                "api": "delete:/api/mock2/sample/$id"
+              }
+            ],
+            "toggled": true
+          }
+        ]
+      }
+    }
+
+  ]
+}
+```
+
+
+
 ## 属性表
 
 当做选择器表单项使用时，除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置
 
-| 属性名       | 类型                                                                                         | 默认值                                          | 说明                                                                                        |
-| ------------ | -------------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| 属性名       | 类型                                                                                         | 默认值                                          | 说明                                                                                        | 版本 |
+| ------------ | -------------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------- | --- |
 | options      | `Array<object>`或`Array<string>`                                                             |                                                 | [选项组](./options#%E9%9D%99%E6%80%81%E9%80%89%E9%A1%B9%E7%BB%84-options)                   |
 | source       | `string`或 [API](../../../docs/types/api) 或 [数据映射](../../../docs/concepts/data-mapping) |                                                 | [动态选项组](./options#%E5%8A%A8%E6%80%81%E9%80%89%E9%A1%B9%E7%BB%84-source)                |
 | multiple     | `boolean`                                                                                    |                                                 | 是否为多选。                                                                                |
@@ -703,6 +1211,17 @@ order: 35
 | modalMode    | `string`                                                                                     | `"dialog"`                                      | 设置 `dialog` 或者 `drawer`，用来配置弹出方式。                                             |
 | pickerSchema | `string`                                                                                     | `{mode: 'list', listItem: {title: '${label}'}}` | 即用 List 类型的渲染，来展示列表信息。更多配置参考 [CRUD](../crud)                          |
 | embed        | `boolean`                                                                                    | `false`                                         | 是否使用内嵌模式                                                                            |
+| overflowConfig        | `OverflowConfig`                                  |                         参考[OverflowConfig](./#overflowconfig)                                                           | 开启最大标签展示数量的相关配置                  | `3.4.0` |
+
+### OverflowConfig
+
+| 属性名       | 类型                                                                                         | 默认值                                          | 说明                                                                                        |
+| ------------ | -------------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| maxTagCount        | `number`                                  |                                `-1`                                                    | 标签的最大展示数量，超出数量后以收纳浮层的方式展示，仅在多选模式开启后生效，默认为`-1` 不开启                  | `3.4.0` |
+| displayPosition        | `('select' \| 'crud')[]`                                  |           `['select', 'crud']`                                                                         | 收纳标签生效的位置，未开启内嵌模式默认为选择器, 开启后默认为选择器和CRUD 顶部，可选值为`'select'`(选择器)、`'crud'`(增删改查)                  | `3.4.0` |
+| overflowTagPopover | `TooltipObject`                           | `{"placement": "top", "trigger": "hover", "showArrow": false, "offset": [0, -10]}` | 选择器内收纳标签的Popover配置，详细配置参考[Tooltip](../tooltip#属性表)                                | `3.4.0` |
+| overflowTagPopoverInCRUD | `TooltipObject`                           | `{"placement": "bottom", "trigger": "hover", "showArrow": false, "offset": [0, 10]}` | CRUD顶部内收纳标签的Popover配置，详细配置参考[Tooltip](../tooltip#属性表)                                | `3.4.0` |
+
 
 ## 事件表
 

--- a/packages/amis-core/src/utils/math.ts
+++ b/packages/amis-core/src/utils/math.ts
@@ -40,3 +40,40 @@ export function numberFormatter(num: number | string, precision: number = 0) {
   }
   return ZERO.toFixed(precision);
 }
+
+/**
+ * 判断一个数字是否为整数，且在给定范围内
+ *
+ * @param num 要判断的数字
+ * @param options 范围选项，包括 start、end、left、right
+ * @param options.start 范围起始值
+ * @param options.end 范围结束值
+ * @param options.left 范围的左边界类型，默认为 'inclusive'，可选值为 'inclusive'(闭区间) 或 'exclusive'(开区间)
+ * @param options.right 范围的右边界类型，默认为 'inclusive'，可选值为 'inclusive'(闭区间) 或 'exclusive'(开区间)
+ * @returns 如果数字在给定范围内则返回 true，否则返回 false
+ */
+export function isIntegerInRange(
+  num: number,
+  options: {
+    start: number;
+    end: number;
+    left: 'inclusive' | 'exclusive';
+    right: 'inclusive' | 'exclusive';
+  }
+) {
+  const {start, end, left = 'inclusive', right = 'inclusive'} = options || {};
+
+  if (num == null || typeof num !== 'number' || !Number.isSafeInteger(num)) {
+    return false;
+  }
+
+  if (left === 'exclusive' && right === 'exclusive') {
+    return num > start && num < end;
+  } else if (left === 'inclusive' && right === 'exclusive') {
+    return num >= start && num < end;
+  } else if (left === 'exclusive' && right === 'inclusive') {
+    return num > start && num <= end;
+  } else {
+    return num >= start && num <= end;
+  }
+}

--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -3620,6 +3620,8 @@
   --Pick-base-value-icon-color: var(--colors-other-5);
   --Picker-iconColor: var(--Pick-base-icon-color);
   --Picker-onHover-iconColor: var(--icon-onHover-color);
+  --Picker-tag-height: #{px2rem(24px)};
+  --Picker-tag-marginBottom: var(--select-multiple-marginBottom);
   --Pick-status-hover-top-border-color: var(--colors-other-5);
   --Pick-status-hover-top-border-width: var(--borders-width-2);
   --Pick-status-hover-top-border-style: var(--borders-style-2);

--- a/packages/amis-ui/scss/_mixins.scss
+++ b/packages/amis-ui/scss/_mixins.scss
@@ -616,3 +616,63 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+@mixin tag-item($component-prefix) {
+  .#{$ns}#{$component-prefix}-value {
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+    vertical-align: middle;
+    line-height: calc(
+      var(--Form-input-lineHeight) * var(--Form-input-fontSize) - #{px2rem(2px)}
+    );
+    display: inline-block;
+    font-size: var(--Pick-base-value-fontSize);
+    color: var(--Pick-base-value-color);
+    font-weight: var(--Pick-base-value-fontWeight);
+    background: var(--Pick-base-value-bgColor);
+    border-width: var(--Pick-base-value-top-border-width)
+      var(--Pick-base-value-right-border-width)
+      var(--Pick-base-value-bottom-border-width)
+      var(--Pick-base-value-left-border-width);
+    border-style: var(--Pick-base-value-top-border-style)
+      var(--Pick-base-value-right-border-style)
+      var(--Pick-base-value-bottom-border-style)
+      var(--Pick-base-value-left-border-style);
+    border-color: var(--Pick-base-value-top-border-color)
+      var(--Pick-base-value-right-border-color)
+      var(--Pick-base-value-bottom-border-color)
+      var(--Pick-base-value-left-border-color);
+    border-radius: var(--Pick-base-top-left-border-radius)
+      var(--Pick-base-top-right-border-radius)
+      var(--Pick-base-bottom-right-border-radius)
+      var(--Pick-base-bottom-left-border-radius);
+    margin-right: var(--gap-xs);
+    margin-bottom: var(--gap-xs);
+    margin-top: var(--gap-xs);
+
+    &:hover {
+      background: var(--Form-selectValue-onHover-bg);
+    }
+
+    &.is-disabled {
+      pointer-events: none;
+      opacity: var(--Button-onDisabled-opacity);
+    }
+  }
+
+  .#{$ns}#{$component-prefix}-valueIcon {
+    color: var(--Pick-base-value-icon-color);
+    cursor: pointer;
+    border-right: px2rem(1px) solid var(--Form-selectValue-borderColor);
+    padding: 1px 5px;
+
+    &:hover {
+      background: var(--Pick-base-value-hover-icon-color);
+    }
+  }
+
+  .#{$ns}#{$component-prefix}-valueLabel {
+    padding: 0 var(--gap-xs);
+  }
+}

--- a/packages/amis-ui/scss/components/_crud.scss
+++ b/packages/amis-ui/scss/components/_crud.scss
@@ -9,6 +9,25 @@
 
   &-selection {
     margin-bottom: var(--gap-base);
+
+    &-overflow {
+      &-wrapper {
+        display: flex;
+        flex-flow: column nowrap;
+        justify-content: flex-start;
+        align-items: flex-start;
+        overflow-x: hidden;
+        overflow-y: auto;
+        height: calc(
+          (var(--Picker-tag-height) + var(--Picker-tag-marginBottom) * 4) * 3
+        );
+        max-height: calc(
+          (var(--Picker-tag-height) + var(--Picker-tag-marginBottom)) * 5
+        );
+
+        @include tag-item(Crud);
+      }
+    }
   }
 
   &-selectionLabel {
@@ -17,61 +36,8 @@
     margin-top: var(--gap-xs);
   }
 
-  &-value {
-    cursor: pointer;
-    vertical-align: middle;
-    user-select: none;
-    line-height: calc(
-      var(--Form-input-lineHeight) * var(--Form-input-fontSize) - #{px2rem(2px)}
-    );
-    display: inline-block;
-    font-size: var(--Pick-base-value-fontSize);
-    color: var(--Pick-base-value-color);
-    font-weight: var(--Pick-base-value-fontWeight);
-    background: var(--Pick-base-value-bgColor);
-    border-width: var(--Pick-base-value-top-border-width)
-      var(--Pick-base-value-right-border-width)
-      var(--Pick-base-value-bottom-border-width)
-      var(--Pick-base-value-left-border-width);
-    border-style: var(--Pick-base-value-top-border-style)
-      var(--Pick-base-value-right-border-style)
-      var(--Pick-base-value-bottom-border-style)
-      var(--Pick-base-value-left-border-style);
-    border-color: var(--Pick-base-value-top-border-color)
-      var(--Pick-base-value-right-border-color)
-      var(--Pick-base-value-bottom-border-color)
-      var(--Pick-base-value-left-border-color);
-    border-radius: var(--Pick-base-top-left-border-radius)
-      var(--Pick-base-top-right-border-radius)
-      var(--Pick-base-bottom-right-border-radius)
-      var(--Pick-base-bottom-left-border-radius);
-    margin-right: var(--gap-xs);
-    margin-top: var(--gap-xs);
-
-    &:hover {
-      background: var(--Form-selectValue-onHover-bg);
-    }
-
-    &.is-disabled {
-      pointer-events: none;
-      opacity: var(--Button-onDisabled-opacity);
-    }
-  }
-
-  &-valueIcon {
-    color: var(--Pick-base-value-icon-color);
-    cursor: pointer;
-    border-right: px2rem(1px) solid var(--Form-selectValue-borderColor);
-    padding: 1px 5px;
-
-    &:hover {
-      background: var(--Form-selectValue-onHover-bg);
-    }
-  }
-
-  &-valueLabel {
-    padding: 0 var(--gap-xs);
-  }
+  /* tag 样式 */
+  @include tag-item(Crud);
 
   &-selectionClear {
     display: inline-block;

--- a/packages/amis-ui/scss/components/form/_picker.scss
+++ b/packages/amis-ui/scss/components/form/_picker.scss
@@ -115,53 +115,8 @@
     line-height: 1;
   }
 
-  .#{$ns}Picker-value {
-    cursor: pointer;
-    user-select: none;
-    white-space: nowrap;
-    vertical-align: middle;
-    line-height: calc(
-      var(--Form-input-lineHeight) * var(--Form-input-fontSize) - #{px2rem(2px)}
-    );
-    display: inline-block;
-    font-size: var(--Pick-base-value-fontSize);
-    color: var(--Pick-base-value-color);
-    font-weight: var(--Pick-base-value-fontWeight);
-    background: var(--Pick-base-value-bgColor);
-    border-width: var(--Pick-base-value-top-border-width)
-      var(--Pick-base-value-right-border-width)
-      var(--Pick-base-value-bottom-border-width)
-      var(--Pick-base-value-left-border-width);
-    border-style: var(--Pick-base-value-top-border-style)
-      var(--Pick-base-value-right-border-style)
-      var(--Pick-base-value-bottom-border-style)
-      var(--Pick-base-value-left-border-style);
-    border-color: var(--Pick-base-value-top-border-color)
-      var(--Pick-base-value-right-border-color)
-      var(--Pick-base-value-bottom-border-color)
-      var(--Pick-base-value-left-border-color);
-    border-radius: var(--Pick-base-top-left-border-radius)
-      var(--Pick-base-top-right-border-radius)
-      var(--Pick-base-bottom-right-border-radius)
-      var(--Pick-base-bottom-left-border-radius);
-    margin-right: var(--gap-xs);
-    margin-bottom: var(--gap-xs);
-  }
-
-  .#{$ns}Picker-valueIcon {
-    color: var(--Pick-base-value-icon-color);
-    cursor: pointer;
-    border-right: px2rem(1px) solid var(--Form-selectValue-borderColor);
-    padding: 1px 5px;
-
-    &:hover {
-      background: var(--Pick-base-value-hover-icon-color);
-    }
-  }
-
-  .#{$ns}Picker-valueLabel {
-    padding: 0 var(--gap-xs);
-  }
+  /* tag 样式 */
+  @include tag-item(Picker);
 
   &-btn {
     cursor: pointer;
@@ -196,6 +151,25 @@
     margin-right: var(--gap-xs);
     svg {
       top: 0;
+    }
+  }
+
+  &-overflow {
+    &-wrapper {
+      display: flex;
+      flex-flow: column nowrap;
+      justify-content: flex-start;
+      align-items: flex-start;
+      overflow-x: hidden;
+      overflow-y: auto;
+      height: calc(
+        (var(--Picker-tag-height) + var(--Picker-tag-marginBottom) * 4) * 3
+      );
+      max-height: calc(
+        (var(--Picker-tag-height) + var(--Picker-tag-marginBottom)) * 5
+      );
+
+      @include tag-item(Picker);
     }
   }
 }

--- a/packages/amis/__tests__/renderers/Picker.test.tsx
+++ b/packages/amis/__tests__/renderers/Picker.test.tsx
@@ -12,8 +12,7 @@ import {
   render,
   fireEvent,
   cleanup,
-  waitFor,
-  getByText
+  screen
 } from '@testing-library/react';
 import '../../src';
 import {render as amisRender} from '../../src';
@@ -25,7 +24,7 @@ afterEach(() => {
   clearStoresCache();
 });
 
-test('Renderer:Picker base', async () => {
+test('1. Renderer:Picker base', async () => {
   const {container, rerender, getByText, getByPlaceholderText, baseElement} =
     render(
       amisRender({
@@ -73,7 +72,7 @@ test('Renderer:Picker base', async () => {
   expect(container).toMatchSnapshot();
 });
 
-test('Renderer:Picker with pickerSchema & valueField & labelField & multiple & value & size', async () => {
+test('2. Renderer:Picker with pickerSchema & valueField & labelField & multiple & value & size', async () => {
   const fetcher = jest.fn().mockImplementation(() =>
     Promise.resolve({
       data: {
@@ -168,7 +167,7 @@ test('Renderer:Picker with pickerSchema & valueField & labelField & multiple & v
   });
 });
 
-test('Renderer:Picker with embed', async () => {
+test('3. Renderer:Picker with embed', async () => {
   const fetcher = jest.fn().mockImplementation(() =>
     Promise.resolve({
       data: {
@@ -241,7 +240,7 @@ test('Renderer:Picker with embed', async () => {
   ).toBeInTheDocument();
 });
 
-test('Renderer:Picker with drawer modalMode', async () => {
+test('4. Renderer:Picker with drawer modalMode', async () => {
   const {container, rerender, getByText, getByPlaceholderText, baseElement} =
     render(
       amisRender({
@@ -273,4 +272,73 @@ test('Renderer:Picker with drawer modalMode', async () => {
   expect(
     baseElement.querySelector('.cxd-Drawer .cxd-Crud')!
   ).toBeInTheDocument();
+});
+
+describe('5. Renderer:Picker with overflowConfig', () => {
+  test('5-1. Renderer:Picker select', async () => {
+    const {container, rerender, getByText, getByPlaceholderText, baseElement} =
+      render(
+        amisRender({
+          type: 'picker',
+          name: 'picker',
+          label: 'picker',
+          modalMode: 'dialog',
+          placeholder: 'picker-placeholder',
+          multiple: true,
+          overflowConfig: {
+            maxTagCount: 2
+          },
+          value: 'a,b,c',
+          options: [
+            {label: 'A', value: 'a'},
+            {label: 'B', value: 'b'},
+            {label: 'C', value: 'c'},
+            {label: 'D', value: 'd'}
+          ]
+        })
+      );
+
+    await wait(500);
+
+    const tags = container.querySelector('.cxd-Picker-values');
+
+    expect(tags).toBeInTheDocument();
+    /** tag 元素数量正确 */
+    expect(tags?.childElementCount).toEqual(3);
+    /** 收纳标签文案正确 */
+    expect(tags?.lastElementChild).toHaveTextContent('+ 1 ...');
+  });
+
+  test('5-2. Renderer:Picker embeded', async () => {
+    const {container, rerender, getByText, getByPlaceholderText, baseElement} =
+      render(
+        amisRender({
+          type: 'picker',
+          name: 'picker',
+          label: 'picker',
+          modalMode: 'dialog',
+          placeholder: 'picker-placeholder',
+          embed: true,
+          multiple: true,
+          overflowConfig: {
+            maxTagCount: 2
+          },
+          value: 'a,b,c',
+          options: [
+            {label: 'A', value: 'a'},
+            {label: 'B', value: 'b'},
+            {label: 'C', value: 'c'},
+            {label: 'D', value: 'd'}
+          ]
+        })
+      );
+
+    await wait(500);
+
+    const tags = container.querySelectorAll('.cxd-Crud-selection .cxd-Crud-value');
+    /** tag 元素数量正确 */
+    expect(tags?.length).toEqual(3);
+    /** 收纳标签文案正确 */
+    expect(tags[tags?.length - 1]).toHaveTextContent('+ 1 ...');
+  });
 });

--- a/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
@@ -2721,8 +2721,6 @@ exports[`13. enderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionL
               >
                 <span
                   class="cxd-Crud-valueIcon"
-                  data-position="bottom"
-                  data-tooltip="删除"
                 >
                   ×
                 </span>
@@ -2741,8 +2739,6 @@ exports[`13. enderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionL
               >
                 <span
                   class="cxd-Crud-valueIcon"
-                  data-position="bottom"
-                  data-tooltip="删除"
                 >
                   ×
                 </span>
@@ -2761,8 +2757,6 @@ exports[`13. enderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionL
               >
                 <span
                   class="cxd-Crud-valueIcon"
-                  data-position="bottom"
-                  data-tooltip="删除"
                 >
                   ×
                 </span>
@@ -2781,8 +2775,6 @@ exports[`13. enderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionL
               >
                 <span
                   class="cxd-Crud-valueIcon"
-                  data-position="bottom"
-                  data-tooltip="删除"
                 >
                   ×
                 </span>

--- a/packages/amis/__tests__/renderers/__snapshots__/Picker.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Picker.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Renderer:Picker base 1`] = `
+exports[`1. Renderer:Picker base 1`] = `
 <body
   class="is-modalOpened"
   style="width: calc(100% - 0px);"
@@ -222,7 +222,7 @@ exports[`Renderer:Picker base 1`] = `
 </body>
 `;
 
-exports[`Renderer:Picker base 2`] = `
+exports[`1. Renderer:Picker base 2`] = `
 <div>
   <div
     class="cxd-Form-item cxd-Form-item--normal"
@@ -261,8 +261,6 @@ exports[`Renderer:Picker base 2`] = `
               >
                 <span
                   class="cxd-Picker-valueIcon"
-                  data-position="bottom"
-                  data-tooltip="删除"
                 >
                   ×
                 </span>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7e8c6ce</samp>

This pull request adds a feature to the `Picker` and `CRUD` components that limits the number of tags displayed in the selection and shows a popover with the rest of the tags when the limit is exceeded or hovered over. The feature is configurable through a new prop `overflowConfig`. The pull request also refactors some SCSS and test code to improve readability, reusability, and coverage. The pull request modifies the files `packages/amis-ui/scss/components/_crud.scss`, `packages/amis-ui/scss/components/form/_picker.scss`, `packages/amis/__tests__/renderers/Picker.test.tsx`, `packages/amis/src/renderers/CRUD.tsx`, `packages/amis/src/renderers/Form/Picker.tsx`, `packages/amis-core/src/utils/math.ts`, `packages/amis-ui/scss/_components.scss`, and `packages/amis-ui/scss/_mixins.scss`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7e8c6ce</samp>

> _`Picker` and `CRUD`_
> _Limit tags with overflow_
> _Autumn leaves hidden_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7e8c6ce</samp>

*  Add a new feature of limiting the number of tags displayed in the `Picker` and `CRUD` components and showing the overflow tag popover ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e4301860018921c04669278018d4efd9880f97b910816dee541b1135b0927b1dR43-R79), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L444-R447), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313R75-R99), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313L118-R162))
  * Add a new function `isIntegerInRange` to check the validity of the `maxTagCount` prop ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e4301860018921c04669278018d4efd9880f97b910816dee541b1135b0927b1dR43-R79))
  * Add two new props `maxTagCount` and `overflowTagPopover` to the `CRUD` component ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L444-R447))
  * Add a new prop `overflowConfig` to the `PickerControl` component with four sub-properties ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313R75-R99))
  * Add default values for the `overflowConfig` prop and its sub-properties ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313L118-R162))
* Update the styles for the tags in the `Picker` and `CRUD` components using SCSS variables and mixins ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4R3623-R3624), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-7e5b8022401a374798841bb3e5655feb6751e8a6c42835e0a7f438250e79132aR618-R677), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-d0fb23bd8e2c0a2ad05037a1542a07e8b36014d7b02adba7d6eb35455da35757R12-R30), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-d0fb23bd8e2c0a2ad05037a1542a07e8b36014d7b02adba7d6eb35455da35757L20-R41), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-cc12e6d192056ec6f3cc34421d366e79e00f5329631ab88ab9c697258061a0f5L118-R120), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-cc12e6d192056ec6f3cc34421d366e79e00f5329631ab88ab9c697258061a0f5R156-R174))
  * Add two new CSS variables to define the height and bottom margin of the tags ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4R3623-R3624))
  * Add a new SCSS mixin `tag-item` to define the common styles for the tags ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-7e5b8022401a374798841bb3e5655feb6751e8a6c42835e0a7f438250e79132aR618-R677))
  * Replace the original SCSS blocks for the tags with the `tag-item` mixin in both components ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-d0fb23bd8e2c0a2ad05037a1542a07e8b36014d7b02adba7d6eb35455da35757L20-R41), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-cc12e6d192056ec6f3cc34421d366e79e00f5329631ab88ab9c697258061a0f5L118-R120))
  * Add new SCSS blocks for the overflow wrappers that contain the tags when they exceed the limit in both components ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-d0fb23bd8e2c0a2ad05037a1542a07e8b36014d7b02adba7d6eb35455da35757R12-R30), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-cc12e6d192056ec6f3cc34421d366e79e00f5329631ab88ab9c697258061a0f5R156-R174))
* Update the JSX code in the `renderSelection` and `renderValues` methods of the `CRUD` and `PickerControl` components to implement the overflow feature ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L2224-R2261), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L2233-R2272), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R2279-R2296), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L2245-R2348), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313L401-R453), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313L413-R573), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313R590-R591), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313L515-R642))
  * Add a new method `renderTag` to both components to render a single tag element ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L2224-R2261), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313L413-R573))
  * Add some logic to calculate the total number of selected items and create a new array of tags that may include an overflow tag ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R2279-R2296), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313R590-R591))
  * Add a conditional logic to render a `TooltipWrapper` component around the overflow tag if it exists ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L2245-R2348), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313L515-R642))
  * Add a new method `getOverflowConfig` to the `PickerControl` component to get the merged value of the `overflowConfig` prop ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313L401-R453))
* Update the import statements in the `CRUD.tsx`, `Picker.tsx`, and `Picker.test.tsx` files to use the new modules and functions ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L18-R22), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313R7), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313L23-R31), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-05ea5262eab2426cabbc0253a1257e8bf1f02d786cfbdbbaf585514451324cb1L15-R15))
  * Import the `isIntegerInRange` function from the `amis-core` module ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L18-R22), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313L23-R31))
  * Import the `TooltipWrapper` component and the `TooltipWrapperSchema` type from the `amis-ui` module ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L18-R22), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313L23-R31))
  * Import the `merge` function from the `lodash` module ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313R7))
  * Import the `omit` function from the `lodash` module ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L18-R22))
  * Import the `Option` type from the `amis-core` module ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-e868445e39871f938455103205009e2de1b7077c30bcaedaa1bf691fd0e22313L23-R31))
  * Import the `screen` object from the `@testing-library/react` module ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-05ea5262eab2426cabbc0253a1257e8bf1f02d786cfbdbbaf585514451324cb1L15-R15))
* Update the test cases in the `Picker.test.tsx` file to test the overflow feature and organize the test cases with prefixes ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-05ea5262eab2426cabbc0253a1257e8bf1f02d786cfbdbbaf585514451324cb1L28-R27), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-05ea5262eab2426cabbc0253a1257e8bf1f02d786cfbdbbaf585514451324cb1L76-R75), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-05ea5262eab2426cabbc0253a1257e8bf1f02d786cfbdbbaf585514451324cb1L171-R170), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-05ea5262eab2426cabbc0253a1257e8bf1f02d786cfbdbbaf585514451324cb1L244-R243), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-05ea5262eab2426cabbc0253a1257e8bf1f02d786cfbdbbaf585514451324cb1R276-R344))
  * Add a prefix to each test name to indicate the order of the test cases ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-05ea5262eab2426cabbc0253a1257e8bf1f02d786cfbdbbaf585514451324cb1L28-R27), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-05ea5262eab2426cabbc0253a1257e8bf1f02d786cfbdbbaf585514451324cb1L76-R75), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-05ea5262eab2426cabbc0253a1257e8bf1f02d786cfbdbbaf585514451324cb1L171-R170), [link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-05ea5262eab2426cabbc0253a1257e8bf1f02d786cfbdbbaf585514451324cb1L244-R243))
  * Add a new test suite with two test cases to test the overflow feature in the selector and the CRUD component ([link](https://github.com/baidu/amis/pull/7897/files?diff=unified&w=0#diff-05ea5262eab2426cabbc0253a1257e8bf1f02d786cfbdbbaf585514451324cb1R276-R344))
