### PR TITLE
feat:图片缩略图占位图地址栏添加fx;占位图支持取fx变量

### DIFF
--- a/packages/amis-editor/src/plugin/Image.tsx
+++ b/packages/amis-editor/src/plugin/Image.tsx
@@ -84,9 +84,8 @@ export class ImagePlugin extends BasePlugin {
 
               isUnderField
                 ? null
-                : getSchemaTpl('imageUrl', {
+                : getSchemaTpl('formulaControl', {
                     name: 'src',
-                    type: 'input-text',
                     label: '缩略图地址',
                     description: '如果已绑定字段名，可以不用设置，支持用变量。'
                   }),
@@ -119,7 +118,7 @@ export class ImagePlugin extends BasePlugin {
                 hiddenOn: 'this.enlargeAble',
                 clearValueOnHidden: true
               },
-              getSchemaTpl('imageUrl', {
+              getSchemaTpl('formulaControl', {
                 name: 'defaultImage',
                 label: tipedLabel('占位图', '无数据时显示的图片')
               })

--- a/packages/amis-editor/src/plugin/Image.tsx
+++ b/packages/amis-editor/src/plugin/Image.tsx
@@ -84,7 +84,7 @@ export class ImagePlugin extends BasePlugin {
 
               isUnderField
                 ? null
-                : getSchemaTpl('formulaControl', {
+                : getSchemaTpl('imageUrl', {
                     name: 'src',
                     label: '缩略图地址',
                     description: '如果已绑定字段名，可以不用设置，支持用变量。'
@@ -118,7 +118,7 @@ export class ImagePlugin extends BasePlugin {
                 hiddenOn: 'this.enlargeAble',
                 clearValueOnHidden: true
               },
-              getSchemaTpl('formulaControl', {
+              getSchemaTpl('imageUrl', {
                 name: 'defaultImage',
                 label: tipedLabel('占位图', '无数据时显示的图片')
               })

--- a/packages/amis/src/renderers/Image.tsx
+++ b/packages/amis/src/renderers/Image.tsx
@@ -508,7 +508,7 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
 
     const defaultValue = defaultImage
       ? filter(defaultImage, data, '| raw')
-      : '';
+      : imagePlaceholder;
     let defaultImageValue = defaultValue || getPropValue(this.props);
 
     return (

--- a/packages/amis/src/renderers/Image.tsx
+++ b/packages/amis/src/renderers/Image.tsx
@@ -509,7 +509,6 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
     const defaultValue = defaultImage
       ? filter(defaultImage, data, '| raw')
       : imagePlaceholder;
-    let defaultImageValue = defaultValue || getPropValue(this.props);
 
     return (
       <div
@@ -533,14 +532,14 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
             thumbClassName={thumbClassName}
             height={height}
             width={width}
-            src={value ? value : defaultImageValue}
+            src={value ? value : defaultValue}
             href={finnalHref}
             title={filter(title, data)}
             caption={filter(imageCaption, data)}
             thumbMode={thumbMode}
             thumbRatio={thumbRatio}
             originalSrc={filter(originalSrc, data, '| raw') ?? value}
-            enlargeAble={enlargeAble && value !== defaultImageValue}
+            enlargeAble={enlargeAble && value !== defaultValue}
             onEnlarge={this.handleEnlarge}
             imageMode={imageMode}
             imageControlClassName={imageControlClassName}

--- a/packages/amis/src/renderers/Image.tsx
+++ b/packages/amis/src/renderers/Image.tsx
@@ -506,9 +506,10 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
     let value = finnalSrc || getPropValue(this.props);
     const finnalHref = href ? filter(href, data, '| raw') : '';
 
-    const defaultValue = defaultImage
-      ? filter(defaultImage, data, '| raw')
-      : imagePlaceholder;
+    const defaultValue =
+      defaultImage && !value
+        ? filter(defaultImage, data, '| raw')
+        : imagePlaceholder;
 
     return (
       <div

--- a/packages/amis/src/renderers/Image.tsx
+++ b/packages/amis/src/renderers/Image.tsx
@@ -505,12 +505,10 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
     const finnalSrc = src ? filter(src, data, '| raw') : '';
     let value = finnalSrc || getPropValue(this.props);
     const finnalHref = href ? filter(href, data, '| raw') : '';
-
     const defaultValue =
       defaultImage && !value
         ? filter(defaultImage, data, '| raw')
         : imagePlaceholder;
-
     return (
       <div
         className={cx(

--- a/packages/amis/src/renderers/Image.tsx
+++ b/packages/amis/src/renderers/Image.tsx
@@ -506,6 +506,11 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
     let value = finnalSrc || getPropValue(this.props);
     const finnalHref = href ? filter(href, data, '| raw') : '';
 
+    const defaultValue = defaultImage
+      ? filter(defaultImage, data, '| raw')
+      : '';
+    let defaultImageValue = defaultValue || getPropValue(this.props);
+
     return (
       <div
         className={cx(
@@ -528,14 +533,14 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
             thumbClassName={thumbClassName}
             height={height}
             width={width}
-            src={value ? value : defaultImage}
+            src={value ? value : defaultImageValue}
             href={finnalHref}
             title={filter(title, data)}
             caption={filter(imageCaption, data)}
             thumbMode={thumbMode}
             thumbRatio={thumbRatio}
             originalSrc={filter(originalSrc, data, '| raw') ?? value}
-            enlargeAble={enlargeAble && value !== defaultImage}
+            enlargeAble={enlargeAble && value !== defaultImageValue}
             onEnlarge={this.handleEnlarge}
             imageMode={imageMode}
             imageControlClassName={imageControlClassName}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5ecae39</samp>

Enhanced the image schema and renderer to support formulas for the `src` and `defaultImage` properties. This allows more flexibility and customization for displaying images based on data variables.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5ecae39</samp>

> _Unleash the power of the formulas_
> _Customize your image fields_
> _No more static URLs to bind you_
> _`src` and `defaultImage` are free_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5ecae39</samp>

*  Allow using formulas to dynamically generate image URL and default image URL for image schema ([link](https://github.com/baidu/amis/pull/8009/files?diff=unified&w=0#diff-080f970ff41a9d0e1619e4d8d2190127b7b241f179ed33b91f4f0fe48475fd41L87-R88), [link](https://github.com/baidu/amis/pull/8009/files?diff=unified&w=0#diff-080f970ff41a9d0e1619e4d8d2190127b7b241f179ed33b91f4f0fe48475fd41L122-R121), [link](https://github.com/baidu/amis/pull/8009/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9R509-R513), [link](https://github.com/baidu/amis/pull/8009/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9L531-R536), [link](https://github.com/baidu/amis/pull/8009/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9L538-R543))
