### PR TITLE
fix:「事件监听」动作配置-页面地址-全屏模式下，默认置灰字体「请输入」和光标对不齐。针对fullscreen类名fix该问题

### DIFF
--- a/packages/amis-editor-core/scss/control/_textarea-formula-control.scss
+++ b/packages/amis-editor-core/scss/control/_textarea-formula-control.scss
@@ -135,6 +135,9 @@
           }
         }
       }
+      &-placeholder {
+        padding: 10px;
+      }
     }
   }
 }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 64935b1</samp>

This pull request improves the appearance of the `textarea-formula-control` component in the `amis-editor-core` package. It adds a padding style to the placeholder element to align it better with the textarea border.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 64935b1</samp>

> _`textarea` style_
> _padding for placeholder_
> _autumn alignment_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 64935b1</samp>

*  Add padding style to placeholder element of textarea-formula-control component to improve alignment and spacing ([link](https://github.com/baidu/amis/pull/7930/files?diff=unified&w=0#diff-a866428d4b4889f641f7fa60f60ba4526c8b563159953b981a8a6306c72254c5R138-R140))
