### PR TITLE
fix: 匹配 markdown 中的 schema 正则兼容 windows

### DIFF
--- a/scripts/markdownPlugin.ts
+++ b/scripts/markdownPlugin.ts
@@ -152,7 +152,7 @@ function markdown2js(content: string, file: string) {
       return _;
     })
     .replace(
-      /```(schema|html)(?::(.*?))?\n([\s\S]*?)```/g,
+      /```(schema|html)(?::(.*?))?[\n|\r\n]([\s\S]*?)```/g,
       function (_, lang, attr, code) {
         const setting: any = {};
         attr &&


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c09e5e2</samp>

Fixed a bug in `markdown2js` that caused code blocks with Windows-style line endings to be ignored. Updated the regex for code blocks with schema or html language in `scripts/markdownPlugin.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c09e5e2</samp>

> _`markdown2js` changed_
> _Windows line breaks accepted_
> _Autumn bug is gone_

### Why
修复问题：[[ERROR] parser.0: The language "schema" has no grammar.](https://github.com/baidu/amis/issues/5762)
问题原因：windows 操作系统的换行符是 \r\n，正则无法在 windows 中匹配到 markdown 文件中的 ```schema 代码段
修复方式：正则兼容 windows 下的换行符 
<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c09e5e2</samp>

* Fix code block parsing for Windows line endings ([link](https://github.com/baidu/amis/pull/7961/files?diff=unified&w=0#diff-b1ac5ae848a3cd8142bd8c8691ad3cd436357167d46c79ffd078fa7a362227a5L155-R155))
