### PR TITLE
fix: 表单项组件开启 static 后部分不合法输入未处理导致异常

### DIFF
--- a/packages/amis/src/renderers/Form/StaticHoc.tsx
+++ b/packages/amis/src/renderers/Form/StaticHoc.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import toString from 'lodash/toString';
 import {getPropValue, FormControlProps} from 'amis-core';
 
 function renderCommonStatic(props: any, defaultValue: string) {
@@ -132,7 +133,11 @@ export function supportStatic<T extends FormControlProps>() {
           body = renderCommonStatic(props, displayValue);
         }
 
-        return <div className={cx(`${ns}Form-static`, className)}>{body}</div>;
+        return (
+          <div className={cx(`${ns}Form-static`, className)}>
+            {React.isValidElement(body) ? body : toString(body)}
+          </div>
+        );
       }
 
       return original.apply(this, args);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e088b73</samp>

Fix bug in static form fields with non-string default values. Use `toString` from lodash in `StaticHoc.tsx` to render valid ReactNodes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e088b73</samp>

> _Oh we're the coders of the sea, and we fix the bugs with glee_
> _We import the `toString` from lodash, and we use it in the `renderCommonStatic`_
> _So haul away, me hearties, haul away_
> _We'll make the forms look nice and neat, by the count of three_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e088b73</samp>

* Import `toString` function from lodash to convert any value to a string ([link](https://github.com/baidu/amis/pull/7918/files?diff=unified&w=0#diff-6743296e062555d6d5ef1ffa806450e07b74989e2b2bcc829517a34a8560e918R2))
