### PR TITLE
feat: 支持静默请求屏蔽报错

### DIFF
--- a/packages/amis-core/src/actions/AjaxAction.ts
+++ b/packages/amis-core/src/actions/AjaxAction.ts
@@ -54,7 +54,7 @@ export class AjaxAction implements RendererAction {
     }
 
     const env = event.context.env;
-    const silent = action?.options?.silent;
+    const silent = action?.options?.silent || (action?.api as ApiObject).silent;
     const messages = (action?.api as ApiObject)?.messages;
     let api = normalizeApi(action.api);
 

--- a/packages/amis-core/src/renderers/Options.tsx
+++ b/packages/amis-core/src/renderers/Options.tsx
@@ -1040,11 +1040,12 @@ export function registerOptionsControl(config: OptionsConfig) {
           });
 
           if (!payload.ok) {
-            env.notify(
-              'error',
-              (addApi as BaseApiObject)?.messages?.failed ??
-                (payload.msg || __('Options.createFailed'))
-            );
+            !(addApi as BaseApiObject).silent &&
+              env.notify(
+                'error',
+                (addApi as BaseApiObject)?.messages?.failed ??
+                  (payload.msg || __('Options.createFailed'))
+              );
             result = null;
           } else {
             result = payload.data || result;
@@ -1052,7 +1053,7 @@ export function registerOptionsControl(config: OptionsConfig) {
         } catch (e) {
           result = null;
           console.error(e);
-          env.notify('error', e.message);
+          !(addApi as BaseApiObject).silent && env.notify('error', e.message);
         }
       }
 
@@ -1166,11 +1167,12 @@ export function registerOptionsControl(config: OptionsConfig) {
           );
 
           if (!payload.ok) {
-            env.notify(
-              'error',
-              (editApi as BaseApiObject)?.messages?.failed ??
-                (payload.msg || __('saveFailed'))
-            );
+            !(editApi as BaseApiObject).silent &&
+              env.notify(
+                'error',
+                (editApi as BaseApiObject)?.messages?.failed ??
+                  (payload.msg || __('saveFailed'))
+              );
             result = null;
           } else {
             result = payload.data || result;
@@ -1178,7 +1180,7 @@ export function registerOptionsControl(config: OptionsConfig) {
         } catch (e) {
           result = null;
           console.error(e);
-          env.notify('error', e.message);
+          !(editApi as BaseApiObject).silent && env.notify('error', e.message);
         }
       }
 
@@ -1253,11 +1255,12 @@ export function registerOptionsControl(config: OptionsConfig) {
             method: 'delete'
           });
           if (!result.ok) {
-            env.notify(
-              'error',
-              (deleteApi as BaseApiObject)?.messages?.failed ??
-                (result.msg || __('deleteFailed'))
-            );
+            !(deleteApi as BaseApiObject).silent &&
+              env.notify(
+                'error',
+                (deleteApi as BaseApiObject)?.messages?.failed ??
+                  (result.msg || __('deleteFailed'))
+              );
             return;
           }
         }
@@ -1286,7 +1289,7 @@ export function registerOptionsControl(config: OptionsConfig) {
         }
       } catch (e) {
         console.error(e);
-        env.notify('error', e.message);
+        !(deleteApi as BaseApiObject).silent && env.notify('error', e.message);
       }
     }
 

--- a/packages/amis-core/src/store/crud.ts
+++ b/packages/amis-core/src/store/crud.ts
@@ -265,16 +265,17 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
               self.__('CRUD.fetchFailed'),
             true
           );
-          getEnv(self).notify(
-            'error',
-            json.msg,
-            json.msgTimeout !== undefined
-              ? {
-                  closeButton: true,
-                  timeout: json.msgTimeout
-                }
-              : undefined
-          );
+          !(api as ApiObject)?.silent &&
+            getEnv(self).notify(
+              'error',
+              json.msg,
+              json.msgTimeout !== undefined
+                ? {
+                    closeButton: true,
+                    timeout: json.msgTimeout
+                  }
+                : undefined
+            );
         } else {
           if (!json.data) {
             throw new Error(self.__('CRUD.invalidData'));
@@ -448,7 +449,7 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
         }
 
         console.error(e);
-        env.notify('error', e.message);
+        !(api as ApiObject)?.silent && env.notify('error', e.message);
         return;
       }
     });
@@ -504,16 +505,17 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
               self.__('saveFailed'),
             true
           );
-          getEnv(self).notify(
-            'error',
-            self.msg,
-            json.msgTimeout !== undefined
-              ? {
-                  closeButton: true,
-                  timeout: json.msgTimeout
-                }
-              : undefined
-          );
+          !(api as ApiObject)?.silent &&
+            getEnv(self).notify(
+              'error',
+              self.msg,
+              json.msgTimeout !== undefined
+                ? {
+                    closeButton: true,
+                    timeout: json.msgTimeout
+                  }
+                : undefined
+            );
           throw new ServerError(self.msg);
         } else {
           self.updateMessage(
@@ -542,7 +544,9 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
           return;
         }
 
-        e.type !== 'ServerError' && getEnv(self).notify('error', e.message);
+        !(api as ApiObject)?.silent &&
+          e.type !== 'ServerError' &&
+          getEnv(self).notify('error', e.message);
         throw e;
       }
     });

--- a/packages/amis-core/src/store/form.ts
+++ b/packages/amis-core/src/store/form.ts
@@ -439,20 +439,22 @@ export const FormStore = ServiceStore.named('FormStore')
         if (ret?.dispatcher?.prevented) {
           return;
         }
-        if (e.type === 'ServerError') {
-          const result = (e as ServerError).response;
-          getEnv(self).notify(
-            'error',
-            e.message,
-            result.msgTimeout !== undefined
-              ? {
-                  closeButton: true,
-                  timeout: result.msgTimeout
-                }
-              : undefined
-          );
-        } else {
-          getEnv(self).notify('error', e.message);
+        if (!(api as ApiObject)?.silent) {
+          if (e.type === 'ServerError') {
+            const result = (e as ServerError).response;
+            getEnv(self).notify(
+              'error',
+              e.message,
+              result.msgTimeout !== undefined
+                ? {
+                    closeButton: true,
+                    timeout: result.msgTimeout
+                  }
+                : undefined
+            );
+          } else {
+            getEnv(self).notify('error', e.message);
+          }
         }
         throw e;
       }

--- a/packages/amis-core/src/store/formItem.ts
+++ b/packages/amis-core/src/store/formItem.ts
@@ -637,17 +637,18 @@ export const FormItemStore = StoreNode.named('FormItemStore')
           if (!msg) {
             msg = `status: ${json.status}`;
           }
-          getEnv(self).notify(
-            'error',
-            apiObject.messages?.failed ??
-              (self.errors.join('') || `${apiObject.url}: ${msg}`),
-            json.msgTimeout !== undefined
-              ? {
-                  closeButton: true,
-                  timeout: json.msgTimeout
-                }
-              : undefined
-          );
+          !(api as any)?.silent &&
+            getEnv(self).notify(
+              'error',
+              apiObject.messages?.failed ??
+                (self.errors.join('') || `${apiObject.url}: ${msg}`),
+              json.msgTimeout !== undefined
+                ? {
+                    closeButton: true,
+                    timeout: json.msgTimeout
+                  }
+                : undefined
+            );
         } else {
           result = json;
         }
@@ -667,7 +668,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
         }
 
         console.error(e);
-        env.notify('error', e.message);
+        !(api as any)?.silent && env.notify('error', e.message);
         return;
       }
     } as any);
@@ -773,6 +774,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
       }
 
       !silent &&
+        !(api as any)?.silent &&
         getEnv(self).notify('info', self.__('FormItem.autoFillLoadFailed'));
 
       return;

--- a/packages/amis-core/src/store/service.ts
+++ b/packages/amis-core/src/store/service.ts
@@ -88,16 +88,17 @@ export const ServiceStore = iRendererStore
               (options && options.errorMessage),
             true
           );
-          getEnv(self).notify(
-            'error',
-            self.msg,
-            json.msgTimeout !== undefined
-              ? {
-                  closeButton: true,
-                  timeout: json.msgTimeout
-                }
-              : undefined
-          );
+          !(api as ApiObject).silent &&
+            getEnv(self).notify(
+              'error',
+              self.msg,
+              json.msgTimeout !== undefined
+                ? {
+                    closeButton: true,
+                    timeout: json.msgTimeout
+                  }
+                : undefined
+            );
         } else {
           self.updatedAt = Date.now();
           let replace = !!(api as ApiObject).replaceData;
@@ -147,7 +148,7 @@ export const ServiceStore = iRendererStore
         if (e && e.message === 'Network Error') {
           message = self.__('networkError');
         }
-        env.notify('error', message);
+        !(api as ApiObject).silent && env.notify('error', message);
         return;
       }
     });
@@ -203,16 +204,17 @@ export const ServiceStore = iRendererStore
               (options && options.errorMessage),
             true
           );
-          getEnv(self).notify(
-            'error',
-            self.msg,
-            json.msgTimeout !== undefined
-              ? {
-                  closeButton: true,
-                  timeout: json.msgTimeout
-                }
-              : undefined
-          );
+          !(api as ApiObject).silent &&
+            getEnv(self).notify(
+              'error',
+              self.msg,
+              json.msgTimeout !== undefined
+                ? {
+                    closeButton: true,
+                    timeout: json.msgTimeout
+                  }
+                : undefined
+            );
         } else {
           if (options && options.onSuccess) {
             const ret = options.onSuccess(json, json.data);
@@ -253,7 +255,7 @@ export const ServiceStore = iRendererStore
         if (e && e.message === 'Network Error') {
           message = self.__('networkError');
         }
-        env.notify('error', message);
+        !(api as ApiObject).silent && env.notify('error', message);
         return;
       }
     });
@@ -345,20 +347,23 @@ export const ServiceStore = iRendererStore
         }
 
         console.error(e);
-        if (e.type === 'ServerError') {
-          const result = (e as ServerError).response;
-          getEnv(self).notify(
-            'error',
-            e.message,
-            result.msgTimeout !== undefined
-              ? {
-                  closeButton: true,
-                  timeout: result.msgTimeout
-                }
-              : undefined
-          );
-        } else {
-          getEnv(self).notify('error', e.message);
+
+        if (!(api as ApiObject).silent) {
+          if (e.type === 'ServerError') {
+            const result = (e as ServerError).response;
+            getEnv(self).notify(
+              'error',
+              e.message,
+              result.msgTimeout !== undefined
+                ? {
+                    closeButton: true,
+                    timeout: result.msgTimeout
+                  }
+                : undefined
+            );
+          } else {
+            getEnv(self).notify('error', e.message);
+          }
         }
 
         throw e;
@@ -416,16 +421,17 @@ export const ServiceStore = iRendererStore
               self.__('fetchFailed'),
             true
           );
-          getEnv(self).notify(
-            'error',
-            self.msg,
-            json.msgTimeout !== undefined
-              ? {
-                  closeButton: true,
-                  timeout: json.msgTimeout
-                }
-              : undefined
-          );
+          !(api as ApiObject)?.silent &&
+            getEnv(self).notify(
+              'error',
+              self.msg,
+              json.msgTimeout !== undefined
+                ? {
+                    closeButton: true,
+                    timeout: json.msgTimeout
+                  }
+                : undefined
+            );
         } else {
           if (json.data) {
             const env = getEnv(self);
@@ -486,7 +492,7 @@ export const ServiceStore = iRendererStore
         if (e && e.message === 'Network Error') {
           message = self.__('networkError');
         }
-        env.notify('error', message);
+        !(api as ApiObject)?.silent && env.notify('error', message);
       }
     });
 

--- a/packages/amis-core/src/store/table2.ts
+++ b/packages/amis-core/src/store/table2.ts
@@ -706,16 +706,17 @@ export const TableStore2 = ServiceStore.named('TableStore2')
               self.__('saveFailed'),
             true
           );
-          getEnv(self).notify(
-            'error',
-            self.msg,
-            json.msgTimeout !== undefined
-              ? {
-                  closeButton: true,
-                  timeout: json.msgTimeout
-                }
-              : undefined
-          );
+          !(api as ApiObject)?.silent &&
+            getEnv(self).notify(
+              'error',
+              self.msg,
+              json.msgTimeout !== undefined
+                ? {
+                    closeButton: true,
+                    timeout: json.msgTimeout
+                  }
+                : undefined
+            );
           throw new ServerError(self.msg);
         } else {
           self.updateMessage(
@@ -744,7 +745,9 @@ export const TableStore2 = ServiceStore.named('TableStore2')
           return;
         }
 
-        e.type !== 'ServerError' && getEnv(self).notify('error', e.message);
+        !(api as ApiObject)?.silent &&
+          e.type !== 'ServerError' &&
+          getEnv(self).notify('error', e.message);
         throw e;
       }
     });

--- a/packages/amis-editor/src/plugin/Form/InputTree.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTree.tsx
@@ -247,6 +247,11 @@ export class TreeControlPlugin extends BasePlugin {
       description: '重置数据'
     },
     {
+      actionType: 'reload',
+      actionLabel: '重新加载',
+      description: '触发组件数据刷新并重新渲染'
+    },
+    {
       actionType: 'setValue',
       actionLabel: '赋值',
       description: '触发组件数据更新'

--- a/packages/amis-editor/src/renderer/APIControl.tsx
+++ b/packages/amis-editor/src/renderer/APIControl.tsx
@@ -610,6 +610,20 @@ export default class APIControl extends React.Component<
                   disabled: false
                 },
                 {
+                  type: 'group',
+                  body: [
+                    {
+                      type: 'switch',
+                      label: tipedLabel(
+                        '静默请求',
+                        '是否静默发送请求，屏蔽报错提示'
+                      ),
+                      name: 'silent',
+                      mode: 'horizontal'
+                    }
+                  ]
+                },
+                {
                   type: 'switch',
                   label: '是否设置缓存',
                   name: 'cache',

--- a/packages/amis-editor/src/tpl/api.tsx
+++ b/packages/amis-editor/src/tpl/api.tsx
@@ -199,6 +199,14 @@ setSchemaTpl('api', (patch: any = {}) => {
 
           {
             type: 'switch',
+            label: '静默请求',
+            name: 'silent',
+            mode: 'inline',
+            description: '是否静默发送请求，屏蔽报错提示'
+          },
+
+          {
+            type: 'switch',
             label: '是否设置缓存',
             name: 'cache',
             className: 'w-full m-b-xs',

--- a/packages/amis/__tests__/renderers/CRUD.test.tsx
+++ b/packages/amis/__tests__/renderers/CRUD.test.tsx
@@ -19,6 +19,7 @@
  * 16. searchable & sortable & filterable
  * 17. api 返回格式支持取对象中的第一个数组
  * 18. CRUD 事件
+ * 19. fetchInitData silent 静默请求
  */
 
 import {
@@ -1048,7 +1049,7 @@ test('17. should use the first array item in the response if provided', async ()
 
   waitFor(() => {
     expect(container.querySelectorAll('tbody>tr').length).toBe(2);
-  })
+  });
 });
 
 describe('18. inner events', () => {
@@ -1088,4 +1089,44 @@ describe('18. inner events', () => {
       expect(mockFn).toBeCalledTimes(1);
     });
   });
+});
+
+test('19. fetchInitData silent true', async () => {
+  const fetcher = jest.fn().mockImplementationOnce(() => {
+    return new Promise(resolve =>
+      resolve({
+        data: {
+          status: 500,
+          msg: 'Internal Error'
+        }
+      })
+    );
+  });
+  const {container} = render(
+    amisRender(
+      {
+        type: 'crud',
+        api: {
+          method: 'get',
+          url: '/api/mock/sample',
+          silent: true
+        },
+        columns: [
+          {
+            name: 'engine',
+            label: 'Rendering engine'
+          }
+        ]
+      },
+      {},
+      {
+        fetcher
+      }
+    )
+  );
+
+  await waitFor(() => {
+    expect(container.querySelector('.cxd-Toast')).not.toBeInTheDocument();
+  });
+  expect(container).toMatchSnapshot();
 });

--- a/packages/amis/__tests__/renderers/CRUD.test.tsx
+++ b/packages/amis/__tests__/renderers/CRUD.test.tsx
@@ -1128,5 +1128,4 @@ test('19. fetchInitData silent true', async () => {
   await waitFor(() => {
     expect(container.querySelector('.cxd-Toast')).not.toBeInTheDocument();
   });
-  expect(container).toMatchSnapshot();
 });

--- a/packages/amis/src/renderers/Chart.tsx
+++ b/packages/amis/src/renderers/Chart.tsx
@@ -475,17 +475,19 @@ export class Chart extends React.Component<ChartProps> {
         isAlive(store) && store.markFetching(false);
 
         if (!result.ok) {
-          return env.notify(
-            'error',
-            (api as ApiObject)?.messages?.failed ??
-              (result.msg || __('fetchFailed')),
-            result.msgTimeout !== undefined
-              ? {
-                  closeButton: true,
-                  timeout: result.msgTimeout
-                }
-              : undefined
-          );
+          !(api as ApiObject)?.silent &&
+            env.notify(
+              'error',
+              (api as ApiObject)?.messages?.failed ??
+                (result.msg || __('fetchFailed')),
+              result.msgTimeout !== undefined
+                ? {
+                    closeButton: true,
+                    timeout: result.msgTimeout
+                  }
+                : undefined
+            );
+          return;
         }
         delete this.reloadCancel;
 
@@ -510,7 +512,7 @@ export class Chart extends React.Component<ChartProps> {
         }
 
         isAlive(store) && store.markFetching(false);
-        env.notify('error', reason);
+        !(api as ApiObject)?.silent && env.notify('error', reason);
         this.echarts?.hideLoading();
       });
   }

--- a/packages/amis/src/renderers/Form/ChainedSelect.tsx
+++ b/packages/amis/src/renderers/Form/ChainedSelect.tsx
@@ -8,7 +8,7 @@ import {
   resolveEventData
 } from 'amis-core';
 import {Select, Spinner} from 'amis-ui';
-import {Api} from 'amis-core';
+import {Api, ApiObject} from 'amis-core';
 import {isEffectiveApi} from 'amis-core';
 import {isMobile, createObject} from 'amis-core';
 import {ActionObject} from 'amis-core';
@@ -215,7 +215,7 @@ export default class ChainedSelectControl extends React.Component<
             );
           })
           .catch(e => {
-            env.notify('error', e.message);
+            !(source as ApiObject)?.silent && env.notify('error', e.message);
           });
       }
     );

--- a/packages/amis/src/renderers/Form/Combo.tsx
+++ b/packages/amis/src/renderers/Form/Combo.tsx
@@ -683,10 +683,11 @@ export default class ComboControl extends React.Component<ComboProps> {
       const result = await env.fetcher(deleteApi as Api, ctx);
 
       if (!result.ok) {
-        env.notify(
-          'error',
-          (deleteApi as ApiObject)?.messages?.failed ?? __('deleteFailed')
-        );
+        !(deleteApi as ApiObject)?.silent &&
+          env.notify(
+            'error',
+            (deleteApi as ApiObject)?.messages?.failed ?? __('deleteFailed')
+          );
         return;
       }
     }

--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -495,11 +495,12 @@ export default class FormTable extends React.Component<TableProps, TableState> {
         if (isEffectiveApi(addApi, ctx)) {
           const payload = await env.fetcher(addApi, ctx);
           if (payload && !payload.ok) {
-            env.notify(
-              'error',
-              (addApi as ApiObject)?.messages?.failed ??
-                (payload.msg || __('fetchFailed'))
-            );
+            !(addApi as ApiObject)?.silent &&
+              env.notify(
+                'error',
+                (addApi as ApiObject)?.messages?.failed ??
+                  (payload.msg || __('fetchFailed'))
+              );
             return;
           } else if (payload && payload.ok) {
             toAdd = payload.data;
@@ -783,7 +784,8 @@ export default class FormTable extends React.Component<TableProps, TableState> {
     }
 
     if (remote && !remote.ok) {
-      env.notify('error', apiMsg ?? (remote.msg || __('saveFailed')));
+      !((isNew ? addApi : updateApi) as ApiObject)?.silent &&
+        env.notify('error', apiMsg ?? (remote.msg || __('saveFailed')));
       const failEventName = isNew ? 'addFail' : 'editFail';
       this.dispatchEvent(failEventName, {
         index: this.state.editIndex,
@@ -876,10 +878,11 @@ export default class FormTable extends React.Component<TableProps, TableState> {
       const result = await env.fetcher(deleteApi, ctx);
 
       if (!result.ok) {
-        env.notify(
-          'error',
-          (deleteApi as ApiObject)?.messages?.failed ?? __('deleteFailed')
-        );
+        !(deleteApi as ApiObject)?.silent &&
+          env.notify(
+            'error',
+            (deleteApi as ApiObject)?.messages?.failed ?? __('deleteFailed')
+          );
         this.dispatchEvent('deleteFail', {index, item, error: result});
         return;
       }
@@ -1680,11 +1683,12 @@ export class TableControlRenderer extends FormTable {
         if (isEffectiveApi(addApi, ctx)) {
           const payload = await env.fetcher(addApi, ctx);
           if (payload && !payload.ok) {
-            env.notify(
-              'error',
-              (addApi as ApiObject)?.messages?.failed ??
-                (payload.msg || __('fetchFailed'))
-            );
+            !(addApi as ApiObject)?.silent &&
+              env.notify(
+                'error',
+                (addApi as ApiObject)?.messages?.failed ??
+                  (payload.msg || __('fetchFailed'))
+              );
             return;
           } else if (payload && payload.ok) {
             toAdd = payload.data;
@@ -1775,11 +1779,12 @@ export class TableControlRenderer extends FormTable {
           createObject(ctx, {deletedItems})
         );
         if (payload && !payload.ok) {
-          env.notify(
-            'error',
-            (deleteApi as ApiObject)?.messages?.failed ??
-              (payload.msg || __('fetchFailed'))
-          );
+          !(deleteApi as ApiObject)?.silent &&
+            env.notify(
+              'error',
+              (deleteApi as ApiObject)?.messages?.failed ??
+                (payload.msg || __('fetchFailed'))
+            );
           return;
         }
       }

--- a/packages/amis/src/renderers/Form/TabsTransfer.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransfer.tsx
@@ -77,9 +77,9 @@ export class BaseTabsTransferRenderer<
       valueField,
       env,
       data,
+      searchApi,
       translate: __
     } = this.props;
-    const {searchApi} = option;
 
     if (searchApi) {
       try {
@@ -114,7 +114,7 @@ export class BaseTabsTransferRenderer<
         });
       } catch (e) {
         if (!env.isCancel(e)) {
-          env.notify('error', e.message);
+          !searchApi.silent && env.notify('error', e.message);
         }
 
         return [];

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -378,7 +378,7 @@ export class BaseTransferRenderer<
           return resolved || item;
         });
       } catch (e) {
-        if (!env.isCancel(e)) {
+        if (!env.isCancel(e) && !searchApi.silent) {
           env.notify('error', e.message);
         }
 

--- a/packages/amis/src/renderers/Log.tsx
+++ b/packages/amis/src/renderers/Log.tsx
@@ -290,7 +290,8 @@ export class Log extends React.Component<LogProps, LogState> {
         }
       }
     } else {
-      env.notify('error', api?.messages?.failed ?? __('fetchFailed'));
+      !api.silent &&
+        env.notify('error', api?.messages?.failed ?? __('fetchFailed'));
     }
   }
 

--- a/packages/amis/src/renderers/Wizard.tsx
+++ b/packages/amis/src/renderers/Wizard.tsx
@@ -616,7 +616,7 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
         this.gotoStep(this.state.currentStep + 1);
       })
       .catch(e => {
-        env.notify('error', e.message);
+        !finnalAsyncApi.silent && env.notify('error', e.message);
         store.markSaving(false);
       });
   }


### PR DESCRIPTION
### 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化语料改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 其他改动（是关于什么的改动？）


### 需求背景和解决方案

https://ku.baidu-int.com/knowledge/HFVrC7hq1Q/tQvrZcAEPS/GxsYWwEpj5/J2M4hcB_753S2J

#### 背景

部分接口希望屏蔽所有报错弹窗，静默发起请求，需要api请求支持屏蔽报错能力

#### 改动
1. api高级设置添加静默请求选项
2. ApiControl、ServiceStore内的屏蔽报错处理
3. 事件动作=>发送请求的屏蔽报错处理
4. 各组件内部的屏蔽报错处理

### 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 英文 | Supports silent requests to mask error messages |
| 中文 | 支持静默请求屏蔽报错提示 |

### 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供