### PR TITLE
fix: Select组件 Tree 模式下搜索点击选项不能正常关闭下拉浮层问题

### DIFF
--- a/docs/zh-CN/components/form/select.md
+++ b/docs/zh-CN/components/form/select.md
@@ -10,7 +10,7 @@ order: 48
 
 ## 基本用法
 
-参考 [Options](options)
+参考 [Options 选择器表单项](options)
 
 ## 自定义菜单
 
@@ -42,6 +42,7 @@ order: 48
 }
 ```
 
+## 展示模式
 ### 分组展示模式
 
 _单选_
@@ -55,6 +56,7 @@ _单选_
       "label": "分组",
       "type": "select",
       "name": "a",
+      "searchable": true,
       "selectMode": "group",
       "options": [
         {
@@ -114,6 +116,7 @@ _多选_
       "type": "select",
       "name": "a",
       "multiple": true,
+      "searchable": true,
       "selectMode": "group",
       "options": [
         {
@@ -176,6 +179,7 @@ _单选_
       "label": "表格形式",
       "type": "select",
       "name": "a",
+      "searchable": true,
       "selectMode": "table",
       "columns": [
         {
@@ -235,6 +239,7 @@ _多选_
       "label": "表格形式",
       "type": "select",
       "name": "a",
+      "searchable": true,
       "selectMode": "table",
       "multiple": true,
       "columns": [
@@ -297,6 +302,7 @@ _单选_
       "label": "树型展示",
       "type": "select",
       "name": "a",
+      "searchable": true,
       "selectMode": "tree",
       "options": [
         {
@@ -355,6 +361,7 @@ _多选_
       "label": "树型展示",
       "type": "select",
       "name": "a",
+      "searchable": true,
       "multiple": true,
       "selectMode": "tree",
       "options": [
@@ -418,6 +425,7 @@ _单选_
       "label": "级联选择",
       "type": "select",
       "name": "a",
+      "searchable": true,
       "selectMode": "chained",
       "options": [
         {
@@ -476,6 +484,7 @@ _多选_
       "label": "级联选择",
       "type": "select",
       "name": "a",
+      "searchable": true,
       "selectMode": "chained",
       "multiple": true,
       "options": [
@@ -524,7 +533,7 @@ _多选_
 }
 ```
 
-### 支持搜索
+## 支持搜索
 
 ```schema: scope="body"
 {
@@ -643,7 +652,43 @@ _多选_
 }
 ```
 
-### 延时加载
+### searchApi
+
+**发送**
+
+默认 GET，携带 term 变量，值为搜索框输入的文字，可从上下文中取数据设置进去。
+
+**响应**
+
+格式要求如下：
+
+```json
+{
+  "status": 0,
+  "msg": "",
+  "data": {
+    "options": [
+      {
+        "label": "描述",
+        "value": "值" // ,
+        // "children": [] // 可以嵌套
+      },
+
+      {
+        "label": "描述2",
+        "value": "值2"
+      }
+    ],
+
+    "value": "值" // 默认值，可以获取列表的同时设置默认值。
+  }
+}
+```
+
+适用于需选择的数据/信息源较多时，用户可直观的知道自己所选择的数据/信息的场景，一般左侧框为数据/信息源，右侧为已选数据/信息，被选中信息同时存在于 2 个框内。
+
+
+## 延时加载
 
 选型设置 defer: true，结合配置组件层的 `deferApi` 来实现。
 
@@ -696,7 +741,7 @@ _多选_
 }
 ```
 
-### 关联选择模式
+## 关联选择模式
 
 分为左右两部分，左边点选后关联出现右边。左右都可以配置展示模式。
 
@@ -1117,41 +1162,6 @@ leftOptions 动态加载，默认 source 接口是返回 options 部分，而 le
   }
 }
 ```
-
-## searchApi
-
-**发送**
-
-默认 GET，携带 term 变量，值为搜索框输入的文字，可从上下文中取数据设置进去。
-
-**响应**
-
-格式要求如下：
-
-```json
-{
-  "status": 0,
-  "msg": "",
-  "data": {
-    "options": [
-      {
-        "label": "描述",
-        "value": "值" // ,
-        // "children": [] // 可以嵌套
-      },
-
-      {
-        "label": "描述2",
-        "value": "值2"
-      }
-    ],
-
-    "value": "值" // 默认值，可以获取列表的同时设置默认值。
-  }
-}
-```
-
-适用于需选择的数据/信息源较多时，用户可直观的知道自己所选择的数据/信息的场景，一般左侧框为数据/信息源，右侧为已选数据/信息，被选中信息同时存在于 2 个框内。
 
 ## 多选全选
 

--- a/packages/amis-ui/src/components/Transfer.tsx
+++ b/packages/amis-ui/src/components/Transfer.tsx
@@ -379,8 +379,13 @@ export class Transfer<
 
   // 树搜索处理
   @autobind
-  handleSearchTreeChange(values: Array<Option>, searchOptions: Array<Option>) {
-    const {onChange, value, valueField = 'value', multiple} = this.props;
+  handleSearchTreeChange(
+    values: Array<Option>,
+    searchOptions: Array<Option>,
+    props: TransferProps
+  ) {
+    /** TransferDropDown的renderSearchResult&renderOptions中对一些属性覆写了  */
+    const {value, valueField = 'value', multiple, onChange} = props;
     const searchAvailableOptions = this.getFlattenArr(searchOptions);
     values = Array.isArray(values) ? values : values ? [values] : [];
 
@@ -605,7 +610,7 @@ export class Transfer<
         value={value}
         disabled={disabled}
         onChange={(value: Array<any>) =>
-          this.handleSearchTreeChange(value, options)
+          this.handleSearchTreeChange(value, options, props)
         }
         joinValues={false}
         showIcon={false}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f44d37c</samp>

This pull request enhances the search functionality of the `select` and `Transfer` components in amis. It adds and updates documentation for the `searchable` and `searchApi` properties of the `select` component in Chinese. It also enables the `Transfer` component to customize the search tree behavior by passing overwritten properties to the `handleSearchTreeChange` method.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f44d37c</samp>

> _Oh we are the coders of the amis site_
> _We document and update with all our might_
> _We make the `select` and `transfer` components shine_
> _With `searchable` and `searchApi` in every line_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f44d37c</samp>

*  Add the `searchable` property to the select component examples in the documentation to enable the search function ([link](https://github.com/baidu/amis/pull/8046/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2R59), [link](https://github.com/baidu/amis/pull/8046/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2R119), [link](https://github.com/baidu/amis/pull/8046/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2R182), [link](https://github.com/baidu/amis/pull/8046/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2R242), [link](https://github.com/baidu/amis/pull/8046/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2R305), [link](https://github.com/baidu/amis/pull/8046/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2R364), [link](https://github.com/baidu/amis/pull/8046/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2R428), [link](https://github.com/baidu/amis/pull/8046/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2R487))
* Update the link text for the Options component to match the Chinese title of the corresponding page ([link](https://github.com/baidu/amis/pull/8046/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2L13-R13))
* Add a new section title for the display mode of the select component in the documentation ([link](https://github.com/baidu/amis/pull/8046/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2R45))
* Change the section titles for the support search feature and the related select mode of the cascade select from code blocks to heading level 2 in the documentation ([link](https://github.com/baidu/amis/pull/8046/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2L527-R536), [link](https://github.com/baidu/amis/pull/8046/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2L699-R744))
* Add a new section title and content for the searchApi feature of the custom search function in the documentation ([link](https://github.com/baidu/amis/pull/8046/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2L646-R692))
* Remove the duplicated content for the searchApi feature from the section of customizing the dropdown area width and alignment in the documentation ([link](https://github.com/baidu/amis/pull/8046/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2L1121-L1155))
* Modify the `handleSearchTreeChange` method of the `Transfer` class to accept an additional parameter `props` from the `TransferDropDown` component ([link](https://github.com/baidu/amis/pull/8046/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L382-R388))
* Modify the `onChange` prop of the `Tree` component to pass the `props` parameter to the `handleSearchTreeChange` method ([link](https://github.com/baidu/amis/pull/8046/files?diff=unified&w=0#diff-bd55f7ae116bb2ea06e9970203ab802432a30d54cc04c7d9b5e3013489439a70L608-R613))
