### PR TITLE
fix:去掉无用的hr全局样式

### DIFF
--- a/packages/amis-ui/scss/base/_normalize.scss
+++ b/packages/amis-ui/scss/base/_normalize.scss
@@ -38,17 +38,6 @@ h1 {
      ========================================================================== */
 
 /**
-   * 1. Add the correct box sizing in Firefox.
-   * 2. Show the overflow in Edge and IE.
-   */
-
-hr {
-  box-sizing: content-box; // 1
-  height: 0; // 2
-  overflow: visible; //2
-}
-
-/**
    * 1. Correct the inheritance and scaling of font size in all browsers.
    * 2. Correct the odd `em` font sizing in all browsers.
    */


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fc42631</samp>

Removed redundant `hr` styles from `_normalize.scss`. This improves the consistency and maintainability of the base stylesheets.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fc42631</samp>

> _`hr` styles removed_
> _No need to repeat them here_
> _Spring cleaning `_scss`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fc42631</samp>

* Remove `hr` element styles from `_normalize.scss` file ([link](https://github.com/baidu/amis/pull/8019/files?diff=unified&w=0#diff-bf0845cc33a7ae677d83ff4fe59186f1f36593f8d260a62cd0cabf2861cf88eaL41-L51)) to avoid duplication and conflicts with `_reboot.scss` file
