### PR TITLE
chore: editor开发态国际化

### DIFF
--- a/i18nConfig.ts
+++ b/i18nConfig.ts
@@ -1,0 +1,40 @@
+export default {
+  entry: {
+    dir: './packages/amis-editor-core/src'
+  },
+  file: {
+    test: /.*(ts|tsx|js|jsx)$/
+  },
+  ignore: {
+    list: [
+      'packages/**/locale/*',
+      'packages/amis/*',
+      'packages/amis-ui/*',
+      'packages/amis-core/*',
+      'packages/amis-formula/*',
+      'packages/**/examples/*'
+    ]
+  },
+  importInfo: {
+    source: 'i18n-runtime',
+    imported: 'i18n',
+    local: '_i18n'
+  },
+  i18nModule: 'i18n-runtime',
+  languages: [
+    {
+      name: 'en-US',
+      path: [
+        './packages/amis-editor-core/src/locale',
+        './packages/amis-editor/src/locale'
+      ]
+    },
+    {
+      name: 'zh-CN',
+      path: [
+        './packages/amis-editor-core/src/locale',
+        './packages/amis-editor/src/locale'
+      ]
+    }
+  ]
+};

--- a/packages/amis-editor/examples/Editor.tsx
+++ b/packages/amis-editor/examples/Editor.tsx
@@ -700,13 +700,19 @@ export default class AMisSchemaEditor extends React.Component<any, any> {
 
             <div className="Editor-header-actions">
               <ShortcutKey />
-              {/* <Select
-                className="margin-left-space "
-                options={editorLanguages}
-                value={curLanguage}
-                clearable={false}
-                onChange={(e: any) => this.changeLocale(e.value)}
-              /> */}
+              {
+                // @ts-ignore
+                // vite编译时替换
+                __editor_i18n ? (
+                  <Select
+                    className="margin-left-space "
+                    options={editorLanguages}
+                    value={curLanguage}
+                    clearable={false}
+                    onChange={(e: any) => this.changeLocale(e.value)}
+                  />
+                ) : null
+              }
 
               {i18nEnabled && (
                 <Button

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ import fis3 from './scripts/fis3plugin';
 import markdown from './scripts/markdownPlugin';
 import mockApi from './scripts/mockApiPlugin';
 import transformMobileHtml from './scripts/transformMobileHtml';
+//@ts-ignore
 import i18nPlugin from 'plugin-react-i18n';
 import i18nConfig from './i18nConfig';
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,9 +32,6 @@ var PROXY_THEME = process.env.PROXY_THEME
     ]
   : [];
 
-if (I18N) {
-}
-
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,10 +8,38 @@ import fis3 from './scripts/fis3plugin';
 import markdown from './scripts/markdownPlugin';
 import mockApi from './scripts/mockApiPlugin';
 import transformMobileHtml from './scripts/transformMobileHtml';
+import i18nPlugin from 'plugin-react-i18n';
+import i18nConfig from './i18nConfig';
+
+var I18N = process.env.I18N;
+
+var PROXY_THEME = process.env.PROXY_THEME
+  ? [
+      {
+        find: 'amis-theme-editor/lib/renderers.css',
+        replacement: path.resolve(
+          __dirname,
+          '../editor/packages/amis-theme-editor/src/renderers/style/_index.scss'
+        )
+      },
+      {
+        find: 'amis-theme-editor/lib',
+        replacement: path.resolve(
+          __dirname,
+          '../editor/packages/amis-theme-editor/src'
+        )
+      }
+    ]
+  : [];
+
+if (I18N) {
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
+    I18N && i18nPlugin(i18nConfig),
+
     fis3(),
     markdown(),
     mockApi(),
@@ -34,8 +62,11 @@ export default defineConfig({
         dimensions: false
       }
     }),
-    monacoEditorPlugin({})
-  ],
+    monacoEditorPlugin({}),
+    replace({
+      __editor_i18n: !!I18N
+    })
+  ].filter(n => n),
   optimizeDeps: {
     include: ['amis-formula/lib/doc'],
     exclude: ['amis-core', 'amis-formula', 'amis', 'amis-ui'],
@@ -97,6 +128,6 @@ export default defineConfig({
         find: 'office-viewer',
         replacement: path.resolve(__dirname, './packages/office-viewer/src')
       }
-    ]
+    ].concat(PROXY_THEME)
   }
 });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2800dfd</samp>

This pull request adds i18n support and theme editor proxying features to the amis project. It introduces a new `i18nConfig.ts` file and some conditional plugins and aliases in the `vite.config.ts` file. It also updates the `Editor.tsx` file to render a language selector for the editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2800dfd</samp>

> _`vite.config.ts`_
> _Adds plugins for i18n, theme_
> _Winter of coding_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2800dfd</samp>

*  Add i18n support for the editor ([link](https://github.com/baidu/amis/pull/7903/files?diff=unified&w=0#diff-54a765e26dfef288d1fa341ddd61f7c223be03921e4fd3ba581cde984e63e3d0R1-R40), [link](https://github.com/baidu/amis/pull/7903/files?diff=unified&w=0#diff-ac37ef7e74b39117226be066461e8c65edafc2318cf9874536ac80f09b6f9f41L703-R715), [link](https://github.com/baidu/amis/pull/7903/files?diff=unified&w=0#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL11-R42), [link](https://github.com/baidu/amis/pull/7903/files?diff=unified&w=0#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL37-R69))
  - Create a new file `i18nConfig.ts` that exports the default configuration for the `plugin-react-i18n` ([link](https://github.com/baidu/amis/pull/7903/files?diff=unified&w=0#diff-54a765e26dfef288d1fa341ddd61f7c223be03921e4fd3ba581cde984e63e3d0R1-R40))
  - Add a conditional `Select` component to `Editor.tsx` that allows choosing the editor language based on the global variable `__editor_i18n` ([link](https://github.com/baidu/amis/pull/7903/files?diff=unified&w=0#diff-ac37ef7e74b39117226be066461e8c65edafc2318cf9874536ac80f09b6f9f41L703-R715))
  - Import and apply the `i18nPlugin` and the `i18nConfig` to the vite plugins array if the `I18N` environment variable is true ([link](https://github.com/baidu/amis/pull/7903/files?diff=unified&w=0#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL11-R42))
  - Import and apply the `replace` plugin to the vite plugins array with a configuration that replaces the `__editor_i18n` variable with the `I18N` value ([link](https://github.com/baidu/amis/pull/7903/files?diff=unified&w=0#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL37-R69))
*  Add proxy support for the theme editor files ([link](https://github.com/baidu/amis/pull/7903/files?diff=unified&w=0#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL100-R131))
  - Concatenate the `PROXY_THEME` array to the `alias` array in the `resolve` option of the vite config ([link](https://github.com/baidu/amis/pull/7903/files?diff=unified&w=0#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL100-R131))
