### PR TITLE
feat: icon组件支持传入svg字符串作为图标

### DIFF
--- a/packages/amis-ui/src/components/icons.tsx
+++ b/packages/amis-ui/src/components/icons.tsx
@@ -358,6 +358,11 @@ export function Icon({
     );
   }
 
+  // 直接传入svg字符串
+  if (typeof icon === 'string' && icon.startsWith('<svg')) {
+    return <i dangerouslySetInnerHTML={{__html: icon}} />;
+  }
+
   // icon是链接
   const isURLIcon = typeof icon === 'string' && icon?.indexOf('.') !== -1;
   if (isURLIcon) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19c2f83</samp>

Add support for raw SVG icons in `Icon` component. This enables more flexibility and customization for icons in `amis-ui`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 19c2f83</samp>

> _`Icon` component_
> _accepts raw SVG string_
> _dangerous beauty_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 19c2f83</samp>

*  Add a new feature to the `Icon` component to render raw SVG strings ([link](https://github.com/baidu/amis/pull/7979/files?diff=unified&w=0#diff-1db9a23d0ea625849dbe5c523e7ccab192bfa73c87891759c8a7de36e2d874efR361-R365))
