### PR TITLE
fix: 修复表单组件的展示态/输入态无法通过 action 切换的问题

### DIFF
--- a/packages/amis/src/renderers/Form/StaticHoc.tsx
+++ b/packages/amis/src/renderers/Form/StaticHoc.tsx
@@ -93,7 +93,12 @@ export function supportStatic<T extends FormControlProps>() {
     const original = descriptor.value;
     descriptor.value = function (...args: any[]) {
       const props = (this as TypedPropertyDescriptor<any> & {props: T}).props;
-      if (props.static) {
+
+      const staticState = props.statusStore.staticState[props.$schema.id];
+      const isStatic =
+        typeof staticState === 'boolean' ? staticState : props.static;
+
+      if (isStatic) {
         const {
           render,
           staticSchema,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a7c9393</samp>

Added `staticState` variable and modified `isStatic` condition in `supportStatic` function to enable dynamic static mode for form components based on `statusStore` value. This change affects the file `StaticHoc.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a7c9393</samp>

> _`staticState` added_
> _Switch form mode with store value_
> _Autumn leaves change too_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a7c9393</samp>

*  Add a new variable `staticState` to get the static state from the `statusStore` prop ([link](https://github.com/baidu/amis/pull/8057/files?diff=unified&w=0#diff-6743296e062555d6d5ef1ffa806450e07b74989e2b2bcc829517a34a8560e918L96-R101))
*  Modify the condition for `isStatic` to use `staticState` if defined, or fallback to `props.static` otherwise ([link](https://github.com/baidu/amis/pull/8057/files?diff=unified&w=0#diff-6743296e062555d6d5ef1ffa806450e07b74989e2b2bcc829517a34a8560e918L96-R101))
*  Enable dynamic switching between static and editable modes for form components based on the `statusStore` value ([link](https://github.com/baidu/amis/pull/8057/files?diff=unified&w=0#diff-6743296e062555d6d5ef1ffa806450e07b74989e2b2bcc829517a34a8560e918L96-R101))
