### PR TITLE
fix: 修复编辑器在 antd 主题下拖入带有编辑弹窗的组件时编辑弹窗不显示的问题

### DIFF
--- a/packages/amis-editor-core/src/component/ScaffoldModal.tsx
+++ b/packages/amis-editor-core/src/component/ScaffoldModal.tsx
@@ -206,6 +206,7 @@ export class ScaffoldModal extends React.Component<SubEditorProps> {
 
     return (
       <Modal
+        theme={theme}
         size={scaffoldFormContext?.size || 'md'}
         contentClassName={scaffoldFormContext?.className}
         show={!!scaffoldFormContext}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7f10eed</samp>

Added `theme` prop to `Modal` component in `ScaffoldModal.tsx` to match the scaffold theme. This fixes the issue of the modal using a different theme from the parent component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7f10eed</samp>

> _`Modal` needs theme_
> _From `ScaffoldModal` prop_
> _Winter of bootstrap_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7f10eed</samp>

*  Add `theme` prop to `Modal` component to pass theme value from `ScaffoldModal` component ([link](https://github.com/baidu/amis/pull/7978/files?diff=unified&w=0#diff-85faab9f8c432f5b71f49bdb3e107d8f36edae4199b8cc13dd9b6a2b391b613dR209))
