### PR TITLE
styles: 修复 CRUD 列元素嵌套表格时, affixOffsetTop计算错误问题

### DIFF
--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -2193,7 +2193,9 @@ export default class Table extends React.Component<TableProps, object> {
         store.firstToggledColumnIndex === props.colIndex,
       onQuery: undefined,
       style,
-      className: cx(column.pristine.className, stickyClassName)
+      className: cx(column.pristine.className, stickyClassName),
+      /** 给子节点的设置默认值，避免取到env.affixHeader的默认值，导致表头覆盖首行 */
+      affixOffsetTop: 0
     };
     delete subProps.label;
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9c7dbb</samp>

Add `affixOffsetTop` prop to Table subProps to control the affixed header offset. This fixes a bug where the header could overlap with the first row of the table.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e9c7dbb</samp>

> _`affixOffsetTop`_
> _A new prop for the header_
> _Sticks in the winter_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e9c7dbb</samp>

* Add a new prop `affixOffsetTop` to the subProps object for the Table component ([link](https://github.com/baidu/amis/pull/8018/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2196-R2198)). This prop sets a default value of 0 for the offset top of the affixed header, which prevents the header from overlapping with the first row of the table. This prop can be overridden by the user if needed. This change fixes some issues with the Table component in `packages/amis/src/renderers/Table/index.tsx`.
