### PR TITLE
fix: office-viewer 的 print 默认不用 page, 避免可能差异太大

### DIFF
--- a/packages/office-viewer/examples/app.ts
+++ b/packages/office-viewer/examples/app.ts
@@ -183,8 +183,8 @@ document.addEventListener(
   false
 );
 
-function renderWord(data, fileName: string) {
-  let word;
+function renderWord(data: ArrayBuffer, fileName: string) {
+  let word: Word;
   if (fileName.endsWith('.xml')) {
     word = new Word(data, renderOptions, new XMLPackageParser());
   } else {

--- a/packages/office-viewer/examples/app.ts
+++ b/packages/office-viewer/examples/app.ts
@@ -156,29 +156,7 @@ const renderOptions = {
 async function renderDocx(fileName: string) {
   const filePath = `${testDir}/${fileName}`;
   const file = await (await fetch(filePath)).arrayBuffer();
-  let word: Word;
-
-  if (filePath.endsWith('.xml')) {
-    word = new Word(file, renderOptions, new XMLPackageParser());
-  } else {
-    word = new Word(file, renderOptions);
-  }
-
-  const fileNameSplit = fileName.split('/');
-  const downloadName = fileNameSplit[fileNameSplit.length - 1].replace(
-    '.xml',
-    '.docx'
-  );
-
-  (window as any).downloadDocx = () => {
-    word.download(downloadName);
-  };
-
-  (window as any).printDocx = () => {
-    word.print();
-  };
-
-  word.render(viewerElement);
+  renderWord(file, fileName);
 }
 
 const url = new URL(location.href);
@@ -200,22 +178,40 @@ document.addEventListener(
     e.preventDefault();
     let dt = e.dataTransfer!;
     let files = dt.files;
-    renderWord(files[0]);
+    renderDropWord(files[0]);
   },
   false
 );
 
-function renderWord(file: File) {
+function renderWord(data, fileName: string) {
+  let word;
+  if (fileName.endsWith('.xml')) {
+    word = new Word(data, renderOptions, new XMLPackageParser());
+  } else {
+    word = new Word(data, renderOptions);
+  }
+  const fileNameSplit = fileName.split('/');
+  const downloadName = fileNameSplit[fileNameSplit.length - 1].replace(
+    '.xml',
+    '.docx'
+  );
+
+  (window as any).downloadDocx = () => {
+    word.download(downloadName);
+  };
+
+  (window as any).printDocx = () => {
+    word.print();
+  };
+
+  word.render(viewerElement);
+}
+
+function renderDropWord(file: File) {
   const reader = new FileReader();
   reader.onload = _e => {
     const data = reader.result as ArrayBuffer;
-    let word;
-    if (file.name.endsWith('.xml')) {
-      word = new Word(data, renderOptions, new XMLPackageParser());
-    } else {
-      word = new Word(data, renderOptions);
-    }
-    word.render(viewerElement);
+    renderWord(data, file.name);
   };
   reader.readAsArrayBuffer(file);
 }

--- a/packages/office-viewer/package.json
+++ b/packages/office-viewer/package.json
@@ -7,6 +7,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "dev": "vite",
+    "start": "vite",
     "build": "npm run clean-dist &&  cross-env NODE_ENV=production rollup -c ",
     "build-esm": "npm run clean-dist &&  cross-env NODE_ENV=production rollup -c rollup.esm.config.js",
     "test": "jest",

--- a/packages/office-viewer/src/Word.ts
+++ b/packages/office-viewer/src/Word.ts
@@ -760,7 +760,6 @@ export default class Word {
       printDocument.getElementById('print') as HTMLElement,
       // 这些配置可以让打印还原度更高
       {
-        page: true,
         pageWrap: false,
         pageShadow: false,
         pageMarginBottom: 0,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7daf3fa</samp>

This pull request enhances the `office-viewer` package and its examples. It refactors the code for rendering word documents, adds download and print features, and fixes layout and styling issues by disabling the page mode rendering.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7daf3fa</samp>

> _Sing, O Muse, of the skillful developers who wrought_
> _The office-viewer package, a marvel of code and thought_
> _They added a `start` script, to run the `vite` command_
> _And swiftly launch the examples on their local land_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7daf3fa</samp>

*  Refactor `renderDocx` function to use common `renderWord` function ([link](https://github.com/baidu/amis/pull/8038/files?diff=unified&w=0#diff-f1f19125a7ebaed7e8dececc6096558d3c70062dd6785b56dd4d6b6a90d1970bL159-R159))
*  Split `renderWord` function into `renderWord` and `renderDropWord` functions ([link](https://github.com/baidu/amis/pull/8038/files?diff=unified&w=0#diff-f1f19125a7ebaed7e8dececc6096558d3c70062dd6785b56dd4d6b6a90d1970bL203-R214))
*  Add functionality to download and print rendered word document using `downloadDocx` and `printDocx` functions ([link](https://github.com/baidu/amis/pull/8038/files?diff=unified&w=0#diff-f1f19125a7ebaed7e8dececc6096558d3c70062dd6785b56dd4d6b6a90d1970bL203-R214))
*  Remove `page: true` option from `renderOptions` object in `Word` constructor ([link](https://github.com/baidu/amis/pull/8038/files?diff=unified&w=0#diff-4d3a7ef3c6b94fc362af89686f8b7f273a256183ce8c5d3738ea1d99ebd477b8L763))
*  Add `start` script to `package.json` file of `office-viewer` package ([link](https://github.com/baidu/amis/pull/8038/files?diff=unified&w=0#diff-5be2752686d7fba13016bc97913cda48bd64cf853a3aaf5e6b8d389adba79f2cR10))
