### PR TITLE
fix: ConditionBuilder从 query 中获取初始值时值类型错误问题

### DIFF
--- a/packages/amis-ui/src/components/formula/Input.tsx
+++ b/packages/amis-ui/src/components/formula/Input.tsx
@@ -132,7 +132,16 @@ const FormulaInput: React.FC<FormulaInputProps> = props => {
     );
   };
 
-  const cmptValue = pipInValue(value ?? inputSettings.defaultValue);
+  let cmptValue = pipInValue(value ?? inputSettings.defaultValue);
+
+  /** 数据来源可能是从 query中下发的（CRUD查询表头），导致数字或者布尔值被转为 string 格式，这里预处理一下 */
+  if (schemaType === 'number') {
+    cmptValue = isNaN(+cmptValue) ? cmptValue : +cmptValue;
+  } else if (schemaType === 'boolean') {
+    cmptValue =
+      cmptValue === 'true' ? true : cmptValue === 'false' ? false : cmptValue;
+  }
+
   const targetVariable =
     variables && cmptValue != null && typeof cmptValue === 'string'
       ? findTree(variables, item => {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5359d34</samp>

Fix input value parsing for query data sources. The change ensures that the input component respects the schema type and converts the value from string to number or boolean if needed.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5359d34</samp>

> _`input` component_
> _preprocesses query values_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5359d34</samp>

* Add a preprocessing step to parse input values from query sources according to schema type ([link](https://github.com/baidu/amis/pull/7939/files?diff=unified&w=0#diff-6a3dacc1d80cbde4dcd1d597b6aeb6d24f7874c3c317bf98ed47721a48e10930L135-R144))
