### PR TITLE
chore: 修复性能优化后 列固定宽度不刷新问题

### DIFF
--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -801,21 +801,21 @@ export const TableStore = iRendererStore
             stickyClassName += ' is-sticky-last-left';
           }
 
-          let left = 0;
+          let left = [];
           while (index >= 0) {
             const col = columns[index];
             if (
               (col && col.fixed === 'left') ||
               autoFixLeftColumns.includes(col.type)
             ) {
-              left += col.width;
+              left.push(`var(--Table-column-${col.rawIndex}-width)`);
             }
             index--;
           }
-          style.left = left;
+          style.left = left.length ? left.join(' + ') : 0;
         } else if (column.fixed === 'right') {
           stickyClassName = 'is-sticky is-sticky-right';
-          let right = 0;
+          let right = [];
           let index = columns.indexOf(column) + 1;
 
           if (columns.slice(0, index - 1).every(col => col.fixed !== 'right')) {
@@ -826,17 +826,30 @@ export const TableStore = iRendererStore
           while (index < len) {
             const col = columns[index];
             if (col && col.fixed === 'right') {
-              right += col.width;
+              right.push(`var(--Table-column-${col.rawIndex}-width)`);
             }
             index++;
           }
-          style.right = right;
+          style.right = right.length ? right.join(' + ') : 0;
         }
         return [style, stickyClassName];
       },
 
       get items() {
         return self.rows.concat();
+      },
+
+      buildStyles(style: any) {
+        style = {...style};
+
+        self.columns.forEach(column => {
+          if (column.fixed) {
+            style[`--Table-column-${column.rawIndex}-width`] =
+              column.width + 'px';
+          }
+        });
+
+        return style;
       }
     };
   })

--- a/packages/amis/__tests__/event-action/renderers/__snapshots__/crud.test.tsx.snap
+++ b/packages/amis/__tests__/event-action/renderers/__snapshots__/crud.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`doAction:crud reload 1`] = `
           >
             <div
               class="cxd-Table cxd-Crud-body"
+              style="--Table-column--2-width: 0px;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -338,6 +339,7 @@ exports[`doAction:crud reload with data1 1`] = `
           >
             <div
               class="cxd-Table cxd-Crud-body"
+              style="--Table-column--2-width: 0px;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -647,6 +649,7 @@ exports[`doAction:crud reload with data2 1`] = `
           >
             <div
               class="cxd-Table cxd-Crud-body"
+              style="--Table-column--2-width: 0px;"
             >
               <div
                 class="cxd-Table-fixedTop"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
@@ -55,6 +55,7 @@ exports[`Renderer:input table 1`] = `
                   >
                     <div
                       class="cxd-Table"
+                      style="--Table-column--2-width: 0px;"
                     >
                       <div
                         class="cxd-Table-contentWrap"
@@ -421,6 +422,7 @@ exports[`Renderer:input table add 1`] = `
           >
             <div
               class="cxd-Table"
+              style="--Table-column--2-width: 0px; --Table-column-2-width: 150px;"
             >
               <div
                 class="cxd-Table-contentWrap"
@@ -774,6 +776,7 @@ exports[`Renderer:input-table cell selects delete 1`] = `
           >
             <div
               class="cxd-Table"
+              style="--Table-column--2-width: 0px;"
             >
               <div
                 class="cxd-Table-contentWrap"
@@ -1186,6 +1189,7 @@ exports[`Renderer:input-table with combo column 1`] = `
           >
             <div
               class="cxd-Table"
+              style="--Table-column--2-width: 0px;"
             >
               <div
                 class="cxd-Table-contentWrap"

--- a/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`1. Renderer:crud basic interval headerToolbar footerToolbar 1`] = `
           >
             <div
               class="cxd-Table cxd-Crud-body"
+              style="--Table-column--2-width: 0px;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -2162,6 +2163,7 @@ exports[`6. Renderer:crud source & alwaysShowPagination 1`] = `
           >
             <div
               class="cxd-Table cxd-Crud-body"
+              style="--Table-column--2-width: 0px;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -2806,6 +2808,7 @@ exports[`13. enderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionL
             </div>
             <div
               class="cxd-Table cxd-Crud-body"
+              style="--Table-column--2-width: 0px;"
             >
               <div
                 class="cxd-Table-fixedTop"

--- a/packages/amis/__tests__/renderers/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Pagination.test.tsx.snap
@@ -84,6 +84,7 @@ exports[`Renderer:Pagination 1`] = `
       </div>
       <div
         class="cxd-Table"
+        style="--Table-column--2-width: 0px;"
       >
         <div
           class="cxd-Table-fixedTop"

--- a/packages/amis/__tests__/renderers/__snapshots__/Table.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Table.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Renderer:table 1`] = `
 >
   <div
     class="cxd-Table"
+    style="--Table-column--2-width: 0px;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -375,6 +376,7 @@ exports[`Renderer:table align 1`] = `
 >
   <div
     class="cxd-Table"
+    style="--Table-column--2-width: 0px;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -782,6 +784,7 @@ exports[`Renderer:table children 1`] = `
           >
             <div
               class="cxd-Table m-b-none"
+              style="--Table-column--2-width: 0px;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -1388,6 +1391,7 @@ exports[`Renderer:table classNameExpr 1`] = `
 >
   <div
     class="cxd-Table"
+    style="--Table-column--2-width: 0px;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -1757,6 +1761,7 @@ exports[`Renderer:table column head style className 1`] = `
 >
   <div
     class="cxd-Table className"
+    style="--Table-column--2-width: 0px; --Table-column-1-width: 0px;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -2152,6 +2157,7 @@ exports[`Renderer:table combine Renderer:table combineNum only 1`] = `
           >
             <div
               class="cxd-Table"
+              style="--Table-column--2-width: 0px;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -2729,6 +2735,7 @@ exports[`Renderer:table combine Renderer:table combineNum with fromIndex 1`] = `
           >
             <div
               class="cxd-Table"
+              style="--Table-column--2-width: 0px;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -3376,6 +3383,7 @@ exports[`Renderer:table groupName-default 1`] = `
           >
             <div
               class="cxd-Table m-b-none"
+              style="--Table-column--2-width: 0px;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -4157,6 +4165,7 @@ exports[`Renderer:table groupName-middleNoGroupName 1`] = `
           >
             <div
               class="cxd-Table m-b-none"
+              style="--Table-column--2-width: 0px;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -4942,6 +4951,7 @@ exports[`Renderer:table groupName-startNoGroupName 1`] = `
           >
             <div
               class="cxd-Table m-b-none"
+              style="--Table-column--2-width: 0px;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -5715,6 +5725,7 @@ exports[`Renderer:table groupName-withTpl 1`] = `
           >
             <div
               class="cxd-Table m-b-none"
+              style="--Table-column--2-width: 0px;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -6481,6 +6492,7 @@ exports[`Renderer:table isHead fixed 1`] = `
 >
   <div
     class="cxd-Table"
+    style="--Table-column--2-width: 0px; --Table-column-1-width: 0px;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -6861,6 +6873,7 @@ exports[`Renderer:table list 1`] = `
 >
   <div
     class="cxd-Table"
+    style="--Table-column--2-width: 0px;"
   >
     <div
       class="cxd-Table-toolbar cxd-Table-headToolbar"

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -675,7 +675,12 @@ export default class Table extends React.Component<TableProps, object> {
     }
 
     this.toDispose.push(
-      resizeSensor(currentNode.parentElement!, this.updateTableInfoLazy)
+      resizeSensor(
+        currentNode.parentElement!,
+        this.updateTableInfoLazy,
+        false,
+        'width'
+      )
     );
     const {store, autoGenerateFilter, onSearchableFromInit} = this.props;
 
@@ -2890,7 +2895,7 @@ export default class Table extends React.Component<TableProps, object> {
           'Table--unsaved': !!store.modified || !!store.moved,
           'Table--autoFillHeight': autoFillHeight
         })}
-        style={style}
+        style={store.buildStyles(style)}
       >
         {autoGenerateFilter ? this.renderAutoFilterForm() : null}
         {this.renderAffixHeader(tableClassName)}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8977403</samp>

The pull request improves the table rendering by using CSS custom properties and calc expressions for the fixed column widths and positions. It modifies the `TableStore` class and the `Table` renderer to implement this change.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8977403</samp>

> _`TableStore` adapts_
> _Using CSS properties_
> _Autumn leaves resize_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8977403</samp>

*  Add `buildStyles` method to `TableStore` class to create custom properties for fixed columns' widths ([link](https://github.com/baidu/amis/pull/8040/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR840-R852))
*  Use `buildStyles` method to pass style prop to table element in `Table/index.tsx` ([link](https://github.com/baidu/amis/pull/8040/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2893-R2893))
*  Change `left` and `right` variables from numbers to arrays of strings in `TableStore` class ([link](https://github.com/baidu/amis/pull/8040/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL804-R804), [link](https://github.com/baidu/amis/pull/8040/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL811-R818))
*  Use `left` and `right` arrays as CSS calc expressions to set `style.left` and `style.right` properties for fixed columns ([link](https://github.com/baidu/amis/pull/8040/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL811-R818), [link](https://github.com/baidu/amis/pull/8040/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL829-R833))
