### PR TITLE
 fix:图片缩略图支持fx取值;占位图fx获取不到值

### DIFF
--- a/packages/amis-editor/src/plugin/Image.tsx
+++ b/packages/amis-editor/src/plugin/Image.tsx
@@ -86,7 +86,6 @@ export class ImagePlugin extends BasePlugin {
                 ? null
                 : getSchemaTpl('imageUrl', {
                     name: 'src',
-                    type: 'input-text',
                     label: '缩略图地址',
                     description: '如果已绑定字段名，可以不用设置，支持用变量。'
                   }),

--- a/packages/amis/src/renderers/Image.tsx
+++ b/packages/amis/src/renderers/Image.tsx
@@ -474,6 +474,11 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
     let value = finnalSrc || getPropValue(this.props);
     const finnalHref = href ? filter(href, data, '| raw') : '';
 
+    const defaultValue =
+      defaultImage && !value
+        ? filter(defaultImage, data, '| raw')
+        : imagePlaceholder;
+
     return (
       <div
         className={cx(
@@ -493,14 +498,14 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
             thumbClassName={thumbClassName}
             height={height}
             width={width}
-            src={value ? value : defaultImage}
+            src={value ? value : defaultValue}
             href={finnalHref}
             title={filter(title, data)}
             caption={filter(imageCaption, data)}
             thumbMode={thumbMode}
             thumbRatio={thumbRatio}
             originalSrc={filter(originalSrc, data, '| raw') ?? value}
-            enlargeAble={enlargeAble && value !== defaultImage}
+            enlargeAble={enlargeAble && value !== defaultValue}
             onEnlarge={this.handleEnlarge}
             imageMode={imageMode}
           />


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58abc62</samp>

This pull request enhances the image renderer and editor in `amis`. It adds a `defaultImage` prop to handle missing or invalid image sources, and removes an unnecessary property from the `ImagePlugin` schema.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 58abc62</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The schema of the image plugin, and removed_
> _The needless type that cluttered the source field_
> _And made the code less elegant and clear._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 58abc62</samp>

*  Add `defaultImage` prop to `ImageField` component to allow users to specify a default image URL for the image renderer ([link](https://github.com/baidu/amis/pull/8049/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9R477-R481))
*  Use `defaultValue` variable to show the default image or a placeholder image when the `value` prop is falsy in the `img` element and the `ImageComponent` ([link](https://github.com/baidu/amis/pull/8049/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9L496-R501), [link](https://github.com/baidu/amis/pull/8049/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9L503-R508))
*  Remove redundant `type: 'input-text'` property from the `src` field of the `ImagePlugin` schema in `Image.tsx` ([link](https://github.com/baidu/amis/pull/8049/files?diff=unified&w=0#diff-080f970ff41a9d0e1619e4d8d2190127b7b241f179ed33b91f4f0fe48475fd41L89))
