### PR TITLE
chore: PickerContaienr ConfirmBox 支持配置  disabled 允许弹出查看但是不可以提交

### DIFF
--- a/packages/amis-ui/src/components/ConfirmBox.tsx
+++ b/packages/amis-ui/src/components/ConfirmBox.tsx
@@ -9,6 +9,7 @@ import {findDOMNode} from 'react-dom';
 
 export interface ConfirmBoxProps extends LocaleProps, ThemeProps {
   show?: boolean;
+  disabled?: boolean;
   closeOnEsc?: boolean;
   beforeConfirm?: (bodyRef?: any) => any;
   onConfirm?: (data: any) => void;
@@ -60,7 +61,8 @@ export function ConfirmBox({
   className,
   bodyClassName,
   footerClassName,
-  mobileUI
+  mobileUI,
+  disabled
 }: ConfirmBoxProps) {
   const [loading, setLoading] = React.useState<boolean>();
   const [error, setError] = React.useState<string>();
@@ -154,7 +156,11 @@ export function ConfirmBox({
             <Button disabled={loading} onClick={onCancel}>
               {__('cancel')}
             </Button>
-            <Button disabled={loading} onClick={handleConfirm} level="primary">
+            <Button
+              disabled={loading || disabled}
+              onClick={handleConfirm}
+              level="primary"
+            >
               {__('confirm')}
             </Button>
           </Modal.Footer>

--- a/packages/amis-ui/src/components/PickerContainer.tsx
+++ b/packages/amis-ui/src/components/PickerContainer.tsx
@@ -31,7 +31,7 @@ export interface PickerContainerProps
   value?: any;
   onFocus?: () => void;
   onClose?: () => void;
-
+  disabled?: boolean;
   onPickerOpen?: (props: PickerContainerProps) => any;
   popOverContainer?: any;
 }
@@ -136,7 +136,8 @@ export class PickerContainer extends React.Component<
       showFooter,
       closeOnEsc,
       popOverContainer,
-      mobileUI
+      mobileUI,
+      disabled
     } = this.props;
     return (
       <>
@@ -160,6 +161,7 @@ export class PickerContainer extends React.Component<
           beforeConfirm={this.confirm}
           popOverContainer={popOverContainer}
           mobileUI={mobileUI}
+          disabled={disabled}
         >
           {({popOverContainer, loading}) =>
             popOverRender({


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6502c5f</samp>

Added `disabled` props to `ConfirmBox` and `PickerContainer` components to improve UI feedback and control.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6502c5f</samp>

> _Oh, we're the crew of the `ConfirmBox`_
> _And we sail the web with skill_
> _We can disable our button when we please_
> _Or enable it with a thrill_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6502c5f</samp>

*  Add `disabled` prop to `ConfirmBox` and `PickerContainer` components to allow disabling user actions ([link](https://github.com/baidu/amis/pull/7916/files?diff=unified&w=0#diff-89c28c278d394e9838591859315788e0d256c58af10e6ac9ed2843aac62ebc78R12), [link](https://github.com/baidu/amis/pull/7916/files?diff=unified&w=0#diff-14e6744577b3c83c5a24878bc24189a129266c7c7a8c6fc4b0f4c978e7e30c1aL34-R34))
*  Pass `disabled` prop from `PickerContainer` to `ConfirmBox` and `Overlay` components as props ([link](https://github.com/baidu/amis/pull/7916/files?diff=unified&w=0#diff-14e6744577b3c83c5a24878bc24189a129266c7c7a8c6fc4b0f4c978e7e30c1aL139-R140), [link](https://github.com/baidu/amis/pull/7916/files?diff=unified&w=0#diff-14e6744577b3c83c5a24878bc24189a129266c7c7a8c6fc4b0f4c978e7e30c1aR164))
*  Use `disabled` prop to conditionally disable the confirm button in `ConfirmBox` along with the `loading` state ([link](https://github.com/baidu/amis/pull/7916/files?diff=unified&w=0#diff-89c28c278d394e9838591859315788e0d256c58af10e6ac9ed2843aac62ebc78L63-R65), [link](https://github.com/baidu/amis/pull/7916/files?diff=unified&w=0#diff-89c28c278d394e9838591859315788e0d256c58af10e6ac9ed2843aac62ebc78L157-R163))
