### PR TITLE
feat: 图片缩略图地址支持fx获取

### DIFF
--- a/packages/amis-editor/src/plugin/Image.tsx
+++ b/packages/amis-editor/src/plugin/Image.tsx
@@ -84,7 +84,7 @@ export class ImagePlugin extends BasePlugin {
 
               isUnderField
                 ? null
-                : getSchemaTpl('tplFormulaControl', {
+                : getSchemaTpl('formulaControl', {
                     name: 'src',
                     label: '缩略图地址',
                     description: '如果已绑定字段名，可以不用设置，支持用变量。'

--- a/packages/amis-editor/src/plugin/Image.tsx
+++ b/packages/amis-editor/src/plugin/Image.tsx
@@ -84,9 +84,8 @@ export class ImagePlugin extends BasePlugin {
 
               isUnderField
                 ? null
-                : getSchemaTpl('imageUrl', {
+                : getSchemaTpl('tplFormulaControl', {
                     name: 'src',
-                    type: 'input-text',
                     label: '缩略图地址',
                     description: '如果已绑定字段名，可以不用设置，支持用变量。'
                   }),


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f902253</samp>

Changed the `src` property of image components to use a formula control instead of a text input. This enables dynamic image sources based on data in `packages/amis-editor/src/plugin/Image.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f902253</samp>

> _`src` type changes_
> _formula for image URL_
> _autumn leaves adapt_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f902253</samp>

* Change the type of the `src` property in the `getSchemaTpl` function call to `tplFormulaControl` to enable formulas in image source URLs ([link](https://github.com/baidu/amis/pull/7905/files?diff=unified&w=0#diff-080f970ff41a9d0e1619e4d8d2190127b7b241f179ed33b91f4f0fe48475fd41L87-R88))
