### PR TITLE
fix: 外观配置修复

### DIFF
--- a/packages/amis-core/src/components/CustomStyle.tsx
+++ b/packages/amis-core/src/components/CustomStyle.tsx
@@ -16,14 +16,8 @@ interface CustomStyleProps {
 }
 
 export default function (props: CustomStyleProps) {
-  const {
-    themeCss,
-    classNames,
-    id,
-    defaultData,
-    wrapperCustomStyle,
-    componentId
-  } = props.config;
+  const {themeCss, classNames, id, defaultData, wrapperCustomStyle} =
+    props.config;
   useEffect(() => {
     insertCustomStyle(
       themeCss,
@@ -35,7 +29,7 @@ export default function (props: CustomStyleProps) {
   }, [props.config.themeCss]);
 
   useEffect(() => {
-    insertEditCustomStyle(wrapperCustomStyle, componentId);
+    insertEditCustomStyle(wrapperCustomStyle, id);
   }, [props.config.wrapperCustomStyle]);
 
   return null;

--- a/packages/amis-core/src/renderers/Item.tsx
+++ b/packages/amis-core/src/renderers/Item.tsx
@@ -984,7 +984,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
             },
             model?.errClassNames,
             wrapperCustomStyle
-              ? `wrapperCustomStyle-${id?.replace('u:', '')}`
+              ? `wrapperCustomStyle-${id?.replace('u:', '')}-item`
               : ''
           )}
           style={style}
@@ -1545,7 +1545,6 @@ export class FormItemWrap extends React.Component<FormItemProps> {
               }
             ],
             wrapperCustomStyle,
-            componentId: id,
             id: id + '-item'
           }}
           env={env}

--- a/packages/amis-core/src/utils/style-helper.ts
+++ b/packages/amis-core/src/utils/style-helper.ts
@@ -166,7 +166,7 @@ export function formatStyle(
         disabled: {}
       };
       for (let key in body) {
-        if (key === '$$id') {
+        if (key === '$$id' || body[key] === '') {
           continue;
         }
         if (!!~key.indexOf(':default')) {

--- a/packages/amis-editor/src/plugin/Carousel.tsx
+++ b/packages/amis-editor/src/plugin/Carousel.tsx
@@ -348,6 +348,27 @@ export class CarouselPlugin extends BasePlugin {
             getSchemaTpl('theme:base', {
               title: '轮播图'
             }),
+            {
+              title: '其他',
+              body: [
+                {
+                  name: 'themeCss.baseControlClassName.--image-images-prev-icon',
+                  label: '左切换图标',
+                  type: 'icon-select',
+                  returnSvg: true
+                },
+                {
+                  name: 'themeCss.baseControlClassName.--image-images-next-icon',
+                  label: '右切换图标',
+                  type: 'icon-select',
+                  returnSvg: true
+                },
+                getSchemaTpl('theme:select', {
+                  label: '切换图标大小',
+                  name: 'themeCss.galleryControlClassName.width:default'
+                })
+              ]
+            },
             getSchemaTpl('theme:cssCode')
           ])
         }

--- a/packages/amis-editor/src/plugin/Image.tsx
+++ b/packages/amis-editor/src/plugin/Image.tsx
@@ -195,23 +195,44 @@ export class ImagePlugin extends BasePlugin {
             body: [
               getSchemaTpl('theme:font', {
                 label: '标题文字',
-                name: 'themeCss.titleControlClassName.font:default',
+                name: 'themeCss.titleControlClassName.font',
                 editorThemePath: 'image.image.default.normal.body.font'
               }),
               getSchemaTpl('theme:paddingAndMargin', {
                 label: '标题边距',
-                name: 'themeCss.titleControlClassName.padding-and-margin:default'
+                name: 'themeCss.titleControlClassName.padding-and-margin'
+              }),
+              getSchemaTpl('theme:font', {
+                label: '描述文字',
+                name: 'themeCss.desControlClassName.font',
+                editorThemePath: 'image.image.default.description.body.font'
               }),
               getSchemaTpl('theme:paddingAndMargin', {
                 label: '描述边距',
-                name: 'themeCss.desControlClassName.padding-and-margin:default'
+                name: 'themeCss.desControlClassName.padding-and-margin'
               }),
               {
                 name: 'themeCss.iconControlClassName.--image-image-normal-icon',
                 label: '放大图标',
                 type: 'icon-select',
                 returnSvg: true
-              }
+              },
+              {
+                name: 'themeCss.galleryControlClassName.--image-images-prev-icon',
+                label: '左切换图标',
+                type: 'icon-select',
+                returnSvg: true
+              },
+              {
+                name: 'themeCss.galleryControlClassName.--image-images-next-icon',
+                label: '右切换图标',
+                type: 'icon-select',
+                returnSvg: true
+              },
+              getSchemaTpl('theme:select', {
+                label: '切换图标大小',
+                name: 'themeCss.galleryControlClassName.--image-images-item-size'
+              })
             ]
           },
           getSchemaTpl('theme:cssCode'),

--- a/packages/amis-editor/src/plugin/Images.tsx
+++ b/packages/amis-editor/src/plugin/Images.tsx
@@ -215,6 +215,27 @@ export class ImagesPlugin extends BasePlugin {
             classname: 'imagesControlClassName',
             title: '图片集'
           }),
+          {
+            title: '其他',
+            body: [
+              {
+                name: 'themeCss.galleryControlClassName.--image-images-prev-icon',
+                label: '左切换图标',
+                type: 'icon-select',
+                returnSvg: true
+              },
+              {
+                name: 'themeCss.galleryControlClassName.--image-images-next-icon',
+                label: '右切换图标',
+                type: 'icon-select',
+                returnSvg: true
+              },
+              getSchemaTpl('theme:select', {
+                label: '切换图标大小',
+                name: 'themeCss.galleryControlClassName.--image-images-item-size'
+              })
+            ]
+          },
           getSchemaTpl('theme:cssCode'),
           {
             title: 'CSS类名',

--- a/packages/amis-editor/src/renderer/style-control/ThemeCssCode.tsx
+++ b/packages/amis-editor/src/renderer/style-control/ThemeCssCode.tsx
@@ -18,6 +18,31 @@ const editorPlaceholder = `自定义样式仅对当前组件生效。示例：
 }
 `;
 
+const editorOptions = {
+  autoIndent: true,
+  formatOnType: true,
+  formatOnPaste: true,
+  selectOnLineNumbers: true,
+  scrollBeyondLastLine: false,
+  folding: true,
+  minimap: {
+    enabled: false
+  },
+  scrollbar: {
+    alwaysConsumeMouseWheel: false
+  },
+  bracketPairColorization: {
+    enabled: true
+  },
+  automaticLayout: true,
+  lineNumbers: 'off',
+  glyphMargin: false,
+  wordWrap: 'on',
+  lineDecorationsWidth: 0,
+  lineNumbersMinChars: 0,
+  overviewRulerBorder: false
+};
+
 function ThemeCssCode(props: FormControlProps) {
   const {data, onBulkChange} = props;
   const {wrapperCustomStyle} = data;
@@ -112,6 +137,7 @@ function ThemeCssCode(props: FormControlProps) {
             placeholder={editorPlaceholder}
             language="scss"
             onChange={handleChange}
+            options={editorOptions}
           />
         </div>
       </div>
@@ -143,6 +169,7 @@ function ThemeCssCode(props: FormControlProps) {
                   placeholder={editorPlaceholder}
                   language="scss"
                   onChange={handleChange}
+                  options={editorOptions}
                 />
               </div>
             </div>

--- a/packages/amis-editor/src/tpl/style.tsx
+++ b/packages/amis-editor/src/tpl/style.tsx
@@ -480,7 +480,7 @@ setSchemaTpl('theme:form-description', () => {
 // 带提示的值输入框
 setSchemaTpl('theme:select', (option: any = {}) => {
   return {
-    mode: 'default',
+    mode: 'horizontal',
     type: 'amis-theme-select',
     label: '大小',
     name: `themeCss.className.select:default`,

--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -3319,6 +3319,8 @@
   --image-images-preview-paddingBottom: var(--sizes-size-3);
   --image-images-preview-paddingLeft: var(--sizes-size-9);
   --image-images-preview-paddingRight: var(--sizes-size-9);
+  --image-images-prev-icon: '<svg viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="currentColor" fill-rule="evenodd"><polyline stroke="currentColor" transform="translate(10.496854, 8.006854) rotate(-135.000000) translate(-10.496854, -8.006854) " points="6.49685425 4.00685425 14.4968542 4.00685425 14.4968542 12.0068542" stroke-width="1" fill="none" stroke-linecap="butt" stroke-linejoin="round"/></g></svg>';
+  --image-images-next-icon: '<svg viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="currentColor" fill-rule="evenodd"><polyline stroke="currentColor" transform="translate(5.496854, 8.006854) scale(-1, 1) rotate(-135.000000) translate(-5.496854, -8.006854) " points="1.49685425 4.00685425 9.49685425 4.00685425 9.49685425 12.0068542" stroke-width="1" fill="none" stroke-linecap="butt" stroke-linejoin="round"/></g></svg>';
 
   --Tag-base-fontSize: var(--fonts-size-8);
   --Tag-base-fontWeight: var(--fonts-weight-6);

--- a/packages/amis-ui/scss/components/_carousel.scss
+++ b/packages/amis-ui/scss/components/_carousel.scss
@@ -14,7 +14,6 @@
     right: 50%;
     transform: translate(-50%, -50%);
     width: var(--Carousel-svg-width);
-    height: var(--Carousel-svg-height);
   }
 }
 

--- a/packages/amis-ui/scss/components/_image-gallery.scss
+++ b/packages/amis-ui/scss/components/_image-gallery.scss
@@ -29,7 +29,7 @@
       color: #fff;
     }
 
-    > svg {
+    svg {
       width: px2rem(16px);
       height: px2rem(16px);
     }
@@ -65,7 +65,7 @@
 
   &-prevBtn,
   &-nextBtn {
-    > svg {
+    svg {
       width: var(--image-images-item-size);
       height: var(--image-images-item-size);
     }
@@ -205,6 +205,14 @@
   }
 }
 
+.ImageGallery-prevBtn {
+  content: var(--image-images-prev-icon);
+}
+
+.ImageGallery-nextBtn {
+  content: var(--image-images-next-icon);
+}
+
 .#{$ns}ImageGallery-toolbar {
   background-color: var(--image-images-preview-bgColor);
   border-radius: var(--image-images-preview-radius);
@@ -237,7 +245,7 @@
       display: block;
       color: var(--black);
 
-      & > svg {
+      svg {
         fill: var(--black);
       }
     }
@@ -249,7 +257,7 @@
       .#{$ns}ImageGallery-toolbar-action-icon {
         color: var(--icon-onDisabled-color);
 
-        & > svg {
+        svg {
           color: var(--icon-onDisabled-color);
         }
       }
@@ -261,7 +269,7 @@
       .#{$ns}ImageGallery-toolbar-action-icon {
         color: var(--primary);
 
-        & > svg {
+        svg {
           fill: var(--primary);
         }
       }

--- a/packages/amis-ui/src/components/ImageGallery.tsx
+++ b/packages/amis-ui/src/components/ImageGallery.tsx
@@ -336,7 +336,11 @@ export class ImageGallery extends React.Component<
                       )}
                       onClick={this.prev}
                     >
-                      <Icon icon="prev" className="icon" />
+                      <Icon
+                        icon="prev"
+                        className="icon"
+                        iconContent="ImageGallery-prevBtn"
+                      />
                     </a>
                     <a
                       className={cx(
@@ -345,7 +349,11 @@ export class ImageGallery extends React.Component<
                       )}
                       onClick={this.next}
                     >
-                      <Icon icon="next" className="icon" />
+                      <Icon
+                        icon="next"
+                        className="icon"
+                        iconContent="ImageGallery-nextBtn"
+                      />
                     </a>
                   </>
                 ) : null}

--- a/packages/amis/src/renderers/Action.tsx
+++ b/packages/amis/src/renderers/Action.tsx
@@ -927,7 +927,6 @@ export class Action extends React.Component<ActionProps, ActionState> {
               }
             ],
             wrapperCustomStyle,
-            componentId: id,
             id
           }}
           env={env}

--- a/packages/amis/src/renderers/Carousel.tsx
+++ b/packages/amis/src/renderers/Carousel.tsx
@@ -463,7 +463,8 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
       wrapperCustomStyle,
       env,
       themeCss,
-      baseControlClassName
+      baseControlClassName,
+      galleryControlClassName
     } = this.props;
     const {options, current, nextAnimation} = this.state;
 
@@ -626,7 +627,10 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
 
         {dots ? this.renderDots() : null}
         {arrows ? (
-          <div className={cx('Carousel-leftArrow')} onClick={this.prev}>
+          <div
+            className={cx('Carousel-leftArrow', galleryControlClassName)}
+            onClick={this.prev}
+          >
             {icons && icons.prev ? (
               React.isValidElement(icons.prev) ? (
                 icons.prev
@@ -634,12 +638,19 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
                 render('arrow-prev', icons.prev)
               )
             ) : (
-              <Icon icon="left-arrow" className="icon" />
+              <Icon
+                icon="left-arrow"
+                className="icon"
+                iconContent="ImageGallery-prevBtn"
+              />
             )}
           </div>
         ) : null}
         {arrows ? (
-          <div className={cx('Carousel-rightArrow')} onClick={this.next}>
+          <div
+            className={cx('Carousel-rightArrow', galleryControlClassName)}
+            onClick={this.next}
+          >
             {icons && icons.next ? (
               React.isValidElement(icons.next) ? (
                 icons.next
@@ -647,19 +658,33 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
                 render('arrow-next', icons.next)
               )
             ) : (
-              <Icon icon="right-arrow" className="icon" />
+              <Icon
+                icon="right-arrow"
+                className="icon"
+                iconContent="ImageGallery-nextBtn"
+              />
             )}
           </div>
         ) : null}
         <CustomStyle
           config={{
             wrapperCustomStyle,
-            componentId: id,
+            id,
             themeCss,
             classNames: [
               {
                 key: 'baseControlClassName',
                 value: baseControlClassName
+              },
+              {
+                key: 'galleryControlClassName',
+                value: galleryControlClassName,
+                weights: {
+                  default: {
+                    suf: ' svg',
+                    important: true
+                  }
+                }
               }
             ]
           }}

--- a/packages/amis/src/renderers/Chart.tsx
+++ b/packages/amis/src/renderers/Chart.tsx
@@ -628,7 +628,7 @@ export class Chart extends React.Component<ChartProps> {
         <CustomStyle
           config={{
             wrapperCustomStyle,
-            componentId: id,
+            id,
             themeCss,
             classNames: [
               {

--- a/packages/amis/src/renderers/Container.tsx
+++ b/packages/amis/src/renderers/Container.tsx
@@ -227,7 +227,7 @@ export default class Container<T> extends React.Component<
         <CustomStyle
           config={{
             wrapperCustomStyle,
-            componentId: id,
+            id,
             themeCss,
             classNames: [
               {

--- a/packages/amis/src/renderers/Flex.tsx
+++ b/packages/amis/src/renderers/Flex.tsx
@@ -148,7 +148,7 @@ export default class Flex extends React.Component<FlexProps, object> {
         <CustomStyle
           config={{
             wrapperCustomStyle,
-            componentId: id,
+            id,
             themeCss,
             classNames: [
               {

--- a/packages/amis/src/renderers/Grid.tsx
+++ b/packages/amis/src/renderers/Grid.tsx
@@ -237,7 +237,7 @@ export default class Grid<T> extends React.Component<GridProps & T, object> {
         <CustomStyle
           config={{
             wrapperCustomStyle,
-            componentId: id,
+            id,
             themeCss,
             classNames: [
               {

--- a/packages/amis/src/renderers/IFrame.tsx
+++ b/packages/amis/src/renderers/IFrame.tsx
@@ -281,7 +281,7 @@ export default class IFrame extends React.Component<IFrameProps, object> {
         <CustomStyle
           config={{
             wrapperCustomStyle,
-            componentId: id,
+            id,
             themeCss,
             classNames: [
               {

--- a/packages/amis/src/renderers/Image.tsx
+++ b/packages/amis/src/renderers/Image.tsx
@@ -437,6 +437,7 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
       showToolbar,
       toolbarActions,
       imageGallaryClassName,
+      galleryControlClassName,
       enlargeWithGallary
     } = this.props;
 
@@ -451,7 +452,9 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
           thumbRatio,
           showToolbar,
           toolbarActions,
-          imageGallaryClassName,
+          imageGallaryClassName: galleryControlClassName
+            ? imageGallaryClassName + ' ' + galleryControlClassName
+            : imageGallaryClassName,
           enlargeWithGallary
         },
         this.props
@@ -495,6 +498,7 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
       titleControlClassName,
       desControlClassName,
       iconControlClassName,
+      galleryControlClassName,
       env
     } = this.props;
 
@@ -534,6 +538,10 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
             enlargeAble={enlargeAble && value !== defaultImage}
             onEnlarge={this.handleEnlarge}
             imageMode={imageMode}
+            imageControlClassName={imageControlClassName}
+            titleControlClassName={titleControlClassName}
+            desControlClassName={desControlClassName}
+            iconControlClassName={iconControlClassName}
           />
         ) : (
           <span className="text-muted">{placeholder}</span>
@@ -541,7 +549,7 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
         <CustomStyle
           config={{
             wrapperCustomStyle,
-            componentId: id,
+            id,
             themeCss,
             classNames: [
               {
@@ -559,6 +567,10 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
               {
                 key: 'iconControlClassName',
                 value: iconControlClassName
+              },
+              {
+                key: 'galleryControlClassName',
+                value: galleryControlClassName
               }
             ]
           }}

--- a/packages/amis/src/renderers/Images.tsx
+++ b/packages/amis/src/renderers/Images.tsx
@@ -192,6 +192,7 @@ export class ImagesField extends React.Component<ImagesProps> {
       showToolbar,
       toolbarActions,
       imageGallaryClassName,
+      galleryControlClassName,
       id,
       wrapperCustomStyle,
       env,
@@ -257,7 +258,11 @@ export class ImagesField extends React.Component<ImagesProps> {
                 enlargeWithGallary={enlargeWithGallary}
                 onEnlarge={this.handleEnlarge}
                 showToolbar={showToolbar}
-                imageGallaryClassName={imageGallaryClassName}
+                imageGallaryClassName={
+                  galleryControlClassName
+                    ? imageGallaryClassName + ' ' + galleryControlClassName
+                    : imageGallaryClassName
+                }
                 toolbarActions={toolbarActions}
               />
             ))}
@@ -277,12 +282,16 @@ export class ImagesField extends React.Component<ImagesProps> {
         <CustomStyle
           config={{
             wrapperCustomStyle,
-            componentId: id,
+            id,
             themeCss,
             classNames: [
               {
                 key: 'imagesControlClassName',
                 value: imagesControlClassName
+              },
+              {
+                key: 'galleryControlClassName',
+                value: galleryControlClassName
               }
             ]
           }}

--- a/packages/amis/src/renderers/Page.tsx
+++ b/packages/amis/src/renderers/Page.tsx
@@ -1028,7 +1028,7 @@ export default class Page extends React.Component<PageProps> {
         <CustomStyle
           config={{
             wrapperCustomStyle,
-            componentId: id,
+            id,
             themeCss,
             classNames: [
               {

--- a/packages/amis/src/renderers/TableView.tsx
+++ b/packages/amis/src/renderers/TableView.tsx
@@ -296,7 +296,7 @@ export default class TableView extends React.Component<TableViewProps, object> {
         <CustomStyle
           config={{
             wrapperCustomStyle,
-            componentId: id,
+            id,
             themeCss,
             classNames: [
               {

--- a/packages/amis/src/renderers/TooltipWrapper.tsx
+++ b/packages/amis/src/renderers/TooltipWrapper.tsx
@@ -286,7 +286,7 @@ export default class TooltipWrapper extends React.Component<
         <CustomStyle
           config={{
             wrapperCustomStyle,
-            componentId: id,
+            id,
             themeCss,
             classNames: [
               {

--- a/packages/amis/src/renderers/Tpl.tsx
+++ b/packages/amis/src/renderers/Tpl.tsx
@@ -226,7 +226,7 @@ export class Tpl extends React.Component<TplProps, TplState> {
         <CustomStyle
           config={{
             wrapperCustomStyle,
-            componentId: id,
+            id,
             themeCss,
             classNames: [
               {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e27b4b2</samp>

This pull request improves the customization and compatibility of various components in the `amis` and `amis-editor` packages, such as the image gallery, the carousel, and the theme CSS code editor. It also simplifies the custom style editing logic by removing the `componentId` prop and using the `id` prop instead in the `CustomStyle` component and its usages. It also fixes some minor style issues and removes unused or redundant code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e27b4b2</samp>

> _`CustomStyle` changed_
> _More options for images_
> _Autumn leaves of code_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e27b4b2</samp>

*  Remove `componentId` prop from various components and use `id` prop instead, as it was redundant ([link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-64f487ea8bb551e6157d95133fcf65572d6990b062dd31bf6502543a77ad9fb5L19-R20), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1548), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-4d89203911a9d3ef38c82118f074ad24c49244699f1f2cbb6072134908f60098L930), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-6fdff4b3fe0b645eefcb5965b67e686313b9dc1264e9235100ea1a392c0b922dR678-R687), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-b835aa79eebadb985fbc93069bbd1973522b0a1d125adbbe7b2300a154647acdL631-R631), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-edd47b0de503479e802bfb81f912b7d272b5425c562cb40c38c5d8357bbabc27L230-R230), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-3c803fbe826ef61d46f35e8fa870aaf229c1bb83bad98847a11f8d70b3bd7095L151-R151), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-fa9481c4bc2fd81f6579dfd66c219657e0157ea342df3f34f8f84b63943a3843L240-R240), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-f8884cc8b937a24a67cbdfc55b94f97a20929b9d10e19ac17144feeeb12a0e81L284-R284), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9L544-R552))
*  Add more configuration options for the carousel component in the `CarouselPlugin` class, such as the left and right switch icons and their size ([link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-db2199816e5d1d4f1050533ef5714a1b6ed8c525d8bbb40f65f1ab1a9fb8ebb8R351-R371))
*  Add more configuration options for the image and images components in the `ImagePlugin` and `ImagesPlugin` classes, such as the font, the left and right switch icons and their size ([link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-080f970ff41a9d0e1619e4d8d2190127b7b241f179ed33b91f4f0fe48475fd41L198-R212), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-080f970ff41a9d0e1619e4d8d2190127b7b241f179ed33b91f4f0fe48475fd41L214-R235), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-56455bda1d9d4fbd51a8c855a272024feb8277669aa011d205c953cde21e2278R218-R238))
*  Modify the `Icon` component to use the `iconContent` prop instead of the `icon` prop, to render the icon from the CSS variable instead of the icon font, in the `ImageGallery` and `Carousel` components ([link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-bed7585d0647a7896dee30a46f94d5624fba9662c725a5946ee61927fcc2d5b8L339-R343), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-bed7585d0647a7896dee30a46f94d5624fba9662c725a5946ee61927fcc2d5b8L348-R356), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-6fdff4b3fe0b645eefcb5965b67e686313b9dc1264e9235100ea1a392c0b922dL650-R665), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-6fdff4b3fe0b645eefcb5965b67e686313b9dc1264e9235100ea1a392c0b922dL657-R672))
*  Add the `galleryControlClassName` prop to the `Carousel` and `ImageField` components, to allow customizing the style of the gallery control buttons, and pass it to the `CustomStyle` component and the `imageGallaryClassName` prop ([link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-6fdff4b3fe0b645eefcb5965b67e686313b9dc1264e9235100ea1a392c0b922dL466-R467), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-6fdff4b3fe0b645eefcb5965b67e686313b9dc1264e9235100ea1a392c0b922dL629-R633), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-6fdff4b3fe0b645eefcb5965b67e686313b9dc1264e9235100ea1a392c0b922dL637-R653), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9R440), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9L454-R457), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9R501), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9R570-R573))
*  Add the `imageControlClassName`, `titleControlClassName`, `desControlClassName`, and `iconControlClassName` props to the `Image` component, to allow customizing the style of the image, title, description, and icon elements, and pass them from the `ImageField` component ([link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9R541-R544))
*  Update the `formatStyle` function to skip empty values in the `body` object, to avoid generating invalid CSS rules ([link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL169-R169))
*  Modify the `wrapperCustomStyle` class name to append `-item` suffix, to avoid style conflicts with other components ([link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L987-R987))
*  Add the `editorOptions` constant to the `ThemeCssCode` component, to define some common options for the Monaco editor used to edit the theme CSS code, and apply it to the `MonacoEditor` components used in the component ([link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-0d09abc7945e56f72384164537e19882a6faf0835c9130a430db6cebad0bc3eaR21-R45), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-0d09abc7945e56f72384164537e19882a6faf0835c9130a430db6cebad0bc3eaR140), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-0d09abc7945e56f72384164537e19882a6faf0835c9130a430db6cebad0bc3eaR172))
*  Modify the `theme:select` schema template to use the `horizontal` mode instead of the `default` mode, to make the UI more consistent and compact ([link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-397f3332bd17c52ed7e468360e1cfe462d1d8646110ccd681b48a6deaa608302L483-R483))
*  Add the `--image-images-prev-icon` and `--image-images-next-icon` CSS variables to the `_components.scss` file, to define the default SVG icons for the image gallery component ([link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4R3322-R3323))
*  Remove the `height` property from the `.Carousel-svg` class in the `_carousel.scss` file, as it was redundant with the `width` property and caused some layout issues ([link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-57df02633063258ea39a7f674d1a425c437977cfdd1f875dbe251bd51db2503cL17))
*  Remove the direct child selector (`>`) from the `.ImageGallery-prevBtn` and `.ImageGallery-nextBtn` classes and their variants in the `_image-gallery.scss` file, to allow more flexibility in the icon rendering ([link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-bd72a320a32366b31cbe1ffb581675380513de7b156d4d534050f4d18022b700L32-R32), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-bd72a320a32366b31cbe1ffb581675380513de7b156d4d534050f4d18022b700L68-R68), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-bd72a320a32366b31cbe1ffb581675380513de7b156d4d534050f4d18022b700L240-R248), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-bd72a320a32366b31cbe1ffb581675380513de7b156d4d534050f4d18022b700L252-R260), [link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-bd72a320a32366b31cbe1ffb581675380513de7b156d4d534050f4d18022b700L264-R272))
*  Add the `.ImageGallery-prevBtn` and `.ImageGallery-nextBtn` classes to the `_image-gallery.scss` file, to define the content of the icons using the CSS variables ([link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-bd72a320a32366b31cbe1ffb581675380513de7b156d4d534050f4d18022b700R208-R215))
*  Remove the `:default` suffix from the theme CSS names in the `ImagePlugin` class, as it was unnecessary ([link](https://github.com/baidu/amis/pull/7998/files?diff=unified&w=0#diff-080f970ff41a9d0e1619e4d8d2190127b7b241f179ed33b91f4f0fe48475fd41L198-R212))
