### PR TITLE
fix: 「配置面板」日期范围组件配置面板在配置hoursago快捷键时无法正常显示的问题

### DIFF
--- a/packages/amis-editor/src/renderer/DateShortCutControl.tsx
+++ b/packages/amis-editor/src/renderer/DateShortCutControl.tsx
@@ -34,6 +34,7 @@ const CertainPresetShorcut = {
 };
 
 const ModifyPresetShorcut = {
+  $hoursago: '最近n小时',
   $daysago: '最近n天',
   $dayslater: 'n天以内',
   $weeksago: '最近n周',
@@ -337,7 +338,8 @@ export class DateShortCutControl extends React.PureComponent<
 
     const key = (option.data as ModifyOptionType)
       .key as keyof typeof ModifyPresetShorcut;
-    const label = ModifyPresetShorcut[key].split('n');
+
+    const label = ModifyPresetShorcut[key]?.split('n') || [];
 
     return render(
       'inner',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 02a8957</samp>

This pull request introduces a new date shortcut `$hoursago` and fixes a bug in the `label` variable for the `DateShortCutControl` component in the AMIS editor. These changes allow users to specify relative dates more easily and avoid unexpected errors.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 02a8957</samp>

> _Time is running out, we need to act fast_
> _Use the `$hoursago` to change the past_
> _Don't let the `label` variable break your flow_
> _We are the masters of the `DateShortCutControl`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 02a8957</samp>

* Add a new date shortcut option `$hoursago` to allow selecting a date range within the last n hours ([link](https://github.com/baidu/amis/pull/8028/files?diff=unified&w=0#diff-0c24457d11a6accf3b53c77070b5294933b3a9109b8b1113fbf4088f54961b03R37))
* Prevent errors or crashes if the `ModifyPresetShorcut` object does not have a matching key or value for the selected option by using nullish coalescing and empty array fallback ([link](https://github.com/baidu/amis/pull/8028/files?diff=unified&w=0#diff-0c24457d11a6accf3b53c77070b5294933b3a9109b8b1113fbf4088f54961b03L340-R343))
