### PR TITLE
feat: 支持maxTagCount和overflowTagPopover配置项

### DIFF
--- a/docs/zh-CN/components/form/condition-builder.md
+++ b/docs/zh-CN/components/form/condition-builder.md
@@ -333,6 +333,7 @@ type Value = ValueGroup;
 - `source` 动态选项，请配置 api。
 - `searchable` 是否可以搜索
 - `autoComplete` 自动提示补全，每次输入新内容后，将调用接口，根据接口返回更新选项。
+- `maxTagCount` 可以限制标签的最大展示数量，超出数量的部分会收纳到 Popover 中，可以通过 `overflowTagPopover` 配置 Popover 相关的属性，注意该属性仅在多选模式开启后生效。
 
 ```schema: scope="body"
 {

--- a/packages/amis-ui/src/components/TabsTransferPicker.tsx
+++ b/packages/amis-ui/src/components/TabsTransferPicker.tsx
@@ -49,6 +49,8 @@ export class TransferPicker extends React.Component<TabsTransferPickerProps> {
       labelField = 'label',
       mobileUI,
       popOverContainer,
+      maxTagCount,
+      overflowTagPopover,
       ...rest
     } = this.props;
 
@@ -104,6 +106,8 @@ export class TransferPicker extends React.Component<TabsTransferPickerProps> {
               <span>{(option && option[labelField]) || 'undefiend'}</span>
             )}
             mobileUI={mobileUI}
+            maxTagCount={maxTagCount}
+            overflowTagPopover={overflowTagPopover}
           >
             {!mobileUI ? (
               <span className={cx('TransferPicker-icon')}>

--- a/packages/amis-ui/src/components/Transfer.tsx
+++ b/packages/amis-ui/src/components/Transfer.tsx
@@ -64,6 +64,8 @@ export interface TransferProps
   leftMode?: 'tree' | 'list' | 'group';
   leftDefaultValue?: any;
   rightMode?: 'table' | 'list' | 'group' | 'tree' | 'chained';
+  maxTagCount?: number;
+  overflowTagPopover?: any;
 
   // search 相关
   searchResultMode?: 'table' | 'list' | 'group' | 'tree' | 'chained';
@@ -388,8 +390,8 @@ export class Transfer<
       (a, b) => a[valueField] === b[valueField]
     );
     const unuseArr = differenceFromAll(
-      values,
       searchAvailableOptions,
+      values,
       item => item[valueField]
     );
 

--- a/packages/amis-ui/src/components/Transfer.tsx
+++ b/packages/amis-ui/src/components/Transfer.tsx
@@ -390,8 +390,8 @@ export class Transfer<
       (a, b) => a[valueField] === b[valueField]
     );
     const unuseArr = differenceFromAll(
-      searchAvailableOptions,
       values,
+      searchAvailableOptions,
       item => item[valueField]
     );
 

--- a/packages/amis-ui/src/components/TransferPicker.tsx
+++ b/packages/amis-ui/src/components/TransferPicker.tsx
@@ -54,6 +54,8 @@ export class TransferPicker extends React.Component<TransferPickerProps> {
       labelField = 'label',
       mobileUI,
       popOverContainer,
+      maxTagCount,
+      overflowTagPopover,
       ...rest
     } = this.props;
 
@@ -110,6 +112,8 @@ export class TransferPicker extends React.Component<TransferPickerProps> {
               <span>{(option && option[labelField]) || 'undefined'}</span>
             )}
             mobileUI={mobileUI}
+            maxTagCount={maxTagCount}
+            overflowTagPopover={overflowTagPopover}
           >
             {!mobileUI ? (
               <span className={cx('TransferPicker-icon')}>

--- a/packages/amis-ui/src/components/condition-builder/Value.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Value.tsx
@@ -149,6 +149,8 @@ export class Value extends React.Component<ValueProps> {
           disabled={disabled}
           popOverContainer={popOverContainer}
           mobileUI={mobileUI}
+          maxTagCount={field.maxTagCount}
+          overflowTagPopover={field.overflowTagPopover}
         />
       );
     } else if (field.type === 'boolean') {

--- a/packages/amis-ui/src/components/condition-builder/types.ts
+++ b/packages/amis-ui/src/components/condition-builder/types.ts
@@ -88,7 +88,8 @@ interface SelectField extends BaseField {
   options?: Array<any>;
   source?: string | BaseApiObject;
   searchable?: boolean;
-
+  maxTagCount?: number;
+  overflowTagPopover?: any;
   /**
    * 自动完成 API，当输入部分文字的时候，会将这些文字通过 ${term} 可以取到，发送给接口。
    * 接口可以返回匹配到的选项，帮助用户输入。

--- a/packages/amis/__tests__/renderers/SearchBox.test.tsx
+++ b/packages/amis/__tests__/renderers/SearchBox.test.tsx
@@ -37,7 +37,7 @@ test('Renderer:Searchbox', async () => {
     )
   );
 
-  await wait(500);
+  await wait(1000);
 
   expect(fetcher).toHaveBeenCalledTimes(1);
   expect(fetcher.mock.calls[0][0].query).toEqual({
@@ -216,12 +216,17 @@ test('Renderer:Searchbox with searchImediately & className', async () => {
 
 test('6. Renderer: Searchbox is not supposed to be triggered with composition input', async () => {
   const onQuery = jest.fn();
-  const {container} = render(amisRender({
-    type: "search-box",
-    name: "keywords",
-  }, {
-    onQuery
-  }))
+  const {container} = render(
+    amisRender(
+      {
+        type: 'search-box',
+        name: 'keywords'
+      },
+      {
+        onQuery
+      }
+    )
+  );
 
   const inputEl = container.querySelector('.cxd-SearchBox input')!;
   expect(inputEl).toBeInTheDocument();
@@ -229,18 +234,18 @@ test('6. Renderer: Searchbox is not supposed to be triggered with composition in
   /** 第一次输入 Enter 后，文本填入 */
 
   fireEvent.compositionStart(inputEl);
-  fireEvent.keyDown(inputEl, { key: 'Enter', keyCode: 13 });
+  fireEvent.keyDown(inputEl, {key: 'Enter', keyCode: 13});
   await wait(200);
   expect(onQuery).not.toHaveBeenCalled();
 
   /** 退出输入法，触发搜索 */
   fireEvent.compositionEnd(inputEl);
   fireEvent.change(inputEl, {target: {value: 'test'}});
-  fireEvent.keyDown(inputEl, { key: 'Enter', keyCode: 13 });
+  fireEvent.keyDown(inputEl, {key: 'Enter', keyCode: 13});
   await wait(200);
 
   expect(onQuery).toHaveBeenCalledTimes(1);
   expect(onQuery.mock.calls[0][0]).toEqual({
     keywords: 'test'
   });
-})
+});

--- a/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
@@ -109,7 +109,9 @@ export class TabsTransferPickerRenderer extends BaseTabsTransferRenderer<TabsTra
       labelField = 'label',
       valueField = 'value',
       mobileUI,
-      env
+      env,
+      maxTagCount,
+      overflowTagPopover
     } = this.props;
 
     return (
@@ -144,6 +146,8 @@ export class TabsTransferPickerRenderer extends BaseTabsTransferRenderer<TabsTra
           valueField={valueField}
           mobileUI={mobileUI}
           popOverContainer={env?.getModalContainer}
+          maxTagCount={maxTagCount}
+          overflowTagPopover={overflowTagPopover}
         />
 
         <Spinner

--- a/packages/amis/src/renderers/Form/TransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TransferPicker.tsx
@@ -90,7 +90,9 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
       menuTpl,
       valueTpl,
       mobileUI,
-      env
+      env,
+      maxTagCount,
+      overflowTagPopover
     } = this.props;
 
     // 目前 LeftOptions 没有接口可以动态加载
@@ -142,6 +144,8 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
           virtualThreshold={virtualThreshold}
           mobileUI={mobileUI}
           popOverContainer={env?.getModalContainer}
+          maxTagCount={maxTagCount}
+          overflowTagPopover={overflowTagPopover}
         />
 
         <Spinner


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f36229</samp>

This pull request enhances the `select` field type in the condition builder component and the related `TransferPicker` and `Transfer` components by adding the ability to limit and customize the display of selected items. It also updates the documentation and the type definitions for the new props.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3f36229</samp>

> _Select your fate with the condition builder_
> _Limit the tags that you can see_
> _Overflow the rest in a dark popover_
> _Transfer your choices to eternity_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3f36229</samp>

*  Add `maxTagCount` and `overflowTagPopover` props to the `select`, `tabs-transfer-picker`, and `transfer-picker` field types in the condition builder component, which allow limiting the number of tags displayed for multiple selections and customizing the popover for the overflowed tags ([link](https://github.com/baidu/amis/pull/7915/files?diff=unified&w=0#diff-a096b5dd2ef60aed7b333308577964333f30bfa95868653a57a4b6594cba200cR336), [link](https://github.com/baidu/amis/pull/7915/files?diff=unified&w=0#diff-a287c0f2429ec6052b29eea871ebdad937ff1e67a6ef4b939e8d27b56076506fL91-R93), [link](https://github.com/baidu/amis/pull/7915/files?diff=unified&w=0#diff-b3d9a4cde668e595a9e905f6d4ce38b014991a0a41b16a89c9297934d9ea5334L112-R114), [link](https://github.com/baidu/amis/pull/7915/files?diff=unified&w=0#diff-b5e07e34c62b71ba2aa268d6e62e8c9c6db92b4f3d71609f840bf806f3a41c15L91-R93)).
