### PR TITLE
chore: condition-builder 的 showIf 功能通过 formulaForIf 配置上下文信息而不是复用值的公式信息

### DIFF
--- a/docs/zh-CN/components/form/condition-builder.md
+++ b/docs/zh-CN/components/form/condition-builder.md
@@ -1279,7 +1279,7 @@ selectMode 为`chained`时，使用`source`字段
               }
             ]
           },
-          "formula": {
+          "formulaForIf": {
             "mode":"input-group",
             "variables": [
               {
@@ -1435,7 +1435,9 @@ selectMode 为`chained`时，使用`source`字段
 | addBtnVisibleOn      | `string`                            |          | 表达式：控制按钮“添加条件”的显示。参数为`depth`、`breadth`，分别代表深度、长度。表达式需要返回`boolean`类型   | `3.2.0` |
 | addGroupBtnVisibleOn | `string`                            |          | 表达式：控制按钮“添加条件组”的显示。参数为`depth`、`breadth`，分别代表深度、长度。表达式需要返回`boolean`类型 | `3.2.0` |
 | inputSettings        | `InputSettings`                     |          | 开启公式编辑模式时的输入控件类型                                                                              | `3.2.0` |
+| formula              | `object`                            |          | 字段输入控件变成公式编辑器。                                                                                  | `3.2.0` |
 | showIf               | `boolean`                           |          | 开启后条件中额外还能配置启动条件。                                                                            | `3.2.0` |
+| formulaForIf         | `object`                            |          | 给 showIF 表达式用的公式信息                                                                                  | `3.4.0` |
 
 ### InputSettings
 

--- a/packages/amis-ui/src/components/condition-builder/Group.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Group.tsx
@@ -32,6 +32,7 @@ export interface ConditionGroupProps extends ThemeProps, LocaleProps {
   showNot?: boolean;
   showANDOR?: boolean;
   showIf?: boolean;
+  formulaForIf?: FormulaPickerProps;
   data?: any;
   disabled?: boolean;
   searchable?: boolean;
@@ -194,7 +195,8 @@ export class ConditionGroup extends React.Component<
       depth,
       isAddBtnVisibleOn,
       isAddGroupBtnVisibleOn,
-      showIf
+      showIf,
+      formulaForIf
     } = this.props;
     const {isCollapsed} = this.state;
 
@@ -286,6 +288,7 @@ export class ConditionGroup extends React.Component<
                   isAddBtnVisibleOn={isAddBtnVisibleOn}
                   isAddGroupBtnVisibleOn={isAddGroupBtnVisibleOn}
                   showIf={showIf}
+                  formulaForIf={formulaForIf}
                 />
               ))
             ) : (

--- a/packages/amis-ui/src/components/condition-builder/GroupOrItem.tsx
+++ b/packages/amis-ui/src/components/condition-builder/GroupOrItem.tsx
@@ -35,6 +35,7 @@ export interface CBGroupOrItemProps extends ThemeProps {
   isAddBtnVisibleOn?: (param: {depth: number; breadth: number}) => boolean;
   isAddGroupBtnVisibleOn?: (param: {depth: number; breadth: number}) => boolean;
   showIf?: boolean;
+  formulaForIf?: FormulaPickerProps;
 }
 
 export class CBGroupOrItem extends React.Component<CBGroupOrItemProps> {
@@ -101,6 +102,7 @@ export class CBGroupOrItem extends React.Component<CBGroupOrItemProps> {
       isAddBtnVisibleOn,
       isAddGroupBtnVisibleOn,
       showIf,
+      formulaForIf,
       mobileUI
     } = this.props;
 
@@ -152,6 +154,7 @@ export class CBGroupOrItem extends React.Component<CBGroupOrItemProps> {
                 isAddBtnVisibleOn={isAddBtnVisibleOn}
                 isAddGroupBtnVisibleOn={isAddGroupBtnVisibleOn}
                 showIf={showIf}
+                formulaForIf={formulaForIf}
               />
             </div>
           ) : (
@@ -182,7 +185,7 @@ export class CBGroupOrItem extends React.Component<CBGroupOrItemProps> {
               />
               {showIf ? (
                 <FormulaPicker
-                  {...formula}
+                  {...formulaForIf}
                   evalMode={true}
                   mixedMode={false}
                   header="设置条件"

--- a/packages/amis-ui/src/components/condition-builder/index.tsx
+++ b/packages/amis-ui/src/components/condition-builder/index.tsx
@@ -33,6 +33,7 @@ export interface ConditionBuilderProps extends ThemeProps, LocaleProps {
   showNot?: boolean; // 是否显示非按钮
   showANDOR?: boolean; // 是否显示并或切换键按钮
   showIf?: boolean; // 是否显示条件
+  formulaForIf?: FormulaPickerProps;
   value?: ConditionGroupValue;
   data?: any;
   onChange: (value?: ConditionGroupValue) => void;
@@ -263,7 +264,8 @@ export class QueryBuilder extends React.Component<
       selectMode,
       isAddBtnVisibleOn,
       isAddGroupBtnVisibleOn,
-      showIf
+      showIf,
+      formulaForIf
     } = this.props;
 
     const normalizedValue = Array.isArray(value?.children)
@@ -308,6 +310,7 @@ export class QueryBuilder extends React.Component<
         isAddBtnVisibleOn={isAddBtnVisibleOn}
         isAddGroupBtnVisibleOn={isAddGroupBtnVisibleOn}
         showIf={showIf}
+        formulaForIf={formulaForIf}
       />
     );
   }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d34c406</samp>

Added support for formula editing and conditional display for the `condition-builder` component. Users can now select a formula for the `showIf` expression of any condition group, which determines its visibility. Updated the documentation and renamed some props for clarity.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d34c406</samp>

> _Show your conditions with a formula_
> _`showIf` expression of your choice_
> _Unleash the power of the `condition-builder`_
> _Edit and display with a mighty voice_

### Why

值的公式上下文信息和 showIf 的公式上下文信息可能不一样，所以分开设置

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d34c406</samp>

*  Rename `formula` property to `formulaForIf` in `condition-builder` component to avoid confusion with `formula` property in `inputSettings` object ([link](https://github.com/baidu/amis/pull/7912/files?diff=unified&w=0#diff-a096b5dd2ef60aed7b333308577964333f30bfa95868653a57a4b6594cba200cL1282-R1282), [link](https://github.com/baidu/amis/pull/7912/files?diff=unified&w=0#diff-e739d54e710cb7e461bb442b0b438b9e44a2ce1f4492a64c16fe1afcd2f5d166L185-R188))
*  Add `formulaForIf` property to `condition-builder` component's props and documentation to provide formula information for `showIf` expression ([link](https://github.com/baidu/amis/pull/7912/files?diff=unified&w=0#diff-a096b5dd2ef60aed7b333308577964333f30bfa95868653a57a4b6594cba200cL1438-R1440), [link](https://github.com/baidu/amis/pull/7912/files?diff=unified&w=0#diff-84402e0383236ea88080c3b736a89c43538f9859b2f8594763c9b90e5d9c84dbR35), [link](https://github.com/baidu/amis/pull/7912/files?diff=unified&w=0#diff-e739d54e710cb7e461bb442b0b438b9e44a2ce1f4492a64c16fe1afcd2f5d166R38), [link](https://github.com/baidu/amis/pull/7912/files?diff=unified&w=0#diff-504cb0e75d6206da3bb94e7bec394d9cd695d3dc89178058a5731d483f54e6b9R36))
*  Pass `formulaForIf` property from `QueryBuilder` component to `ConditionGroup` component to render formula picker for top-level group of conditions ([link](https://github.com/baidu/amis/pull/7912/files?diff=unified&w=0#diff-504cb0e75d6206da3bb94e7bec394d9cd695d3dc89178058a5731d483f54e6b9L266-R268), [link](https://github.com/baidu/amis/pull/7912/files?diff=unified&w=0#diff-504cb0e75d6206da3bb94e7bec394d9cd695d3dc89178058a5731d483f54e6b9R313))
*  Pass `formulaForIf` property from `ConditionGroup` component to `CBGroupOrItem` component to render formula picker for single condition or nested group of conditions ([link](https://github.com/baidu/amis/pull/7912/files?diff=unified&w=0#diff-84402e0383236ea88080c3b736a89c43538f9859b2f8594763c9b90e5d9c84dbL197-R199), [link](https://github.com/baidu/amis/pull/7912/files?diff=unified&w=0#diff-84402e0383236ea88080c3b736a89c43538f9859b2f8594763c9b90e5d9c84dbR291), [link](https://github.com/baidu/amis/pull/7912/files?diff=unified&w=0#diff-e739d54e710cb7e461bb442b0b438b9e44a2ce1f4492a64c16fe1afcd2f5d166R105), [link](https://github.com/baidu/amis/pull/7912/files?diff=unified&w=0#diff-e739d54e710cb7e461bb442b0b438b9e44a2ce1f4492a64c16fe1afcd2f5d166R157))
