### PR TITLE
feat: add a new clear event for input-text component

### DIFF
--- a/docs/zh-CN/components/form/input-text.md
+++ b/docs/zh-CN/components/form/input-text.md
@@ -453,6 +453,7 @@ order: 56
 | focus    | `[name]: string` 组件的值 | 输入框获取焦点时触发                           |
 | blur     | `[name]: string` 组件的值 | 输入框失去焦点时触发                           |
 | change   | `[name]: string` 组件的值 | 值变化时触发                                   |
+| clear    | `[name]: string` 组件的值 | 点击清除按钮时触发                             |
 
 ## 动作表
 

--- a/packages/amis/__tests__/renderers/Form/inputText.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/inputText.test.tsx
@@ -1,0 +1,79 @@
+import {render, fireEvent, waitFor, screen} from '@testing-library/react';
+import '../../../src';
+import {render as amisRender} from '../../../src';
+
+describe('clearable', () => {
+  const initSchema = (action = {} as any) => ({
+    type: 'form',
+    body: [
+      {
+        name: 'text',
+        type: 'input-text',
+        placeholder: 'email',
+        resetValue: '',
+        clearable: true,
+        onEvent: {
+          clear: {
+            actions: [action]
+          }
+        }
+      }
+    ]
+  });
+
+  test('should execute the clear event handler while clicking the clear icon', async () => {
+    const mockScript = jest.fn();
+
+    const {container} = render(
+      amisRender(initSchema({actionType: 'custom', script: mockScript}))
+    );
+
+    const inputEl = screen.queryByPlaceholderText('email');
+    fireEvent.change(inputEl!, {target: {value: 'baidu'}});
+
+    expect(screen.queryByDisplayValue('baidu')).toBeInTheDocument();
+
+    await waitFor(() => {
+      const clearEl = container.querySelector('a.cxd-TextControl-clear');
+
+      expect(clearEl).toBeInTheDocument();
+      fireEvent.click(clearEl!);
+    });
+
+    await waitFor(() => {
+      expect(mockScript).toBeCalledTimes(1);
+      expect(screen.queryByDisplayValue('baidu')).not.toBeInTheDocument();
+    });
+  });
+
+  test('should not modify the value of the input if the property preventDefault of the clear event is true', async () => {
+    const mockScript = jest.fn();
+
+    const {container} = render(
+      amisRender(
+        initSchema({
+          actionType: 'custom',
+          script: mockScript,
+          preventDefault: true
+        })
+      )
+    );
+
+    const inputEl = screen.queryByPlaceholderText('email');
+    fireEvent.change(inputEl!, {target: {value: 'baidu'}});
+
+    expect(screen.queryByDisplayValue('baidu')).toBeInTheDocument();
+
+    await waitFor(() => {
+      const clearEl = container.querySelector('a.cxd-TextControl-clear');
+
+      expect(clearEl).toBeInTheDocument();
+      fireEvent.click(clearEl!);
+    });
+
+    await waitFor(() => {
+      expect(mockScript).toBeCalledTimes(1);
+      expect(screen.queryByDisplayValue('baidu')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -285,8 +285,17 @@ export default class TextControl extends React.PureComponent<
     }
   }
 
-  clearValue() {
-    const {onChange, resetValue} = this.props;
+  async clearValue() {
+    const {onChange, resetValue, dispatchEvent} = this.props;
+
+    const rendererEvent = await dispatchEvent(
+      'clear',
+      resolveEventData(this.props, {value: resetValue})
+    );
+
+    if (rendererEvent?.prevented) {
+      return;
+    }
 
     onChange(resetValue);
     this.setState(


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f5f8d82</samp>

This pull request adds a new `clear` event to the input-text component, which is triggered when the user clicks the clear button. The event allows the user to customize the behavior of the clear action, such as preventing the input from being cleared or performing some other logic. The pull request also updates the documentation and the test cases for the input-text component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f5f8d82</samp>

> _`input-text` clears_
> _`clear` event lets you choose_
> _autumn leaves falling_

### Why

虽然通过change事件的值为空字符串也能判断为clear事件,但在明确需要clear事件时还是略显麻烦

特殊需求场景下需要将change事件和clear事件区分开来
vant等移动端UI库都有clear事件,符合前端开发人员使用习惯

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f5f8d82</samp>

*  Add a `clear` event to the input-text component, which is triggered when the user clicks the clear button and allows the user to customize the behavior of the clear action. ([link](https://github.com/baidu/amis/pull/7999/files?diff=unified&w=0#diff-6168ac65de5239321577435909f0cdf4416fab03222927b17af4ccacaee7f12aR456), [link](https://github.com/baidu/amis/pull/7999/files?diff=unified&w=0#diff-8f20373653b524cecb7b1d8d8796e388e86adb0e9597d645b3ae149aba5de033R1-R79), [link](https://github.com/baidu/amis/pull/7999/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L288-R299))
  * Update the documentation of the input-text component in `docs/zh-CN/components/form/input-text.md` to include the `clear` event and its parameter in the event table. ([link](https://github.com/baidu/amis/pull/7999/files?diff=unified&w=0#diff-6168ac65de5239321577435909f0cdf4416fab03222927b17af4ccacaee7f12aR456))
  * Modify the `clearValue` method of the input-text component in `packages/amis/src/renderers/Form/InputText.tsx` to dispatch the `clear` event using the `dispatchEvent` prop and check if the event object has a `prevented` property, which indicates that the user has canceled the default behavior of clearing the input value. If not, call the `onChange` prop with the `resetValue` prop. ([link](https://github.com/baidu/amis/pull/7999/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L288-R299))
