### PR TITLE
fix: buttonGroupSelect传入buttons时没有选中态

### DIFF
--- a/packages/amis/src/renderers/Form/ButtonGroupSelect.tsx
+++ b/packages/amis/src/renderers/Form/ButtonGroupSelect.tsx
@@ -115,7 +115,7 @@ export default class ButtonGroupControl extends React.Component<
 
     if (options && options.length) {
       body = options.map((option, key) => {
-        const active = !!~selectedOptions?.indexOf(option);
+        const active = !!~selectedOptions.indexOf(option);
         const optionBadge = this.getBadgeConfig(badge, option);
 
         return render(

--- a/packages/amis/src/renderers/Form/ButtonGroupSelect.tsx
+++ b/packages/amis/src/renderers/Form/ButtonGroupSelect.tsx
@@ -115,7 +115,7 @@ export default class ButtonGroupControl extends React.Component<
 
     if (options && options.length) {
       body = options.map((option, key) => {
-        const active = !!~selectedOptions.indexOf(option);
+        const active = !!~selectedOptions?.indexOf(option);
         const optionBadge = this.getBadgeConfig(badge, option);
 
         return render(
@@ -150,7 +150,6 @@ export default class ButtonGroupControl extends React.Component<
     } else if (Array.isArray(buttons)) {
       body = buttons.map((button, key) => {
         const buttonBadge = this.getBadgeConfig(badge, button);
-        const active = !!~selectedOptions.indexOf(button);
         return render(
           `button/${key}`,
           {
@@ -164,11 +163,7 @@ export default class ButtonGroupControl extends React.Component<
           },
           {
             key,
-            className: cx(
-              button.className,
-              btnClassName,
-              active && 'ButtonGroup-button--active'
-            )
+            className: cx(button.className, btnClassName)
           }
         );
       });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ef8ed2</samp>

Fix and improve `buttonGroupSelect` component in `Form` renderer. This component can now handle dynamic sources correctly and display the buttons more elegantly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6ef8ed2</samp>

> _Oh we're the coders of the `buttonGroupSelect`_
> _We make it work with any source you can get_
> _We optimize the code and style of the buttons_
> _And we fix the bugs with skill and gumption_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6ef8ed2</samp>

* Fix bug that caused error when using `buttonGroupSelect` with dynamic source by adding optional chaining to `selectedOptions` array ([link](https://github.com/baidu/amis/pull/7926/files?diff=unified&w=0#diff-2ec706af1c78093f89e55e260abb9f49005f045251e7e0f3d7a24bfd460a6b16L118-R118))
* Optimize and simplify code for checking active state of buttons by removing redundant logic and relying on `ButtonGroup` component ([link](https://github.com/baidu/amis/pull/7926/files?diff=unified&w=0#diff-2ec706af1c78093f89e55e260abb9f49005f045251e7e0f3d7a24bfd460a6b16L153), [link](https://github.com/baidu/amis/pull/7926/files?diff=unified&w=0#diff-2ec706af1c78093f89e55e260abb9f49005f045251e7e0f3d7a24bfd460a6b16L167-R166))
* Clean up and improve consistency of code by removing unused `ButtonGroup-button--active` class from button props ([link](https://github.com/baidu/amis/pull/7926/files?diff=unified&w=0#diff-2ec706af1c78093f89e55e260abb9f49005f045251e7e0f3d7a24bfd460a6b16L167-R166))
