### PR TITLE
fix: editor-修复大纲里activeId变化时，无法自动滚动到可视区的问题

### DIFF
--- a/packages/amis-editor-core/src/manager.ts
+++ b/packages/amis-editor-core/src/manager.ts
@@ -53,7 +53,8 @@ import {
   isString,
   isObject,
   isLayoutPlugin,
-  JSONPipeOut
+  JSONPipeOut,
+  scrollToActive
 } from './util';
 import {hackIn, makeSchemaFormRender, makeWrapper} from './component/factory';
 import {env} from './env';
@@ -297,6 +298,7 @@ export class EditorManager {
           this.buildToolbars();
           await this.buildRenderers();
           this.buildPanels();
+          scrollToActive(`[data-node-id="${id}"]`);
 
           this.trigger(
             'active',

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -8,11 +8,12 @@ import {isExpression, resolveVariableAndFilter} from 'amis-core';
 import type {VariableItem} from 'amis-ui';
 import {isObservable, reaction} from 'mobx';
 import DeepDiff, {Diff} from 'deep-diff';
-import assign from 'lodash/assign'
-import cloneDeep from 'lodash/cloneDeep'
-import isPlainObject from 'lodash/isPlainObject'
-import isEqual from 'lodash/isEqual'
-import isNumber from 'lodash/isNumber'
+import assign from 'lodash/assign';
+import cloneDeep from 'lodash/cloneDeep';
+import isPlainObject from 'lodash/isPlainObject';
+import isEqual from 'lodash/isEqual';
+import isNumber from 'lodash/isNumber';
+import debounce from 'lodash/debounce';
 
 const {
   guid,
@@ -1094,7 +1095,10 @@ export function needFillPlaceholder(curProps: any) {
   }
 
   // 支持在plugin中配置
-  return !!(curProps.$$editor?.needFillPlaceholder || curProps.regionConfig?.needFillPlaceholder);
+  return !!(
+    curProps.$$editor?.needFillPlaceholder ||
+    curProps.regionConfig?.needFillPlaceholder
+  );
 }
 // 设置主题数据
 export function setThemeConfig(config: any) {
@@ -1211,3 +1215,16 @@ export const updateComponentContext = (variables: any[]) => {
   }
   return items;
 };
+
+/**
+ * dom 滚动到可见区域
+ * @param selector dom 选择器
+ */
+export const scrollToActive = debounce((selector: string) => {
+  const dom = document.querySelector(selector);
+  if (dom) {
+    (dom as any).scrollIntoViewIfNeeded
+      ? (dom as any).scrollIntoViewIfNeeded()
+      : dom.scrollIntoView();
+  }
+}, 200);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 80370cc</samp>

Added auto-scrolling feature to outline panel in `amis-editor-core`. The feature uses `lodash.debounce` and `OutlinePanel.componentDidUpdate` to scroll to the active node in the editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 80370cc</samp>

> _`OutlinePanel` scrolls_
> _to active node in editor_
> _debounced by `lodash`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 80370cc</samp>

*  Add `componentDidUpdate` method to `OutlinePanel` component to scroll to the active node in the outline panel when the `id` prop changes ([link](https://github.com/baidu/amis/pull/7982/files?diff=unified&w=0#diff-8b99cb77af146c5d93db0eae96fa971525a3951110615cb271f2ed0e2f31e800R25-R30))
* Import `debounce` function from `lodash` and define `scrollToActive` function as a utility for scrolling the outline panel ([link](https://github.com/baidu/amis/pull/7982/files?diff=unified&w=0#diff-8b99cb77af146c5d93db0eae96fa971525a3951110615cb271f2ed0e2f31e800L8-R18))
