### PR TITLE
fix: 修复多层级拖拽发送的 order 字段没有包含子层级的问题  Close #7615

### DIFF
--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -3985,7 +3985,8 @@
   --Table-onChecked-onHover-bg: var(--colors-neutral-fill-10);
   --Table-onChecked-onHover-borderColor: var(--colors-neutral-line-8);
   --Table-onChecked-onHover-color: var(--colors-neutral-line-4);
-  --Table-onDragging-opacity: 0.1;
+  --Table-onDragging-opacity: 1;
+  --Table-onDragging-bg: var(--table-body-hover-bg-color);
   // 背景用到了 rgba，所以必须再提供这种写法，搜一下这个变量就知道为什么了
   --Table-onHover-bg-rgb: 245, 251, 255;
   --Table-onHover-bg: var(--table-body-hover-bg-color);

--- a/packages/amis-ui/scss/components/_table.scss
+++ b/packages/amis-ui/scss/components/_table.scss
@@ -515,7 +515,18 @@
 
       &.is-dragging {
         opacity: var(--Table-onDragging-opacity);
+        background-color: var(--Table-onDragging-bg);
       }
+    }
+
+    > tbody.is-dragging > tr:not(.is-dragging) {
+      background: var(--Table-bg);
+      color: var(--Table-color);
+    }
+
+    > tbody.is-dragging > tr:not(.is-drop-allowed):not(.is-dragging) {
+      color: var(--table-body-disabled-color);
+      background-color: var(--table-body-disabled-bg-color);
     }
 
     .#{$ns}Table-divider2 {

--- a/packages/amis-ui/scss/components/_table2.scss
+++ b/packages/amis-ui/scss/components/_table2.scss
@@ -383,6 +383,7 @@
 
       &.is-dragging {
         opacity: var(--Table-onDragging-opacity);
+        background-color: var(--Table-onDragging-bg);
       }
     }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c39d796</samp>

This pull request adds nested and sortable rows to the table and table2 components, with animation effects and visual indicators. It uses functions and variables from `amis-core` and `amis-ui` to handle the data manipulation and the styling. It modifies the files `CRUD.tsx`, `Table/index.tsx`, `_components.scss`, `_table.scss`, and `_table2.scss`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c39d796</samp>

> _The table renderer got a boost_
> _With nested and sortable rows to use_
> _It also can drag and drop_
> _With animation and color swap_
> _Using `mapTree` and `animation` from `amis-core` as tools_

### Why

Close #7615

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c39d796</samp>

*  Add drag and drop feature for table and table2 components, with smooth animation and nested table support ([link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4L3988-R3989), [link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dL518-R531), [link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-454e6ead402be0ea4c02bde78c3cb25833f8c6ee15c4f067be5f388c1a5ab80bR386), [link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L5-R5), [link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1495-R1497), [link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1503-R1521), [link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL8-R9), [link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1322-R1326), [link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1368-R1371), [link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1374-R1385), [link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR1415))
  * Modify CSS variables and rules for the table components to indicate the dragging state and the drop-allowed status ([link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4L3988-R3989), [link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dL518-R531), [link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-454e6ead402be0ea4c02bde78c3cb25833f8c6ee15c4f067be5f388c1a5ab80bR386))
  * Import `mapTree` and `animation` utilities from `amis-core` to traverse and transform the nested table data and handle the animation effects ([link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L5-R5), [link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL8-R9))
  * Use `mapTree` to assign the order field value to the table rows, taking into account the nested level ([link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1495-R1497))
  * Modify the logic to generate the ids and order values for the table rows, using a recursive function and `mapTree` ([link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1503-R1521))
  * Add the class `is-dragging` to the tbody element and the dragged row, and cast the tbody element to HTMLTableElement ([link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1322-R1326))
  * Check if the animation is in progress, and abort the drag and drop logic if so ([link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1368-R1371))
  * Use `animation` to capture the initial positions of the table rows, insert the dragged row to the desired position, and animate all the rows to their final positions ([link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1374-R1385))
  * Remove the class `is-dragging` from the tbody element after the drag and drop operation is finished ([link](https://github.com/baidu/amis/pull/7955/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR1415))
