### PR TITLE
fix: 源码编辑优化&去掉类名

### DIFF
--- a/packages/amis-core/src/utils/style-helper.ts
+++ b/packages/amis-core/src/utils/style-helper.ts
@@ -340,11 +340,18 @@ export function insertEditCustomStyle(customStyle: any, id?: string) {
     const className = `wrapperCustomStyle-${id?.replace('u:', '')}`;
     for (let key in styles) {
       if (styles.hasOwnProperty(key)) {
-        if (isObject(styles[key])) {
+        if (!isObject(styles[key])) {
+          content += `\n.${className} {\n  ${key}: ${styles[key]}\n}`;
+        } else if (key === 'root') {
+          const res = map(styles[key], (value, key) => `${key}: ${value};`);
+          content += `\n.${className} {\n  ${res.join('\n  ')}\n}`;
+        } else if (/^root:/.test(key)) {
+          const res = map(styles[key], (value, key) => `${key}: ${value};`);
+          const nowKey = key.replace('root', '');
+          content += `\n.${className} ${nowKey} {\n  ${res.join('\n  ')}\n}`;
+        } else {
           const res = map(styles[key], (value, key) => `${key}: ${value};`);
           content += `\n.${className} ${key} {\n  ${res.join('\n  ')}\n}`;
-        } else {
-          content += `\n.${className} {\n  ${key}: ${styles[key]}\n}`;
         }
       }
     }

--- a/packages/amis-editor/src/plugin/Carousel.tsx
+++ b/packages/amis-editor/src/plugin/Carousel.tsx
@@ -337,8 +337,7 @@ export class CarouselPlugin extends BasePlugin {
                     type: 'button',
                     label: 'px'
                   }
-                },
-                getSchemaTpl('className')
+                }
               ]
             },
             {

--- a/packages/amis-editor/src/plugin/Container.tsx
+++ b/packages/amis-editor/src/plugin/Container.tsx
@@ -304,11 +304,7 @@ export class ContainerPlugin extends LayoutBasePlugin {
         title: '外观',
         className: 'p-none',
         body: getSchemaTpl('collapseGroup', [
-          ...getSchemaTpl('theme:common', {exclude: ['layout']}),
-          {
-            title: '自定义 CSS 类名',
-            body: [getSchemaTpl('className')]
-          }
+          ...getSchemaTpl('theme:common', {exclude: ['layout']})
         ])
       },
       {

--- a/packages/amis-editor/src/plugin/Image.tsx
+++ b/packages/amis-editor/src/plugin/Image.tsx
@@ -235,25 +235,7 @@ export class ImagePlugin extends BasePlugin {
               })
             ]
           },
-          getSchemaTpl('theme:cssCode'),
-          {
-            title: 'CSS类名',
-            body: [
-              getSchemaTpl('className', {
-                label: '外层'
-              }),
-
-              getSchemaTpl('className', {
-                name: 'imageClassName',
-                label: '图片'
-              }),
-
-              getSchemaTpl('className', {
-                name: 'thumbClassName',
-                label: '缩略图'
-              })
-            ]
-          }
+          getSchemaTpl('theme:cssCode')
         ])
       }
     ]);

--- a/packages/amis-editor/src/plugin/Images.tsx
+++ b/packages/amis-editor/src/plugin/Images.tsx
@@ -236,21 +236,7 @@ export class ImagesPlugin extends BasePlugin {
               })
             ]
           },
-          getSchemaTpl('theme:cssCode'),
-          {
-            title: 'CSS类名',
-            body: [
-              getSchemaTpl('className', {
-                autoComplete: false,
-                label: '外层'
-              }),
-
-              getSchemaTpl('className', {
-                name: 'listClassName',
-                label: '图片列表'
-              })
-            ]
-          }
+          getSchemaTpl('theme:cssCode')
         ])
       }
     ]);

--- a/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
+++ b/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
@@ -208,11 +208,7 @@ export class FlexPluginBase extends LayoutBasePlugin {
           title: '外观',
           className: 'p-none',
           body: getSchemaTpl('collapseGroup', [
-            ...getSchemaTpl('theme:common', {exclude: ['layout']}),
-            {
-              title: '自定义 CSS 类名',
-              body: [getSchemaTpl('className')]
-            }
+            ...getSchemaTpl('theme:common', {exclude: ['layout']})
           ])
         }
       ])

--- a/packages/amis-editor/src/plugin/Page.tsx
+++ b/packages/amis-editor/src/plugin/Page.tsx
@@ -306,15 +306,19 @@ export class PagePlugin extends BasePlugin {
                         label: '文字',
                         name: 'font'
                       })
-                    ]
+                    ],
+                    hiddenOn: 'data.regions && !data.regions.includes("header")'
                   }),
                   getSchemaTpl('theme:base', {
                     classname: 'toolbarControlClassName',
-                    title: '工具栏样式'
+                    title: '工具栏样式',
+                    hiddenOn:
+                      'data.regions && !data.regions.includes("toolbar")'
                   }),
                   getSchemaTpl('theme:base', {
                     classname: 'asideControlClassName',
-                    title: '边栏样式'
+                    title: '边栏样式',
+                    hiddenOn: 'data.regions && !data.regions.includes("aside")'
                   })
                 ]
               })

--- a/packages/amis-editor/src/plugin/Sparkline.tsx
+++ b/packages/amis-editor/src/plugin/Sparkline.tsx
@@ -68,11 +68,7 @@ export class SparklinePlugin extends BasePlugin {
         {
           title: '外观',
           body: getSchemaTpl('collapseGroup', [
-            ...getSchemaTpl('theme:common', {exclude: ['layout']}),
-            {
-              title: '自定义 CSS 类名',
-              body: [getSchemaTpl('className')]
-            }
+            ...getSchemaTpl('theme:common', {exclude: ['layout']})
           ])
         }
       ])

--- a/packages/amis-editor/src/plugin/TooltipWrapper.tsx
+++ b/packages/amis-editor/src/plugin/TooltipWrapper.tsx
@@ -278,19 +278,7 @@ export class TooltipWrapperPlugin extends BasePlugin {
                   title: '浮层样式'
                 })
               ]
-            }),
-            {
-              title: 'CSS 类名',
-              body: [
-                getSchemaTpl('className', {
-                  label: '内容区CSS类名'
-                }),
-                getSchemaTpl('className', {
-                  label: '浮层CSS类名',
-                  name: 'tooltipClassName'
-                })
-              ]
-            }
+            })
           ])
         }
       ])

--- a/packages/amis-editor/src/renderer/style-control/ThemeCssCode.tsx
+++ b/packages/amis-editor/src/renderer/style-control/ThemeCssCode.tsx
@@ -13,6 +13,11 @@ import isEmpty from 'lodash/isEmpty';
 import {Icon} from '../../icons/index';
 
 const editorPlaceholder = `自定义样式仅对当前组件生效。示例：
+// 当前层级
+root {
+  color: #000;
+}
+// 子层级
 .text-color: {
   color: #fff;
 }
@@ -131,7 +136,7 @@ function ThemeCssCode(props: FormControlProps) {
         >
           <Icon icon="expand-alt" className="icon" />
         </a>
-        <div className="ThemeCssCode-editor-wrap" style={{height: '120px'}}>
+        <div className="ThemeCssCode-editor-wrap" style={{height: '180px'}}>
           <Editor
             value={value}
             placeholder={editorPlaceholder}

--- a/packages/amis-editor/src/tpl/style.tsx
+++ b/packages/amis-editor/src/tpl/style.tsx
@@ -578,12 +578,14 @@ setSchemaTpl(
     extra?: any[];
     classname?: string;
     title?: string;
+    hiddenOn?: string;
   }) => {
     const {
       collapsed = false,
       extra = [],
       classname = 'baseControlClassName',
-      title = '基本样式'
+      title = '基本样式',
+      hiddenOn
     } = option;
     const styleStateFunc = (visibleOn: string, state: string) => {
       return [
@@ -654,7 +656,8 @@ setSchemaTpl(
     return {
       title,
       collapsed,
-      body: styles
+      body: styles,
+      hiddenOn
     };
   }
 );


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 89115d1</samp>

This pull request enhances the custom style editing feature in the AMIS editor by allowing more complex CSS selectors, adding conditional hiding of style schemas, and removing redundant `className` schemas. It affects the `ThemeCssCode` component and several plugins that use the `StyleSchema` interface. It also updates the `style-helper.ts` utility function to handle the new selectors.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 89115d1</samp>

> _We are the masters of style, we bend the CSS to our will_
> _We use the `root` and `root:` selectors, to customize every skill_
> _We don't need the `className` schema, it's redundant and weak_
> _We hide the irrelevant schemas, with the `hiddenOn` technique_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 89115d1</samp>

*  Support more complex CSS selectors for custom styles in `style-helper.ts` ([link](https://github.com/baidu/amis/pull/8004/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL343-R354))
*  Remove redundant `className` schema from various component plugins in the AMIS editor ([link](https://github.com/baidu/amis/pull/8004/files?diff=unified&w=0#diff-db2199816e5d1d4f1050533ef5714a1b6ed8c525d8bbb40f65f1ab1a9fb8ebb8L340-R340), [link](https://github.com/baidu/amis/pull/8004/files?diff=unified&w=0#diff-a8bde19ea54cb5b89af40437705c677c4ed3ed7d653c8821c63841a1a96fd18cL307-R307), [link](https://github.com/baidu/amis/pull/8004/files?diff=unified&w=0#diff-080f970ff41a9d0e1619e4d8d2190127b7b241f179ed33b91f4f0fe48475fd41L238-R238), [link](https://github.com/baidu/amis/pull/8004/files?diff=unified&w=0#diff-56455bda1d9d4fbd51a8c855a272024feb8277669aa011d205c953cde21e2278L239-R239), [link](https://github.com/baidu/amis/pull/8004/files?diff=unified&w=0#diff-0c77368e9183efe6a72ad9cdc7339d1c15ab5f70f8518721c1bda55460262a07L211-R211), [link](https://github.com/baidu/amis/pull/8004/files?diff=unified&w=0#diff-2c7032695c46bb2049d4e8c345f846e11f8a567f4fc1c09ce3dc9bb4dd7c131aL71-R71), [link](https://github.com/baidu/amis/pull/8004/files?diff=unified&w=0#diff-f385699470ffb153e0fccfed03964f82c7037329d342cb441877d2fb7d70a198L281-R281))
*  Add `hiddenOn` property to `theme:base` schemas in `PagePlugin` to hide irrelevant style schemas based on page regions ([link](https://github.com/baidu/amis/pull/8004/files?diff=unified&w=0#diff-4e3988acdee43b9a8f0c6fa2a99f1a94dc43fae57be0bffca0890574a1af5552L309-R321))
*  Add `hiddenOn` property and parameter to `StyleSchema` interface and `getSchemaTpl` function in `style.tsx` to support conditional hiding of style schemas ([link](https://github.com/baidu/amis/pull/8004/files?diff=unified&w=0#diff-397f3332bd17c52ed7e468360e1cfe462d1d8646110ccd681b48a6deaa608302R581), [link](https://github.com/baidu/amis/pull/8004/files?diff=unified&w=0#diff-397f3332bd17c52ed7e468360e1cfe462d1d8646110ccd681b48a6deaa608302L586-R588), [link](https://github.com/baidu/amis/pull/8004/files?diff=unified&w=0#diff-397f3332bd17c52ed7e468360e1cfe462d1d8646110ccd681b48a6deaa608302L657-R660))
*  Increase the height of the custom style editor in `ThemeCssCode.tsx` and add comments with examples of using `root` and `root:` selectors ([link](https://github.com/baidu/amis/pull/8004/files?diff=unified&w=0#diff-0d09abc7945e56f72384164537e19882a6faf0835c9130a430db6cebad0bc3eaR16-R20), [link](https://github.com/baidu/amis/pull/8004/files?diff=unified&w=0#diff-0d09abc7945e56f72384164537e19882a6faf0835c9130a430db6cebad0bc3eaL134-R139))
