### PR TITLE
fix: 命名拼写错误

### DIFF
--- a/packages/amis-core/src/components/PopOver.tsx
+++ b/packages/amis-core/src/components/PopOver.tsx
@@ -14,7 +14,7 @@ export interface Offset {
   y: number;
 }
 
-export interface PopOverPorps {
+export interface PopOverProps {
   className?: string;
   placement?: string;
   positionTop?: number;
@@ -36,7 +36,7 @@ interface PopOverState {
   yOffset: number;
 }
 
-export class PopOver extends React.PureComponent<PopOverPorps, PopOverState> {
+export class PopOver extends React.PureComponent<PopOverProps, PopOverState> {
   static defaultProps = {
     className: '',
     offset: {

--- a/packages/amis-core/src/locale.tsx
+++ b/packages/amis-core/src/locale.tsx
@@ -99,8 +99,8 @@ export function getDefaultLocale() {
   return defaultLocale;
 }
 
-export function setDefaultLocale(loacle: string) {
-  defaultLocale = loacle;
+export function setDefaultLocale(locale: string) {
+  defaultLocale = locale;
 }
 
 export interface LocaleProps {

--- a/packages/amis-core/src/theme.tsx
+++ b/packages/amis-core/src/theme.tsx
@@ -122,7 +122,7 @@ export interface ThemeProps {
   };
 }
 
-export interface ThemeOutterProps extends Partial<ThemeProps> {}
+export interface ThemeOuterProps extends Partial<ThemeProps> {}
 
 export let defaultTheme: string = 'cxd';
 export const ThemeContext = React.createContext('');
@@ -136,7 +136,7 @@ export function themeable<
     T,
     Omit<React.ComponentProps<T>, keyof ThemeProps>
   > &
-    ThemeOutterProps;
+    ThemeOuterProps;
 
   const result = hoistNonReactStatic(
     class extends React.Component<OuterProps> {


### PR DESCRIPTION
- `loacle` => `locale`
- `ThemeOutterProps` => `ThemeOuterProps`
- `PopOverPorps` => `PopOverProps`