### PR TITLE
styles: 分割线默认样式为实线

### DIFF
--- a/packages/amis/__tests__/renderers/Form/__snapshots__/combo.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/combo.test.tsx.snap
@@ -1631,7 +1631,7 @@ exports[`Renderer:combo with items & multiLine 1`] = `
           />
         </div>
         <div
-          class="cxd-Divider cxd-Divider--dashed"
+          class="cxd-Divider cxd-Divider--solid"
         />
         <div
           class="cxd-Form-item cxd-Form-item--horizontal"

--- a/packages/amis/__tests__/renderers/__snapshots__/Action.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Action.test.tsx.snap
@@ -180,7 +180,7 @@ exports[`Renderers:Action all levels 1`] = `
             </span>
           </button>
           <div
-            class="cxd-Divider cxd-Divider--dashed"
+            class="cxd-Divider cxd-Divider--solid"
           />
           <div
             class="cxd-Button cxd-Button--link cxd-Button--size-default is-disabled"

--- a/packages/amis/__tests__/renderers/__snapshots__/GridNav.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/GridNav.test.tsx.snap
@@ -108,7 +108,7 @@ exports[`Renderer:gridnav 1`] = `
             </div>
           </div>
           <div
-            class="cxd-Divider cxd-Divider--dashed"
+            class="cxd-Divider cxd-Divider--solid"
           />
           <div
             class="cxd-GridNav  cxd-GridNav-top u-hairline"

--- a/packages/amis/__tests__/renderers/__snapshots__/Image.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Image.test.tsx.snap
@@ -472,7 +472,7 @@ exports[`Renderer:images images:basic 1`] = `
             </div>
           </div>
           <div
-            class="cxd-Divider cxd-Divider--dashed"
+            class="cxd-Divider cxd-Divider--solid"
           />
           <div
             class="cxd-ImagesField"

--- a/packages/amis/src/renderers/Divider.tsx
+++ b/packages/amis/src/renderers/Divider.tsx
@@ -19,7 +19,7 @@ export interface DividerProps
 export default class Divider extends React.Component<DividerProps, object> {
   static defaultProps: Pick<DividerProps, 'className' | 'lineStyle'> = {
     className: '',
-    lineStyle: 'dashed'
+    lineStyle: 'solid'
   };
 
   render() {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e63dd1</samp>

Changed the default `lineStyle` of the `Divider` component to `solid` in `packages/amis/src/renderers/Divider.tsx`. This improved the visibility and consistency of the UI design.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8e63dd1</samp>

> _`lineStyle` changes_
> _Divider now solid, clear_
> _Winter clarity_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8e63dd1</samp>

* Changed the default value of the `lineStyle` prop for the `Divider` component from `dashed` to `solid` to improve visibility and consistency ([link](https://github.com/baidu/amis/pull/8052/files?diff=unified&w=0#diff-2b4abdb9c1e1ff34f56e1905b7e5b25fe4ecc472d34817411bec72f4f926c02fL22-R22))
