### PR TITLE
fix: ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ npm test --workspaces
 # 测试某个用例
 # <spec-name>为用例名称，比如inputImage
 npm test --workspace amis <spec-name>
+npm test --workspace amis inputDate
+npm test --workspace amis dateRange
 
 # 查看测试用例覆盖率
 npm run coverage

--- a/packages/amis/src/renderers/Form/StaticHoc.tsx
+++ b/packages/amis/src/renderers/Form/StaticHoc.tsx
@@ -93,7 +93,8 @@ export function supportStatic<T extends FormControlProps>() {
     const original = descriptor.value;
     descriptor.value = function (...args: any[]) {
       const props = (this as TypedPropertyDescriptor<any> & {props: T}).props;
-      if (props.static) {
+      const isStatic = !!props.static;
+      if (isStatic) {
         const {
           render,
           staticSchema,


### PR DESCRIPTION
FAIL: Renderer:inputDate with shortcuts
FAIL: Renderer:dateRange with relative default

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bce4b03</samp>

This pull request modifies the GitHub workflow and the `README.md` file to run and document two specific test cases for the `amis` workspace. This is for debugging and testing purposes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bce4b03</samp>

> _`test` step modified_
> _only `amis` tests run_
> _autumn debugging_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bce4b03</samp>

*  Modify the `test` step in the GitHub workflow to run only two specific test cases for the `amis` workspace ([link](https://github.com/baidu/amis/pull/8060/files?diff=unified&w=0#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eL46-R52))
*  Update the `README.md` file to document the commands to run the two specific test cases for the `amis` workspace ([link](https://github.com/baidu/amis/pull/8060/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R67-R68))
