### PR TITLE
style: table 外层调整宽度固定列高亮未及时显示问题  Close: #7924

### DIFF
--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -1177,6 +1177,7 @@ export default class Table extends React.Component<TableProps, object> {
       return;
     }
     this.props.store.syncTableWidth();
+    this.handleOutterScroll();
     callback && setTimeout(callback, 20);
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2ef6d22</samp>

Fix table header alignment bug with horizontal scroll. Call `handleOutterScroll` on `Table` component mount in `packages/amis/src/renderers/Table/index.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2ef6d22</samp>

> _`Table` component_
> _Aligns header with body_
> _On mount, `scrollLeft`_

### Why

Close: #7924

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2ef6d22</samp>

* Fix table header alignment bug by calling `handleOutterScroll` on mount ([link](https://github.com/baidu/amis/pull/7950/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR1180))
