### PR TITLE
fix: 修复指定列数 > 1 的情况下 form 最后一行 margin-bottom 不为 0 的问题

### DIFF
--- a/packages/amis-ui/scss/components/form/_form.scss
+++ b/packages/amis-ui/scss/components/form/_form.scss
@@ -456,36 +456,72 @@
   width: 50%;
 }
 
+.#{$ns}Form--column-2 > .#{$ns}Form-item:nth-last-child(2) {
+  margin-bottom: 0;
+}
+
 .#{$ns}Form--column-3 > .#{$ns}Form-item {
   width: 33%;
+}
+
+.#{$ns}Form--column-3 > .#{$ns}Form-item:nth-last-child(-n + 3) {
+  margin-bottom: 0;
 }
 
 .#{$ns}Form--column-4 > .#{$ns}Form-item {
   width: 25%;
 }
 
+.#{$ns}Form--column-4 > .#{$ns}Form-item:nth-last-child(-n + 4) {
+  margin-bottom: 0;
+}
+
 .#{$ns}Form--column-5 > .#{$ns}Form-item {
   width: 20%;
+}
+
+.#{$ns}Form--column-5 > .#{$ns}Form-item:nth-last-child(-n + 5) {
+  margin-bottom: 0;
 }
 
 .#{$ns}Form--column-6 > .#{$ns}Form-item {
   width: 16.6%;
 }
 
+.#{$ns}Form--column-6 > .#{$ns}Form-item:nth-last-child(-n + 6) {
+  margin-bottom: 0;
+}
+
 .#{$ns}Form--column-7 > .#{$ns}Form-item {
   width: 14.2%;
+}
+
+.#{$ns}Form--column-7 > .#{$ns}Form-item:nth-last-child(-n + 7) {
+  margin-bottom: 0;
 }
 
 .#{$ns}Form--column-8 > .#{$ns}Form-item {
   width: 12.5%;
 }
 
+.#{$ns}Form--column-8 > .#{$ns}Form-item:nth-last-child(-n + 8) {
+  margin-bottom: 0;
+}
+
 .#{$ns}Form-column-9 > .#{$ns}Form-item {
   width: 11.1%;
 }
 
+.#{$ns}Form--column-9 > .#{$ns}Form-item:nth-last-child(-n + 9) {
+  margin-bottom: 0;
+}
+
 .#{$ns}Form-column-10 > .#{$ns}Form-item {
   width: 10%;
+}
+
+.#{$ns}Form--column-10 > .#{$ns}Form-item:nth-last-child(-n + 10) {
+  margin-bottom: 0;
 }
 
 /* 移动端样式调整 */


### PR DESCRIPTION
修改完成后，仍然遗留一个问题：
编辑器状态下，最后一个元素是编辑器预留的 placeholder，因此选择器会有错位，导致仍然有期望外的 margin bottom。
在正常渲染时没有这个问题，如果改成 last-type-of 的话，表单中加入其他非 form-item 的元素，会导致选择器选择的 dom 不符合预期。
