### PR TITLE
feat(amis-editor): Select, Checkboxes, InputTree & TreeSelect组件新增、编辑、删除控件

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Checkboxes.tsx
+++ b/packages/amis-editor/src/plugin/Form/Checkboxes.tsx
@@ -191,27 +191,16 @@ export class CheckboxesControlPlugin extends BasePlugin {
               getSchemaTpl('optionControlV2', {
                 multiple: true
               }),
-              getSchemaTpl('creatable', {
-                formType: 'extend',
-                hiddenOnDefault: true,
-                form: {
-                  body: [getSchemaTpl('createBtnLabel'), getSchemaTpl('addApi')]
-                }
+              /** 新增选项 */
+              getSchemaTpl('optionAddControl', {
+                manager: this.manager
               }),
-              getSchemaTpl('editable', {
-                formType: 'extend',
-                hiddenOnDefault: true,
-                form: {
-                  body: [getSchemaTpl('editApi')]
-                }
+              /** 编辑选项 */
+              getSchemaTpl('optionEditControl', {
+                manager: this.manager
               }),
-              getSchemaTpl('removable', {
-                formType: 'extend',
-                hiddenOnDefault: true,
-                form: {
-                  body: [getSchemaTpl('deleteApi')]
-                }
-              })
+              /** 删除选项 */
+              getSchemaTpl('optionDeleteControl')
             ]
           },
           getSchemaTpl('status', {isFormItem: true}),

--- a/packages/amis-editor/src/plugin/Form/InputTree.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTree.tsx
@@ -444,41 +444,54 @@ export class TreeControlPlugin extends BasePlugin {
                 label: '只可选择叶子节点',
                 name: 'onlyLeaf'
               }),
-              getSchemaTpl('creatable', {
-                formType: 'extend',
-                hiddenOnDefault: true,
-                label: '可新增',
-                form: {
-                  body: [
-                    getSchemaTpl('switch', {
-                      label: '顶层可新增',
-                      value: true,
-                      name: 'rootCreatable'
-                    }),
-                    {
-                      type: 'input-text',
-                      label: '顶层文案',
-                      value: '添加一级节点',
-                      name: 'rootCreateTip',
-                      hiddenOn: '!data.rootCreatable'
-                    },
-                    getSchemaTpl('addApi')
-                  ]
-                }
+              /** 新增选项 */
+              getSchemaTpl('optionAddControl', {
+                manager: this.manager,
+                replace: true,
+                collections: [
+                  getSchemaTpl('switch', {
+                    label: '顶层可新增',
+                    value: true,
+                    name: 'rootCreatable'
+                  }),
+                  {
+                    type: 'input-text',
+                    label: '根节点文案',
+                    value: '添加一级节点',
+                    name: 'rootCreateTip',
+                    hiddenOn: '!data.rootCreatable'
+                  },
+                  {
+                    type: 'input-text',
+                    label: '新增文案提示',
+                    value: '添加子节点',
+                    name: 'createTip'
+                  }
+                ]
               }),
-              getSchemaTpl('editable', {
-                formType: 'extend',
-                hiddenOnDefault: true,
-                form: {
-                  body: [getSchemaTpl('editApi')]
-                }
+              /** 编辑选项 */
+              getSchemaTpl('optionEditControl', {
+                manager: this.manager,
+                collections: [
+                  {
+                    type: 'input-text',
+                    label: '编辑文案提示',
+                    value: '编辑该节点',
+                    name: 'editTip'
+                  }
+                ]
               }),
-              getSchemaTpl('removable', {
-                formType: 'extend',
-                hiddenOnDefault: true,
-                form: {
-                  body: [getSchemaTpl('deleteApi')]
-                }
+              /** 删除选项 */
+              getSchemaTpl('optionDeleteControl', {
+                manager: this.manager,
+                collections: [
+                  {
+                    type: 'input-text',
+                    label: '删除文案提示',
+                    value: '移除该节点',
+                    name: 'removeTip'
+                  }
+                ]
               })
             ]
           },

--- a/packages/amis-editor/src/plugin/Form/Select.tsx
+++ b/packages/amis-editor/src/plugin/Form/Select.tsx
@@ -1,44 +1,68 @@
-import {EditorNodeType, getSchemaTpl} from 'amis-editor-core';
-import {registerEditorPlugin} from 'amis-editor-core';
-import {BasePlugin, BaseEventContext} from 'amis-editor-core';
+import React from 'react';
+import omit from 'lodash/omit';
+import {findObjectsWithKey} from 'amis-core';
+import {Button, Icon} from 'amis-ui';
+import {
+  registerEditorPlugin,
+  getSchemaTpl,
+  BasePlugin,
+  tipedLabel,
+  JSONPipeOut
+} from 'amis-editor-core';
 
-import {tipedLabel} from 'amis-editor-core';
 import {ValidatorTag} from '../../validator';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
-import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 import {resolveOptionType} from '../../util';
+
+import type {RendererProps} from 'amis';
+import type {
+  EditorNodeType,
+  RendererPluginAction,
+  RendererPluginEvent,
+  BaseEventContext
+} from 'amis-editor-core';
 
 export class SelectControlPlugin extends BasePlugin {
   static id = 'SelectControlPlugin';
+
   static scene = ['layout'];
-  // 关联渲染器名字
+
+  name = '下拉框';
+
+  panelTitle = '下拉框';
+
   rendererName = 'select';
+
+  icon = 'fa fa-th-list';
+
+  panelIcon = 'fa fa-th-list';
+
+  pluginIcon = 'select-plugin';
+
+  isBaseComponent = true;
+
+  panelJustify = true;
+
+  notRenderFormZone = true;
+
   $schema = '/schemas/SelectControlSchema.json';
 
-  // 组件名称
-  name = '下拉框';
-  isBaseComponent = true;
-  icon = 'fa fa-th-list';
-  pluginIcon = 'select-plugin';
   description = '支持多选，输入提示，可使用 source 获取选项';
+
   docLink = '/amis/zh-CN/components/form/select';
+
   tags = ['表单项'];
+
   scaffold = {
     type: 'select',
     label: '选项',
     name: 'select',
     options: [
-      {
-        label: '选项A',
-        value: 'A'
-      },
-
-      {
-        label: '选项B',
-        value: 'B'
-      }
+      {label: '选项A', value: 'A'},
+      {label: '选项B', value: 'B'}
     ]
   };
+
   previewSchema: any = {
     type: 'form',
     className: 'text-left',
@@ -50,10 +74,6 @@ export class SelectControlPlugin extends BasePlugin {
       }
     ]
   };
-
-  notRenderFormZone = true;
-
-  panelTitle = '下拉框';
 
   // 事件定义
   events: RendererPluginEvent[] = [
@@ -243,7 +263,6 @@ export class SelectControlPlugin extends BasePlugin {
     }
   ];
 
-  panelJustify = true;
   panelBodyCreator = (context: BaseEventContext) => {
     return getSchemaTpl('tabs', [
       {
@@ -302,51 +321,16 @@ export class SelectControlPlugin extends BasePlugin {
                 manager: this.manager,
                 onChange: (value: any) => {}
               }),
-              getSchemaTpl('creatable', {
-                formType: 'extend',
-                hiddenOnDefault: true,
-                form: {
-                  body: [
-                    getSchemaTpl('createBtnLabel'),
-                    getSchemaTpl('addApi')
-                    // {
-                    //   label: '按钮位置',
-                    //   name: 'valueType',
-                    //   type: 'button-group-select',
-                    //   size: 'sm',
-                    //   tiled: true,
-                    //   value: 'asUpload',
-                    //   mode: 'row',
-                    //   options: [
-                    //     {
-                    //       label: '顶部',
-                    //       value: ''
-                    //     },
-                    //     {
-                    //       label: '底部',
-                    //       value: ''
-                    //     },
-                    //   ],
-                    // },
-                  ]
-                }
+              /** 新增选项 */
+              getSchemaTpl('optionAddControl', {
+                manager: this.manager
               }),
-              getSchemaTpl('editable', {
-                type: 'ae-Switch-More',
-                formType: 'extend',
-                hiddenOnDefault: true,
-                form: {
-                  body: [getSchemaTpl('editApi')]
-                }
+              /** 编辑选项 */
+              getSchemaTpl('optionEditControl', {
+                manager: this.manager
               }),
-              getSchemaTpl('removable', {
-                type: 'ae-Switch-More',
-                formType: 'extend',
-                hiddenOnDefault: true,
-                form: {
-                  body: [getSchemaTpl('deleteApi')]
-                }
-              })
+              /** 删除选项 */
+              getSchemaTpl('optionDeleteControl')
             ]
           },
           {

--- a/packages/amis-editor/src/plugin/Form/TreeSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/TreeSelect.tsx
@@ -447,41 +447,53 @@ export class TreeSelectControlPlugin extends BasePlugin {
                 label: '只可选择叶子节点',
                 name: 'onlyLeaf'
               }),
-              getSchemaTpl('creatable', {
-                formType: 'extend',
-                hiddenOnDefault: true,
-                label: '可新增',
-                form: {
-                  body: [
-                    getSchemaTpl('switch', {
-                      label: '顶层可新增',
-                      value: true,
-                      name: 'rootCreatable'
-                    }),
-                    {
-                      type: 'input-text',
-                      label: '顶层文案',
-                      value: '添加一级节点',
-                      name: 'rootCreateTip',
-                      hiddenOn: '!data.rootCreatable'
-                    },
-                    getSchemaTpl('addApi')
-                  ]
-                }
+              /** 新增选项 */
+              getSchemaTpl('optionAddControl', {
+                manager: this.manager,
+                collections: [
+                  getSchemaTpl('switch', {
+                    label: '顶层可新增',
+                    value: true,
+                    name: 'rootCreatable'
+                  }),
+                  {
+                    type: 'input-text',
+                    label: '根节点文案',
+                    value: '添加一级节点',
+                    name: 'rootCreateTip',
+                    hiddenOn: '!data.rootCreatable'
+                  },
+                  {
+                    type: 'input-text',
+                    label: '新增文案提示',
+                    value: '添加子节点',
+                    name: 'createTip'
+                  }
+                ]
               }),
-              getSchemaTpl('editable', {
-                formType: 'extend',
-                hiddenOnDefault: true,
-                form: {
-                  body: [getSchemaTpl('editApi')]
-                }
+              /** 编辑选项 */
+              getSchemaTpl('optionEditControl', {
+                manager: this.manager,
+                collections: [
+                  {
+                    type: 'input-text',
+                    label: '编辑文案提示',
+                    value: '编辑该节点',
+                    name: 'editTip'
+                  }
+                ]
               }),
-              getSchemaTpl('removable', {
-                formType: 'extend',
-                hiddenOnDefault: true,
-                form: {
-                  body: [getSchemaTpl('deleteApi')]
-                }
+              /** 删除选项 */
+              getSchemaTpl('optionDeleteControl', {
+                manager: this.manager,
+                collections: [
+                  {
+                    type: 'input-text',
+                    label: '删除文案提示',
+                    value: '移除该节点',
+                    name: 'removeTip'
+                  }
+                ]
               })
             ]
           },

--- a/packages/amis-editor/src/renderer/OptionControl.tsx
+++ b/packages/amis-editor/src/renderer/OptionControl.tsx
@@ -815,9 +815,38 @@ export default class OptionControl extends React.Component<
     this.setState({valueField}, this.onChange);
   }
 
+  /** 获取功能性字段控件 schema */
+  getFuncFieldSchema(): Record<string, any>[] {
+    const {labelField, valueField} = this.state;
+
+    return [
+      {
+        label: tipedLabel(
+          '显示字段',
+          '选项文本对应的数据字段，多字段合并请通过模板配置'
+        ),
+        type: 'input-text',
+        name: 'labelField',
+        clearable: true,
+        value: labelField,
+        placeholder: '选项文本对应的字段',
+        onChange: this.handleLableFieldChange
+      },
+      {
+        label: '值字段',
+        type: 'input-text',
+        name: 'valueField',
+        clearable: true,
+        value: valueField,
+        placeholder: '值对应的字段',
+        onChange: this.handleValueFieldChange
+      }
+    ];
+  }
+
   renderApiPanel() {
     const {render} = this.props;
-    const {source, api, labelField, valueField} = this.state;
+    const {source, api} = this.state;
 
     return render(
       'api',
@@ -830,27 +859,7 @@ export default class OptionControl extends React.Component<
         value: api,
         onChange: this.handleAPIChange,
         sourceType: source,
-        footer: [
-          {
-            label: tipedLabel(
-              '显示字段',
-              '选项文本对应的数据字段，多字段合并请通过模板配置'
-            ),
-            type: 'input-text',
-            name: 'labelField',
-            value: labelField,
-            placeholder: '选项文本对应的字段',
-            onChange: this.handleLableFieldChange
-          },
-          {
-            label: '值字段',
-            type: 'input-text',
-            name: 'valueField',
-            value: valueField,
-            placeholder: '值对应的字段',
-            onChange: this.handleValueFieldChange
-          }
-        ]
+        footer: this.getFuncFieldSchema()
       })
     );
   }
@@ -863,6 +872,7 @@ export default class OptionControl extends React.Component<
       <div className={cx('ae-OptionControl', className)}>
         {this.renderHeader()}
 
+        {/* 自定义选项 */}
         {source === 'custom' ? (
           <div className="ae-OptionControl-wrapper">
             {Array.isArray(options) && options.length ? (
@@ -890,21 +900,24 @@ export default class OptionControl extends React.Component<
           </div>
         ) : null}
 
+        {/* API 接口 */}
         {source === 'api' || source === 'apicenter'
           ? this.renderApiPanel()
           : null}
 
+        {/* 上下文变量 */}
         {source === 'variable'
-          ? render(
-              'variable',
-              getSchemaTpl('sourceBindControl', {
-                label: false,
-                className: 'ae-ExtendMore'
-              }),
-              {
-                onChange: this.handleAPIChange
-              }
-            )
+          ? render('variable', {
+              type: 'control',
+              label: false,
+              className: 'ae-ExtendMore',
+              body: [
+                getSchemaTpl('sourceBindControl', {
+                  label: false,
+                  onChange: this.handleAPIChange
+                })
+              ].concat(this.getFuncFieldSchema())
+            })
           : null}
       </div>
     );

--- a/packages/amis-editor/src/tpl/options.tsx
+++ b/packages/amis-editor/src/tpl/options.tsx
@@ -1,14 +1,21 @@
+import React from 'react';
 import {
   setSchemaTpl,
   getSchemaTpl,
   defaultValue,
-  getI18nEnabled
+  getI18nEnabled,
+  tipedLabel,
+  JSONPipeOut
 } from 'amis-editor-core';
-import {tipedLabel} from 'amis-editor-core';
+import {findObjectsWithKey} from 'amis-core';
+import {Button, Icon} from 'amis-ui';
 import type {SchemaObject} from 'amis';
 import assign from 'lodash/assign';
 import cloneDeep from 'lodash/cloneDeep';
 import omit from 'lodash/omit';
+
+import type {RendererProps} from 'amis';
+import type {EditorManager} from 'amis-editor-core';
 
 setSchemaTpl('options', () => {
   const i18nEnabled = getI18nEnabled();
@@ -244,10 +251,10 @@ setSchemaTpl('addApi', () => {
 });
 
 setSchemaTpl('createBtnLabel', {
-  label: '按钮名称',
+  label: '新增按钮名称',
   name: 'createBtnLabel',
   type: 'input-text',
-  placeholder: '新建'
+  placeholder: '新增选项'
 });
 
 setSchemaTpl('editable', (schema: Partial<SchemaObject> = {}) => {
@@ -264,6 +271,15 @@ setSchemaTpl('editApi', () =>
   getSchemaTpl('apiControl', {
     label: '编辑接口',
     name: 'editApi',
+    mode: 'row',
+    visibleOn: 'data.editable'
+  })
+);
+
+setSchemaTpl('editInitApi', () =>
+  getSchemaTpl('apiControl', {
+    label: '编辑初始化接口',
+    name: 'editInitApi',
     mode: 'row',
     visibleOn: 'data.editable'
   })
@@ -445,4 +461,272 @@ setSchemaTpl('dataMap', {
       ]
     })
   ]
+});
+
+export interface OptionControlParams {
+  manager: EditorManager;
+  /** switch-more 控制器的配置 */
+  controlSchema?: Record<string, any>;
+  /** 子表单中的配置集合 */
+  collections?: Record<string, any>[];
+  /** 是否替换除了addControls以外的其他属性 */
+  replace?: boolean;
+}
+
+/**
+ * 选项类组件新增单选项控件
+ */
+setSchemaTpl('optionAddControl', (params: OptionControlParams) => {
+  const {manager, controlSchema = {}, collections = [], replace} = params || {};
+  const customFormItems = Array.isArray(collections)
+    ? collections
+    : [collections];
+
+  return getSchemaTpl('creatable', {
+    formType: 'extend',
+    autoFocus: false,
+    hiddenOnDefault: false,
+    ...controlSchema,
+    form: {
+      body: [
+        ...(replace
+          ? customFormItems
+          : [...customFormItems, getSchemaTpl('createBtnLabel')]),
+        getSchemaTpl('addApi'),
+        /** 用于关闭开关后清空相关配置 */
+        {
+          type: 'hidden',
+          name: 'addDialog'
+        },
+        {
+          name: 'addControls',
+          asFormItem: true,
+          label: false,
+          children: (props: RendererProps) => {
+            const {value, data: ctx, onBulkChange} = props || {};
+            const {addApi, createBtnLabel, addDialog, optionLabel} = ctx || {};
+            /** 新增表单弹窗 */
+            const scaffold = {
+              type: 'dialog',
+              title: createBtnLabel || `新增${optionLabel || '选项'}`,
+              ...addDialog,
+              body: {
+                /** 标识符，用于 SubEditor 确认后找到对应的 Schema */
+                'amis-select-addControls': true,
+                'type': 'form',
+                'api': addApi,
+                /** 这里是为了兼容旧版，比如type: text类型的组件会被渲染为input-text */
+                'controls': [
+                  ...(value
+                    ? Array.isArray(value)
+                      ? value
+                      : [value]
+                    : [
+                        /** FIXME: 这里是没做任何配置时的默认 scaffold */
+                        {
+                          type: 'input-text',
+                          name: 'label',
+                          label: false,
+                          required: true,
+                          placeholder: '请输入名称'
+                        }
+                      ])
+                ]
+              }
+            };
+
+            return (
+              <Button
+                className="w-full flex flex-col items-center"
+                level="enhance"
+                size="sm"
+                onClick={() => {
+                  manager.openSubEditor({
+                    title: '配置新增表单',
+                    value: scaffold,
+                    onChange: (value, diff: any) => {
+                      const pureSchema = JSONPipeOut(
+                        value,
+                        (key, propValue) =>
+                          key.substring(0, 2) === '__' || key === 'id'
+                      );
+                      const addDialog = omit(pureSchema, [
+                        'type',
+                        'body',
+                        'id'
+                      ]);
+                      const targetForm = findObjectsWithKey(
+                        pureSchema,
+                        'amis-select-addControls'
+                      );
+                      const addApi = targetForm?.[0]?.api;
+                      const addControls =
+                        targetForm?.[0]?.controls ?? targetForm?.[0]?.body;
+
+                      onBulkChange({addApi, addDialog, addControls});
+                    }
+                  });
+                }}
+              >
+                配置新增表单
+              </Button>
+            );
+          }
+        }
+        // {
+        //   label: '按钮位置',
+        //   name: 'valueType',
+        //   type: 'button-group-select',
+        //   size: 'sm',
+        //   tiled: true,
+        //   value: 'asUpload',
+        //   mode: 'row',
+        //   options: [
+        //     {
+        //       label: '顶部',
+        //       value: ''
+        //     },
+        //     {
+        //       label: '底部',
+        //       value: ''
+        //     },
+        //   ],
+        // }
+      ]
+    }
+  });
+});
+
+/**
+ * 选项类组件编辑单选项控件
+ */
+setSchemaTpl('optionEditControl', (params: OptionControlParams) => {
+  const {manager, controlSchema = {}, collections = [], replace} = params || {};
+  const customFormItems = Array.isArray(collections)
+    ? collections
+    : [collections];
+
+  return getSchemaTpl('editable', {
+    formType: 'extend',
+    autoFocus: false,
+    hiddenOnDefault: false,
+    ...controlSchema,
+    form: {
+      body: [
+        ...(replace ? customFormItems : [...customFormItems]),
+        getSchemaTpl('editInitApi'),
+        getSchemaTpl('editApi'),
+        /** 用于关闭开关后清空相关配置 */
+        {
+          type: 'hidden',
+          name: 'editDialog'
+        },
+        {
+          name: 'editControls',
+          asFormItem: true,
+          label: false,
+          children: (props: RendererProps) => {
+            const {value, data: ctx, onBulkChange} = props || {};
+            const {editApi, editInitApi, editDialog, optionLabel} = ctx || {};
+            /** 新增表单弹窗 */
+            const scaffold = {
+              type: 'dialog',
+              title: '编辑选项',
+              ...editDialog,
+              body: {
+                /** 标识符，用于 SubEditor 确认后找到对应的 Schema */
+                'amis-select-editControls': true,
+                'type': 'form',
+                'api': editApi,
+                'initApi': editInitApi,
+                /** 这里是为了兼容旧版，比如type: text类型的组件会被渲染为input-text */
+                'controls': [
+                  ...(value
+                    ? Array.isArray(value)
+                      ? value
+                      : [value]
+                    : [
+                        /** FIXME: 这里是没做任何配置时的默认 scaffold */
+                        {
+                          type: 'input-text',
+                          name: 'label',
+                          label: false,
+                          required: true,
+                          placeholder: '请输入名称'
+                        }
+                      ])
+                ]
+              }
+            };
+
+            return (
+              <Button
+                className="w-full flex flex-col items-center"
+                level="enhance"
+                size="sm"
+                onClick={() => {
+                  manager.openSubEditor({
+                    title: '配置编辑表单',
+                    value: scaffold,
+                    onChange: (value, diff: any) => {
+                      const pureSchema = JSONPipeOut(
+                        value,
+                        (key, propValue) =>
+                          key.substring(0, 2) === '__' || key === 'id'
+                      );
+                      const editDialog = omit(pureSchema, [
+                        'type',
+                        'body',
+                        'id'
+                      ]);
+                      const targetForm = findObjectsWithKey(
+                        pureSchema,
+                        'amis-select-editControls'
+                      );
+                      const editApi = targetForm?.[0]?.api;
+                      const editInitApi = targetForm?.[0]?.initApi;
+                      const editControls =
+                        targetForm?.[0]?.controls ?? targetForm?.[0]?.body;
+
+                      onBulkChange({
+                        editApi,
+                        editInitApi,
+                        editDialog,
+                        editControls
+                      });
+                    }
+                  });
+                }}
+              >
+                配置编辑表单
+              </Button>
+            );
+          }
+        }
+      ]
+    }
+  });
+});
+
+/**
+ * 选项类组件删除单选项控件
+ */
+setSchemaTpl('optionDeleteControl', (params: OptionControlParams) => {
+  const {manager, controlSchema = {}, collections = [], replace} = params || {};
+  const customFormItems = Array.isArray(collections)
+    ? collections
+    : [collections];
+
+  return getSchemaTpl('removable', {
+    formType: 'extend',
+    autoFocus: false,
+    hiddenOnDefault: false,
+    ...controlSchema,
+    form: {
+      body: [
+        ...(replace ? customFormItems : [...customFormItems]),
+        getSchemaTpl('deleteApi')
+      ]
+    }
+  });
 });

--- a/packages/amis-ui/scss/components/form/_checks.scss
+++ b/packages/amis-ui/scss/components/form/_checks.scss
@@ -708,6 +708,14 @@
     margin-right: 0;
     margin-bottom: 0;
   }
+
+  .#{$ns}Checkboxes-addBtn {
+    > svg {
+      width: px2rem(14px);
+      height: px2rem(14px);
+      margin-right: var(--Checkbox-gap);
+    }
+  }
 }
 
 .#{$ns}RadiosControl-group,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 045759e</samp>

This pull request refactors the option control logic for option-based components in `amis-editor`, such as `Select`, `Checkboxes`, `InputTree` and `TreeSelect`. It extracts the common schema logic for the option data and uses custom schema templates to replace the hard-coded properties for option management features. It also improves the code style and the UI of the option control components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 045759e</samp>

> _We are the masters of option control_
> _We refactor, customize and reuse_
> _We break the chains of old properties_
> _We unleash the power of schema templates_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 045759e</samp>

*  Refactor the option control logic for checkboxes, input tree, select and tree select components, replacing the `creatable`, `editable` and `removable` properties with custom schema templates `optionAddControl`, `optionEditControl` and `optionDeleteControl` ([link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-4a3c5c6e5498b74e1254ee4f776efe0e8de65ee84a90f59472e29990f67e2978L194-R203), [link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-55fdd7d5626a1567f50acdbe20595be990fee38dbea26e0ea0e235f7cba3c57fL447-R494), [link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-83d37f4c45d6ac38e41a04b6511b7921d73c2b0a35163df31401c8c0f408e0c4L305-R333), [link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-90baebf200b81ed14dd4240db28e6f322004b03cd30f304d5757560f6b7b65ecL450-R496))
*  Extract the common schema logic for the `labelField` and `valueField` properties of the option data to a new method `getFuncFieldSchema` in the `OptionControl` class ([link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-9cfcdc8b6fd4efb5b016c90e20ac9e0bd7269232de6fd1aee47462f0b4a64834L818-R849))
*  Use the extracted schema logic for the `labelField` and `valueField` properties in the `api` and `variable` option control scenarios in the `OptionControl` class ([link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-9cfcdc8b6fd4efb5b016c90e20ac9e0bd7269232de6fd1aee47462f0b4a64834L833-R862), [link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-9cfcdc8b6fd4efb5b016c90e20ac9e0bd7269232de6fd1aee47462f0b4a64834L893-R920))
*  Define reusable and customizable schema templates for the option control logic in `packages/amis-editor/src/tpl/options.tsx`, including `editInitApi` for the edit option feature and `createBtnLabel` for the add option feature ([link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-4ff8190ccb19edb2d788deb7ebf73420c1799a07d6061d2aeb89ab77e9e66b95R279-R287), [link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-4ff8190ccb19edb2d788deb7ebf73420c1799a07d6061d2aeb89ab77e9e66b95R465-R732), [link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-4ff8190ccb19edb2d788deb7ebf73420c1799a07d6061d2aeb89ab77e9e66b95L247-R257))
*  Remove some redundant or unused properties from the `SelectControlPlugin` class, such as `notRenderFormZone`, `panelTitle` and `panelJustify` ([link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-83d37f4c45d6ac38e41a04b6511b7921d73c2b0a35163df31401c8c0f408e0c4L54-L57), [link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-83d37f4c45d6ac38e41a04b6511b7921d73c2b0a35163df31401c8c0f408e0c4L246))
*  Format the `options` property of the `scaffold` object in the `SelectControlPlugin` class, removing the extra line breaks and spaces between the option objects ([link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-83d37f4c45d6ac38e41a04b6511b7921d73c2b0a35163df31401c8c0f408e0c4L31-R65))
*  Add some import statements to `packages/amis-editor/src/plugin/Form/Select.tsx` and `packages/amis-editor/src/tpl/options.tsx` for using modules such as `React`, `findObjectsWithKey`, `Button` and `Icon` in the option control logic ([link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-83d37f4c45d6ac38e41a04b6511b7921d73c2b0a35163df31401c8c0f408e0c4L1-R55), [link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-4ff8190ccb19edb2d788deb7ebf73420c1799a07d6061d2aeb89ab77e9e66b95L1-R11))
*  Add some type import statements to `packages/amis-editor/src/tpl/options.tsx` for using types such as `RendererProps` and `EditorManager` in the custom schema templates ([link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-4ff8190ccb19edb2d788deb7ebf73420c1799a07d6061d2aeb89ab77e9e66b95R17-R19))
*  Add a comment to the `OptionControl` class, indicating the start of the custom option logic ([link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-9cfcdc8b6fd4efb5b016c90e20ac9e0bd7269232de6fd1aee47462f0b4a64834R875))
*  Add some style rules for the `.amis-Checkboxes-addBtn` class in `packages/amis-ui/scss/components/form/_checks.scss`, adjusting the icon size and margin of the add button for the checkboxes component ([link](https://github.com/baidu/amis/pull/8075/files?diff=unified&w=0#diff-829b5bc506f2ec460bcc671888102485c14f2c31fa6a7472d1c1cb109d8cc1e5R711-R718))
