### PR TITLE
chore: 导出 Excel 遇到整数的时候不用科学计数法

### DIFF
--- a/examples/components/CRUD/ExportCSVExcel.jsx
+++ b/examples/components/CRUD/ExportCSVExcel.jsx
@@ -20,7 +20,8 @@ export default {
             version: '4/2'
           },
           date: '1591326307',
-          city: '310100'
+          city: '310100',
+          num: '12312334234234523'
         },
         {
           link: 'https://www.microsoft.com/',
@@ -33,7 +34,8 @@ export default {
           },
           notExport: '1',
           grade: 'B',
-          date: '1591322307'
+          date: '1591322307',
+          num: 1231233423232
         },
         {
           link: 'https://www.microsoft.com/',
@@ -206,6 +208,10 @@ export default {
         name: 'city',
         label: 'city',
         type: 'input-city'
+      },
+      {
+        name: 'num',
+        label: 'num'
       }
     ]
   }

--- a/packages/amis/src/renderers/Table/exportExcel.ts
+++ b/packages/amis/src/renderers/Table/exportExcel.ts
@@ -441,6 +441,12 @@ export async function exportExcel(
           sheetRow.getCell(columIndex).value = value;
         }
       }
+
+      // 如果是纯数字，不用科学计数法
+      const cellValue = sheetRow.getCell(columIndex).value;
+      if (Number.isInteger(cellValue)) {
+        sheetRow.getCell(columIndex).numFmt = '0';
+      }
     }
   }
 

--- a/packages/amis/src/renderers/TableView.tsx
+++ b/packages/amis/src/renderers/TableView.tsx
@@ -261,7 +261,7 @@ export default class TableView extends React.Component<TableViewProps, object> {
   }
 
   render() {
-    const {width, trs, classnames: cx, className} = this.props;
+    const {width, trs = [], classnames: cx, className} = this.props;
 
     return (
       <table


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 283e7f5</samp>

This pull request enhances the CSV and Excel export features of the `Table` renderer. It adds a new field to the example data and schema in `ExportCSVExcel.jsx` and fixes the number formatting issue in `exportExcel.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 283e7f5</samp>

> _`exportExcel` changed_
> _Large numbers stay as they are_
> _No more e notation_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 283e7f5</samp>

*  Prevent large numbers from being formatted as scientific notation in Excel export ([link](https://github.com/baidu/amis/pull/7900/files?diff=unified&w=0#diff-8814befa6c6247c465ab39fa28f3db15c2280e238d8254286fa1f29d29500c51R444-R449))
* Add a new field `num` to mock data and table schema in `ExportCSVExcel.jsx` example ([link](https://github.com/baidu/amis/pull/7900/files?diff=unified&w=0#diff-77b473f79a97cfa505ba4f7f306487c5a1d3fda83053e968d30ac472a7f9e936L23-R24), [link](https://github.com/baidu/amis/pull/7900/files?diff=unified&w=0#diff-77b473f79a97cfa505ba4f7f306487c5a1d3fda83053e968d30ac472a7f9e936L36-R38), [link](https://github.com/baidu/amis/pull/7900/files?diff=unified&w=0#diff-77b473f79a97cfa505ba4f7f306487c5a1d3fda83053e968d30ac472a7f9e936R211-R214))
