### PR TITLE
fix: nav垂直模式下内容宽度自适应问题修复

### DIFF
--- a/packages/amis-ui/scss/components/_menu.scss
+++ b/packages/amis-ui/scss/components/_menu.scss
@@ -189,7 +189,6 @@
   }
 
   &-item-link {
-    max-width: var(--Menu-width);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -215,12 +214,21 @@
 
   &-item-icon,
   &-item-icon-after {
+    display: inline-block;
+    zoom: 1;
+    vertical-align: middle;
+
     img,
     svg {
       width: var(--Tabs-linkFontSize);
       height: var(--Tabs-linkFontSize);
-      vertical-align: middle;
       fill: currentColor;
+    }
+
+    i,
+    img,
+    svg {
+      float: left;
     }
   }
 
@@ -331,9 +339,6 @@
     position: relative;
     padding: 0 px2rem(16px);
     display: block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 
     &:active {
       @include item-active();
@@ -440,6 +445,10 @@
             display: none;
           }
         }
+      }
+
+      .#{$ns}Nav-Menu-item-link {
+        max-width: var(--Menu-width);
       }
     }
   }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at df1e1d2</samp>

This pull request enhances the menu component's style and layout in `packages/amis-ui/scss/components/_menu.scss`. It makes the menu more adaptable to different screen sizes and content lengths.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at df1e1d2</samp>

> _No more limits on the menu of doom_
> _The label wraps around the link of gloom_
> _The container expands to fill the screen_
> _The menu item link is the only thing seen_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at df1e1d2</samp>

* Remove the max-width property from the menu container to make it responsive to different screen sizes ([link](https://github.com/baidu/amis/pull/7954/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL192))
* Allow the menu item label to wrap to multiple lines if it is too long by removing the white-space, overflow, and text-overflow properties ([link](https://github.com/baidu/amis/pull/7954/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcL334-L336))
* Limit the width of the menu item link to the same as the menu container by adding the max-width property ([link](https://github.com/baidu/amis/pull/7954/files?diff=unified&w=0#diff-4c9ecc2c82e446c763c271a8cd618985103d2892eb2bced01f91c5beab95fadcR440-R443))
