### PR TITLE
fix: 修复Transfer 搜索后选择导致已选项清空

### DIFF
--- a/packages/amis-ui/src/components/Transfer.tsx
+++ b/packages/amis-ui/src/components/Transfer.tsx
@@ -388,8 +388,8 @@ export class Transfer<
       (a, b) => a[valueField] === b[valueField]
     );
     const unuseArr = differenceFromAll(
-      searchAvailableOptions,
       values,
+      searchAvailableOptions,
       item => item[valueField]
     );
 

--- a/packages/amis/__tests__/renderers/Form/transfer.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/transfer.test.tsx
@@ -1501,5 +1501,4 @@ test('Renderer:transfer tree search', async () => {
   expect(onSubmit.mock.calls[0][0]).toEqual({
     transfer: "caocao,libai"
   });
-  
 });

--- a/packages/amis/__tests__/renderers/Form/transfer.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/transfer.test.tsx
@@ -1390,3 +1390,116 @@ test('Renderer:transfer search highlight', async () => {
   const isMatchDom = container.querySelector('.is-matched');
   expect(isMatchDom).not.toBeNull();
 });
+
+test('Renderer:transfer tree search', async () => {
+
+  const onSubmit = jest.fn();
+  const {container, findByText, getByText} = render(
+    amisRender(
+      {
+        "type": "form",
+        "api": "/api/mock2/form/saveForm",
+        "body": [
+          {
+            "label": "默认",
+            "type": "transfer",
+            "name": "transfer",
+            "selectMode": "tree",
+            "searchable": true,
+            "options": [
+              {
+                "label": "法师",
+                "children": [
+                  {
+                    "label": "诸葛亮",
+                    "value": "zhugeliang"
+                  }
+                ]
+              },
+              {
+                "label": "战士",
+                "children": [
+                  {
+                    "label": "曹操",
+                    "value": "caocao"
+                  },
+                  {
+                    "label": "钟无艳",
+                    "value": "zhongwuyan"
+                  }
+                ]
+              },
+              {
+                "label": "打野",
+                "children": [
+                  {
+                    "label": "李白",
+                    "value": "libai"
+                  },
+                  {
+                    "label": "韩信",
+                    "value": "hanxin"
+                  },
+                  {
+                    "label": "云中君",
+                    "value": "yunzhongjun"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {onSubmit},
+      makeEnv({})
+    )
+  )
+
+  const input = container.querySelectorAll('input[type=text]')[0];
+
+  expect(input).not.toBeNull();
+
+  fireEvent.change(input, {
+    target: {
+      value: '战士'
+    }
+  });
+
+  await(300);
+
+  const caocao = getByText('曹操');
+  expect(caocao).not.toBeNull();
+  fireEvent.click(caocao);
+
+  fireEvent.change(input, {
+    target: {
+      value: ''
+    }
+  });
+
+  await(300);
+
+  fireEvent.change(input, {
+    target: {
+      value: '打野'
+    }
+  });
+
+  await(300);
+  
+  const libai = getByText('李白');
+  expect(libai).not.toBeNull();
+  fireEvent.click(libai);
+
+  await wait(500);
+
+  fireEvent.click(getByText('提交'));
+
+  await wait(300);
+  expect(onSubmit).toBeCalledTimes(1);
+
+  expect(onSubmit.mock.calls[0][0]).toEqual({
+    transfer: "caocao,libai"
+  });
+  
+});


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab26434</samp>

This pull request fixes a bug in the `Transfer` component that prevented searching and selecting options in tree mode. It also adds a test case for this scenario in `transfer.test.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ab26434</samp>

> _`Transfer` bug fixed_
> _Searching preserves selections_
> _Autumn leaves submit_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab26434</samp>

* Fix bug in `Transfer` component that filtered out selected options when searching ([link](https://github.com/baidu/amis/pull/7927/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L391-R392))
* Add test case for `Transfer` component with `selectMode` set to `tree` and `searchable` set to `true` ([link](https://github.com/baidu/amis/pull/7927/files?diff=unified&w=0#diff-5f8efdd91ce02f5eb0f1e3040ac9adbb2e5dfc5ce6054c843f7e81bac4daa0f0L1392-R1503))
