### PR TITLE
fix: inputRange输入大小限制

### DIFF
--- a/docs/zh-CN/components/form/input-range.md
+++ b/docs/zh-CN/components/form/input-range.md
@@ -45,6 +45,7 @@ order: 38
             "name": "range",
             "label": "range",
             "multiple": true,
+            "joinValues": false,
             "value": {
                 "min": 10,
                 "max": 50

--- a/packages/amis/src/renderers/Form/InputRange.tsx
+++ b/packages/amis/src/renderers/Form/InputRange.tsx
@@ -330,13 +330,13 @@ export class Input extends React.Component<RangeItemProps, any> {
    */
   @autobind
   handleInputNumberChange(value: number) {
-    const {multiple, value: originValue, type, min, onChange} = this.props;
+    const {multiple, value: originValue, type, min, max, onChange} = this.props;
     const _value = this.getValue(value, type);
 
     onChange?.(
       multiple
         ? {...(originValue as MultipleValue), [type]: _value}
-        : value ?? min
+        : Math.max(Math.min(value, max), min)
     );
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5407e07</samp>

This pull request enhances the `input-range` component in `amis` by adding a `max` parameter, a `joinValues` property, and adjusting the editor plugin. The changes improve the validation, customization, and usability of the component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5407e07</samp>

> _`input-range` changed_
> _max and joinValues added_
> _autumn of options_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5407e07</samp>

*  Add `joinValues` property to `input-range` component to control comma separation of range values ([link](https://github.com/baidu/amis/pull/7973/files?diff=unified&w=0#diff-8cb007029b4ce9a96f030e2815c2874a593aad1ed8aeb9b768a1e73fc7e784b8R48))
*  Simplify editor plugin for `input-range` component by disabling multiple, addable, and removable options ([link](https://github.com/baidu/amis/pull/7973/files?diff=unified&w=0#diff-785d17e956a3abfd5fcf93db4ac2b50aed00bb5bf2eb2a3f9c3776e81774d097L43-R45))
*  Validate range input values against `min` and `max` props in `InputRange.tsx` using `Math.max` and `Math.min` functions ([link](https://github.com/baidu/amis/pull/7973/files?diff=unified&w=0#diff-1cc263ed7b5f9385af4c3b91ead6471259bb7683f677c90867f665c26ea39665L333-R333), [link](https://github.com/baidu/amis/pull/7973/files?diff=unified&w=0#diff-1cc263ed7b5f9385af4c3b91ead6471259bb7683f677c90867f665c26ea39665L339-R339))
