### PR TITLE
styles: 分割线默认样式为实线

### DIFF
--- a/docs/zh-CN/components/divider.md
+++ b/docs/zh-CN/components/divider.md
@@ -36,7 +36,7 @@ order: 42
 | --------- | -------- | ------------ | ------------------------------------------ |
 | type      | `string` |              | `"divider"` 指定为 分割线 渲染器           |
 | className | `string` |              | 外层 Dom 的类名                            |
-| lineStyle | `string` | `dashed`     | 分割线的样式，支持`dashed`和`solid`        |
+| lineStyle | `string` | `solid`      | 分割线的样式，支持`dashed`和`solid`        |
 | direction | `string` | `horizontal` | 分割线的方向，支持`horizontal`和`vertical` |
 | color     | `string` |              | 分割线的颜色                               |
 | rotate    | `number` |              | 分割线的旋转角度                           |

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/combo.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/combo.test.tsx.snap
@@ -1631,7 +1631,7 @@ exports[`Renderer:combo with items & multiLine 1`] = `
           />
         </div>
         <div
-          class="cxd-Divider cxd-Divider--dashed cxd-Divider--horizontal"
+          class="cxd-Divider cxd-Divider--solid cxd-Divider--horizontal"
         />
         <div
           class="cxd-Form-item cxd-Form-item--horizontal"

--- a/packages/amis/__tests__/renderers/__snapshots__/Action.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Action.test.tsx.snap
@@ -180,7 +180,7 @@ exports[`Renderers:Action all levels 1`] = `
             </span>
           </button>
           <div
-            class="cxd-Divider cxd-Divider--dashed cxd-Divider--horizontal"
+            class="cxd-Divider cxd-Divider--solid cxd-Divider--horizontal"
           />
           <div
             class="cxd-Button cxd-Button--link cxd-Button--size-default is-disabled"

--- a/packages/amis/__tests__/renderers/__snapshots__/GridNav.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/GridNav.test.tsx.snap
@@ -108,7 +108,7 @@ exports[`Renderer:gridnav 1`] = `
             </div>
           </div>
           <div
-            class="cxd-Divider cxd-Divider--dashed cxd-Divider--horizontal"
+            class="cxd-Divider cxd-Divider--solid cxd-Divider--horizontal"
           />
           <div
             class="cxd-GridNav  cxd-GridNav-top u-hairline"

--- a/packages/amis/__tests__/renderers/__snapshots__/Image.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Image.test.tsx.snap
@@ -472,7 +472,7 @@ exports[`Renderer:images images:basic 1`] = `
             </div>
           </div>
           <div
-            class="cxd-Divider cxd-Divider--dashed cxd-Divider--horizontal"
+            class="cxd-Divider cxd-Divider--solid cxd-Divider--horizontal"
           />
           <div
             class="cxd-ImagesField"

--- a/packages/amis/src/renderers/Divider.tsx
+++ b/packages/amis/src/renderers/Divider.tsx
@@ -22,7 +22,7 @@ export interface DividerProps
 export default class Divider extends React.Component<DividerProps, object> {
   static defaultProps: Pick<DividerProps, 'className' | 'lineStyle'> = {
     className: '',
-    lineStyle: 'dashed'
+    lineStyle: 'solid'
   };
 
   render() {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 67bd4df</samp>

Changed the default value of the `lineStyle` property in the `Divider` component from `dashed` to `solid` and updated the documentation accordingly. This change enhances the visibility and contrast of the divider and aligns the code and the docs.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 67bd4df</samp>

> _`lineStyle` changes_
> _Divider looks more solid_
> _Breaking change in fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 67bd4df</samp>

* Change the default value of the `lineStyle` property in the `Divider` component from `dashed` to `solid` ([link](https://github.com/baidu/amis/pull/8076/files?diff=unified&w=0#diff-2b4abdb9c1e1ff34f56e1905b7e5b25fe4ecc472d34817411bec72f4f926c02fL25-R25), [link](https://github.com/baidu/amis/pull/8076/files?diff=unified&w=0#diff-58d57050233f8dd7e8a71e64c04e800d7554b9c3eb34a4578c9eab610a09c8c8L39-R39))
