### PR TITLE
fix: 修复 editor 环境下默认的 fetcher 无法传入 headers 的问题

### DIFF
--- a/packages/amis-editor-core/src/env.ts
+++ b/packages/amis-editor-core/src/env.ts
@@ -10,7 +10,7 @@ export const env: RenderOptions = {
   jumpTo: () => {
     toast.info('温馨提示：预览模式下禁止跳转');
   },
-  fetcher: async ({url, method, data, config}: any) => {
+  fetcher: async ({url, method, data, config, headers}: any) => {
     config = config || {};
     config.url = url;
     config.withCredentials = true;
@@ -19,7 +19,9 @@ export const env: RenderOptions = {
       config.cancelToken = new axios.CancelToken(config.cancelExecutor);
     }
 
-    config.headers = config.headers || {};
+    config.headers = headers
+      ? {...config.headers, ...headers}
+      : config.headers ?? {};
     config.method = method;
     config.data = data;
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e68b72b</samp>

Enhanced `fetcher` function in `env.ts` to support custom headers for HTTP requests. This allows `amis-editor-core` to communicate with different server configurations and APIs.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e68b72b</samp>

> _To make HTTP requests more flexible_
> _The `fetcher` function was made extensible_
> _It can now send custom headers_
> _To handle different server matters_
> _And support the `amis-editor-core` package's objectives_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e68b72b</samp>

*  Add an optional `headers` parameter to the `env.fetcher` function to allow passing custom headers to the HTTP request ([link](https://github.com/baidu/amis/pull/7970/files?diff=unified&w=0#diff-d925f9b5a4ca7881b911fc829bdb900bc2321ac9ac0c91e10882c36113f02920L13-R13),[link](https://github.com/baidu/amis/pull/7970/files?diff=unified&w=0#diff-d925f9b5a4ca7881b911fc829bdb900bc2321ac9ac0c91e10882c36113f02920L22-R24))
*  Use the `headers` parameter in the `fetcher` function to merge with or override the existing `config.headers` object ([link](https://github.com/baidu/amis/pull/7970/files?diff=unified&w=0#diff-d925f9b5a4ca7881b911fc829bdb900bc2321ac9ac0c91e10882c36113f02920L22-R24))
