### PR TITLE
fix: table2设计态loading报错、拖拽无效、单元格渲染property组件问题修复

### DIFF
--- a/docs/zh-CN/components/table2.md
+++ b/docs/zh-CN/components/table2.md
@@ -28,7 +28,36 @@ order: 67
                 },
                 {
                     "title": "Version",
-                    "name": "version"
+                    "name": "version",
+                    "type": "property",
+                    "items": [
+                        {
+                            "label": "cpu",
+                            "content": "1 core"
+                        },
+                        {
+                            "label": "memory",
+                            "content": "4G"
+                        },
+                        {
+                            "label": "disk",
+                            "content": "80G"
+                        },
+                        {
+                            "label": "network",
+                            "content": "4M",
+                            "span": 2
+                        },
+                        {
+                            "label": "IDC",
+                            "content": "beijing"
+                        },
+                        {
+                            "label": "Note",
+                            "content": "其它说明",
+                            "span": 3
+                        }
+                    ]
                 },
                 {
                     "title": "Browser",

--- a/packages/amis-ui/scss/components/_table2.scss
+++ b/packages/amis-ui/scss/components/_table2.scss
@@ -621,7 +621,7 @@
         }
       }
 
-      > thead > tr > th:not(:last-child):not(:first-child) {
+      > thead > tr > th:not(:last-child) {
         &.#{$ns}Table-cell-fix-left-last {
           border-right: none;
         }
@@ -678,7 +678,13 @@
           bottom: 0;
           user-select: none;
           cursor: col-resize;
-          z-index: 3000;
+          z-index: 15;
+          opacity: 0.5;
+
+          &:hover,
+          &.is-resizing {
+            background: var(--primary);
+          }
         }
       }
     }
@@ -686,7 +692,6 @@
 
   .#{$ns}Table-loading {
     padding: var(--Table-loading-padding);
-    text-align: center;
   }
 
   .#{$ns}TableCell-sortBtn {

--- a/packages/amis-ui/src/components/table/Cell.tsx
+++ b/packages/amis-ui/src/components/table/Cell.tsx
@@ -29,6 +29,8 @@ export interface Props extends ThemeProps, LocaleProps {
   wrapperComponent: any;
   groupId?: string; // 表头分组随机生成的id
   depth?: number; // 表头分组
+  col?: string;
+  index?: number;
   classnames: ClassNamesFn;
 }
 
@@ -52,6 +54,8 @@ export class BodyCell extends React.Component<Props> {
       style,
       groupId,
       depth,
+      index,
+      col,
       wrapperComponent: Component,
       classnames: cx
     } = this.props;
@@ -68,6 +72,8 @@ export class BodyCell extends React.Component<Props> {
         style={fixed ? {position: 'sticky', zIndex, ...style} : {...style}}
         data-group-id={groupId || null}
         data-depth={depth || null}
+        data-col={col}
+        data-index={index === -1 ? null : index}
       >
         {children}
       </Component>

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -29,7 +29,7 @@ import {
   isArrayChildrenModified,
   filterTarget
 } from 'amis-core';
-import {Icon, Table, Spinner, BadgeObject, SpinnerExtraProps} from 'amis-ui';
+import {Icon, Table, BadgeObject, SpinnerExtraProps} from 'amis-ui';
 import type {
   SortProps,
   ColumnProps,
@@ -435,6 +435,37 @@ export interface Table2Props extends RendererProps, SpinnerExtraProps {
 export default class Table2 extends React.Component<Table2Props, object> {
   static contextType = ScopedContext;
 
+  static propsList: Array<string> = [
+    'source',
+    'columnsTogglable',
+    'columns',
+    'items',
+    'rowSelection',
+    'expandable',
+    'sticky',
+    'itemBadge',
+    'popOverContainer',
+    'keyField',
+    'childrenColumnName',
+    'rowClassNameExpr',
+    'lineHeight',
+    'bordered',
+    'footer',
+    'maxKeepItemSelectionLength',
+    'keepItemSelectionOnPageChange',
+    'itemActions',
+    'headingClassName',
+    'footSummary',
+    'headSummary',
+    'saveImmediately',
+    'selectable',
+    'multiple',
+    'primaryField',
+    'hideQuickSaveBtn',
+    'selected',
+    'placeholder'
+  ];
+
   renderedToolbars: Array<string> = [];
   tableRef?: any;
   subForms: any = {};
@@ -672,6 +703,7 @@ export default class Table2 extends React.Component<Table2Props, object> {
       // title 不应该传递到 cell-field 的 column 中，否则部分组件会将其渲染出来
       // 但是 cell-field 需要这个字段，展示列的名称
       const {width, children, title, ...rest} = schema;
+
       return render(
         'cell-field',
         {
@@ -1770,13 +1802,7 @@ export default class Table2 extends React.Component<Table2Props, object> {
   }
 
   render() {
-    const {
-      classnames: cx,
-      style,
-      loading = false,
-      loadingConfig,
-      store
-    } = this.props;
+    const {classnames: cx, style, store} = this.props;
 
     this.renderedToolbars = []; // 用来记录哪些 toolbar 已经渲染了
 
@@ -1792,8 +1818,6 @@ export default class Table2 extends React.Component<Table2Props, object> {
         {this.renderActions('header')}
         {heading}
         {this.renderTable()}
-
-        <Spinner overlay show={loading} loadingConfig={loadingConfig} />
       </div>
     );
   }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a4277e</samp>

This pull request adds a column resizing feature and a loading state to the `amis-ui` table component and renderer, and improves the table style and functionality. It also updates the documentation and fixes some bugs and code quality issues.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1a4277e</samp>

> _We are the masters of the table, we control the width and the style_
> _We fix the bugs and enhance the features, we make the data worth the while_
> _We sync the cells and resize the columns, we show the spinner when we load_
> _We simplify the code and customize the text, we are the table overlord_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1a4277e</samp>

*  Add column resizing feature to Table component and Table2 renderer ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-454e6ead402be0ea4c02bde78c3cb25833f8c6ee15c4f067be5f388c1a5ab80bL624-R624),  [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-454e6ead402be0ea4c02bde78c3cb25833f8c6ee15c4f067be5f388c1a5ab80bL689), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-539af974c4e9aa075965626eaefbccaa30877dfc60c3be8b9b2527a1e469acd7R32-R33), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-539af974c4e9aa075965626eaefbccaa30877dfc60c3be8b9b2527a1e469acd7R57-R58), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-539af974c4e9aa075965626eaefbccaa30877dfc60c3be8b9b2527a1e469acd7R75-R76), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R54), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L383-R386), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L392-R395), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L441-L452), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R441-R445), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L496-L497), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L510-R489), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L621-R590), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L803-R782), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L863-R796), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L891-R823), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L916-R837), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R927-R928), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R937-R940), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R1072-R1073), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L2020-R2033), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R2067-R2068), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R2096))
  * Use generic type for `ColumnProps` interface to allow additional props such as `minWidth` and `resizable` ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R54))
  * Add new props to `Cell` component to store column index and name ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-539af974c4e9aa075965626eaefbccaa30877dfc60c3be8b9b2527a1e469acd7R32-R33), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-539af974c4e9aa075965626eaefbccaa30877dfc60c3be8b9b2527a1e469acd7R57-R58), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-539af974c4e9aa075965626eaefbccaa30877dfc60c3be8b9b2527a1e469acd7R75-R76))
  * Add new state variables to `Table` component to store resizing column information ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L383-R386), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L392-R395))
  * Remove unused `bodyDom` ref and rename `contentDom` ref ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L392-R395), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1839-R1780), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1974-R1900))
  * Remove unused `updateColWidths` method and move related calls to `componentDidUpdate` and `componentDidMount` ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L441-L452), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R441-R445), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L496-L497), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L510-R489))
  * Add null check to `tbodyDom` ref in `initDragging` method ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L621-R590))
  * Simplify `renderColGroup` method by removing extra logic for special columns and using state `colWidths` directly ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L803-R782), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1942-R1870))
  * Modify `onResizeMouseDown`, `onResizeMouseMove` and `onResizeMouseUp` methods to handle mouse events on resizable column handle ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L863-R796), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L891-R823), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L916-R837))
  * Add style and col props to special columns in `renderTHead` method to set width and column name ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R883), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R927-R928), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R937-R940))
  * Add col and index props to table header cell in `renderTHead` method to pass column name and index ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R1072-R1073))
  * Add `syncTableWidth` method to sync column widths by creating hidden div with two tables and comparing their widths ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L2020-R2033))
  * Add `columnWidthReady` variable to check if state `colWidths` has been populated by `syncTableWidth` method ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R2067-R2068))
  * Add span element with `updateTableInfoRef` ref callback to trigger `syncTableWidth` method when table is rendered or resized ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R2096))
* Add loading state and spinner configuration to Table component ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1636-R1561), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1647-R1588), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1853-L1865), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1899-R1832))
  * Add new props to `Table` component to control loading state and spinner configuration ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1636-R1561))
  * Add new condition to `renderTHead` method to render loading row with spinner if loading prop is true ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1647-R1588))
  * Remove unused `renderLoading` method and loading condition from `renderScrollTableHeader` method ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1853-L1865), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1899-R1832))
* Remove loading state and spinner configuration from Table2 renderer ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L32-R32), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R706), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1773-R1805), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1795-L1796))
  * Remove unused `Spinner` import and props from `Table2` renderer ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L32-R32), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R706), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1773-R1805))
  * Remove unused `Spinner` element from `render` method of `Table2` renderer ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1795-L1796))
* Add placeholder prop to Table2 renderer to customize empty text ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R438-R468))
  * Add new prop to `propsList` of `Table2` renderer to allow placeholder customization ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R438-R468))
* Add version column to table example in documentation ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-e8b85e81bbe5cff7411adaeb4a91921da046554867928fe7598fb18cd94c6b42L31-R60))
  * Add new column to table example with property type, multiple items and span settings ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-e8b85e81bbe5cff7411adaeb4a91921da046554867928fe7598fb18cd94c6b42L31-R60))
* Fix table style bugs and improve interaction effects ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-454e6ead402be0ea4c02bde78c3cb25833f8c6ee15c4f067be5f388c1a5ab80bL624-R624), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-454e6ead402be0ea4c02bde78c3cb25833f8c6ee15c4f067be5f388c1a5ab80bL681-R687), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-454e6ead402be0ea4c02bde78c3cb25833f8c6ee15c4f067be5f388c1a5ab80bL689), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1876-R1806), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1929-R1854), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1965-R1892), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1987-R1916))
  * Fix bug where last fixed left column should not have right border ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-454e6ead402be0ea4c02bde78c3cb25833f8c6ee15c4f067be5f388c1a5ab80bL624-R624))
  * Add style and interaction effects to resizable column handle ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-454e6ead402be0ea4c02bde78c3cb25833f8c6ee15c4f067be5f388c1a5ab80bL681-R687), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-454e6ead402be0ea4c02bde78c3cb25833f8c6ee15c4f067be5f388c1a5ab80bL689))
  * Remove unnecessary style rule for table header text alignment ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-454e6ead402be0ea4c02bde78c3cb25833f8c6ee15c4f067be5f388c1a5ab80bL689))
  * Remove tableLayout style from tableStyle object and add it to table element ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1876-R1806), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1929-R1854), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1965-R1892), [link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1987-R1916))
* Remove redundant span element from table header cell ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1124-R1056))
  * Remove unnecessary nesting and simplify markup ([link](https://github.com/baidu/amis/pull/7945/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1124-R1056))
