### PR TITLE
fix: 修复divider组件切换方向时宽高异常问题

### DIFF
--- a/packages/amis-editor/src/plugin/Divider.tsx
+++ b/packages/amis-editor/src/plugin/Divider.tsx
@@ -78,14 +78,16 @@ export class DividerPlugin extends BasePlugin {
               label: '长度',
               name: 'style.width',
               placeholder: '100%',
-              visibleOn: 'direction !== "vertical"'
+              visibleOn: 'direction !== "vertical"',
+              clearValueOnHidden: true
             }),
             getSchemaTpl('theme:select', {
               mode: 'horizontal',
               label: '长度',
               name: 'style.height',
               placeholder: 'var(--sizes-base-15)',
-              visibleOn: 'direction === "vertical"'
+              visibleOn: 'direction === "vertical"',
+              clearValueOnHidden: true
             }),
             getSchemaTpl('theme:select', {
               mode: 'horizontal',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c3bd64</samp>

Added an option to clear style values for hidden dividers in `amis-editor`. This improves the output of the `DividerPlugin` in `packages/amis-editor/src/plugin/Divider.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3c3bd64</samp>

> _Sing, O Muse, of the cunning coder who devised_
> _A subtle scheme to clear the values of the fields_
> _That govern width and height of hidden dividers,_
> _And thus reduce the style output that they yield._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c3bd64</samp>

*  Add `clearValueOnHidden` property to `style.width` and `style.height` fields in `DividerPlugin` class to avoid unnecessary style attributes for hidden dividers ([link](https://github.com/baidu/amis/pull/8001/files?diff=unified&w=0#diff-b06ad49b8b64d0e50fe3529a2d3d5b4efe25aca142e28e03c0d9411b397134c8L81-R82), [link](https://github.com/baidu/amis/pull/8001/files?diff=unified&w=0#diff-b06ad49b8b64d0e50fe3529a2d3d5b4efe25aca142e28e03c0d9411b397134c8L88-R90))
