### PR TITLE
fix: 修复在字段集中插入input-table后打开的表达式弹窗报错问题

### DIFF
--- a/packages/amis-editor/src/plugin/Form/InputTable.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTable.tsx
@@ -1144,7 +1144,7 @@ export class TableControlPlugin extends BasePlugin {
       }
     }
 
-    const cells: any = columns.children.concat();
+    const cells: any = columns?.children.concat() || [];
     while (cells.length > 0) {
       const cell = cells.shift() as EditorNodeType;
       // cell的孩子貌似只会有一个


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 08b226f</samp>

Fixed a bug in `amis-editor` that caused the editor to crash when deleting a table column. Added null checks and fallback values for `columns` and `cells` in `Form/InputTable.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 08b226f</samp>

> _`columns` may be null_
> _handle with care and grace_
> _autumn bug is fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 08b226f</samp>

* Fix a bug that causes the editor to crash when deleting a table column ([link](https://github.com/baidu/amis/pull/7974/files?diff=unified&w=0#diff-01999eae047ec7fdb8502c22801699d39f7a54c994a9414462c0fbe21634ecd8L1147-R1147))
