### PR TITLE
fix: 修复 crud 自动过滤器中 select 下拉 zIndex 问题 Close: #8031

### DIFF
--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -1737,7 +1737,8 @@ export default class Table extends React.Component<TableProps, object> {
         onSubmit: onSearchableFromSubmit,
         onInit: onSearchableFromInit,
         formStore: undefined,
-        data: query ? createObject(data, query) : data
+        data: query ? createObject(data, query) : data,
+        popOverContainer: this.getPopOverContainer
       }
     );
   }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 32ff479</samp>

Added `popOverContainer` prop to `renderForm` in `Table` renderer to fix popover positioning in table filter. This prop helps the popovers stay aligned with the table header when scrolling.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 32ff479</samp>

> _`popOverContainer`_
> _fixes filter position_
> _with table scroll_

### Why

Close: #8031

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 32ff479</samp>

* Add `popOverContainer` prop to `renderForm` call to fix popover positioning in table filter ([link](https://github.com/baidu/amis/pull/8039/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1740-R1741))
