### PR TITLE
fix: 解决表单项 pipeIn 和 pipeOut 的 this 丢失

### DIFF
--- a/packages/amis-core/src/renderers/wrapControl.tsx
+++ b/packages/amis-core/src/renderers/wrapControl.tsx
@@ -649,7 +649,8 @@ export function wrapControl<
 
             if (pipeOut) {
               const oldValue = this.model.value;
-              value = callStrFunction(
+              value = callStrFunction.call(
+                this,
                 pipeOut,
                 ['value', 'oldValue', 'data'],
                 value,
@@ -774,7 +775,8 @@ export function wrapControl<
             } = this.props;
 
             if (pipeOut) {
-              value = callStrFunction(
+              value = callStrFunction.call(
+                this,
                 pipeOut,
                 ['value', 'oldValue', 'data'],
                 value,
@@ -797,7 +799,8 @@ export function wrapControl<
             let value: any = this.model ? this.model.tmpValue : control.value;
 
             if (control.pipeIn) {
-              value = callStrFunction(
+              value = callStrFunction.call(
+                this,
                 control.pipeIn,
                 ['value', 'data'],
                 value,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 633317e</samp>

Fix `pipeOut` and `pipeIn` bug in `wrapControl.tsx`. This ensures that the value of the control is correctly transformed when interacting with other components or the API.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 633317e</samp>

> _Sing, O Muse, of the skillful coder who fixed the bug_
> _That plagued the wrapControl, the cunning component_
> _That transforms the value of the input and output_
> _With pipeOut and pipeIn, the swift and subtle functions_

### Why

amis version: 3.4.0
amis-editor version: 5.6.0-beta.0

使用 `input-kv` 组件，无法新增 key 和 value。

复现步骤：在 `amis-editor-demo` 仓库的编辑器中添加 `input-kv`

![截屏2023-09-05 10 57 58](https://github.com/baidu/amis/assets/74137084/1e3d3d5e-abf6-40a5-ade2-154c8ebacfdf)

原因：`pipeIn` 和 `pipeOut` 函数调用的 `this` 指向为 undefined。与 #7963 的更改有关系。

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 633317e</samp>

*  Fix bug where `pipeOut` and `pipeIn` functions were not bound to the correct `this` context ([link](https://github.com/baidu/amis/pull/8007/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL652-R653), [link](https://github.com/baidu/amis/pull/8007/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL777-R779), [link](https://github.com/baidu/amis/pull/8007/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL800-R803))
