### PR TITLE
fix: 修复 table 组件提前映射了 lable, 导致 label 使用数据容器获取到的远程数据时无法正确获取到值的问题

### DIFF
--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -1023,10 +1023,7 @@ export const TableStore = iRendererStore
             pristine: item.pristine || item,
             toggled: item.toggled !== false,
             breakpoint: item.breakpoint,
-            /** 提前映射变量，方便后续view中使用 */
-            label: isPureVariable(item.label)
-              ? resolveVariableAndFilter(item.label, self.data)
-              : item.label
+            isPrimary: index === PARTITION_INDEX
           };
         });
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d4ab72</samp>

Removed `label` property from column object in `packages/amis-core/src/store/table.ts` to fix a bug with `columnsTogglable` option. This change simplifies the column data structure and avoids variable conflicts.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6d4ab72</samp>

> _`label` property_
> _causes bug in table columns_
> _removed in springtime_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6d4ab72</samp>

* Remove `label` property from column object to fix variable resolution bug ([link](https://github.com/baidu/amis/pull/8056/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL993-R993))
