### PR TITLE
fix: 复制后粘贴组件schema会被schemaFilter方法转换，出现一些异常的结果

### DIFF
--- a/packages/amis-editor-core/src/store/editor.ts
+++ b/packages/amis-editor-core/src/store/editor.ts
@@ -410,8 +410,7 @@ export const MainStore = types
 
       // 用于剔除多余的字段
       getSimpleSchema(curSchema: any) {
-        const schema = JSONPipeOut(curSchema);
-        return getEnv(self).schemaFilter?.(schema) ?? schema;
+        return JSONPipeOut(curSchema);
       },
 
       getPanelKey() {

--- a/packages/amis-editor/examples/Editor.tsx
+++ b/packages/amis-editor/examples/Editor.tsx
@@ -194,27 +194,27 @@ const variableSchemas = {
   type: 'object',
   $id: 'appVariables',
   properties: {
-    'appVariables.ProductName': {
+    ProductName: {
       type: 'string',
       title: '产品名称',
       default: '对象存储'
     },
-    'appVariables.Banlance': {
+    Banlance: {
       type: 'number',
       title: '账户余额',
       default: '0.00'
     },
-    'appVariables.ProductNum': {
+    ProductNum: {
       type: 'integer',
       title: '产品数量',
       default: '0.00'
     },
-    'appVariables.isOnline': {
+    isOnline: {
       type: 'boolean',
       title: '是否线上环境',
       default: 'false'
     },
-    'appVariables.ProductList': {
+    ProductList: {
       type: 'array',
       items: {
         type: 'string',
@@ -223,7 +223,7 @@ const variableSchemas = {
       title: '产品列表',
       default: '["BOS", "CFS", "PFS", "CloudFlow", "MongoDB"]'
     },
-    'appVariables.PROFILE': {
+    PROFILE: {
       type: 'object',
       title: '个人信息',
       properties: {
@@ -661,7 +661,8 @@ export default class AMisSchemaEditor extends React.Component<any, any> {
         ctx={{
           __page: {
             num: 2
-          }
+          },
+          ...variableDefaultData
         }}
       />
     );

--- a/packages/amis-ui/scss/components/_json-schema-editor.scss
+++ b/packages/amis-ui/scss/components/_json-schema-editor.scss
@@ -63,7 +63,7 @@
     flex-wrap: wrap;
     gap: var(--gap-sm);
 
-    align-items: flex-start;
+    align-items: stretch;
     position: relative;
   }
 


### PR DESCRIPTION
### What

1. 去除粘贴函数中，将schema经过schemaFilter函数处理的操作，原因是在SaaS中的schemaFilter方法中有一些对schema的变更，如：配置关联权限后，经过schemaFilter会在acl.can中加上page:xxxx信息
2. 上下文变量结构调整后，页面设计器中内存变量的demo进行结构上的调整
3. jsonSchemaEditor 输入框没有撑满，修复样式问题

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at eee7ed6</samp>

> _We are the masters of the schema_
> _We crush the bugs and make it faster_
> _We stretch the items to the limit_
> _We fill the variables with our spirit_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eee7ed6</samp>

*  Simplify `getSimpleSchema` function to avoid unnecessary call to undefined `schemaFilter` ([link](https://github.com/baidu/amis/pull/7919/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8L413-R413))
*  Fix variable replacement bug by removing redundant `appVariables.` prefix from `variableSchemas` properties ([link](https://github.com/baidu/amis/pull/7919/files?diff=unified&w=0#diff-ac37ef7e74b39117226be066461e8c65edafc2318cf9874536ac80f09b6f9f41L197-R217), [link](https://github.com/baidu/amis/pull/7919/files?diff=unified&w=0#diff-ac37ef7e74b39117226be066461e8c65edafc2318cf9874536ac80f09b6f9f41L226-R226))
*  Add `variableDefaultData` object to `data` prop of `AmisEditor` component to render variables correctly ([link](https://github.com/baidu/amis/pull/7919/files?diff=unified&w=0#diff-ac37ef7e74b39117226be066461e8c65edafc2318cf9874536ac80f09b6f9f41L664-R665))
*  Improve editor layout by changing `align-items` property of `.json-schema-editor` class to `stretch` ([link](https://github.com/baidu/amis/pull/7919/files?diff=unified&w=0#diff-023ace062aeb128a42b1e84e9fdf885ea2f11c27c5b2f05897fa4d76a431e7ddL66-R66))
