### PR TITLE
fix: crud列排序重置后orderDir参数未置空问题

### DIFF
--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -1949,7 +1949,7 @@ export default class Table extends React.Component<TableProps, object> {
               orderBy = column.name as string;
             }
 
-            const order = orderDir ? 'desc' : 'asc';
+            const order = orderBy ? (orderDir ? 'desc' : 'asc') : '';
             const rendererEvent = await dispatchEvent(
               'columnSort',
               createObject(data, {
@@ -1965,7 +1965,7 @@ export default class Table extends React.Component<TableProps, object> {
             if (
               !onQuery ||
               onQuery({
-                orderBy: orderBy,
+                orderBy,
                 orderDir: order
               }) === false
             ) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8ce4e8f</samp>

Enhanced the table renderer to handle sorting and querying more flexibly. Fixed a potential bug with the `order` parameter in `packages/amis/src/renderers/Table/index.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8ce4e8f</samp>

> _The table renderer had a flaw_
> _It sorted by `order` by default_
> _But now it is fixed_
> _With `orderBy` and `onQuery` tricks_
> _And the shorthand syntax is more compact_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8ce4e8f</samp>

* Changed the default value of `order` to an empty string when `orderBy` is falsy, to avoid sending unnecessary query parameters when sorting is not applied ([link](https://github.com/baidu/amis/pull/8032/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1952-R1952))
* Simplified the `onQuery` function call to use shorthand property names for `orderBy` and `orderDir` ([link](https://github.com/baidu/amis/pull/8032/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1968-R1968))
