### PR TITLE
chore: 将主题的默认数据绑定到数据链上,避免数据无效diff

### DIFF
--- a/packages/amis-editor-core/src/component/factory.tsx
+++ b/packages/amis-editor-core/src/component/factory.tsx
@@ -13,7 +13,7 @@ import {EditorNodeContext, EditorNodeType} from '../store/node';
 import {EditorManager} from '../manager';
 import flatten from 'lodash/flatten';
 import {render as reactRender, unmountComponentAtNode} from 'react-dom';
-import {autobind, diff, getThemeDefaultData} from '../util';
+import {autobind, diff, getThemeConfig} from '../util';
 import {createObject, createObjectFromChain} from 'amis-core';
 import {CommonConfigWrapper} from './CommonConfigWrapper';
 import type {Schema} from 'amis';
@@ -305,7 +305,7 @@ function SchemaFrom({
 
   value = value || {};
   const finalValue = pipeIn ? pipeIn(value) : value;
-  const themeConfig = getThemeDefaultData();
+  const themeConfig = getThemeConfig();
 
   return render(
     schema,
@@ -315,9 +315,7 @@ function SchemaFrom({
         const diffValue = diff(value, newValue);
         onChange(newValue, diffValue);
       },
-      data: ctx
-        ? createObjectFromChain([ctx, themeConfig, finalValue])
-        : createObject(themeConfig, finalValue),
+      data: createObjectFromChain([ctx, themeConfig, finalValue]),
       node: node,
       manager: manager,
       popOverContainer

--- a/packages/amis-editor-core/src/component/factory.tsx
+++ b/packages/amis-editor-core/src/component/factory.tsx
@@ -13,13 +13,8 @@ import {EditorNodeContext, EditorNodeType} from '../store/node';
 import {EditorManager} from '../manager';
 import flatten from 'lodash/flatten';
 import {render as reactRender, unmountComponentAtNode} from 'react-dom';
-import {
-  autobind,
-  deleteThemeConfigData,
-  diff,
-  setThemeDefaultData
-} from '../util';
-import {createObject} from 'amis-core';
+import {autobind, diff, getThemeDefaultData} from '../util';
+import {createObject, createObjectFromChain} from 'amis-core';
 import {CommonConfigWrapper} from './CommonConfigWrapper';
 import type {Schema} from 'amis';
 import type {DataScope} from 'amis-core';
@@ -309,19 +304,20 @@ function SchemaFrom({
   }
 
   value = value || {};
-  const finalValue = setThemeDefaultData(pipeIn ? pipeIn(value) : value);
+  const finalValue = pipeIn ? pipeIn(value) : value;
+  const themeConfig = getThemeDefaultData();
 
   return render(
     schema,
     {
       onFinished: async (newValue: any) => {
-        newValue = deleteThemeConfigData(
-          pipeOut ? await pipeOut(newValue) : newValue
-        );
+        newValue = pipeOut ? await pipeOut(newValue) : newValue;
         const diffValue = diff(value, newValue);
         onChange(newValue, diffValue);
       },
-      data: ctx ? createObject(ctx, finalValue) : finalValue,
+      data: ctx
+        ? createObjectFromChain([ctx, themeConfig, finalValue])
+        : createObject(themeConfig, finalValue),
       node: node,
       manager: manager,
       popOverContainer

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -1107,26 +1107,8 @@ export function setThemeConfig(config: any) {
 }
 
 // 将主题数据传入组件的schema
-export function setThemeDefaultData(data: any) {
-  const schemaData = cloneDeep(data);
-  schemaData.themeConfig = themeConfig;
-  assign(schemaData, themeOptionsData);
-  return schemaData;
-}
-
-// 删除主题的配置数据
-export function deleteThemeConfigData(data: any) {
-  if (!data) {
-    return data;
-  }
-  const schemaData = cloneDeep(data);
-
-  delete schemaData.themeConfig;
-  Object.keys(themeOptionsData).forEach(key => {
-    delete schemaData[key];
-  });
-
-  return schemaData;
+export function getThemeDefaultData() {
+  return {themeConfig, ...themeOptionsData};
 }
 
 /**

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -1106,8 +1106,8 @@ export function setThemeConfig(config: any) {
   themeOptionsData = getGlobalData(themeConfig);
 }
 
-// 将主题数据传入组件的schema
-export function getThemeDefaultData() {
+// 获取主题数据和样式选择器数据
+export function getThemeConfig() {
   return {themeConfig, ...themeOptionsData};
 }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7426371</samp>

This pull request refactors the theme data handling in `amis-editor-core`, using a new function from `amis-core` to create the data object for rendering, and avoiding unnecessary mutations of the data. This improves the performance and readability of the component factory and the utility functions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7426371</samp>

> _`getThemeDefaultData`_
> _Simplifies the component_
> _No more mutations_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7426371</samp>

* Use `createObjectFromChain` from `amis-core` to merge theme data and schema data for rendering components ([link](https://github.com/baidu/amis/pull/7986/files?diff=unified&w=0#diff-5bcb2370bda7a8f3b1b692f3d568f62e4fd6aadd951424c0b7340c1ef5f40fe1L16-R17), [link](https://github.com/baidu/amis/pull/7986/files?diff=unified&w=0#diff-5bcb2370bda7a8f3b1b692f3d568f62e4fd6aadd951424c0b7340c1ef5f40fe1L318-R320))
* Remove unused and mutating functions `setThemeDefaultData` and `deleteThemeConfigData` from `../util` ([link](https://github.com/baidu/amis/pull/7986/files?diff=unified&w=0#diff-5bcb2370bda7a8f3b1b692f3d568f62e4fd6aadd951424c0b7340c1ef5f40fe1L16-R17), [link](https://github.com/baidu/amis/pull/7986/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL1110-R1113))
* Add `getThemeDefaultData` to `../util` to return the theme data object based on the schema type and theme name ([link](https://github.com/baidu/amis/pull/7986/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL1110-R1113))
* Pass the theme data object to the `render` function in `factory.tsx` as a separate argument ([link](https://github.com/baidu/amis/pull/7986/files?diff=unified&w=0#diff-5bcb2370bda7a8f3b1b692f3d568f62e4fd6aadd951424c0b7340c1ef5f40fe1L312-R308))
