### PR TITLE
feat: add a new clear event for input-text component

### DIFF
--- a/docs/zh-CN/components/form/input-text.md
+++ b/docs/zh-CN/components/form/input-text.md
@@ -453,6 +453,7 @@ order: 56
 | focus    | `[name]: string` 组件的值 | 输入框获取焦点时触发                           |
 | blur     | `[name]: string` 组件的值 | 输入框失去焦点时触发                           |
 | change   | `[name]: string` 组件的值 | 值变化时触发                                   |
+| clear    | `[name]: string` 组件的值 | 点击清除按钮时触发                             |
 
 ## 动作表
 

--- a/packages/amis/__tests__/renderers/Form/inputText.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/inputText.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * @Description:
+ * @Date: 2023-09-01 18:18:19
+ * @Author: ranqirong 274544338@qq.com
+ */
+import {
+  render,
+  fireEvent,
+  cleanup,
+  getByText,
+  within,
+  waitFor,
+  screen
+} from '@testing-library/react';
+import '../../../src';
+import {render as amisRender} from '../../../src';
+import {makeEnv, replaceReactAriaIds, wait} from '../../helper';
+
+describe('clearable', () => {
+  const initSchema = (action = {} as any) => ({
+    type: 'form',
+    body: [
+      {
+        name: 'text',
+        type: 'input-text',
+        placeholder: 'email',
+        resetValue: '',
+        clearable: true,
+        onEvent: {
+          clear: {
+            actions: [action]
+          }
+        }
+      }
+    ]
+  });
+
+  test('should execute the clear event handler while clicking the clear icon', async () => {
+    const mockScript = jest.fn();
+
+    const {container} = render(
+      amisRender(initSchema({actionType: 'custom', script: mockScript}))
+    );
+
+    const inputEl = screen.queryByPlaceholderText('email');
+    fireEvent.change(inputEl!, {target: {value: 'baidu'}});
+
+    expect(screen.queryByDisplayValue('baidu')).toBeInTheDocument();
+
+    await waitFor(() => {
+      const clearEl = container.querySelector('a.cxd-TextControl-clear');
+
+      expect(clearEl).toBeInTheDocument();
+      fireEvent.click(clearEl!);
+    });
+
+    await waitFor(() => {
+      expect(mockScript).toBeCalledTimes(1);
+      expect(screen.queryByDisplayValue('baidu')).not.toBeInTheDocument();
+    });
+  });
+
+  test('should not modify the value of the input if the property preventDefault of the clear event is true', async () => {
+    const mockScript = jest.fn();
+
+    const {container} = render(
+      amisRender(
+        initSchema({
+          actionType: 'custom',
+          script: mockScript,
+          preventDefault: true
+        })
+      )
+    );
+
+    const inputEl = screen.queryByPlaceholderText('email');
+    fireEvent.change(inputEl!, {target: {value: 'baidu'}});
+
+    expect(screen.queryByDisplayValue('baidu')).toBeInTheDocument();
+
+    await waitFor(() => {
+      const clearEl = container.querySelector('a.cxd-TextControl-clear');
+
+      expect(clearEl).toBeInTheDocument();
+      fireEvent.click(clearEl!);
+    });
+
+    await waitFor(() => {
+      expect(mockScript).toBeCalledTimes(1);
+      expect(screen.queryByDisplayValue('baidu')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/amis/package.json
+++ b/packages/amis/package.json
@@ -6,7 +6,7 @@
   "module": "esm/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "test": "jest",
+    "test": "jest --watch",
     "update-snapshot": "jest --updateSnapshot",
     "coverage": "jest --coverage",
     "publish-to-internal": "sh build.sh && sh publish.sh",

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -285,8 +285,17 @@ export default class TextControl extends React.PureComponent<
     }
   }
 
-  clearValue() {
-    const {onChange, resetValue} = this.props;
+  async clearValue() {
+    const {onChange, resetValue, dispatchEvent} = this.props;
+
+    const rendererEvent = await dispatchEvent(
+      'clear',
+      resolveEventData(this.props, {value: resetValue})
+    );
+
+    if (rendererEvent?.prevented) {
+      return;
+    }
 
     onChange(resetValue);
     this.setState(


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b5f45e4</samp>

This pull request adds a new feature of clearable input-text to the amis package, which allows the user to clear the input value by clicking a button. It also adds a new `clear` event to the input-text component, which can be handled by custom logic. The pull request updates the documentation, the test file, and the component code to support this feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b5f45e4</samp>

> _`InputText` clears_
> _A new event and test file_
> _Autumn leaves the docs_

### Why
虽然通过change事件的值为空字符串也能判断为clear事件,但在明确需要clear事件时还是略显麻烦

1. 特殊需求场景下需要将change事件和clear事件区分开来
2. vant等移动端UI库都有clear事件,符合前端开发人员使用习惯

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b5f45e4</samp>

* Implement the clear event handler for the clearable input-text feature ([link](https://github.com/baidu/amis/pull/7996/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L288-R299))
* Add a new test file for the clearable input-text feature and the clear event handler ([link](https://github.com/baidu/amis/pull/7996/files?diff=unified&w=0#diff-8f20373653b524cecb7b1d8d8796e388e86adb0e9597d645b3ae149aba5de033R1-R93))
* Update the documentation of the input-text component to include the clear event ([link](https://github.com/baidu/amis/pull/7996/files?diff=unified&w=0#diff-6168ac65de5239321577435909f0cdf4416fab03222927b17af4ccacaee7f12aR456))
* Modify the test script in the `package.json` file of the amis package to enable the watch mode ([link](https://github.com/baidu/amis/pull/7996/files?diff=unified&w=0#diff-b49028542a3bb14de6e47e46a9f09f23ffeff3afea2a17d5ddace75726a33e12L9-R9))
