### PR TITLE
fix: select组件国际化问题

### DIFF
--- a/packages/amis-ui/src/components/Select.tsx
+++ b/packages/amis-ui/src/components/Select.tsx
@@ -1193,7 +1193,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
         ) : null}
         {multiple && valuesNoWrap ? (
           <div className={cx('Select-option')}>
-            已选择({selectionValues.length})
+            {__('Select.selected')}({selectionValues.length})
           </div>
         ) : null}
         {multiple && checkAll && filtedOptions.length ? (

--- a/packages/amis-ui/src/locale/de-DE.ts
+++ b/packages/amis-ui/src/locale/de-DE.ts
@@ -219,6 +219,7 @@ register('de-DE', {
   'Select.createLabel': 'Neue Option',
   'Select.placeholder': 'Auswählen',
   'Select.searchPromptText': 'Eingeben zum Suchen',
+  'Select.selected': 'Ausgewählt',
   'sort': 'Sortieren',
   'SubForm.button': 'Configurieren',
   'SubForm.editDetail': 'Details bearbeiten',

--- a/packages/amis-ui/src/locale/en-US.ts
+++ b/packages/amis-ui/src/locale/en-US.ts
@@ -212,6 +212,7 @@ register('en-US', {
   'Select.createLabel': 'New option',
   'Select.placeholder': 'Select',
   'Select.searchPromptText': 'Input to search',
+  'Select.selected': 'Selected',
   'sort': 'Sort',
   'stop': 'Stop',
   'SubForm.button': 'Config',

--- a/packages/amis-ui/src/locale/zh-CN.ts
+++ b/packages/amis-ui/src/locale/zh-CN.ts
@@ -218,6 +218,7 @@ register('zh-CN', {
   'Select.createLabel': '新增选项',
   'Select.placeholder': '请选择',
   'Select.searchPromptText': '搜索',
+  'Select.selected': '已选择',
   'sort': '排序',
   'SubForm.button': '设置',
   'SubForm.editDetail': '编辑详情',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d9ad56a</samp>

Added localization support for the `Select` component's multiple selection label. Added translations for the key `Select.selected` in German, English, and Chinese language files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d9ad56a</samp>

> _`Select` component_
> _uses localized strings now_
> _better for users_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d9ad56a</samp>

*  Localize the label of the multiple selection option in the `Select` component ([link](https://github.com/baidu/amis/pull/8000/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL1196-R1196))
*  Add the translations for the key `Select.selected` in the language files for German ([link](https://github.com/baidu/amis/pull/8000/files?diff=unified&w=0#diff-7c7473c7eeac8c306a9c1dbf7f116bf87b1bcd4c31e9e0f8c619febc67faf8a5R222)), English ([link](https://github.com/baidu/amis/pull/8000/files?diff=unified&w=0#diff-fb22f243566a7ed671bc6279e3cc6f0a1eddc2fe4259d84b4cb8a7f596987e49R215)), and Chinese ([link](https://github.com/baidu/amis/pull/8000/files?diff=unified&w=0#diff-2fd35dabf975bb2b4ad936c4efcf03b6ce58a0954eba2964acffa8e557091e64R221))
