### PR TITLE
style: 修复 app 模式下边栏收起时 tooltip 被挡住的问题 Close: #7661

### DIFF
--- a/packages/amis-ui/scss/layout/_layout.scss
+++ b/packages/amis-ui/scss/layout/_layout.scss
@@ -430,7 +430,6 @@ body {
         overflow: visible;
         // position: relative;
         // top: 0;
-        z-index: 15;
       }
 
       .#{$ns}Layout-asideInner {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f22ebd8</samp>

Removed `z-index` from `.amis-layout` to fix modal overlap bug. This change allows the user to interact with the modal dialog when it is displayed over the layout.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f22ebd8</samp>

> _`z-index` removed_
> _layout no longer blocks modal_
> _spring cleaning the code_

### Why

Close: #7661

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f22ebd8</samp>

* Fix layout overlapping modal bug by removing `z-index` property from `.amis-layout` class ([link](https://github.com/baidu/amis/pull/7951/files?diff=unified&w=0#diff-2beb3f83f0f709e5d5b6c0a772d8d394848b0ef4068a051979ff1bea74dad8a6L433))
