### PR TITLE
fix: 修复transfer高亮带来的transfer-picker显示options问题

### DIFF
--- a/docs/zh-CN/components/form/transfer-picker.md
+++ b/docs/zh-CN/components/form/transfer-picker.md
@@ -117,8 +117,12 @@ icon:
 ```
 
 ## 属性表
+下面属性为`transfer-picker`独占属性, 更多属性用法，参考[穿梭器（Transfer）](./transfer)
 
-更多配置请参考[穿梭器（Transfer）](./transfer)。
+| 属性名            | 类型      | 默认值  | 说明                                              
+| ----------------- | --------- | ------- | ------------------------------------------------- 
+| borderMode | `'full'` \| `'half'` \| `'none'` |  | 边框模式，`'full'`为全边框，`'half'`为半边框，`'none'`为没边框       |
+| pickerSize          | string |  | 弹窗大小，支持: xs、sm、md、lg、xl、full                                |
 
 ## 事件表
 

--- a/packages/amis-ui/src/components/Transfer.tsx
+++ b/packages/amis-ui/src/components/Transfer.tsx
@@ -676,7 +676,6 @@ export class Transfer<
       rightMode,
       cellRender,
       leftDefaultValue,
-      optionItemRender,
       multiple,
       noResultsText,
       labelField,
@@ -717,7 +716,7 @@ export class Transfer<
         value={value}
         onChange={onChange!}
         onlyChildren={onlyChildren ?? !this.state.isTreeDeferLoad}
-        itemRender={optionItemRender}
+        itemRender={this.optionItemRender}
         onDeferLoad={onDeferLoad}
         joinValues={false}
         showIcon={false}
@@ -740,7 +739,7 @@ export class Transfer<
         onChange={onChange}
         option2value={option2value}
         onDeferLoad={onDeferLoad}
-        itemRender={optionItemRender}
+        itemRender={this.optionItemRender}
         multiple={multiple}
         labelField={labelField}
         valueField={valueField}
@@ -765,7 +764,7 @@ export class Transfer<
         leftMode={leftMode}
         rightMode={rightMode}
         leftDefaultValue={leftDefaultValue}
-        itemRender={optionItemRender}
+        itemRender={this.optionItemRender}
         multiple={multiple}
         labelField={labelField}
         valueField={valueField}
@@ -785,7 +784,7 @@ export class Transfer<
         onChange={onChange}
         option2value={option2value}
         onDeferLoad={onDeferLoad}
-        itemRender={optionItemRender}
+        itemRender={this.optionItemRender}
         multiple={multiple}
         labelField={labelField}
         valueField={valueField}

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/tabsTransfer.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/tabsTransfer.test.tsx.snap
@@ -213,11 +213,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                           class="cxd-Tree-itemText"
                                           title="法师"
                                         >
-                                          <span
-                                            class=""
-                                          >
-                                            法师
-                                          </span>
+                                          法师
                                         </span>
                                         <div
                                           class="cxd-Tree-item-icons"
@@ -253,11 +249,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                           class="cxd-Tree-itemText"
                                           title="诸葛亮"
                                         >
-                                          <span
-                                            class=""
-                                          >
-                                            诸葛亮
-                                          </span>
+                                          诸葛亮
                                         </span>
                                         <div
                                           class="cxd-Tree-item-icons"
@@ -298,11 +290,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                           class="cxd-Tree-itemText"
                                           title="战士"
                                         >
-                                          <span
-                                            class=""
-                                          >
-                                            战士
-                                          </span>
+                                          战士
                                         </span>
                                         <div
                                           class="cxd-Tree-item-icons"
@@ -338,11 +326,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                           class="cxd-Tree-itemText"
                                           title="曹操"
                                         >
-                                          <span
-                                            class=""
-                                          >
-                                            曹操
-                                          </span>
+                                          曹操
                                         </span>
                                         <div
                                           class="cxd-Tree-item-icons"
@@ -378,11 +362,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                           class="cxd-Tree-itemText"
                                           title="钟无艳"
                                         >
-                                          <span
-                                            class=""
-                                          >
-                                            钟无艳
-                                          </span>
+                                          钟无艳
                                         </span>
                                         <div
                                           class="cxd-Tree-item-icons"
@@ -423,11 +403,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                           class="cxd-Tree-itemText"
                                           title="打野"
                                         >
-                                          <span
-                                            class=""
-                                          >
-                                            打野
-                                          </span>
+                                          打野
                                         </span>
                                         <div
                                           class="cxd-Tree-item-icons"
@@ -463,11 +439,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                           class="cxd-Tree-itemText"
                                           title="李白"
                                         >
-                                          <span
-                                            class=""
-                                          >
-                                            李白
-                                          </span>
+                                          李白
                                         </span>
                                         <div
                                           class="cxd-Tree-item-icons"
@@ -503,11 +475,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                           class="cxd-Tree-itemText"
                                           title="韩信"
                                         >
-                                          <span
-                                            class=""
-                                          >
-                                            韩信
-                                          </span>
+                                          韩信
                                         </span>
                                         <div
                                           class="cxd-Tree-item-icons"
@@ -543,11 +511,7 @@ exports[`Renderer:tabsTransfer 1`] = `
                                           class="cxd-Tree-itemText"
                                           title="云中君"
                                         >
-                                          <span
-                                            class=""
-                                          >
-                                            云中君
-                                          </span>
+                                          云中君
                                         </span>
                                         <div
                                           class="cxd-Tree-item-icons"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/transfer.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/transfer.test.tsx.snap
@@ -1775,7 +1775,11 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="法师"
                           >
-                            法师
+                            <span
+                              class=""
+                            >
+                              法师
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -1811,7 +1815,11 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="诸葛亮"
                           >
-                            诸葛亮
+                            <span
+                              class=""
+                            >
+                              诸葛亮
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -1852,7 +1860,11 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="战士"
                           >
-                            战士
+                            <span
+                              class=""
+                            >
+                              战士
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -1888,7 +1900,11 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="曹操"
                           >
-                            曹操
+                            <span
+                              class=""
+                            >
+                              曹操
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -1924,7 +1940,11 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="钟无艳"
                           >
-                            钟无艳
+                            <span
+                              class=""
+                            >
+                              钟无艳
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -1965,7 +1985,11 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="打野"
                           >
-                            打野
+                            <span
+                              class=""
+                            >
+                              打野
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2001,7 +2025,11 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="李白"
                           >
-                            李白
+                            <span
+                              class=""
+                            >
+                              李白
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2037,7 +2065,11 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="韩信"
                           >
-                            韩信
+                            <span
+                              class=""
+                            >
+                              韩信
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2073,7 +2105,11 @@ exports[`Renderer:transfer follow left mode 1`] = `
                             class="cxd-Tree-itemText"
                             title="云中君"
                           >
-                            云中君
+                            <span
+                              class=""
+                            >
+                              云中君
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2407,7 +2443,11 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="法师"
                           >
-                            法师
+                            <span
+                              class=""
+                            >
+                              法师
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2443,7 +2483,11 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="诸葛亮"
                           >
-                            诸葛亮
+                            <span
+                              class=""
+                            >
+                              诸葛亮
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2484,7 +2528,11 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="战士"
                           >
-                            战士
+                            <span
+                              class=""
+                            >
+                              战士
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2520,7 +2568,11 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="曹操"
                           >
-                            曹操
+                            <span
+                              class=""
+                            >
+                              曹操
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2556,7 +2608,11 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="钟无艳"
                           >
-                            钟无艳
+                            <span
+                              class=""
+                            >
+                              钟无艳
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2597,7 +2653,11 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="打野"
                           >
-                            打野
+                            <span
+                              class=""
+                            >
+                              打野
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2633,7 +2693,11 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="李白"
                           >
-                            李白
+                            <span
+                              class=""
+                            >
+                              李白
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2669,7 +2733,11 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="韩信"
                           >
-                            韩信
+                            <span
+                              class=""
+                            >
+                              韩信
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -2705,7 +2773,11 @@ exports[`Renderer:transfer follow left mode 2`] = `
                             class="cxd-Tree-itemText"
                             title="云中君"
                           >
-                            云中君
+                            <span
+                              class=""
+                            >
+                              云中君
+                            </span>
                           </span>
                           <div
                             class="cxd-Tree-item-icons"
@@ -5825,7 +5897,11 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="法师"
                                   >
-                                    法师
+                                    <span
+                                      class=""
+                                    >
+                                      法师
+                                    </span>
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -5861,7 +5937,11 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="诸葛亮"
                                   >
-                                    诸葛亮
+                                    <span
+                                      class=""
+                                    >
+                                      诸葛亮
+                                    </span>
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -5902,7 +5982,11 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="战士"
                                   >
-                                    战士
+                                    <span
+                                      class=""
+                                    >
+                                      战士
+                                    </span>
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -5938,7 +6022,11 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="曹操"
                                   >
-                                    曹操
+                                    <span
+                                      class=""
+                                    >
+                                      曹操
+                                    </span>
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -5974,7 +6062,11 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="钟无艳"
                                   >
-                                    钟无艳
+                                    <span
+                                      class=""
+                                    >
+                                      钟无艳
+                                    </span>
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -6015,7 +6107,11 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="打野"
                                   >
-                                    打野
+                                    <span
+                                      class=""
+                                    >
+                                      打野
+                                    </span>
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -6051,7 +6147,11 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="李白"
                                   >
-                                    李白
+                                    <span
+                                      class=""
+                                    >
+                                      李白
+                                    </span>
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -6087,7 +6187,11 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="韩信"
                                   >
-                                    韩信
+                                    <span
+                                      class=""
+                                    >
+                                      韩信
+                                    </span>
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -6123,7 +6227,11 @@ exports[`Renderer:transfer tree 1`] = `
                                     class="cxd-Tree-itemText"
                                     title="云中君"
                                   >
-                                    云中君
+                                    <span
+                                      class=""
+                                    >
+                                      云中君
+                                    </span>
                                   </span>
                                   <div
                                     class="cxd-Tree-item-icons"
@@ -6323,7 +6431,11 @@ exports[`Renderer:transfer with showInvalidMatch & unmatched do not add 1`] = `
                       class="cxd-Tree-itemText"
                       title="诸葛亮"
                     >
-                      诸葛亮
+                      <span
+                        class=""
+                      >
+                        诸葛亮
+                      </span>
                     </span>
                     <div
                       class="cxd-Tree-item-icons"
@@ -6359,7 +6471,11 @@ exports[`Renderer:transfer with showInvalidMatch & unmatched do not add 1`] = `
                       class="cxd-Tree-itemText"
                       title="曹操"
                     >
-                      曹操
+                      <span
+                        class=""
+                      >
+                        曹操
+                      </span>
                     </span>
                     <div
                       class="cxd-Tree-item-icons"
@@ -6395,7 +6511,11 @@ exports[`Renderer:transfer with showInvalidMatch & unmatched do not add 1`] = `
                       class="cxd-Tree-itemText"
                       title="钟无艳"
                     >
-                      钟无艳
+                      <span
+                        class=""
+                      >
+                        钟无艳
+                      </span>
                     </span>
                     <div
                       class="cxd-Tree-item-icons"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/transferPicker.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/transferPicker.test.tsx.snap
@@ -3,138 +3,155 @@
 exports[`Renderer:transfer-picker 1`] = `
 <div>
   <div
-    class="cxd-Panel cxd-Panel--default cxd-Panel--form"
-    style="position: relative;"
+    class="cxd-Page"
   >
     <div
-      class="cxd-Panel-heading"
+      class="cxd-Page-content"
     >
-      <h3
-        class="cxd-Panel-title"
+      <div
+        class="cxd-Page-main"
       >
-        <span
-          class="cxd-TplField"
-        >
-          <span>
-            表单
-          </span>
-        </span>
-      </h3>
-    </div>
-    <div
-      class="cxd-Panel-body"
-    >
-      <form
-        class="cxd-Form cxd-Form--normal"
-        novalidate=""
-      >
-        <input
-          style="display: none;"
-          type="submit"
-        />
         <div
-          class="cxd-Form-item cxd-Form-item--normal"
-          data-role="form-item"
+          class="cxd-Page-body"
+          role="page-body"
         >
-          <label
-            class="cxd-Form-label"
-          >
-            <span>
-              <span
-                class="cxd-TplField"
-              >
-                <span>
-                  组合穿梭器
-                </span>
-              </span>
-            </span>
-          </label>
           <div
-            class="cxd-TransferControl cxd-Form-control"
+            class="cxd-Panel cxd-Panel--default cxd-Panel--form"
+            style="position: relative;"
           >
             <div
-              class="cxd-ResultBox cxd-TransferPicker is-clickable is-group"
-              tabindex="-1"
+              class="cxd-Panel-heading"
             >
-              <div
-                class="cxd-ResultBox-value-wrap"
+              <h3
+                class="cxd-Panel-title"
               >
                 <span
-                  class="cxd-ResultBox-placeholder"
+                  class="cxd-TplField"
                 >
-                  请选择
+                  <span>
+                    表单
+                  </span>
                 </span>
-                <span
-                  class="cxd-TransferPicker-icon"
+              </h3>
+            </div>
+            <div
+              class="cxd-Panel-body"
+            >
+              <form
+                class="cxd-Form cxd-Form--normal"
+                novalidate=""
+              >
+                <input
+                  style="display: none;"
+                  type="submit"
+                />
+                <div
+                  class="cxd-Form-item cxd-Form-item--normal"
+                  data-role="form-item"
                 >
-                  <icon-mock
-                    classname="icon icon-pencil"
-                    icon="pencil"
-                  />
-                </span>
-              </div>
+                  <label
+                    class="cxd-Form-label"
+                  >
+                    <span>
+                      <span
+                        class="cxd-TplField"
+                      >
+                        <span>
+                          组合穿梭器
+                        </span>
+                      </span>
+                    </span>
+                  </label>
+                  <div
+                    class="cxd-TransferControl cxd-Form-control"
+                  >
+                    <div
+                      class="cxd-ResultBox cxd-TransferPicker is-active is-clickable is-group"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="cxd-ResultBox-value-wrap"
+                      >
+                        <span
+                          class="cxd-ResultBox-placeholder"
+                        >
+                          请选择
+                        </span>
+                        <span
+                          class="cxd-TransferPicker-icon"
+                        >
+                          <icon-mock
+                            classname="icon icon-pencil"
+                            icon="pencil"
+                          />
+                        </span>
+                      </div>
+                      <div
+                        class="cxd-ResultBox-actions"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </form>
+            </div>
+            <div
+              class="cxd-Panel-footerWrap"
+            >
               <div
-                class="cxd-ResultBox-actions"
+                class="cxd-Panel-btnToolbar cxd-Panel-footer"
+              >
+                <button
+                  class="cxd-Button cxd-Button--primary cxd-Button--size-default"
+                  type="submit"
+                >
+                  <span>
+                    提交
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="resize-sensor"
+              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
+            >
+              
+  
+              <div
+                class="resize-sensor-expand"
+                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+              >
+                
+    
+                <div
+                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                />
+                
+  
+              </div>
+              
+  
+              <div
+                class="resize-sensor-shrink"
+                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+              >
+                
+    
+                <div
+                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                />
+                
+  
+              </div>
+              
+  
+              <div
+                class="resize-sensor-appear"
+                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
               />
             </div>
           </div>
         </div>
-      </form>
-    </div>
-    <div
-      class="cxd-Panel-footerWrap"
-    >
-      <div
-        class="cxd-Panel-btnToolbar cxd-Panel-footer"
-      >
-        <button
-          class="cxd-Button cxd-Button--primary cxd-Button--size-default"
-          type="submit"
-        >
-          <span>
-            提交
-          </span>
-        </button>
       </div>
-    </div>
-    <div
-      class="resize-sensor"
-      style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-    >
-      
-  
-      <div
-        class="resize-sensor-expand"
-        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-      >
-        
-    
-        <div
-          style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-        />
-        
-  
-      </div>
-      
-  
-      <div
-        class="resize-sensor-shrink"
-        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-      >
-        
-    
-        <div
-          style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-        />
-        
-  
-      </div>
-      
-  
-      <div
-        class="resize-sensor-appear"
-        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-      />
     </div>
   </div>
 </div>

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/transferPicker.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/transferPicker.test.tsx.snap
@@ -1,0 +1,141 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Renderer:transfer-picker 1`] = `
+<div>
+  <div
+    class="cxd-Panel cxd-Panel--default cxd-Panel--form"
+    style="position: relative;"
+  >
+    <div
+      class="cxd-Panel-heading"
+    >
+      <h3
+        class="cxd-Panel-title"
+      >
+        <span
+          class="cxd-TplField"
+        >
+          <span>
+            表单
+          </span>
+        </span>
+      </h3>
+    </div>
+    <div
+      class="cxd-Panel-body"
+    >
+      <form
+        class="cxd-Form cxd-Form--normal"
+        novalidate=""
+      >
+        <input
+          style="display: none;"
+          type="submit"
+        />
+        <div
+          class="cxd-Form-item cxd-Form-item--normal"
+          data-role="form-item"
+        >
+          <label
+            class="cxd-Form-label"
+          >
+            <span>
+              <span
+                class="cxd-TplField"
+              >
+                <span>
+                  组合穿梭器
+                </span>
+              </span>
+            </span>
+          </label>
+          <div
+            class="cxd-TransferControl cxd-Form-control"
+          >
+            <div
+              class="cxd-ResultBox cxd-TransferPicker is-clickable is-group"
+              tabindex="-1"
+            >
+              <div
+                class="cxd-ResultBox-value-wrap"
+              >
+                <span
+                  class="cxd-ResultBox-placeholder"
+                >
+                  请选择
+                </span>
+                <span
+                  class="cxd-TransferPicker-icon"
+                >
+                  <icon-mock
+                    classname="icon icon-pencil"
+                    icon="pencil"
+                  />
+                </span>
+              </div>
+              <div
+                class="cxd-ResultBox-actions"
+              />
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div
+      class="cxd-Panel-footerWrap"
+    >
+      <div
+        class="cxd-Panel-btnToolbar cxd-Panel-footer"
+      >
+        <button
+          class="cxd-Button cxd-Button--primary cxd-Button--size-default"
+          type="submit"
+        >
+          <span>
+            提交
+          </span>
+        </button>
+      </div>
+    </div>
+    <div
+      class="resize-sensor"
+      style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
+    >
+      
+  
+      <div
+        class="resize-sensor-expand"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      >
+        
+    
+        <div
+          style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+        />
+        
+  
+      </div>
+      
+  
+      <div
+        class="resize-sensor-shrink"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      >
+        
+    
+        <div
+          style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+        />
+        
+  
+      </div>
+      
+  
+      <div
+        class="resize-sensor-appear"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/packages/amis/__tests__/renderers/Form/transfer.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/transfer.test.tsx
@@ -1311,3 +1311,81 @@ test('Renderer:transfer tree onlyChildren true', async () => {
     transfer: "zhugeliang,zhongwuyan,libai,hanxin,yunzhongjun"
   });
 });
+
+test('Renderer:transfer tree onlyChildren true', async () => {
+  const onSubmit = jest.fn();
+  const schema = {
+    "type": "form",
+    "api": "/api/mock2/form/saveForm",
+    "debug": true,
+    "body": [
+      {
+        "label": "默认",
+        "type": "transfer",
+        "name": "transfer",
+        "selectMode": "tree",
+        "searchable": true,
+        "options": [
+          {
+            "label": "法师",
+            "children": [
+              {
+                "label": "诸葛亮",
+                "value": "zhugeliang"
+              }
+            ]
+          },
+          {
+            "label": "战士",
+            "children": [
+              {
+                "label": "曹操",
+                "disabled": true,
+                "value": "caocao"
+              },
+              {
+                "label": "钟无艳",
+                "value": "zhongwuyan"
+              }
+            ]
+          },
+          {
+            "label": "打野",
+            "children": [
+              {
+                "label": "李白",
+                "value": "libai"
+              },
+              {
+                "label": "韩信",
+                "value": "hanxin"
+              },
+              {
+                "label": "云中君",
+                "value": "yunzhongjun"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  };
+
+  const {container} = render(
+    amisRender(schema, {onSubmit}, makeEnv({}))
+  );
+
+  const input = container.querySelector('input')!;
+  expect(input).not.toBeNull();
+
+  fireEvent.change(input, {
+    target: {
+      value: '战士'
+    }
+  });
+
+  await wait(300);
+
+  const isMatchDom = container.querySelector('.is-matched');
+  expect(isMatchDom).not.toBeNull();
+});

--- a/packages/amis/__tests__/renderers/Form/transfer.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/transfer.test.tsx
@@ -1312,79 +1312,80 @@ test('Renderer:transfer tree onlyChildren true', async () => {
   });
 });
 
-test('Renderer:transfer tree onlyChildren true', async () => {
+test('Renderer:transfer search highlight', async () => {
+
   const onSubmit = jest.fn();
-  const schema = {
-    "type": "form",
-    "api": "/api/mock2/form/saveForm",
-    "debug": true,
-    "body": [
+  const {container} = render(
+    amisRender(
       {
-        "label": "默认",
-        "type": "transfer",
-        "name": "transfer",
-        "selectMode": "tree",
-        "searchable": true,
-        "options": [
+        "type": "form",
+        "api": "/api/mock2/form/saveForm",
+        "body": [
           {
-            "label": "法师",
-            "children": [
+            "label": "默认",
+            "type": "transfer",
+            "name": "transfer",
+            "selectMode": "tree",
+            "searchable": true,
+            "options": [
               {
-                "label": "诸葛亮",
-                "value": "zhugeliang"
-              }
-            ]
-          },
-          {
-            "label": "战士",
-            "children": [
-              {
-                "label": "曹操",
-                "disabled": true,
-                "value": "caocao"
+                "label": "法师",
+                "children": [
+                  {
+                    "label": "诸葛亮",
+                    "value": "zhugeliang"
+                  }
+                ]
               },
               {
-                "label": "钟无艳",
-                "value": "zhongwuyan"
-              }
-            ]
-          },
-          {
-            "label": "打野",
-            "children": [
-              {
-                "label": "李白",
-                "value": "libai"
+                "label": "战士",
+                "children": [
+                  {
+                    "label": "曹操",
+                    "disabled": true,
+                    "value": "caocao"
+                  },
+                  {
+                    "label": "钟无艳",
+                    "value": "zhongwuyan"
+                  }
+                ]
               },
               {
-                "label": "韩信",
-                "value": "hanxin"
-              },
-              {
-                "label": "云中君",
-                "value": "yunzhongjun"
+                "label": "打野",
+                "children": [
+                  {
+                    "label": "李白",
+                    "value": "libai"
+                  },
+                  {
+                    "label": "韩信",
+                    "value": "hanxin"
+                  },
+                  {
+                    "label": "云中君",
+                    "value": "yunzhongjun"
+                  }
+                ]
               }
             ]
           }
         ]
-      }
-    ]
-  };
+      },
+      {onSubmit},
+      makeEnv({})
+    )
+  )
 
-  const {container} = render(
-    amisRender(schema, {onSubmit}, makeEnv({}))
-  );
+  const input = container.querySelectorAll('input[type=text]')[0];
 
-  const input = container.querySelector('input')!;
   expect(input).not.toBeNull();
 
   fireEvent.change(input, {
-    target: {
-      value: '战士'
-    }
+    target: {value: '战士'}
   });
 
-  await wait(300);
+  await wait(500);
 
   const isMatchDom = container.querySelector('.is-matched');
   expect(isMatchDom).not.toBeNull();

--- a/packages/amis/__tests__/renderers/Form/transferPicker.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/transferPicker.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * 组件名称：transfer-picker
+ *
+ */
+
+import {fireEvent, render, waitFor} from '@testing-library/react';
+import '../../../src';
+import {render as amisRender} from '../../../src';
+import {makeEnv, wait} from '../../helper';
+
+test('Renderer:transfer-picker', async () => {
+  const onSubmit = jest.fn();
+  const {container, findByText} = render(
+    amisRender(
+      {
+        "type": "page",
+        "body": {
+          "type": "form",
+          "api": "/api/mock2/form/saveForm",
+          "body": [
+            {
+              "label": "组合穿梭器",
+              "type": "transfer-picker",
+              "name": "a",
+              "sortable": true,
+              "selectMode": "tree",
+              "searchable": true,
+              "options": [
+                {
+                  "label": "法师",
+                  "children": [
+                    {
+                      "label": "诸葛亮",
+                      "value": "zhugeliang"
+                    }
+                  ]
+                },
+                {
+                  "label": "战士",
+                  "children": [
+                    {
+                      "label": "曹操",
+                      "value": "caocao"
+                    },
+                    {
+                      "label": "钟无艳",
+                      "value": "zhongwuyan"
+                    }
+                  ]
+                },
+                {
+                  "label": "打野",
+                  "children": [
+                    {
+                      "label": "李白",
+                      "value": "libai"
+                    },
+                    {
+                      "label": "韩信",
+                      "value": "hanxin"
+                    },
+                    {
+                      "label": "云中君",
+                      "value": "yunzhongjun"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {onSubmit},
+      makeEnv({})
+    )
+  );
+
+  const dom = container.querySelector('.cxd-ResultBox')!;
+  expect(dom).not.toBeNull();
+
+  fireEvent.click(dom);
+
+  await wait(3000);
+
+  const zhugeliang = await findByText('诸葛亮');
+  expect(zhugeliang).not.toBeNull();
+  fireEvent.click(zhugeliang);
+  const yunzhongjun = await findByText('云中君');
+  fireEvent.click(yunzhongjun);
+
+  await wait(500);
+  expect(container).toMatchSnapshot();
+
+  const ok = await findByText('确认');
+  fireEvent.click(ok);
+
+  await wait(2000);
+
+  const summit = await findByText('提交');
+  fireEvent.click(summit);
+
+  await wait(500);
+  expect(onSubmit).toBeCalled();
+  expect(onSubmit.mock.calls[0][0]).toEqual({
+    a: 'zhugeliang,yunzhongjun'
+  });
+
+}, 10000);
+ 
+ 

--- a/packages/amis/src/renderers/Form/TabsTransfer.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransfer.tsx
@@ -301,6 +301,8 @@ export class TabsTransferRenderer extends BaseTabsTransferRenderer<TabsTransferP
       loadingConfig,
       valueField = 'value',
       labelField = 'label',
+      valueTpl,
+      menuTpl,
       data,
       mobileUI
     } = this.props;
@@ -323,8 +325,8 @@ export class TabsTransferRenderer extends BaseTabsTransferRenderer<TabsTransferP
           onLeftDeferLoad={leftDeferLoad}
           selectTitle={selectTitle}
           resultTitle={resultTitle}
-          optionItemRender={this.optionItemRender}
-          resultItemRender={this.resultItemRender}
+          optionItemRender={menuTpl ? this.optionItemRender : undefined}
+          resultItemRender={valueTpl ? this.resultItemRender : undefined}
           onTabChange={this.onTabChange}
           itemHeight={
             toNumber(itemHeight) > 0 ? toNumber(itemHeight) : undefined

--- a/packages/amis/src/renderers/Form/TransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TransferPicker.tsx
@@ -87,6 +87,8 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
       loadingConfig,
       labelField = 'label',
       valueField = 'value',
+      menuTpl,
+      valueTpl,
       mobileUI,
       env
     } = this.props;
@@ -128,8 +130,8 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
           columns={columns}
           leftMode={leftMode}
           leftOptions={leftOptions}
-          optionItemRender={this.optionItemRender}
-          resultItemRender={this.resultItemRender}
+          optionItemRender={menuTpl ? this.optionItemRender : undefined}
+          resultItemRender={valueTpl ? this.resultItemRender : undefined}
           onFocus={() => this.dispatchEvent('focus')}
           onBlur={() => this.dispatchEvent('blur')}
           labelField={labelField}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a053e48</samp>

This pull request improves the customization and rendering of the `Transfer`, `TabsTransfer`, and `TransferPicker` components by supporting custom templates for the options and values. It also updates the documentation for the `transfer-picker` component with more attributes and a reference to the `transfer` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a053e48</samp>

> _Sing, O Muse, of the skillful coder who refined the Transfer component_
> _And made it more versatile and elegant with custom templates_
> _He added a table of attributes for the TransferPicker, swift and sleek_
> _And linked it to the Transfer, source of many options and modes_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a053e48</samp>

*  Add `valueTpl` and `menuTpl` props to `TransferPickerRenderer` and `TabsTransferRenderer` components, which allow customizing the display of selected and available options ([link](https://github.com/baidu/amis/pull/7917/files?diff=unified&w=0#diff-b5e07e34c62b71ba2aa268d6e62e8c9c6db92b4f3d71609f840bf806f3a41c15R90-R91), [link](https://github.com/baidu/amis/pull/7917/files?diff=unified&w=0#diff-36d4a19803ba21094b5aee307abb8b8c5cad04fcb3c373082cddf1566b591f21R304-R305))
*  Pass `optionItemRender` and `resultItemRender` props to `TransferPicker` and `Transfer` components based on the presence of `valueTpl` and `menuTpl` props, using custom render methods that handle the templates ([link](https://github.com/baidu/amis/pull/7917/files?diff=unified&w=0#diff-b5e07e34c62b71ba2aa268d6e62e8c9c6db92b4f3d71609f840bf806f3a41c15L131-R134), [link](https://github.com/baidu/amis/pull/7917/files?diff=unified&w=0#diff-36d4a19803ba21094b5aee307abb8b8c5cad04fcb3c373082cddf1566b591f21L326-R329))
*  Remove `optionItemRender` prop from `Transfer` component, as it is no longer needed ([link](https://github.com/baidu/amis/pull/7917/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L679))
*  Replace `itemRender` prop with custom `optionItemRender` method in `Transfer`, `LeftOptions`, `RightOptions`, and `ResultOptions` components, which render the `menuTpl` prop if provided, or fall back to the default item render ([link](https://github.com/baidu/amis/pull/7917/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L720-R719), [link](https://github.com/baidu/amis/pull/7917/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L743-R742), [link](https://github.com/baidu/amis/pull/7917/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L768-R767), [link](https://github.com/baidu/amis/pull/7917/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L788-R787))
*  Update the documentation for the `transfer-picker` component in `docs/zh-CN/components/form/transfer-picker.md`, adding a table of attributes and a link to the `transfer` component ([link](https://github.com/baidu/amis/pull/7917/files?diff=unified&w=0#diff-325bfbb9c8f71f4a209cb855f8a71335486d09ddd8313c15821c27a713871291L120-R125))
