### PR TITLE
fix: 修复 input-file 和 input-image 组件请求适配器 context 获取不到的问题

### DIFF
--- a/packages/amis-core/src/utils/api.ts
+++ b/packages/amis-core/src/utils/api.ts
@@ -94,7 +94,7 @@ export function buildApi(
     ) as any;
   }
 
-  if (!data) {
+  if (!data || api.data instanceof FormData) {
     return api;
   } else if (
     data instanceof FormData ||

--- a/packages/amis/src/renderers/Form/InputFile.tsx
+++ b/packages/amis/src/renderers/Form/InputFile.tsx
@@ -1015,9 +1015,9 @@ export default class FileControl extends React.Component<FileProps, FileState> {
 
     // Note: File类型字段放在后面，可以支持第三方云存储鉴权
     fd.append(config.fieldName || 'file', file);
-
+    api.data = fd;
     try {
-      return await this._send(file, api, fd, {}, onProgress);
+      return await this._send(file, api, {}, onProgress);
     } finally {
       this.removeFileCanelExecutor(file);
     }
@@ -1169,12 +1169,12 @@ export default class FileControl extends React.Component<FileProps, FileState> {
 
           // Note: File类型字段放在后面，可以支持第三方云存储鉴权
           fd.append(config.fieldName || 'file', blob, file.name);
+          api.data = fd;
 
           return self
             ._send(
               file,
               api,
-              fd,
               {},
               progress => updateProgress(task.partNumber, progress),
               3
@@ -1219,7 +1219,6 @@ export default class FileControl extends React.Component<FileProps, FileState> {
   async _send(
     file: FileX,
     api: ApiObject | ApiString,
-    data?: any,
     options?: object,
     onProgress?: (progress: number) => void,
     maxRetryLimit = 0
@@ -1232,7 +1231,7 @@ export default class FileControl extends React.Component<FileProps, FileState> {
     }
 
     try {
-      const result = await env.fetcher(api, data, {
+      const result = await env.fetcher(api, this.props.data, {
         method: 'post',
         ...options,
         withCredentials: true,
@@ -1256,14 +1255,7 @@ export default class FileControl extends React.Component<FileProps, FileState> {
       return result;
     } catch (error) {
       if (maxRetryLimit > 0) {
-        return this._send(
-          file,
-          api,
-          data,
-          options,
-          onProgress,
-          maxRetryLimit - 1
-        );
+        return this._send(file, api, options, onProgress, maxRetryLimit - 1);
       }
       throw error;
     }

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -1320,6 +1320,8 @@ export default class ImageControl extends React.Component<
     // Note: File类型字段放在后面，可以支持第三方云存储鉴权
     fd.append(fileField, file, (file as File).name || this.state.cropFileName);
 
+    api.data = fd;
+
     const env = this.props.env;
 
     if (!env || !env.fetcher) {
@@ -1327,7 +1329,7 @@ export default class ImageControl extends React.Component<
     }
 
     try {
-      return await env.fetcher(api, fd, {
+      return await env.fetcher(api, this.props.data, {
         method: 'post',
         cancelExecutor: (cancelExecutor: () => void) => {
           // 记录取消器，取消的时候要调用


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 15b3aca</samp>

This pull request enhances the file upload feature of the `InputFile` and `InputImage` renderers by using FormData objects and fixing some bugs. It improves the compatibility and reliability of the file upload api.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 15b3aca</samp>

> _Sing, O Muse, of the skillful coder who fixed the bug_
> _That plagued the InputFile renderer, a source of woe_
> _For many users who wished to upload their files with ease_
> _But found their FormData objects mangled by the api._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 15b3aca</samp>

* Fix file upload bug by assigning FormData object to `api.data` property and passing original `data` as second argument of `_send` and `env.fetcher` methods ([link](https://github.com/baidu/amis/pull/7968/files?diff=unified&w=0#diff-5797b78d8d3f6d8899dfdb4fdebd4cf26bfb055b5b98c285726d6b8cad948b33L1019-R1022), [link](https://github.com/baidu/amis/pull/7968/files?diff=unified&w=0#diff-5797b78d8d3f6d8899dfdb4fdebd4cf26bfb055b5b98c285726d6b8cad948b33L1173-R1181), [link](https://github.com/baidu/amis/pull/7968/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9R1323-R1324), [link](https://github.com/baidu/amis/pull/7968/files?diff=unified&w=0#diff-0afd0a5b88c4c84072e0ac4e45b8ebc6015138be1138828ccc1b191774e230e9L1330-R1332))
