### PR TITLE
feat: 表单项支持配置字符串形式的 pipeIn 和 pipeOut 钩子 Close: #7057

### DIFF
--- a/packages/amis-core/src/renderers/wrapControl.tsx
+++ b/packages/amis-core/src/renderers/wrapControl.tsx
@@ -32,6 +32,7 @@ import {FormBaseControl, FormItemWrap} from './Item';
 import {Api} from '../types';
 import {TableStore} from '../store/table';
 import pick from 'lodash/pick';
+import {callStrFunction} from '../utils';
 
 export interface ControlOutterProps extends RendererProps {
   formStore?: IFormStore;
@@ -648,7 +649,13 @@ export function wrapControl<
 
             if (pipeOut) {
               const oldValue = this.model.value;
-              value = pipeOut.call(this, value, oldValue, data);
+              value = callStrFunction(
+                pipeOut,
+                ['value', 'oldValue', 'data'],
+                value,
+                oldValue,
+                data
+              );
             }
 
             this.model.changeTmpValue(value, 'input');
@@ -767,7 +774,13 @@ export function wrapControl<
             } = this.props;
 
             if (pipeOut) {
-              value = pipeOut.call(this, value, oldValue, data);
+              value = callStrFunction(
+                pipeOut,
+                ['value', 'oldValue', 'data'],
+                value,
+                oldValue,
+                data
+              );
             }
 
             if (model.extraName) {
@@ -784,7 +797,12 @@ export function wrapControl<
             let value: any = this.model ? this.model.tmpValue : control.value;
 
             if (control.pipeIn) {
-              value = control.pipeIn.call(this, value, data);
+              value = callStrFunction(
+                control.pipeIn,
+                ['value', 'data'],
+                value,
+                data
+              );
             }
 
             return value;

--- a/packages/amis-core/src/utils/api.ts
+++ b/packages/amis-core/src/utils/api.ts
@@ -343,6 +343,20 @@ export function str2AsyncFunction(
   }
 }
 
+export function callStrFunction(
+  this: any,
+  fn: string | Function,
+  argNames: Array<string>,
+  ...args: Array<any>
+) {
+  if (typeof fn === 'function') {
+    return fn.apply(this, args);
+  } else if (typeof fn === 'string' && fn) {
+    const func = str2function(fn, ...argNames)!;
+    return func?.apply(this, args);
+  }
+}
+
 export function responseAdaptor(ret: fetcherResult, api: ApiObject) {
   let data = ret.data;
   let hasStatusField = true;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2618f83</samp>

This pull request adds a new utility function `callStrFunction` to `api.ts` and uses it to enable string expressions for the `pipeOut` and `pipeIn` properties of the control component in `wrapControl.tsx`. This enhances the functionality and usability of the control component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2618f83</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever function, `callStrFunction`, to apply_
> _Both functions and expressions to the arguments given_
> _And transform the value of the control with wisdom._

### Why

 Close: #7057

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2618f83</samp>

*  Add `callStrFunction` utility function to `api.ts` ([link](https://github.com/baidu/amis/pull/7963/files?diff=unified&w=0#diff-b9db43e7745ad0b69a6a8b249fb0a118cc1ccdd5555293350b2f87390b7f8d0cR346-R359)), which allows using string expressions or functions for various properties of the control component.
