### PR TITLE
fix: 「配置面板」日期范围组件配置面板在配置hoursago快捷键时无法正常显示的问题

### DIFF
--- a/packages/amis-editor/src/renderer/DateShortCutControl.tsx
+++ b/packages/amis-editor/src/renderer/DateShortCutControl.tsx
@@ -34,6 +34,7 @@ const CertainPresetShorcut = {
 };
 
 const ModifyPresetShorcut = {
+  $hoursago: '最近n小时',
   $daysago: '最近n天',
   $dayslater: 'n天以内',
   $weeksago: '最近n周',
@@ -337,7 +338,8 @@ export class DateShortCutControl extends React.PureComponent<
 
     const key = (option.data as ModifyOptionType)
       .key as keyof typeof ModifyPresetShorcut;
-    const label = ModifyPresetShorcut[key].split('n');
+
+    const label = ModifyPresetShorcut[key]?.split('n') || [];
 
     return render(
       'inner',

--- a/packages/amis/src/renderers/Form/DiffEditor.tsx
+++ b/packages/amis/src/renderers/Form/DiffEditor.tsx
@@ -199,7 +199,14 @@ export class DiffEditor extends React.Component<DiffEditorProps, any> {
       value !== prevProps.value &&
       !this.state.focused
     ) {
-      this.modifiedEditor.getModel().setValue(normalizeValue(value, language));
+      this.modifiedEditor.getModel().setValue(
+        isPureVariable(value as string)
+          ? normalizeValue(
+              resolveVariableAndFilter(value || '', data, '| raw', () => ''),
+              language
+            )
+          : normalizeValue(value, language)
+      );
     }
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 02b6010</samp>

This pull request adds a new date shortcut option for the last n hours in the `DateShortCutControl` component and improves the variable handling in the `DiffEditor` component. These changes enhance the usability and functionality of the AMIS editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 02b6010</samp>

> _We are the masters of the diff_
> _We edit data with no fear_
> _We resolve the variables with `raw`_
> _We see the truth in every line_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 02b6010</samp>

* Add a new option for the date shortcut control to select the last n hours ([link](https://github.com/baidu/amis/pull/8030/files?diff=unified&w=0#diff-0c24457d11a6accf3b53c77070b5294933b3a9109b8b1113fbf4088f54961b03R37))
* Fix a potential bug with undefined labels in the date shortcut control ([link](https://github.com/baidu/amis/pull/8030/files?diff=unified&w=0#diff-0c24457d11a6accf3b53c77070b5294933b3a9109b8b1113fbf4088f54961b03L340-R343))
* Improve the handling of variables in the diff editor for JSON or YAML data ([link](https://github.com/baidu/amis/pull/8030/files?diff=unified&w=0#diff-5ea6188310ac5c7ac30a6da095a1ecfe92e2bd94c7a6f440d21a1309fab7d981L202-R209))
