### PR TITLE
styles: 修复select箭头对不齐问题和buttonGroupSelect选中态颜色问题

### DIFF
--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -1027,8 +1027,8 @@
   --inputNumber-base-default-bottom-left-border-radius: var(--borders-radius-3);
   --inputNumber-base-default-paddingTop: var(--sizes-size-3);
   --inputNumber-base-default-paddingBottom: var(--sizes-size-3);
-  --inputNumber-base-default-paddingLeft: var(--sizes-size-7);
-  --inputNumber-base-default-paddingRight: var(--sizes-size-7);
+  --inputNumber-base-default-paddingLeft: var(--sizes-size-6);
+  --inputNumber-base-default-paddingRight: var(--sizes-size-6);
   --inputNumber-base-default-bg-color: var(--colors-neutral-fill-11);
   --inputNumber-base-hover-top-border-color: var(--colors-brand-5);
   --inputNumber-base-hover-top-border-width: var(--borders-width-2);
@@ -2945,7 +2945,7 @@
   --inputDate-default-paddingTop: var(--sizes-size-3);
   --inputDate-default-paddingBottom: var(--sizes-size-3);
   --inputDate-default-paddingLeft: var(--sizes-size-6);
-  --inputDate-default-paddingRight: var(--sizes-base-6);
+  --inputDate-default-paddingRight: var(--sizes-size-6);
   --inputDate-default-fontSize: var(--fonts-size-7);
   --inputDate-default-fontWeight: var(--fonts-weight-6);
   --inputDate-default-height: var(--sizes-base-16);

--- a/packages/amis-ui/scss/_properties.scss
+++ b/packages/amis-ui/scss/_properties.scss
@@ -250,13 +250,8 @@ $Table-strip-bg: transparent;
   --ColorPicker-onFocused-borderColor: var(--Form-input-onFocused-borderColor);
   --ColorPicker-onHover-bg: var(--colors-neutral-fill-11);
   --ColorPicker-onHover-borderColor: var(--colors-brand-5);
-  --ColorPicker-paddingX: #{px2rem(12px)};
-  --ColorPicker-paddingY: calc(
-    (
-        var(--ColorPicker-height) - var(--ColorPicker-lineHeight) *
-          var(--ColorPicker-fontSize)
-      ) / 2 - var(--ColorPicker-borderWidth)
-  );
+  --ColorPicker-paddingX: var(--sizes-size-6);
+  --ColorPicker-paddingY: var(--sizes-size-3);
   --ColorPicker-placeholderColor: var(--colors-neutral-text-6);
   --ColorPicker-boxShadow: var(--shadows-shadow-normal);
 
@@ -345,12 +340,7 @@ $Table-strip-bg: transparent;
   --Form-input-password-icon-size: var(--sizes-size-9);
   --Form-input-password-icon-color: var(--colors-neutral-text-5);
 
-  --Form-input-paddingY: calc(
-    (
-        var(--Form-input-height) - var(--Form-input-lineHeight) *
-          var(--Form-input-fontSize) - #{px2rem(2px)}
-      ) / 2
-  );
+  --Form-input-paddingY: var(--sizes-size-3);
   --Form-input-placeholderColor: var(--text--muted-color);
   --Form-input-onDisabled-color: var(--colors-neutral-text-5);
 

--- a/packages/amis-ui/scss/components/_button-group.scss
+++ b/packages/amis-ui/scss/components/_button-group.scss
@@ -48,6 +48,9 @@
   &--block {
     display: block;
   }
+  &-button--active {
+    z-index: 1;
+  }
 }
 
 .#{$ns}ButtonToolbar {

--- a/packages/amis-ui/scss/components/_result-box.scss
+++ b/packages/amis-ui/scss/components/_result-box.scss
@@ -127,10 +127,9 @@
   }
 
   &-actions {
+    width: var(--gap-md);
     display: flex;
-    align-items: center;
-    flex-shrink: 0;
-    padding-left: px2rem(5px);
+    justify-content: center;
 
     > * {
       &:not(:last-child) {

--- a/packages/amis-ui/scss/components/_result-box.scss
+++ b/packages/amis-ui/scss/components/_result-box.scss
@@ -115,10 +115,6 @@
     }
   }
 
-  &.#{$ns}NestedSelect {
-    padding-left: var(--gap-base);
-  }
-
   &-value-wrap {
     flex-grow: 1;
     display: flex;
@@ -127,15 +123,9 @@
   }
 
   &-actions {
-    width: var(--gap-md);
+    margin-left: px2rem(4px);
     display: flex;
     justify-content: center;
-
-    > * {
-      &:not(:last-child) {
-        margin-right: px2rem(5px);
-      }
-    }
   }
 
   &-singleValue {
@@ -148,10 +138,12 @@
   }
 
   &-pc-arrow {
+    width: var(--gap-md);
     height: 100%;
     margin: auto 0;
     display: flex;
     align-items: center;
+    justify-content: center;
     transition: transform var(--animation-duration) ease;
     transform: rotate(90deg);
 
@@ -172,15 +164,6 @@
     height: 100%;
     margin: auto 0;
     background-color: unset;
-
-    &-wrap {
-      width: px2rem(16px);
-      height: px2rem(16px);
-      border-radius: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
 
     &-with-arrow {
       right: 33px;

--- a/packages/amis-ui/scss/components/form/_color.scss
+++ b/packages/amis-ui/scss/components/form/_color.scss
@@ -82,8 +82,6 @@
   }
 
   &-arrow {
-    margin-right: var(--gap-xs);
-    // margin-left: var(--gap-xs);
     width: var(--gap-md);
     text-align: center;
     display: flex;

--- a/packages/amis-ui/scss/components/form/_combo.scss
+++ b/packages/amis-ui/scss/components/form/_combo.scss
@@ -20,6 +20,9 @@
     margin-top: var(--gap-xs);
     display: inline-block;
   }
+  &-itemInner {
+    margin-right: px2rem(12px);
+  }
 
   &-addBtn {
     > svg {

--- a/packages/amis-ui/scss/components/form/_location.scss
+++ b/packages/amis-ui/scss/components/form/_location.scss
@@ -4,7 +4,7 @@
   flex-wrap: nowrap;
   border: var(--borders-width-2) solid var(--colors-neutral-line-8);
   font-size: var(--fonts-size-7);
-  padding: var(--sizes-size-4) var(--sizes-size-7);
+  padding: var(--sizes-size-3) var(--sizes-size-6);
   height: var(--sizes-base-16);
   outline: none;
   white-space: nowrap;

--- a/packages/amis-ui/scss/components/form/_select.scss
+++ b/packages/amis-ui/scss/components/form/_select.scss
@@ -176,7 +176,6 @@
     user-select: none;
     position: relative;
     flex-grow: 1;
-    line-height: 1;
     width: auto;
     max-width: 100%;
     overflow: hidden;

--- a/packages/amis-ui/scss/components/form/_select.scss
+++ b/packages/amis-ui/scss/components/form/_select.scss
@@ -180,6 +180,7 @@
     width: auto;
     max-width: 100%;
     overflow: hidden;
+    padding-right: px2rem(4px);
   }
   &-valuesNoWrap {
     white-space: nowrap;
@@ -222,10 +223,6 @@
         display: inline-block;
         width: px2rem(100px);
         margin-bottom: var(--gap-xs);
-      }
-
-      .#{$ns}Select-placeholder {
-        margin-left: var(--gap-sm);
       }
     }
     .#{$ns}Select-values + .#{$ns}Select-input {

--- a/packages/amis-ui/scss/components/form/_text.scss
+++ b/packages/amis-ui/scss/components/form/_text.scss
@@ -369,8 +369,7 @@
   &-input--multiple {
     height: auto;
     min-height: var(--Form-input-height);
-    padding: calc(var(--Form-input-paddingY) - #{px2rem(2px)})
-      calc(var(--Form-input-paddingX) - #{px2rem(3px)});
+    padding: var(--Form-input-paddingY) var(--Form-input-paddingX);
   }
 
   &-input--multiple &-placeholder {

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/buttonGroupSelect.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/buttonGroupSelect.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`Renderer:button-group with btnActiveLevel 1`] = `
             class="cxd-ButtonGroup cxd-Form-control"
           >
             <button
-              class="cxd-Button cxd-Button--warning cxd-Button--size-default is-active"
+              class="cxd-Button cxd-Button--warning cxd-Button--size-default cxd-ButtonGroup-button--active"
               type="button"
             >
               <span>
@@ -406,7 +406,7 @@ exports[`Renderer:button-group:multiple clearable 1`] = `
             class="cxd-ButtonGroup cxd-Form-control"
           >
             <button
-              class="cxd-Button cxd-Button--primary cxd-Button--size-default is-active"
+              class="cxd-Button cxd-Button--primary cxd-Button--size-default cxd-ButtonGroup-button--active"
               type="button"
             >
               <span>
@@ -552,7 +552,7 @@ exports[`Renderer:button-group:multiple clearable 2`] = `
             class="cxd-ButtonGroup cxd-Form-control"
           >
             <button
-              class="cxd-Button cxd-Button--primary cxd-Button--size-default is-active"
+              class="cxd-Button cxd-Button--primary cxd-Button--size-default cxd-ButtonGroup-button--active"
               type="button"
             >
               <span>
@@ -560,7 +560,7 @@ exports[`Renderer:button-group:multiple clearable 2`] = `
               </span>
             </button>
             <button
-              class="cxd-Button cxd-Button--primary cxd-Button--size-default is-active"
+              class="cxd-Button cxd-Button--primary cxd-Button--size-default cxd-ButtonGroup-button--active"
               type="button"
             >
               <span>
@@ -698,7 +698,7 @@ exports[`Renderer:button-group:multiple clearable 3`] = `
             class="cxd-ButtonGroup cxd-Form-control"
           >
             <button
-              class="cxd-Button cxd-Button--primary cxd-Button--size-default is-active"
+              class="cxd-Button cxd-Button--primary cxd-Button--size-default cxd-ButtonGroup-button--active"
               type="button"
             >
               <span>

--- a/packages/amis/src/renderers/Form/ButtonGroupSelect.tsx
+++ b/packages/amis/src/renderers/Form/ButtonGroupSelect.tsx
@@ -71,7 +71,8 @@ export default class ButtonGroupControl extends React.Component<
 
   getBadgeConfig(config: BadgeObject, item: Option) {
     return config
-      ? item?.badge && (typeof item.badge === 'string' || typeof item.badge === 'number')
+      ? item?.badge &&
+        (typeof item.badge === 'string' || typeof item.badge === 'number')
         ? {...config, text: item.badge}
         : item?.badge && isObject(item.badge)
         ? {...config, ...item.badge}
@@ -129,9 +130,12 @@ export default class ButtonGroupControl extends React.Component<
           },
           {
             key: key,
-            active,
             level: (active ? btnActiveLevel : '') || option.level || btnLevel,
-            className: cx(option.className, btnClassName),
+            className: cx(
+              option.className,
+              btnClassName,
+              active && 'ButtonGroup-button--active'
+            ),
             disabled: option.disabled || disabled,
             onClick: (e: React.UIEvent<any>) => {
               if (disabled) {
@@ -160,7 +164,11 @@ export default class ButtonGroupControl extends React.Component<
           },
           {
             key,
-            className: cx(button.className, btnClassName)
+            className: cx(
+              button.className,
+              btnClassName,
+              active && 'ButtonGroup-button--active'
+            )
           }
         );
       });

--- a/packages/amis/src/renderers/Form/ButtonGroupSelect.tsx
+++ b/packages/amis/src/renderers/Form/ButtonGroupSelect.tsx
@@ -150,7 +150,7 @@ export default class ButtonGroupControl extends React.Component<
     } else if (Array.isArray(buttons)) {
       body = buttons.map((button, key) => {
         const buttonBadge = this.getBadgeConfig(badge, button);
-
+        const active = !!~selectedOptions.indexOf(button);
         return render(
           `button/${key}`,
           {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ebcff64</samp>

This pull request fixes a console warning and improves the UI of the `ButtonGroupSelect` and `ResultBox` components. It refactors the code and CSS rules to use a consistent class name and z-index for the active button state, and to render the result box actions as a button group.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ebcff64</samp>

> _Oh we're the coders of the sea, we write the CSS with glee_
> _We fix the props and the z-index, we make the buttons look their best_
> _Heave away, me hearties, heave away_
> _On the count of three, we push the PR, hooray_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ebcff64</samp>

*  Increase the z-index of the active button in a button group ([link](https://github.com/baidu/amis/pull/7910/files?diff=unified&w=0#diff-77c5d145544bc877664f55f072962fee43b7152e9468862cc0dcd44990f3601dR51-R53))
*  Remove the `active` prop from the button props and use a class name instead, to avoid passing an invalid prop to the `Button` component and to style the active button ([link](https://github.com/baidu/amis/pull/7910/files?diff=unified&w=0#diff-2ec706af1c78093f89e55e260abb9f49005f045251e7e0f3d7a24bfd460a6b16L132-R138), [link](https://github.com/baidu/amis/pull/7910/files?diff=unified&w=0#diff-2ec706af1c78093f89e55e260abb9f49005f045251e7e0f3d7a24bfd460a6b16L163-R171))
*  Move the CSS rule for the result box actions to the `_button-group.scss` file, since they are now rendered as a button group, and adjust the width, display and justify-content properties ([link](https://github.com/baidu/amis/pull/7910/files?diff=unified&w=0#diff-21f40f2463597a4f1f9a6a1513592095223ecfd51987e33cd984dd4ab7faa087L130-R132))
*  Add a line break to improve the readability of the `getBadgeConfig` method in `ButtonGroupSelect.tsx` ([link](https://github.com/baidu/amis/pull/7910/files?diff=unified&w=0#diff-2ec706af1c78093f89e55e260abb9f49005f045251e7e0f3d7a24bfd460a6b16L74-R75))
