### PR TITLE
refactor: 提取各个 ActionSchema 的公共Key

### DIFF
--- a/packages/amis/src/renderers/Action.tsx
+++ b/packages/amis/src/renderers/Action.tsx
@@ -483,93 +483,29 @@ export const createSyntheticEvent = <T extends Element, E extends Event>(
   };
 };
 
+type CommonKeys =
+  | 'type'
+  | 'className'
+  | 'iconClassName'
+  | 'rightIconClassName'
+  | 'loadingClassName';
+
 export interface ActionProps
   extends Omit<
       ButtonSchema,
       'className' | 'iconClassName' | 'rightIconClassName' | 'loadingClassName'
     >,
     ThemeProps,
-    Omit<
-      AjaxActionSchema,
-      | 'type'
-      | 'className'
-      | 'iconClassName'
-      | 'rightIconClassName'
-      | 'loadingClassName'
-    >,
-    Omit<
-      UrlActionSchema,
-      | 'type'
-      | 'className'
-      | 'iconClassName'
-      | 'rightIconClassName'
-      | 'loadingClassName'
-    >,
-    Omit<
-      LinkActionSchema,
-      | 'type'
-      | 'className'
-      | 'iconClassName'
-      | 'rightIconClassName'
-      | 'loadingClassName'
-    >,
-    Omit<
-      DialogActionSchema,
-      | 'type'
-      | 'className'
-      | 'iconClassName'
-      | 'rightIconClassName'
-      | 'loadingClassName'
-    >,
-    Omit<
-      DrawerActionSchema,
-      | 'type'
-      | 'className'
-      | 'iconClassName'
-      | 'rightIconClassName'
-      | 'loadingClassName'
-    >,
-    Omit<
-      ToastSchemaBase,
-      | 'type'
-      | 'className'
-      | 'iconClassName'
-      | 'rightIconClassName'
-      | 'loadingClassName'
-    >,
-    Omit<
-      CopyActionSchema,
-      | 'type'
-      | 'className'
-      | 'iconClassName'
-      | 'rightIconClassName'
-      | 'loadingClassName'
-    >,
-    Omit<
-      ReloadActionSchema,
-      | 'type'
-      | 'className'
-      | 'iconClassName'
-      | 'rightIconClassName'
-      | 'loadingClassName'
-    >,
-    Omit<
-      EmailActionSchema,
-      | 'type'
-      | 'className'
-      | 'iconClassName'
-      | 'rightIconClassName'
-      | 'loadingClassName'
-      | 'body'
-    >,
-    Omit<
-      OtherActionSchema,
-      | 'type'
-      | 'className'
-      | 'iconClassName'
-      | 'rightIconClassName'
-      | 'loadingClassName'
-    >,
+    Omit<AjaxActionSchema, CommonKeys>,
+    Omit<UrlActionSchema, CommonKeys>,
+    Omit<LinkActionSchema, CommonKeys>,
+    Omit<DialogActionSchema, CommonKeys>,
+    Omit<DrawerActionSchema, CommonKeys>,
+    Omit<ToastSchemaBase, CommonKeys>,
+    Omit<CopyActionSchema, CommonKeys>,
+    Omit<ReloadActionSchema, CommonKeys>,
+    Omit<EmailActionSchema, CommonKeys | 'body'>,
+    Omit<OtherActionSchema, CommonKeys>,
     SpinnerExtraProps {
   actionType: any;
   onAction?: (


### PR DESCRIPTION
### What

重构 ActionPorps，提取公共的 key，让结构更清晰,减少重复代码。

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9a969e3</samp>

> _We are the common keys, we share the same fate_
> _We are the common keys, we don't need to duplicate_
> _We are the common keys, we simplify the action_
> _We are the common keys, we are the refraction_

### Why

原来的太冗长了， SpinnerExtraProps 也能单独提取出来， 下次再优化吧

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9a969e3</samp>

*  Define a type alias `CommonKeys` for the common keys that are omitted from various action schema types in `Action.tsx` ([link](https://github.com/baidu/amis/pull/8008/files?diff=unified&w=0#diff-4d89203911a9d3ef38c82118f074ad24c49244699f1f2cbb6072134908f60098R486-R492))
*  Simplify the `ActionProps` interface by using the `CommonKeys` type alias instead of listing the omitted keys explicitly for each action schema type ([link](https://github.com/baidu/amis/pull/8008/files?diff=unified&w=0#diff-4d89203911a9d3ef38c82118f074ad24c49244699f1f2cbb6072134908f60098L492-R508))
