### PR TITLE
feat: form 插件支持配置 columnCount

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Form.tsx
+++ b/packages/amis-editor/src/plugin/Form/Form.tsx
@@ -874,6 +874,23 @@ export class FormPlugin extends BasePlugin {
             },
 
             {
+              name: 'columnCount',
+              label: '列数',
+              type: 'input-number',
+              step: 1,
+              min: 2,
+              max: 10,
+              labelRemark: {
+                className: 'm-l-xs',
+                trigger: 'click',
+                rootClose: true,
+                content:
+                  '当输入 2 - 10 整数时，表单将固定分成若干列展示表单元素，留空时不分列。',
+                placement: 'left'
+              }
+            },
+
+            {
               name: 'labelAlign',
               label: '标签对齐方式',
               type: 'button-group-select',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 558ea8d</samp>

Add `columnCount` property to `FormPlugin` to enable multi-column layout for forms. Update `Form.tsx` to handle the new property and provide a tooltip for users.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 558ea8d</samp>

> _`FormPlugin` adds_
> _`columnCount` property_
> _Autumn leaves arrange_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 558ea8d</samp>

* Add a new feature to allow users to specify the number of columns for the form component in the amis-editor ([link](https://github.com/baidu/amis/pull/7969/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dR877-R893),                         
