### PR TITLE
feat(amis-editor): InputRange组件默认值控件

### DIFF
--- a/packages/amis-editor-core/scss/control/_formItem-control.scss
+++ b/packages/amis-editor-core/scss/control/_formItem-control.scss
@@ -64,12 +64,21 @@
     }
   }
 
-  .inputGroup-addOn-no-border {
-    .inputGroup-split-line {
+  .ae-InputRangeValue-input-group {
+    &-delimiter {
       border: none;
       padding-left: 5px;
       padding-right: 5px;
       line-height: 30px;
+    }
+  }
+
+  .ae-sub-content {
+    @include extend-more();
+    margin-bottom: var(--Form-item-gap);
+
+    &.is-bottom {
+      margin-bottom: 0;
     }
   }
 }

--- a/packages/amis-editor/src/index.tsx
+++ b/packages/amis-editor/src/index.tsx
@@ -46,6 +46,8 @@ import './renderer/TableColumnWidthControl';
 import './renderer/crud2-control/CRUDColumnControl';
 import './renderer/crud2-control/CRUDToolbarControl';
 import './renderer/crud2-control/CRUDFiltersControl';
+import './renderer/InputRangeValueControl';
+
 import 'amis-theme-editor/lib/locale/zh-CN';
 import 'amis-theme-editor/lib/locale/en-US';
 import 'amis-theme-editor/lib/renderers/Border';

--- a/packages/amis-editor/src/plugin/Form/InputRange.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputRange.tsx
@@ -9,6 +9,8 @@ import {BasePlugin, BaseEventContext} from 'amis-editor-core';
 import {ValidatorTag} from '../../validator';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 
+import type {IFormStore, IFormItemStore} from 'amis-core';
+
 export class RangeControlPlugin extends BasePlugin {
   static id = 'RangeControlPlugin';
   // 关联渲染器名字
@@ -145,26 +147,43 @@ export class RangeControlPlugin extends BasePlugin {
               getSchemaTpl('formItemName', {
                 required: true
               }),
-
-              getSchemaTpl('label', {
-                label: 'Label'
+              getSchemaTpl('label'),
+              getSchemaTpl('switch', {
+                label: '双滑块',
+                name: 'multiple'
               }),
-
               {
-                label: '方式',
-                name: 'multiple',
-                type: 'select',
-                value: false,
-                options: [
-                  {
-                    label: '单滑块',
-                    value: false
-                  },
-                  {
-                    label: '双滑块',
-                    value: true
-                  }
+                type: 'container',
+                className: 'ae-sub-content',
+                visibleOn: 'data.multiple',
+                body: [
+                  getSchemaTpl('joinValues', {
+                    onChange: (
+                      value: boolean,
+                      oldValue: boolean,
+                      model: IFormItemStore,
+                      form: IFormStore
+                    ) => {
+                      form.deleteValueByName('value');
+                    }
+                  }),
+                  getSchemaTpl('delimiter', {
+                    onChange: (
+                      value: string,
+                      oldValue: string,
+                      model: IFormItemStore,
+                      form: IFormStore
+                    ) => {
+                      form.deleteValueByName('value');
+                    }
+                  })
                 ]
+              },
+              {
+                type: 'ae-input-range-value',
+                name: 'value',
+                label: '默认值',
+                visibleOn: 'data.multiple'
               },
 
               getSchemaTpl('valueFormula', {
@@ -189,7 +208,6 @@ export class RangeControlPlugin extends BasePlugin {
                 label: '最小值',
                 valueType: 'number'
               }),
-
               getSchemaTpl('valueFormula', {
                 name: 'max',
                 rendererSchema: {
@@ -201,34 +219,6 @@ export class RangeControlPlugin extends BasePlugin {
                 label: '最大值',
                 valueType: 'number'
               }),
-
-              {
-                label: '默认值',
-                type: 'input-group',
-                name: 'value',
-                visibleOn: 'data.multiple',
-                className: 'inputGroup-addOn-no-border',
-                body: [
-                  {
-                    type: 'input-number',
-                    validations: 'isNumeric',
-                    name: 'value.min',
-                    value: 0
-                  },
-                  {
-                    type: 'html',
-                    html: '-',
-                    className: 'inputGroup-split-line'
-                  },
-                  {
-                    type: 'input-number',
-                    validations: 'isNumeric',
-                    name: 'value.max',
-                    value: 100
-                  }
-                ]
-              },
-
               {
                 label: '步长',
                 name: 'step',

--- a/packages/amis-editor/src/renderer/InputRangeValueControl.tsx
+++ b/packages/amis-editor/src/renderer/InputRangeValueControl.tsx
@@ -1,0 +1,144 @@
+/**
+ * @file InputRangeValue
+ * @description 滑块组件默认值控件
+ */
+
+import React, {useCallback} from 'react';
+import {FormItem} from 'amis';
+
+import type {FormControlProps} from 'amis-core';
+
+export interface InputRangeValueProps extends FormControlProps {
+  value?: any;
+  minField?: string;
+  maxField?: string;
+  onChange: (value: any) => void;
+}
+
+const InputRangeValue: React.FC<InputRangeValueProps> = props => {
+  const {
+    classnames: cx,
+    minField = 'min',
+    maxField = 'max',
+    data: ctx,
+    name,
+    onChange,
+    value,
+    render
+  } = props;
+  const key = 'InputRangeValue';
+  const joinValues = ctx?.joinValues ?? true;
+  /** delimiter变化需要重新计算默认值 */
+  const delimiter = ctx?.delimiter || ',';
+  const extraName = ctx?.extraName;
+
+  /** 转化成对象格式 */
+  const pipeInValue = useCallback(
+    (value: any) => {
+      if (!value) {
+        return {[minField]: undefined, [maxField]: undefined};
+      }
+
+      if (typeof value === 'string') {
+        const [lhs, rhs] = value.split(delimiter);
+
+        return {[minField]: lhs, [maxField]: rhs};
+      } else if (Array.isArray(value)) {
+        return {[minField]: value[0], [maxField]: value[1]};
+      } else {
+        return value;
+      }
+    },
+    [minField, maxField, delimiter, value, joinValues, extraName]
+  );
+
+  const handleSubmit = useCallback(
+    (value: Record<string, any>, action: any) => {
+      let updatedValue: any = value;
+
+      if (value[minField] == null || value[maxField] == null) {
+        return;
+      }
+
+      if (extraName) {
+        updatedValue = [value[minField], value[maxField]];
+      } else {
+        if (joinValues) {
+          updatedValue = [value[minField], value[maxField]].join(
+            delimiter || ','
+          );
+        } else {
+          updatedValue = {
+            [minField]: value[minField],
+            [maxField]: value[maxField]
+          };
+        }
+      }
+
+      onChange?.(updatedValue);
+    },
+    [key, minField, maxField, delimiter, joinValues, extraName, value]
+  );
+
+  return (
+    <>
+      {render(
+        'input-range-value-control',
+        {
+          type: 'form',
+          wrapWithPanel: false,
+          panelClassName: 'border-none shadow-none mb-0',
+          bodyClassName: 'p-none',
+          actionsClassName: 'border-none mt-2.5',
+          wrapperComponent: 'div',
+          formLazyChange: true,
+          preventEnterSubmit: true,
+          submitOnChange: true,
+          body: [
+            {
+              label: false,
+              type: 'input-group',
+              name: key,
+              className: cx('ae-InputRangeValue-input-group'),
+              body: [
+                {
+                  type: 'input-number',
+                  validations: 'isNumeric',
+                  name: minField,
+                  value: 0
+                },
+                {
+                  type: 'html',
+                  html: '-',
+                  className: cx('ae-InputRangeValue-input-group-delimiter')
+                },
+                {
+                  type: 'input-number',
+                  validations: 'isNumeric',
+                  name: maxField,
+                  value: 100
+                }
+              ]
+            }
+          ]
+        },
+        {
+          data: name ? pipeInValue(ctx[name]) : {},
+          onSubmit: handleSubmit
+        }
+      )}
+    </>
+  );
+};
+
+InputRangeValue.defaultProps = {
+  minField: 'min',
+  maxField: 'max'
+};
+
+@FormItem({type: 'ae-input-range-value'})
+export default class InputRangeValueRenderer extends React.Component<FormControlProps> {
+  render() {
+    return <InputRangeValue {...this.props} />;
+  }
+}

--- a/packages/amis-editor/src/tpl/options.tsx
+++ b/packages/amis-editor/src/tpl/options.tsx
@@ -192,7 +192,7 @@ setSchemaTpl('checkAll', () => {
   ];
 });
 
-setSchemaTpl('joinValues', () =>
+setSchemaTpl('joinValues', (schemaPatches: Record<string, any> = {}) =>
   getSchemaTpl('switch', {
     label: tipedLabel(
       '拼接值',
@@ -200,7 +200,8 @@ setSchemaTpl('joinValues', () =>
     ),
     name: 'joinValues',
     visibleOn: 'data.multiple',
-    value: true
+    value: true,
+    ...schemaPatches
   })
 );
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a456c69</samp>

This pull request improves the input range control in the AMIS editor by simplifying its schema, adding a custom value control, and enhancing the join values option. The custom value control, `InputRangeValueControl`, renders an input group with two input numbers and a delimiter, and handles the value conversion logic. The join values option, `joinValues`, allows custom schema patches for the switch schema of the input range control. The changes affect the files `InputRange.tsx`, `InputRangeValueControl.tsx`, `_formItem-control.scss`, `options.tsx`, and `index.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a456c69</samp>

> _Sing, O Muse, of the skillful pull request_
> _That brought new glory to the amis-editor,_
> _The splendid package that renders forms with ease_
> _And shapes the data with divine order._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a456c69</samp>

*  Refactor input range control schema to use schema template functions and input range value control ([link](https://github.com/baidu/amis/pull/8027/files?diff=unified&w=0#diff-ad586248b6059a15e1c09636a8e51839939f678192d349a60249b858bb5c4801L148-R187))
*  Add input range value control file that defines a custom form control for input range values ([link](https://github.com/baidu/amis/pull/8027/files?diff=unified&w=0#diff-aa2aed447ae41a2371825723f0f8651f489e590a4b5d3991bc9524fdde8e4b85R1-R144))
*  Import input range value control renderer to the index file of the amis-editor package ([link](https://github.com/baidu/amis/pull/8027/files?diff=unified&w=0#diff-fa77f562c6a58cf12dee0f269ae4d27bbbdd30fb852016af309b4bd6fe1b6cd5R49-R50))
*  Remove redundant default value options for single and double slider modes ([link](https://github.com/baidu/amis/pull/8027/files?diff=unified&w=0#diff-ad586248b6059a15e1c09636a8e51839939f678192d349a60249b858bb5c4801L192), [link](https://github.com/baidu/amis/pull/8027/files?diff=unified&w=0#diff-ad586248b6059a15e1c09636a8e51839939f678192d349a60249b858bb5c4801L204-R222))
*  Modify schema template function for join values option to accept optional schema patches ([link](https://github.com/baidu/amis/pull/8027/files?diff=unified&w=0#diff-4ff8190ccb19edb2d788deb7ebf73420c1799a07d6061d2aeb89ab77e9e66b95L195-R195))
*  Use schema patches to pass additional properties to the switch schema for join values option ([link](https://github.com/baidu/amis/pull/8027/files?diff=unified&w=0#diff-4ff8190ccb19edb2d788deb7ebf73420c1799a07d6061d2aeb89ab77e9e66b95L203-R204))
*  Change input group class name for input range value control to avoid conflicts ([link](https://github.com/baidu/amis/pull/8027/files?diff=unified&w=0#diff-cf5d81915ddfe41869a60d2bb90a8e8d542686d0e6ce7504a8666a1c6a42e931L67-R68))
*  Add sub-content class to style the sub-content of the input range control ([link](https://github.com/baidu/amis/pull/8027/files?diff=unified&w=0#diff-cf5d81915ddfe41869a60d2bb90a8e8d542686d0e6ce7504a8666a1c6a42e931R75-R83))
*  Import type definitions of form store and form item store to the input range control file ([link](https://github.com/baidu/amis/pull/8027/files?diff=unified&w=0#diff-ad586248b6059a15e1c09636a8e51839939f678192d349a60249b858bb5c4801R12-R13))
