### PR TITLE
style: 调整 table badge 的 zIndex

### DIFF
--- a/packages/amis-ui/scss/components/_table.scss
+++ b/packages/amis-ui/scss/components/_table.scss
@@ -954,6 +954,7 @@
     position: absolute;
     top: 0;
     left: 0;
+    z-index: 25; // 因为 sticky 的时候是 20
   }
 
   &--autoFillHeight {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at af548bc</samp>

Added `z-index` to table header in `_table.scss` to fix horizontal scrolling bug. This prevents the header from being hidden by the sticky table body.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at af548bc</samp>

> _`z-index` fixes_
> _table header and body clash_
> _autumn leaves scroll by_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at af548bc</samp>

* Add `z-index` property to `.table-header` selector to fix table header overlap bug ([link](https://github.com/baidu/amis/pull/7975/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dR957))
