### PR TITLE
feat: Tabs组件支持titleSchema/tabSchema/addedTabSchema

### DIFF
--- a/docs/zh-CN/components/tabs.md
+++ b/docs/zh-CN/components/tabs.md
@@ -12,6 +12,8 @@ order: 68
 
 ## 基本用法
 
+#### 静态配置数据
+
 ```schema: scope="body"
 {
     "type": "tabs",
@@ -29,7 +31,37 @@ order: 68
 }
 ```
 
-默认想要显示多少选项卡配置多少个 `tabs` 成员即可。但是有时候你可能会想根据某个数据来动态生成。这个时候需要额外配置 `source` 属性如。
+#### 通过 source 动态配置数据
+
+若想根据某个数据来动态生成可配置 `source` 属性
+
+```schema
+{
+    "type": "page",
+    "data": {
+        "arr": [
+            {
+                "a": "收入",
+                "b": 199
+            },
+
+            {
+                "a": "支出",
+                "b": 299
+            }
+        ]
+    },
+
+    "body": [
+        {
+            "type": "tabs",
+            "source": "${arr}"
+        }
+    ]
+}
+```
+
+通过`source` 属性动态获取数据时，可搭配`titleSchema` 属性配置默认 tab 页标题，搭配`tabSchema` 属性配置默认 tab 页内容。(>`3.5.0` 及以上版本支持)
 
 ```schema
 {
@@ -52,13 +84,16 @@ order: 68
         {
             "type": "tabs",
             "source": "${arr}",
-            "tabs": [
+            "titleSchema": "${a}",
+            "tabSchema": [
                 {
-                    "title": "${a}",
-                    "body": {
-                        "type": "tpl",
-                        "tpl": "金额：${b|number}元"
-                    }
+                    "type": "tpl",
+                    "tpl": "金额：${b|number}元"
+                },
+                {
+                    "type": "button",
+                    "label": "按钮",
+                    "size": "sm"
                 }
             ]
         }
@@ -89,9 +124,9 @@ order: 68
 }
 ```
 
-## 可增加、删除
+## 可增加
 
-`tab` 设置的 `closable` 优先级高于整体。使用 `addBtnText` 设置新增按钮文案
+`addable` 属性支持是否可新增 `addable` 为 `true` 时，使用 `addBtnText` 设置新增按钮文案
 
 ```schema: scope="body"
 {
@@ -113,9 +148,59 @@ order: 68
 }
 ```
 
+`addable`为 `true` 时，`addedTabSchema` 属性可统一配置新增 tab 页样式
+
+```schema: scope="body"
+{
+    "type": "tabs",
+    "closable": true,
+    "addable": true,
+    "addedTabSchema": {
+        "title": "我是新增的tab title",
+        "tab": {
+            "type": "button",
+            "label": "新增tab"
+        }
+    },
+    "tabs": [
+        {
+            "title": "Tab 1",
+            "tab": "Content 1",
+            "closable": false
+        },
+        {
+            "title": "Tab 2",
+            "tab": "Content 2"
+        }
+    ]
+}
+```
+
+## 可删除
+
+`tab` 设置的 `closable` 优先级高于整体。
+
+```schema: scope="body"
+{
+    "type": "tabs",
+    "closable": true,
+    "tabs": [
+        {
+            "title": "Tab 1",
+            "tab": "Content 1",
+            "closable": false
+        },
+        {
+            "title": "Tab 2",
+            "tab": "Content 2"
+        }
+    ]
+}
+```
+
 ## 可编辑标签名
 
-双击标签名，可开启编辑
+`editable`属性为 `true` 时支持标签名编辑，双击标签名，可开启编辑
 
 ```schema: scope="body"
 {
@@ -159,10 +244,35 @@ order: 68
 
 ## 显示提示
 
+`showTip`属性为 `true` 时支持开启标签名提示，默认提示内容为 tab 名称
+
 ```schema: scope="body"
 {
     "type": "tabs",
     "showTip": true,
+    "tabs": [
+        {
+            "title": "Tab 1",
+            "tab": "Content 1"
+        },
+        {
+            "title": "Tab 2",
+            "tab": "Content 2"
+        }
+    ]
+}
+```
+
+`showTip`属性为 `true` 时，可通过配置`tipSchema`属性自定义提示内容
+
+```schema: scope="body"
+{
+    "type": "tabs",
+    "showTip": true,
+    "tipSchema": {
+        "type": "button",
+        "tpl": "我是提示"
+    },
     "tabs": [
         {
             "title": "Tab 1",
@@ -722,9 +832,7 @@ order: 68
 }
 ```
 
-
-
-## title自定义
+## title 自定义
 
 > 3.2.0 及以上版本
 
@@ -835,44 +943,48 @@ order: 68
 
 ## 属性表
 
-| 属性名                | 类型                              | 默认值                              | 说明                                                                                                       |
-| --------------------- | --------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| type                  | `string`                          | `"tabs"`                            | 指定为 Tabs 渲染器                                                                                         |
-| defaultKey            | `string` / `number`               |                                     | 组件初始化时激活的选项卡，hash 值或索引值，支持使用表达式 `2.7.1 以上版本`                                 |
-| activeKey             | `string` / `number`               |                                     | 激活的选项卡，hash 值或索引值，支持使用表达式，可响应上下文数据变化                                        |
-| className             | `string`                          |                                     | 外层 Dom 的类名                                                                                            |
-| linksClassName        | `string`                          |                                     | Tabs 标题区的类名                                                                                            |
-| contentClassName      | `string`                          |                                     | Tabs 内容区的类名                                                                                            |
-| tabsMode              | `string`                          |                                     | 展示模式，取值可以是 `line`、`card`、`radio`、`vertical`、`chrome`、`simple`、`strong`、`tiled`、`sidebar` |
-| tabs                  | `Array`                           |                                     | tabs 内容                                                                                                  |
-| source                | `string`                          |                                     | tabs 关联数据，关联后可以重复生成选项卡                                                                    |
-| toolbar               | [SchemaNode](../types/schemanode) |                                     | tabs 中的工具栏                                                                                            |
-| toolbarClassName      | `string`                          |                                     | tabs 中工具栏的类名                                                                                        |
-| tabs[x].title         | `string` \| [SchemaNode](../types/schemanode)                        |                                     | Tab 标题，当是 [SchemaNode](../types/schemanode) 时，该 title 不支持 editable 为 true 的双击编辑                                                                                               |
-| tabs[x].icon          | `icon`                            |                                     | Tab 的图标                                                                                                 |
-| tabs[x].iconPosition  | `left` / `right`                  | `left`                              | Tab 的图标位置                                                                                             |
-| tabs[x].tab           | [SchemaNode](../types/schemanode) |                                     | 内容区                                                                                                     |
-| tabs[x].hash          | `string`                          |                                     | 设置以后将跟 url 的 hash 对应                                                                              |
-| tabs[x].reload        | `boolean`                         |                                     | 设置以后内容每次都会重新渲染，对于 crud 的重新拉取很有用                                                   |
-| tabs[x].unmountOnExit | `boolean`                         |                                     | 每次退出都会销毁当前 tab 栏内容                                                                            |
-| tabs[x].className     | `string`                          | `"bg-white b-l b-r b-b wrapper-md"` | Tab 区域样式                                                                                               |
-| tabs[x].tip     | `string`                          |                         | `3.2.0及以上版本支持` Tab 提示，当开启 `showTip` 时生效，作为 Tab 在 hover 时的提示显示，可不配置，如不设置，`tabs[x].title` 作为提示显示                                                |
-| tabs[x].closable      | `boolean`                         | false                               | 是否支持删除，优先级高于组件的 `closable`                                                                  |
-| tabs[x].disabled      | `boolean`                         | false                               | 是否禁用                                                                                                   |
-| mountOnEnter          | `boolean`                         | false                               | 只有在点中 tab 的时候才渲染                                                                                |
-| unmountOnExit         | `boolean`                         | false                               | 切换 tab 的时候销毁                                                                                        |
-| addable               | `boolean`                         | false                               | 是否支持新增                                                                                               |
-| addBtnText            | `string`                          | 增加                                | 新增按钮文案                                                                                               |
-| closable              | `boolean`                         | false                               | 是否支持删除                                                                                               |
-| draggable             | `boolean`                         | false                               | 是否支持拖拽                                                                                               |
-| showTip               | `boolean`                         | false                               | 是否支持提示                                                                                               |
-| showTipClassName      | `string`                          | `'' `                               | 提示的类                                                                                                   |
-| editable              | `boolean`                         | false                               | 是否可编辑标签名。当 `tabs[x].title` 为 [SchemaNode](../types/schemanode) 时，双击编辑 Tab 的 title 显示空的内容                                                                                          |
-| scrollable            | `boolean`                         | true                                | 是否导航支持内容溢出滚动。（属性废弃）                                                                     |
-| sidePosition          | `left` / `right`                  | `left`                              | `sidebar` 模式下，标签栏位置                                                                               |
-| collapseOnExceed      | `number`                          |                                     | 当 tabs 超出多少个时开始折叠                                                                               |
-| collapseBtnLabel      | `string`                          | `more`                              | 用来设置折叠按钮的文字                                                                                     |
-| swipeable             | `boolean`                         | false                               | 是否开启手势滑动切换（移动端生效）                                                                         |
+| 属性名                | 类型                                                         | 默认值                              | 说明                                                                                                                                      | 版本                                    |
+| --------------------- | ------------------------------------------------------------ | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| type                  | `string`                                                     | `"tabs"`                            | 指定为 Tabs 渲染器                                                                                                                        |
+| defaultKey            | `string` / `number`                                          |                                     | 组件初始化时激活的选项卡，hash 值或索引值，支持使用表达式 `2.7.1 以上版本`                                                                |
+| activeKey             | `string` / `number`                                          |                                     | 激活的选项卡，hash 值或索引值，支持使用表达式，可响应上下文数据变化                                                                       |
+| className             | `string`                                                     |                                     | 外层 Dom 的类名                                                                                                                           |
+| linksClassName        | `string`                                                     |                                     | Tabs 标题区的类名                                                                                                                         |
+| contentClassName      | `string`                                                     |                                     | Tabs 内容区的类名                                                                                                                         |
+| tabsMode              | `string`                                                     |                                     | 展示模式，取值可以是 `line`、`card`、`radio`、`vertical`、`chrome`、`simple`、`strong`、`tiled`、`sidebar`                                |
+| tabs                  | `Array`                                                      |                                     | tabs 内容                                                                                                                                 |
+| source                | `string`                                                     |                                     | tabs 关联数据                                                                                                                             |
+| toolbar               | [SchemaNode](../types/schemanode)                            |                                     | tabs 中的工具栏                                                                                                                           |
+| toolbarClassName      | `string`                                                     |                                     | tabs 中工具栏的类名                                                                                                                       |
+| tabs[x].title         | `string` \| [SchemaNode](../types/schemanode)                |                                     | Tab 标题，当是 [SchemaNode](../types/schemanode) 时，该 title 不支持 editable 为 true 的双击编辑                                          |
+| tabs[x].icon          | `icon`                                                       |                                     | Tab 的图标                                                                                                                                |
+| tabs[x].iconPosition  | `left` / `right`                                             | `left`                              | Tab 的图标位置                                                                                                                            |
+| tabs[x].body          | [SchemaNode](../types/schemanode)                            |                                     | 内容区                                                                                                                                    |
+| tabs[x].hash          | `string`                                                     |                                     | 设置以后将跟 url 的 hash 对应                                                                                                             |
+| tabs[x].reload        | `boolean`                                                    |                                     | 设置以后内容每次都会重新渲染，对于 crud 的重新拉取很有用                                                                                  |
+| tabs[x].unmountOnExit | `boolean`                                                    |                                     | 每次退出都会销毁当前 tab 栏内容                                                                                                           |
+| tabs[x].className     | `string`                                                     | `"bg-white b-l b-r b-b wrapper-md"` | Tab 区域样式                                                                                                                              |
+| tabs[x].tip           | `string`                                                     |                                     | `3.2.0及以上版本支持` Tab 提示，当开启 `showTip` 时生效，作为 Tab 在 hover 时的提示显示，可不配置，如不设置，`tabs[x].title` 作为提示显示 |
+| tabs[x].closable      | `boolean`                                                    | false                               | 是否支持删除，优先级高于组件的 `closable`                                                                                                 |
+| tabs[x].disabled      | `boolean`                                                    | false                               | 是否禁用                                                                                                                                  |
+| mountOnEnter          | `boolean`                                                    | false                               | 只有在点中 tab 的时候才渲染                                                                                                               |
+| unmountOnExit         | `boolean`                                                    | false                               | 切换 tab 的时候销毁                                                                                                                       |
+| addable               | `boolean`                                                    | false                               | 是否支持新增                                                                                                                              |
+| addBtnText            | `string                                       \| SchemaNode` | 增加                                | 新增按钮文案                                                                                                                              | >`3.5.0` 及以上版本支持 SchemaNode 类型 |
+| closable              | `boolean`                                                    | false                               | 是否支持删除                                                                                                                              |
+| draggable             | `boolean`                                                    | false                               | 是否支持拖拽                                                                                                                              |
+| showTip               | `boolean`                                                    | false                               | 是否支持提示                                                                                                                              |
+| showTipClassName      | `string`                                                     | `'' `                               | 提示的类                                                                                                                                  |
+| editable              | `boolean`                                                    | false                               | 是否可编辑标签名。当 `tabs[x].title` 为 [SchemaNode](../types/schemanode) 时，双击编辑 Tab 的 title 显示空的内容                          |
+| scrollable            | `boolean`                                                    | true                                | 是否导航支持内容溢出滚动。（属性废弃）                                                                                                    |
+| sidePosition          | `left` / `right`                                             | `left`                              | `sidebar` 模式下，标签栏位置                                                                                                              |
+| collapseOnExceed      | `number`                                                     |                                     | 当 tabs 超出多少个时开始折叠                                                                                                              |
+| collapseBtnLabel      | `string`                                                     | `more`                              | 用来设置折叠按钮的文字                                                                                                                    |
+| swipeable             | `boolean`                                                    | false                               | 是否开启手势滑动切换（移动端生效）                                                                                                        |
+| addedTabSchema        | `Record<{tab: SchemaNode, title: SchemaNode}>`               |                                     | 新增 tab 页默认样式模板                                                                                                                   | `3.5.0`                                 |
+| titleSchema           | `string \|SchemaNode`                                        |                                     | 新增 tab 标题模板, 搭配 source                                                                                                            | `3.5.0`                                 |
+| tabSchema             | `string \|SchemaNode`                                        |                                     | 新增 tab 内容模板, 搭配 source                                                                                                            | `3.5.0`                                 |
+| tipSchema             | `string`                                                     |                                     | 标题提示, 搭配 showTip 使用                                                                                                               | `3.5.0`                                 |
 
 ## 事件表
 

--- a/package.json
+++ b/package.json
@@ -40,9 +40,11 @@
     ]
   },
   "dependencies": {
+    "@rc-component/portal": "^1.1.2",
+    "@testing-library/react": "^14.0.0",
+    "path-to-regexp": "^6.2.0",
     "postcss": "^8.4.14",
-    "qs": "6.9.7",
-    "path-to-regexp": "^6.2.0"
+    "qs": "6.9.7"
   },
   "devDependencies": {
     "@babel/generator": "^7.22.9",

--- a/packages/amis-editor-core/scss/control/_tabs-control.scss
+++ b/packages/amis-editor-core/scss/control/_tabs-control.scss
@@ -1,0 +1,79 @@
+.ae-TabsControl {
+  &-header {
+    @include flexBox();
+    width: 100%;
+    height: #{px2rem(24px)};
+    margin-bottom: #{px2rem(12px)};
+  }
+
+  &-content {
+    @include flexBox(column, flex-start);
+    margin: 0;
+    padding: 0;
+
+    .ae-TabsControlItem {
+      display: block;
+      width: 100%;
+
+      &-input {
+        flex: 1;
+        margin: 0;
+        input {
+          width: 100%;
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+        }
+        .cxd-Form-label {
+          display: none;
+        }
+      }
+
+      &-Main {
+        @include flexBox();
+        width: 100%;
+        background: #fff;
+        padding-bottom: px2rem(12px);
+      }
+
+      &--dragging {
+        height: 0 !important;
+        padding: 0;
+        border-top: 2px solid var(--primary);
+        overflow: hidden;
+        background: #e9effd;
+      }
+
+      &-dragBar {
+        display: inline-flex;
+        margin-left: 0;
+        margin-right: var(--gap-sm);
+        cursor: move;
+        color: #8c8c8c;
+      }
+
+      &-dropdown i {
+        margin-right: 0px;
+      }
+
+      &-delButton {
+        color: var(--sizes-size-7);
+        width: 20px;
+        padding: 0;
+      }
+    }
+  }
+
+  &-border {
+    background-color: #e5e5e5;
+    width: 100%;
+    height: 1px;
+    margin-top: px2rem(12px);
+    margin-bottom: px2rem(12px);
+  }
+
+  &-placeholder {
+    text-align: center;
+    padding-bottom: px2rem(12px);
+  }
+}

--- a/packages/amis-editor-core/scss/editor.scss
+++ b/packages/amis-editor-core/scss/editor.scss
@@ -43,6 +43,7 @@
 @import './control/_flex-setting-control';
 @import './control/table-column-width-control.scss';
 @import './control/crud2-control';
+@import './control/tabs-control';
 
 /* 样式控件 */
 @import './style-control/box-model';

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -1192,6 +1192,7 @@ export async function getVariables(that: any) {
   let variablesArr: any[] = [];
 
   const {variables, requiredDataPropsVariables} = that.props;
+
   if (!variables || requiredDataPropsVariables) {
     // 从amis数据域中取变量数据
     const {node, manager} = that.props.formProps || that.props;

--- a/packages/amis-editor/src/index.tsx
+++ b/packages/amis-editor/src/index.tsx
@@ -48,7 +48,7 @@ import './renderer/crud2-control/CRUDToolbarControl';
 import './renderer/crud2-control/CRUDFiltersControl';
 import './renderer/InputRangeValueControl';
 import './renderer/FunctionEditorControl';
-
+import './renderer/TabsControl';
 import 'amis-theme-editor/lib/locale/zh-CN';
 import 'amis-theme-editor/lib/locale/en-US';
 import 'amis-theme-editor/lib/renderers/Border';

--- a/packages/amis-editor/src/plugin/Tabs.tsx
+++ b/packages/amis-editor/src/plugin/Tabs.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import {getI18nEnabled, registerEditorPlugin} from 'amis-editor-core';
+import {
+  diff,
+  getI18nEnabled,
+  getVariables,
+  registerEditorPlugin
+} from 'amis-editor-core';
 import {
   BaseEventContext,
   BasePlugin,
@@ -14,14 +19,17 @@ import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {mapReactElement} from 'amis-editor-core';
 import {VRenderer} from 'amis-editor-core';
 import findIndex from 'lodash/findIndex';
+import cloneDeep from 'lodash/cloneDeep';
 import {RegionWrapper as Region} from 'amis-editor-core';
-import {Tab} from 'amis';
+import {BaseSchema, Tab, resolveVariableAndFilter} from 'amis';
 import {tipedLabel} from 'amis-editor-core';
 import {ValidatorTag} from '../validator';
 import {
   getArgsWrapper,
   getEventControlConfig
 } from '../renderer/event-control/helper';
+import {schemaArrayFormat, schemaToArray} from '../util';
+import {filter, keys, map, omit, reduce} from 'lodash';
 
 export class TabsPlugin extends BasePlugin {
   static id = 'TabsPlugin';
@@ -121,53 +129,181 @@ export class TabsPlugin extends BasePlugin {
   ];
 
   panelJustify = true;
+
   panelBodyCreator = (context: BaseEventContext) => {
+    const isSubEditor =
+      context.path?.indexOf('tabs') === 0 && this.manager.store?.schema?.isSlot;
     const isNewTabMode =
       'data.tabsMode !=="vertical" && data.tabsMode !=="sidebar" && data.tabsMode !=="chrome"';
+    const i18nEnabled = getI18nEnabled();
+    const that = this;
+
+    async function getOptionVars() {
+      let schema = that.manager.store.valueWithoutHiddenProps;
+      let children = [];
+
+      if (schema.tabs) {
+        let optionItem = reduce(
+          schema.tabs,
+          function (result, item) {
+            return {...result, ...item};
+          },
+          {}
+        );
+        delete optionItem?.id;
+
+        let otherItem = map(
+          keys(optionItem).filter(
+            item => item === 'title' || item === 'body' || item === 'tab'
+          ),
+          item => ({
+            label:
+              item === 'title'
+                ? '选项卡标题'
+                : item === 'body' || item === 'tab'
+                ? '选项卡内容'
+                : item,
+            value: item,
+            tag: typeof optionItem[item]
+          })
+        );
+
+        children.push(...otherItem);
+      }
+
+      let variablesArr = [
+        {
+          label: '选项字段',
+          children
+        }
+      ];
+      return variablesArr;
+    }
 
     return getSchemaTpl('tabs', [
       {
         title: '属性',
+        visible: !isSubEditor,
         body: getSchemaTpl('collapseGroup', [
           {
-            title: '基本',
+            title: '关联数据',
             body: [
               getSchemaTpl('layout:originPosition', {value: 'left-top'}),
-              getSchemaTpl('combo-container', {
-                type: 'combo',
+              getSchemaTpl('tabsControl', {
                 label: '选项卡',
                 mode: 'normal',
                 name: 'tabs',
-                draggableTip: '',
-                draggable: true,
-                multiple: true,
-                minLength: 1,
-                scaffold: {
-                  title: '选项卡',
-                  body: {
-                    type: 'tpl',
-                    tpl: '内容',
-                    inline: false
-                  }
+                type: 'ae-tabsControl'
+              })
+            ]
+          },
+          {
+            title: '选项卡',
+            body: [
+              {
+                type: 'ae-switch-more',
+                mode: 'normal',
+                label: '可新增',
+                hiddenOnDefault: false,
+                bulk: true,
+                name: 'addable',
+                formType: 'extend',
+                form: {
+                  body: [
+                    {
+                      label: '按钮名称',
+                      name: 'addBtnText',
+                      type: i18nEnabled ? 'input-text-i18n' : 'input-text',
+                      placeholder: '请输入新增按钮名称',
+                      pipeIn: (value: any) => {
+                        return typeof value !== 'string' ? 'Schema配置' : value;
+                      },
+                      pipeOut: (value: any) => {
+                        return context.schema?.addBtnText;
+                      }
+                    },
+                    {
+                      type: 'button',
+                      level: 'primary',
+                      size: 'sm',
+                      visibleOn: !i18nEnabled,
+                      style: {
+                        margin: 'auto auto 12px auto'
+                      },
+                      name: 'addBtnText',
+                      block: true,
+                      onClick: this.editAddedBtn.bind(this, context),
+                      label: '配置新增按钮名称模板'
+                    },
+                    {
+                      type: 'button',
+                      level: 'primary',
+                      size: 'sm',
+                      name: 'addBtnText',
+                      block: true,
+                      onClick: this.handleAddedSchema.bind(this, context),
+                      label: '配置新增选项卡模板'
+                    }
+                  ]
                 },
-                items: [
-                  getSchemaTpl('title', {
-                    label: false,
-                    required: true
-                  })
-                ]
-              }),
-
+                pipeIn: (value: any) => {
+                  return typeof value !== 'undefined';
+                },
+                pipeOut: (value: any) => {
+                  return value;
+                }
+              },
               getSchemaTpl('switch', {
-                name: 'showTip',
+                name: 'closable',
+                label: '可删除',
+                visibleOn: isNewTabMode,
+                clearValueOnHidden: true
+              }),
+              getSchemaTpl('switch', {
+                name: 'draggable',
+                label: tipedLabel('拖拽排序', '开启后可通过拖拽调整tab顺序'),
+                visibleOn: isNewTabMode,
+                clearValueOnHidden: true
+              }),
+              getSchemaTpl('switch', {
+                name: 'editable',
                 label: tipedLabel(
-                  '标题提示',
-                  '鼠标移动到选项卡标题时弹出提示，适用于标题超长时进行完整提示'
+                  '快速编辑',
+                  '标题为字符串时该配置生效，开启后双击标题可直接编辑'
                 ),
                 visibleOn: isNewTabMode,
                 clearValueOnHidden: true
               }),
-
+              {
+                type: 'ae-switch-more',
+                formType: 'extend',
+                mode: 'normal',
+                label: tipedLabel(
+                  '标题提示',
+                  '鼠标移动到选项卡标题时弹出提示，适用于标题超长时进行完整提示'
+                ),
+                name: 'showTip',
+                form: {
+                  body: [
+                    getSchemaTpl('textareaFormulaControl', {
+                      name: 'tipSchema',
+                      mode: 'normal',
+                      label: tipedLabel(
+                        '提示模板',
+                        '自定义标题渲染模板，支持JSX、数据域变量使用'
+                      ),
+                      variables: getOptionVars,
+                      requiredDataPropsVariables: true
+                    })
+                  ]
+                }
+              }
+            ]
+          },
+          getSchemaTpl('status'),
+          {
+            title: '高级',
+            body: [
               {
                 label: tipedLabel(
                   '初始选项卡',
@@ -179,7 +315,6 @@ export class TabsPlugin extends BasePlugin {
                 pipeOut: (data: string) =>
                   data === '' || isNaN(Number(data)) ? data : Number(data)
               },
-
               {
                 label: tipedLabel(
                   '激活的选项卡',
@@ -190,17 +325,40 @@ export class TabsPlugin extends BasePlugin {
                 placeholder: '默认激活的选项卡',
                 pipeOut: (data: string) =>
                   data === '' || isNaN(Number(data)) ? data : Number(data)
-              }
-            ]
-          },
-          getSchemaTpl('status'),
-          {
-            title: '高级',
-            body: [
-              getSchemaTpl('sourceBindControl', {
+              },
+              {
+                type: 'ae-switch-more',
+                formType: 'extend',
+                mode: 'normal',
                 label: tipedLabel(
-                  '关联数据',
-                  '根据该数据来动态重复渲染所配置的选项卡'
+                  '超出折叠',
+                  '折叠配置仅对PC端生效移动端不生效，移动端均为超出滚动切换'
+                ),
+                form: {
+                  body: [
+                    getSchemaTpl('formulaControl', {
+                      label: '最大展示数量',
+                      type: 'ae-formulaControl',
+                      name: 'collapseOnExceed',
+                      clearValueOnHidden: true,
+                      require: true,
+                      pipeOut: (data: string) =>
+                        data === '' || isNaN(Number(data)) ? data : Number(data)
+                    }),
+                    {
+                      label: '折叠按钮名称',
+                      name: 'collapseBtnLabel',
+                      type: i18nEnabled ? 'input-text-i18n' : 'input-text',
+                      placeholder: '请输入折叠按钮名称'
+                    }
+                  ]
+                }
+              },
+              getSchemaTpl('switch', {
+                name: 'swipeable',
+                label: tipedLabel(
+                  '选项滚动切换',
+                  '选项滚动切换为移动端特有功能'
                 )
               }),
               getSchemaTpl('switch', {
@@ -351,30 +509,34 @@ export class TabsPlugin extends BasePlugin {
                 {
                   name: 'title',
                   label: '标题',
-                  type: i18nEnabled ? 'input-text-i18n' : 'input-text',
+                  block: false,
+                  visibleOn: i18nEnabled,
+                  type: 'input-text',
                   required: true
                 },
-
                 {
-                  type: 'ae-switch-more',
-                  formType: 'extend',
-                  mode: 'normal',
-                  label: '标题图标',
-                  form: {
-                    body: [
-                      getSchemaTpl('icon'),
-
-                      getSchemaTpl('horizontal-align', {
-                        label: '位置',
-                        name: 'iconPosition',
-                        pipeIn: defaultValue('left'),
-                        visibleOn: 'data.icon',
-                        clearValueOnHidden: true
-                      })
-                    ]
+                  name: 'title',
+                  label: '标题',
+                  block: false,
+                  visibleOn: !i18nEnabled,
+                  type: 'input-text',
+                  required: true,
+                  addOn: {
+                    type: 'button',
+                    name: 'title',
+                    label: '配置',
+                    block: false,
+                    onClick: this.editTabTtile.bind(this, context)
                   }
                 },
-
+                {
+                  label: tipedLabel(
+                    '标题提示',
+                    '当开启 showTip 时生效，若不配置默认值使用tab.title 作为提示显示'
+                  ),
+                  name: 'tip',
+                  type: 'input-text'
+                },
                 {
                   label: tipedLabel(
                     'Hash',
@@ -389,6 +551,14 @@ export class TabsPlugin extends BasePlugin {
             {
               title: '高级',
               body: [
+                getSchemaTpl('switch', {
+                  name: 'reload',
+                  label: tipedLabel(
+                    '重新渲染',
+                    '设置以后内容每次都会重新渲染，对于 crud 的重新拉取很有用。'
+                  ),
+                  clearValueOnHidden: true
+                }),
                 getSchemaTpl('switch', {
                   name: 'mountOnEnter',
                   label: tipedLabel(
@@ -553,6 +723,118 @@ export class TabsPlugin extends BasePlugin {
     }
 
     return;
+  }
+
+  // 配置标题
+  editTabTtile(context: BaseEventContext) {
+    const {id, schema} = context;
+    const manager = this.manager;
+    const store = manager.store;
+    const node = store.getNodeById(id);
+    const value = store.getValueOf(id);
+    const defaultItemSchema = value?.title
+      ? typeof value.title === 'string'
+        ? {
+            type: 'tpl',
+            tpl: value.title
+          }
+        : value?.title
+      : {
+          type: 'tpl',
+          tpl: '请编辑内容'
+        };
+    node &&
+      value &&
+      manager.openSubEditor({
+        title: '配置标签页标题',
+        value: schemaToArray(defaultItemSchema),
+        data: schema,
+        slot: {
+          type: 'container',
+          body: '$$'
+        },
+        onChange: (newValue: BaseSchema) => {
+          const newTabsValue = cloneDeep(value);
+          newTabsValue.title = schemaArrayFormat(newValue);
+
+          manager.panelChangeValue(newValue, diff(value, newTabsValue));
+        }
+      });
+  }
+
+  // 配置新增按钮模板
+  editAddedBtn(context: BaseEventContext) {
+    const {id, schema} = context;
+    const manager = this.manager;
+    const store = manager.store;
+    const node = store.getNodeById(id);
+    const value = store.getValueOf(id);
+    const defaultAddBtnText =
+      value.addBtnText && typeof value.addBtnText === 'object'
+        ? value.addBtnText
+        : {
+            type: 'tpl',
+            tpl: value.addBtnText ?? '新增'
+          };
+    node &&
+      value &&
+      this.manager.openSubEditor({
+        title: '配置新增按钮名称',
+        value: schemaToArray(defaultAddBtnText),
+        slot: {
+          type: 'container',
+          body: '$$'
+        },
+        onChange: (newValue: any) => {
+          newValue = {...value, addBtnText: schemaArrayFormat(newValue)};
+          manager.panelChangeValue(newValue, diff(value, newValue));
+        },
+        data: schema
+      });
+  }
+
+  // 配置新增tab页模板
+  handleAddedSchema(context: BaseEventContext) {
+    const {id, schema} = context;
+    const manager = this.manager;
+    const store = manager.store;
+    const node = store.getNodeById(id);
+    const value = store.getValueOf(id);
+    const defaultAddedTabSchema = value.addedTabSchema ?? {
+      title: '新增选项卡',
+      body: [
+        {
+          type: 'tpl',
+          tpl: '新增选项卡内容'
+        }
+      ]
+    };
+    const subEditorTabs = !schema.source
+      ? schema.tabs.map((item: {title: any; tab: any}) => ({
+          title: item.title,
+          disabled: true
+        }))
+      : [];
+    const defaultSchema = {
+      type: 'tabs',
+      tabs: '$$',
+      defaultKey: subEditorTabs.length,
+      activeKey: subEditorTabs.length
+    };
+    node &&
+      value &&
+      this.manager.openSubEditor({
+        title: '新增选项卡模板',
+        value: schemaToArray([...subEditorTabs, defaultAddedTabSchema]),
+        slot: defaultSchema,
+        onChange: (newValue: any) => {
+          newValue = {
+            ...value,
+            addedTabSchema: schemaArrayFormat(newValue[newValue.length - 1])
+          };
+          manager.panelChangeValue(newValue, diff(value, newValue));
+        }
+      });
   }
 }
 

--- a/packages/amis-editor/src/renderer/TabsControl.tsx
+++ b/packages/amis-editor/src/renderer/TabsControl.tsx
@@ -1,0 +1,499 @@
+/**
+ * @file Tabs组件关联数据的可视化编辑控件
+ */
+import React from 'react';
+import {findDOMNode} from 'react-dom';
+import cx from 'classnames';
+import cloneDeep from 'lodash/cloneDeep';
+import Sortable from 'sortablejs';
+import {
+  render as amisRender,
+  BaseSchema,
+  Button,
+  FormItem,
+  Icon,
+  SchemaCollection,
+  SchemaObject
+} from 'amis';
+import {
+  BaseEventContext,
+  diff,
+  getI18nEnabled,
+  tipedLabel,
+  autobind,
+  getSchemaTpl,
+  anyChanged
+} from 'amis-editor-core';
+import type {FormControlProps} from 'amis-core';
+import {schemaArrayFormat, schemaToArray} from '../util';
+
+type TabProp = {
+  title: string | SchemaObject;
+  body: SchemaCollection;
+};
+export interface TabsControlProps extends FormControlProps {}
+
+export interface TabsState {
+  tabs: Array<TabProp>;
+  srcType: 'custom' | 'variable';
+  source?: string;
+  titleSchema?: SchemaCollection;
+  tabSchema?: SchemaCollection;
+}
+
+export default class TabsControl extends React.Component<
+  TabsControlProps,
+  TabsState
+> {
+  sortable?: Sortable;
+  drag?: HTMLElement | null;
+  target: HTMLElement | null;
+
+  constructor(props: TabsControlProps) {
+    super(props);
+    this.state = {
+      tabs: props.data.tabs,
+      srcType: props.data.source ? 'variable' : 'custom',
+      source: props.data.source,
+      titleSchema: props.data.titleSchema,
+      tabSchema: props.data.tabSchema
+    };
+  }
+
+  componentDidUpdate(prevProps: any, preState: any) {
+    const props = this.props;
+
+    // json更新tabs代码，更新右侧配置面板
+    if (anyChanged(['tabs'], prevProps?.data ?? {}, props?.data ?? {})) {
+      this.setState({tabs: props?.data?.tabs});
+    }
+  }
+  /**
+   * 切换选项来源类型
+   */
+  @autobind
+  handleSourceChange(srcType: 'custom' | 'variable') {
+    this.setState({srcType: srcType}, this.handleChange);
+  }
+
+  /**
+   * 更改source绑定的上下文变量
+   * @param source 绑定的上下文变量
+   */
+  @autobind
+  handleVariableChange(source: string) {
+    this.setState({source}, this.handleChange);
+  }
+
+  handleChange() {
+    const {srcType, source, tabs, titleSchema, tabSchema} = this.state;
+    const {onBulkChange} = this.props;
+    const data: Partial<TabsControlProps> = {
+      srcType: undefined,
+      tabs: undefined,
+      titleSchema: undefined,
+      tabSchema: undefined,
+      source: undefined
+    };
+    const defaultTabs = [
+      {
+        title: '选项卡1',
+        body: '内容1'
+      },
+      {
+        title: '选项卡2',
+        body: '内容2'
+      }
+    ];
+
+    if (srcType === 'custom') {
+      data.tabs = (tabs || defaultTabs).map(item => ({...item}));
+    }
+    if (srcType === 'variable') {
+      if (!source?.length && tabs) {
+        data.tabs = tabs?.map(item => ({...item}));
+      }
+      data.source = source;
+      data.titleSchema = titleSchema;
+      data.tabSchema = tabSchema;
+    }
+    onBulkChange && onBulkChange(data);
+  }
+
+  // 删除tab
+  handleDelete(index: number) {
+    const tabs = this.state.tabs.concat();
+    tabs.splice(index, 1);
+    this.setState({tabs}, this.handleChange);
+  }
+
+  // 处理标题
+  handleTitleChange(index: number, value?: string) {
+    const {manager, context} = this.props;
+    const tabs = this.state.tabs.concat();
+    // 输入字符串
+    if (typeof value === 'string') {
+      // 上下文配置模板
+      if (index === -1) {
+        return this.setState({titleSchema: value}, () => this.handleChange());
+      }
+
+      tabs.splice(index, 1, {...tabs[index], title: value});
+      return this.setState({tabs}, () => this.handleChange());
+    }
+
+    const store = manager.store;
+    // 获取tabs组件id
+    const tabsNode = store.getNodeById(store?.activeId);
+    // 配置处理单个tab页，使其选中对应选项卡
+    if (index !== -1) {
+      const control = tabsNode.getComponent();
+      if (control?.switchTo) {
+        control.switchTo(index);
+      }
+      return;
+    }
+
+    // 配置schema
+    const prevValue = store.getValueOf(store?.activeId);
+
+    const defaultItemSchema = tabs[index]?.title ?? {
+      type: 'tpl',
+      tpl: '请编辑内容'
+    };
+
+    tabsNode &&
+      prevValue &&
+      manager.openSubEditor({
+        title: '配置标签页标题',
+        value: schemaToArray(defaultItemSchema),
+        slot: {
+          type: 'container',
+          body: '$$'
+        },
+        onChange: (newValue: BaseSchema) => {
+          const newTabsValue = cloneDeep(prevValue);
+
+          if (index === -1) {
+            newTabsValue.titleSchema = newValue;
+          } else {
+            newTabsValue.tabs[index].title = schemaArrayFormat(newValue);
+          }
+
+          manager.panelChangeValue(newValue, diff(prevValue, newTabsValue));
+        }
+      });
+  }
+
+  // 编辑tab内容模板
+  editTabSchema(field: 'title' | 'tab') {
+    const {manager} = this.props;
+    const store = manager.store;
+    const node = store.getNodeById(store?.activeId);
+    const prevValue = store.getValueOf(store?.activeId);
+
+    const text = field === 'title' ? '标题' : '内容';
+    const prevScema =
+      field === 'title' ? prevValue.titleSchema : prevValue.tabSchema;
+    const defaultItemSchema = prevScema
+      ? typeof prevScema === 'string'
+        ? {
+            type: 'tpl',
+            tpl: prevScema
+          }
+        : prevScema
+      : {
+          type: 'tpl',
+          tpl: '请编辑内容'
+        };
+
+    node &&
+      prevValue &&
+      manager.openSubEditor({
+        title: `配置标签页${text}`,
+        value: schemaToArray(defaultItemSchema),
+        slot: {
+          type: 'container',
+          body: '$$'
+        },
+        onChange: (newValue: BaseSchema) => {
+          const newTabsValue = cloneDeep(prevValue);
+
+          field === 'title'
+            ? (newTabsValue.titleSchema = newValue)
+            : (newTabsValue.tabSchema = newValue);
+
+          manager.panelChangeValue(newValue, diff(prevValue, newTabsValue));
+        }
+      });
+  }
+
+  @autobind
+  handleAdd() {
+    var {tabs} = this.state;
+    const defaultTab: TabProp = {
+      title: `选项卡${tabs?.length + 1 || 1}`,
+      body: [
+        {
+          type: 'tpl',
+          tpl: `内容${tabs?.length + 1 || 1}`
+        }
+      ]
+    };
+    const newTabs = Array.isArray(tabs)
+      ? tabs.concat(defaultTab)
+      : [defaultTab];
+    this.setState({tabs: newTabs}, this.handleChange);
+  }
+
+  @autobind
+  dragRef(ref: any) {
+    if (!this.drag && ref) {
+      this.initDragging();
+    } else if (this.drag && !ref) {
+      this.destroyDragging();
+    }
+
+    this.drag = ref;
+  }
+
+  initDragging() {
+    const dom = findDOMNode(this) as HTMLElement;
+
+    this.sortable = new Sortable(
+      dom.querySelector('.ae-TabsControl-content') as HTMLElement,
+      {
+        group: 'TabsControlGroup',
+        animation: 150,
+        handle: '.ae-TabsControlItem-dragBar',
+        ghostClass: 'ae-TabsControlItem--dragging',
+        onEnd: (e: any) => {
+          // 没有移动
+          if (e.newIndex === e.oldIndex) {
+            return;
+          }
+          // 交换后的list
+          const parent = e.to as HTMLElement;
+          if (
+            e.newIndex < e.oldIndex &&
+            e.oldIndex < parent.childNodes.length - 1
+          ) {
+            // 前移
+            parent.insertBefore(e.item, parent.childNodes[e.oldIndex + 1]);
+          } else if (e.oldIndex < parent.childNodes.length - 1) {
+            // 后移
+            parent.insertBefore(e.item, parent.childNodes[e.oldIndex]);
+          } else {
+            parent.appendChild(e.item);
+          }
+
+          const tabs = this.state.tabs.concat();
+          tabs.splice(e.newIndex, 0, tabs.splice(e.oldIndex, 1)[0]);
+          this.setState({tabs}, () => this.handleChange());
+        }
+      }
+    );
+  }
+
+  destroyDragging() {
+    this.sortable && this.sortable.destroy();
+  }
+
+  renderHeader() {
+    const {render, label, useMobileUI, env, popOverContainer, classPrefix} =
+      this.props;
+    const {srcType} = this.state;
+    const optionSourceList = (
+      [
+        {
+          label: '自定义选项',
+          value: 'custom'
+        },
+        {
+          label: '上下文变量',
+          value: 'variable'
+        }
+      ] as Array<{
+        label: string;
+        value: 'custom' | 'variable';
+      }>
+    ).map(item => ({
+      ...item,
+      onClick: () => this.handleSourceChange(item.value)
+    }));
+
+    return (
+      <header className="ae-TabsControl-header">
+        <label className={cx(`${classPrefix}Form-label`)}>
+          {label || ''}
+          {render('label-remark', {
+            type: 'remark',
+            tooltip: '切换后将会清空原先数据源配置',
+            className: cx(`Form-lableRemark`),
+            useMobileUI,
+            container: popOverContainer || env.getModalContainer
+          })}
+        </label>
+        <div>
+          {render(
+            'tabs-source',
+            {
+              type: 'dropdown-button',
+              level: 'link',
+              size: 'sm',
+              label: '${selected}',
+              align: 'right',
+              closeOnClick: true,
+              closeOnOutside: true,
+              buttons: optionSourceList
+            },
+            {
+              popOverContainer: null,
+              data: {
+                selected: optionSourceList.find(item => item.value === srcType)!
+                  .label
+              }
+            }
+          )}
+        </div>
+      </header>
+    );
+  }
+
+  // 每个选项卡
+  renderOption(props: TabProp & {index: number}) {
+    const {title, index} = props;
+    const {render} = this.props;
+    const delDisabled = this.state.tabs?.length <= 1;
+    const i18nEnabled = getI18nEnabled();
+    return (
+      <li className="ae-TabsControlItem" key={index}>
+        <div className="ae-TabsControlItem-Main">
+          <a className="ae-TabsControlItem-dragBar">
+            <Icon icon="drag-bar" className="icon" />
+          </a>
+          {render('ae-TabsControlItem-title', {
+            type: i18nEnabled ? 'input-text-i18n' : 'input-text',
+            className: 'ae-TabsControlItem-input',
+            value: title,
+            label: '',
+            placeholder: '请输入标题',
+            clearable: false,
+            onChange: (value: string) => this.handleTitleChange(index, value)
+          })}
+          <Button
+            className="ae-TabsControlItem-redirectButton"
+            size="sm"
+            tooltip={{
+              enterable: false,
+              content: '编辑器选中当前标签页',
+              tooltipTheme: 'dark',
+              placement: 'left',
+              mouseLeaveDelay: 0
+            }}
+            level="link"
+            onClick={this.handleTitleChange.bind(this, index)}
+          >
+            选中
+          </Button>
+          {!delDisabled ? (
+            <Button
+              className="ae-TabsControlItem-delButton "
+              size="sm"
+              level="link"
+              onClick={this.handleDelete.bind(this, index)}
+            >
+              <Icon
+                icon="status-close"
+                className={cx(
+                  'ae-config-schema-icon',
+                  'icon-config-schema',
+                  'icon'
+                )}
+              />
+            </Button>
+          ) : null}
+        </div>
+      </li>
+    );
+  }
+
+  render() {
+    const {srcType, tabs} = this.state;
+    const i18nEnabled = getI18nEnabled();
+    const {render, className} = this.props;
+    return (
+      <div className={cx('ae-TabsControl', className)}>
+        {this.renderHeader()}
+        {srcType === 'custom' ? (
+          <div className="ae-TabsControl-wrapper">
+            {Array.isArray(tabs) && tabs.length ? (
+              <ul className="ae-TabsControl-content" ref={this.dragRef}>
+                {tabs.map((item: TabProp, index: number) =>
+                  this.renderOption({...item, index})
+                )}
+              </ul>
+            ) : (
+              <div className="ae-TabsControl-placeholder">无选项卡</div>
+            )}
+
+            <div className="ae-TabsControl-footer">
+              {render('ae-TabsControl-footer', {
+                type: 'button',
+                level: 'enhance',
+                size: 'sm',
+                block: true,
+                onClick: this.handleAdd.bind(this),
+                label: '新增'
+              })}
+            </div>
+          </div>
+        ) : null}
+
+        {srcType === 'variable' ? (
+          <div>
+            {render(
+              'variable',
+              getSchemaTpl('sourceBindControl', {
+                label: tipedLabel(
+                  '关联数据',
+                  '根据该数据来动态重复渲染所配置的选项卡'
+                )
+              }),
+              {
+                onChange: this.handleVariableChange
+              }
+            )}
+            {render('titleSchema', {
+              title: '基本',
+              label: '点击配置标签页标题模板',
+              type: 'button',
+              level: 'enhance',
+              size: 'sm',
+              name: 'titleSchema',
+              block: true,
+              onClick: this.editTabSchema.bind(this, 'title')
+            })}
+            {render('tabSchema', {
+              title: '基本',
+              label: '点击配置标签页内容模板',
+              type: 'button',
+              level: 'enhance',
+              size: 'sm',
+              block: true,
+              name: 'tabSchema',
+              onClick: this.editTabSchema.bind(this, 'tab')
+            })}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+}
+
+@FormItem({type: 'ae-tabsControl', renderLabel: false})
+export class TabsControlRenderer extends React.Component<TabsControlProps> {
+  render() {
+    return <TabsControl {...this.props} />;
+  }
+}

--- a/packages/amis-ui/scss/components/_tabs.scss
+++ b/packages/amis-ui/scss/components/_tabs.scss
@@ -402,6 +402,10 @@
           }
         }
       }
+
+      .cxd-Tabs-addable {
+        height: max-content;
+      }
     }
 
     > .#{$ns}Tabs-content {

--- a/packages/amis-ui/src/components/Tabs.tsx
+++ b/packages/amis-ui/src/components/Tabs.tsx
@@ -5,7 +5,13 @@
  */
 
 import React from 'react';
-import {ClassName, localeable, LocaleProps, Schema} from 'amis-core';
+import {
+  ClassName,
+  evalExpression,
+  localeable,
+  LocaleProps,
+  Schema
+} from 'amis-core';
 import Transition, {ENTERED, ENTERING} from 'react-transition-group/Transition';
 import {themeable, ThemeProps, noop} from 'amis-core';
 import {uncontrollable} from 'amis-core';
@@ -40,7 +46,7 @@ export type TabsMode =
   | 'sidebar';
 
 export interface TabProps extends ThemeProps {
-  title?: string | React.ReactNode; // 标题
+  title?: React.ReactNode; // 标题
   icon?: string;
   iconPosition?: 'left' | 'right';
   disabled?: boolean | string;
@@ -175,10 +181,11 @@ export interface TabsProps extends ThemeProps, LocaleProps {
   editable?: boolean;
   onEdit?: (index: number, text: string) => void;
   sidePosition?: 'left' | 'right';
-  addBtnText?: string;
+  addBtnText?: React.ReactNode;
   collapseOnExceed?: number;
-  collapseBtnLabel?: string;
+  collapseBtnLabel?: React.ReactNode;
   popOverContainer?: any;
+  tipSchema?: string | null;
   children?: React.ReactNode | Array<React.ReactNode>;
 }
 
@@ -585,7 +592,8 @@ export class Tabs extends React.Component<TabsProps, any> {
       draggable,
       showTip,
       showTipClassName,
-      editable
+      editable,
+      tipSchema
     } = this.props;
 
     const {
@@ -607,7 +615,6 @@ export class Tabs extends React.Component<TabsProps, any> {
       activeKeyProp === undefined && index === 0 ? eventKey : activeKeyProp;
 
     const iconElement = <Icon cx={cx} icon={icon} className="Icon" />;
-
     const link = (
       <a title={typeof title === 'string' ? title : undefined}>
         {editable && editingIndex === index ? (
@@ -645,7 +652,6 @@ export class Tabs extends React.Component<TabsProps, any> {
         )}
       </a>
     );
-
     return (
       <li
         className={cx(
@@ -665,7 +671,9 @@ export class Tabs extends React.Component<TabsProps, any> {
         {showTip ? (
           <TooltipWrapper
             placement="top"
-            tooltip={tip ?? (typeof title === 'string' ? title : '')}
+            tooltip={
+              tip ?? tipSchema ?? (typeof title === 'string' ? title : '')
+            }
             trigger="hover"
             tooltipClassName={showTipClassName}
           >
@@ -836,7 +844,6 @@ export class Tabs extends React.Component<TabsProps, any> {
       addBtnText,
       mobileUI
     } = this.props;
-
     const {isOverflow} = this.state;
     if (!Array.isArray(children)) {
       return null;

--- a/packages/amis/__tests__/renderers/Tabs.test.tsx
+++ b/packages/amis/__tests__/renderers/Tabs.test.tsx
@@ -1,6 +1,6 @@
 /**
  * 组件名称：Tabs 选项卡
- * 
+ *
  * 单测内容：
  1. 点击切换
  2. 各种展示模式
@@ -14,6 +14,7 @@
  10. disabled 可禁用
  11. tabs 作为表单项
  12. collapseOnExceed 配置超出折叠
+ 13. 新增tab支持通过 addedTabSchema 统一配置
  */
 
 import {
@@ -544,4 +545,87 @@ test('Renderer:tabs with collapseOnExceed', async () => {
   expect(
     container.querySelector('.is-active.cxd-Tabs-pane')!
   ).toHaveTextContent('Content 5');
+});
+
+// 13. addedTabSchema
+test('Renderer:tabs addedTabSchema', async () => {
+  const {container, getByText} = render(
+    amisRender(
+      {
+        type: 'tabs',
+        closable: true,
+        addable: true,
+        addBtnText: '新增Tab',
+        addedTabSchema: {
+          title: '我是新增的title',
+          tab: [
+            {
+              type: 'input-text',
+              value: '我是新增的body'
+            }
+          ]
+        },
+        tabs: [
+          {
+            title: 'Tab 1',
+            tab: 'Content 1',
+            closable: false
+          },
+          {
+            title: 'Tab 2',
+            tab: 'Content 2'
+          }
+        ]
+      },
+      {},
+      makeEnv()
+    )
+  );
+
+  fireEvent.click(getByText('新增Tab'));
+  await waitFor(() => {
+    getByText('我是新增的title');
+  });
+  expect(!getByText('我是新增的title')).toBeFalsy();
+  const inputElement = container.querySelector('input[type="text"]') as any;
+  expect(inputElement?.value).toBe('我是新增的body');
+});
+
+// 14. 通过 source 获取数据，配合titleSchema/tabSchema
+test('Renderer:tabs source', async () => {
+  const {getByText} = render(
+    amisRender(
+      {
+        type: 'page',
+        data: {
+          arr: [
+            {
+              a: '收入',
+              b: 199
+            },
+
+            {
+              a: '支出',
+              b: 299
+            }
+          ]
+        },
+        body: [
+          {
+            type: 'tabs',
+            source: '${arr}',
+            titleSchema: '${a}',
+            tabSchema: {
+              type: 'tpl',
+              tpl: '金额：${b|number}元'
+            }
+          }
+        ]
+      },
+      {},
+      makeEnv()
+    )
+  );
+  expect(!getByText('收入')).toBeFalsy();
+  expect(!getByText('支出')).toBeFalsy();
 });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5d6c18f</samp>

This pull request enhances the `Tabs` component and its schema with various new features and options, such as custom tooltips, schemas, and expressions. It also adds a test case and fixes a typo.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5d6c18f</samp>

> _Oh we are the coders of the `Tabs` component_
> _We add new features and options with our talent_
> _We use `tipTpl` and `evalExpression` to make it fancy_
> _And we test our code with care, so pull it if you can, see_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5d6c18f</samp>

*  Import `evalExpression` function from `amis-core` to evaluate expressions in `Tabs` component and schema ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-a8528873d96ea45fbce88fecf2afa9ce19691b42a5208772b24767f6c85b549eL8-R14), [link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL2-R7))
*  Add `tipTpl` property to `TabsProps`, `TabsState`, and `TabsSchema` interfaces to allow passing a template for the tab title tooltip ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-a8528873d96ea45fbce88fecf2afa9ce19691b42a5208772b24767f6c85b549eL178-R188), [link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-a8528873d96ea45fbce88fecf2afa9ce19691b42a5208772b24767f6c85b549eL588-R596), [link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aR220-R238), [link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL235-R263), [link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL278-R319))
*  Add `tipTpl` property to `TooltipWrapper` component props and `CTabs` component props to pass the tooltip template ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-a8528873d96ea45fbce88fecf2afa9ce19691b42a5208772b24767f6c85b549eL668-R675), [link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL760-R843), [link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL777-R864))
*  Evaluate `tipTpl` property using `evalExpression` and `resolveVariableAndFilter` functions and store the result in `resolvedTiptpl` variable ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aR853-R858))
*  Add `addedTabSchema` property to `TabsSchema` interface to allow configuring the schema for the added tab ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aR220-R238))
*  Modify `handleAdd` method in `Tabs` component to use `addedTabSchema` property if provided, or the default schema otherwise, when adding a new tab ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL559-R623))
*  Add `titleSchema` and `tabSchema` properties to `TabsState` and `TabsSchema` interfaces to allow configuring the title and content of the tabs from the source data ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aR220-R238), [link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL235-R263), [link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL278-R319))
*  Add `titleSchema` and `tabSchema` properties to `Tabs` component constructor and state and pass them to `initTabArray` method ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL256-R283), [link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL278-R319))
*  Modify `initTabArray` method in `Tabs` component to generate the tabs from the source data using `titleSchema` and `tabSchema` properties, and handle the cases when the tabs or the source data are empty or invalid ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL297-R363))
*  Compare `titleSchema` and `tabSchema` properties in `shallowEquals` function call and pass them to `initTabArray` method when updating the local tabs state ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL364-R416), [link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL372-R436))
*  Modify `renderTabTitle` method in `Tabs` component to render `titleSchema` property as a schema object and pass the `index` and `data` properties to the `render` function ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL712-R783))
*  Add `renderAddBtn` method in `Tabs` component to render `addBtnText` property as a schema object or a string and pass it to the `render` function ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aR796-R807))
*  Change the type of `addBtnText` property in `TabsSchema` interface to allow passing a schema object as well as a string ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL190-R195))
*  Change the type of `collapseOnExceed` property in `TabsSchema` interface to allow passing a string expression as well as a number ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL205-R210))
*  Evaluate `collapseOnExceed` property using `evalExpression` and `resolveVariableAndFilter` functions and store the result in `resolvedCollapseOnExceed` variable ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aR853-R858))
*  Replace `addBtnText` prop with `renderAddBtn` method call and `collapseOnExceed` prop with `resolvedCollapseOnExceed` variable in `CTabs` component render ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL869-R956), [link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL891-R981))
*  Add `add` event to `TabsRendererEvent` type and `changeActiveKey` action to `TabsRendererAction` type ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL235-R263))
*  Add a test case for `Tabs` component to check the `addedTabSchema` feature in `packages/amis/__tests__/renderers/Tabs.test.tsx` ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-897696757facadc600df91bd88b3550092101bb0d13ceaef92e22628021f01cdR17), [link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-897696757facadc600df91bd88b3550092101bb0d13ceaef92e22628021f01cdR549-R592))
*  Remove some empty lines for formatting purposes ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-a8528873d96ea45fbce88fecf2afa9ce19691b42a5208772b24767f6c85b549eL648), [link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-a8528873d96ea45fbce88fecf2afa9ce19691b42a5208772b24767f6c85b549eL839))
*  Fix a typo in a comment in `packages/amis/__tests__/renderers/Tabs.test.tsx` ([link](https://github.com/baidu/amis/pull/8041/files?diff=unified&w=0#diff-897696757facadc600df91bd88b3550092101bb0d13ceaef92e22628021f01cdL3-R3))
