### PR TITLE
chore: 调整table nested 样式 & table 默认还原成 auto 布局

### DIFF
--- a/docs/zh-CN/components/table.md
+++ b/docs/zh-CN/components/table.md
@@ -1846,6 +1846,7 @@ popOver 的其它配置请参考 [popover](./popover)
 | selectable       | `boolean`                                                | `false`                   | 支持勾选                                                                  |                                   |
 | multiple         | `boolean`                                                | `false`                   | 勾选 icon 是否为多选样式`checkbox`， 默认为`radio`                        |                                   |
 | lazyRenderAfter  | `number`                                                 | `100`                     | 用来控制从第几行开始懒渲染行，用来渲染大表格时有用                        |                                   |
+| tableLayout      | `auto` \| `fixed`                                        | `auto`                    | 当配置为 fixed 时，内容将不会撑开表格，自动换行                           |                                   |
 
 ### 列配置属性表
 

--- a/examples/components/CRUD/Nested.jsx
+++ b/examples/components/CRUD/Nested.jsx
@@ -15,7 +15,7 @@ export default {
         sortable: true,
         type: 'text',
         toggled: true,
-        width: 100
+        width: 150
       },
       {
         name: 'engine',

--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -61,6 +61,7 @@ export const Column = types
     rawIndex: 0,
     width: 0,
     minWidth: 0,
+    realWidth: 0,
     breakpoint: types.optional(types.frozen(), undefined),
     pristine: types.optional(types.frozen(), undefined),
     remark: types.optional(types.frozen(), undefined),
@@ -89,11 +90,16 @@ export const Column = types
       table.persistSaveToggledColumns();
     },
 
-    setWidth(value: number, minWidth?: number) {
+    setMinWidth(value: number) {
+      self.minWidth = value;
+    },
+
+    setWidth(value: number) {
       self.width = value;
-      if (typeof minWidth === 'number') {
-        self.minWidth = minWidth;
-      }
+    },
+
+    setRealWidth(value: number) {
+      self.realWidth = value;
     }
   }));
 
@@ -256,6 +262,12 @@ export const Row = types
       }
 
       return true;
+    },
+
+    get indentStyle() {
+      return {
+        paddingLeft: `calc(${self.depth - 1} * var(--Table-tree-indent))`
+      };
     }
   }))
   .actions(self => ({
@@ -375,7 +387,8 @@ export const TableStore = iRendererStore
     // 导出 Excel 按钮的 loading 状态
     exportExcelLoading: false,
     searchFormExpanded: false, // 用来控制搜索框是否展开了，那个自动根据 searchable 生成的表单 autoGenerateFilter
-    lazyRenderAfter: 100
+    lazyRenderAfter: 100,
+    tableLayout: 'auto'
   })
   .views(self => {
     function getColumnsExceptBuiltinTypes() {
@@ -427,7 +440,7 @@ export const TableStore = iRendererStore
             : item.type === '__dragme'
             ? self.dragging
             : item.type === '__expandme'
-            ? (getFootableColumns().length || self.isNested) && !self.dragging
+            ? getFootableColumns().length && !self.dragging
             : (item.toggled || !item.toggable) &&
               (!self.footable ||
                 !item.breakpoint ||
@@ -808,11 +821,15 @@ export const TableStore = iRendererStore
               (col && col.fixed === 'left') ||
               autoFixLeftColumns.includes(col.type)
             ) {
-              left.push(`var(--Table-column-${col.rawIndex}-width)`);
+              left.push(`var(--Table-column-${col.index}-width)`);
             }
             index--;
           }
-          style.left = left.length ? left.join(' + ') : 0;
+          style.left = left.length
+            ? left.length === 1
+              ? left[0]
+              : `calc(${left.join(' + ')})`
+            : 0;
         } else if (column.fixed === 'right') {
           stickyClassName = 'is-sticky is-sticky-right';
           let right = [];
@@ -826,11 +843,15 @@ export const TableStore = iRendererStore
           while (index < len) {
             const col = columns[index];
             if (col && col.fixed === 'right') {
-              right.push(`var(--Table-column-${col.rawIndex}-width)`);
+              right.push(`var(--Table-column-${col.index}-width)`);
             }
             index++;
           }
-          style.right = right.length ? right.join(' + ') : 0;
+          style.right = right.length
+            ? right.length === 1
+              ? right[0]
+              : `calc(${right.join(' + ')})`
+            : 0;
         }
         return [style, stickyClassName];
       },
@@ -842,11 +863,9 @@ export const TableStore = iRendererStore
       buildStyles(style: any) {
         style = {...style};
 
-        self.columns.forEach(column => {
-          if (column.fixed) {
-            style[`--Table-column-${column.rawIndex}-width`] =
-              column.width + 'px';
-          }
+        getFilteredColumns().forEach(column => {
+          style[`--Table-column-${column.index}-width`] =
+            column.realWidth + 'px';
         });
 
         return style;
@@ -858,6 +877,10 @@ export const TableStore = iRendererStore
 
     function setTable(ref: HTMLElement | null) {
       tableRef = ref;
+    }
+
+    function getTable() {
+      return tableRef;
     }
 
     function update(config: Partial<STableStore>) {
@@ -913,7 +936,10 @@ export const TableStore = iRendererStore
         (self.canAccessSuperData = !!config.canAccessSuperData);
 
       typeof config.lazyRenderAfter === 'number' &&
-        self.lazyRenderAfter === config.lazyRenderAfter;
+        (self.lazyRenderAfter = config.lazyRenderAfter);
+
+      typeof config.tableLayout === 'string' &&
+        (self.tableLayout = config.tableLayout);
 
       if (config.columns && Array.isArray(config.columns)) {
         let columns: Array<SColumn> = config.columns
@@ -1002,28 +1028,52 @@ export const TableStore = iRendererStore
       }
     }
 
-    function syncTableWidth() {
+    function initTableWidth() {
       const table = tableRef;
       if (!table) {
         return;
       }
       const tableWidth = table.parentElement!.offsetWidth;
       const thead = table.querySelector(':scope>thead')!;
-      const tbody = table.querySelector(':scope>tbody');
+      let tbody: HTMLElement | null = null;
       const div = document.createElement('div');
       div.className = 'amis-scope'; // jssdk 里面 css 会在这一层
       div.style.cssText += `visibility: hidden!important;`;
-      div.innerHTML =
-        `<table style="table-layout:auto!important;width:0!important;min-width:0!important;" class="${table.className}">${thead.outerHTML}</table>` +
+      const htmls: Array<string> = [];
+      const isFixed = self.tableLayout === 'fixed';
+
+      const minWidths: {
+        [propName: string]: number;
+      } = {};
+
+      // fixed 模式需要参考 auto 获得列最小宽度
+      if (isFixed) {
+        tbody = table.querySelector(':scope>tbody');
+        htmls.push(
+          `<table style="table-layout:auto!important;width:0!important;min-width:0!important;" class="${table.className}">${thead.outerHTML}</table>`
+        );
+      }
+
+      htmls.push(
         `<table style="table-layout:auto!important;min-width:${tableWidth}px!important;width:${tableWidth}px!important;" class="${table.className.replace(
           'is-layout-fixed',
           ''
         )}">${thead.outerHTML}${
           tbody ? `<tbody>${tbody.innerHTML}</tbody>` : ''
-        }</table>`;
-      const ths1: Array<HTMLTableCellElement> = [].slice.call(
-        div.querySelectorAll(':scope>table:first-child>thead>tr>th[data-index]')
+        }</table>`
       );
+
+      div.innerHTML = htmls.join('');
+      let ths1: Array<HTMLTableCellElement> = [];
+
+      if (isFixed) {
+        ths1 = [].slice.call(
+          div.querySelectorAll(
+            ':scope>table:first-child>thead>tr>th[data-index]'
+          )
+        );
+      }
+
       const ths2: Array<HTMLTableCellElement> = [].slice.call(
         div.querySelectorAll(':scope>table:last-child>thead>tr>th[data-index]')
       );
@@ -1040,15 +1090,17 @@ export const TableStore = iRendererStore
             ? `width: ${column.pristine.width}px;`
             : column.pristine.width
             ? `width: ${column.pristine.width};`
-            : ''
+            : '' // todo 可能需要让修改过列宽的保持相应宽度，目前这样相当于重置了
         }`;
       });
+
       document.body.appendChild(div);
-      const minWidths: {
-        [propName: string]: number;
-      } = {};
+
       ths1.forEach((th: HTMLTableCellElement) => {
-        minWidths[th.getAttribute('data-index')!] = th.clientWidth;
+        const index = parseInt(th.getAttribute('data-index')!, 10);
+        minWidths[index] = th.clientWidth;
+        const column = self.columns[index];
+        column.setMinWidth(minWidths[index]);
       });
 
       ths2.forEach((col: HTMLElement) => {
@@ -1059,13 +1111,27 @@ export const TableStore = iRendererStore
             typeof column.pristine.width === 'number'
               ? column.pristine.width
               : col.clientWidth - 2,
-            minWidths[index]
-          ),
-          minWidths[index]
+            minWidths[index] || 0
+          )
         );
       });
 
       document.body.removeChild(div);
+    }
+
+    function syncTableWidth() {
+      const table = tableRef;
+      if (!table) {
+        return;
+      }
+      const cols = [].slice.call(
+        table.querySelectorAll(':scope>colgroup>col[data-index]')!
+      );
+      cols.forEach((col: HTMLElement) => {
+        const index = parseInt(col.getAttribute('data-index')!, 10);
+        const column = self.columns[index];
+        column.setRealWidth(col.clientWidth);
+      });
     }
 
     function invalidTableColumnWidth() {
@@ -1669,8 +1735,10 @@ export const TableStore = iRendererStore
 
     return {
       setTable,
+      getTable,
       update,
       updateColumns,
+      initTableWidth,
       syncTableWidth,
       invalidTableColumnWidth,
       initRows,

--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -4011,6 +4011,7 @@
   --Table-toolbar-marginX: #{px2rem(4px)};
   --Table-toolbar-marginY: var(--gap-base);
   --Table-tree-borderColor: var(--colors-neutral-line-8);
+  --Table-tree-indent: var(--gap-lg);
   --Table-searchableForm-backgroundColor: #f6f7f8;
   --Table-searchableForm-borderRadius: #{px2rem(4px)};
   --Table-empty-icon-size: #{px2rem(74px)};

--- a/packages/amis-ui/scss/components/_table.scss
+++ b/packages/amis-ui/scss/components/_table.scss
@@ -360,6 +360,7 @@
 
         .#{$ns}TableCell--title {
           min-width: fit-content;
+          display: inline-block;
         }
       }
     }
@@ -547,42 +548,6 @@
       background: var(--Table-tree-borderColor);
     }
 
-    @for $i from 2 through 10 {
-      tr.#{$ns}Table-tr--#{$i}th.is-expanded {
-        .#{$ns}Table-expandCell:before {
-          left: px2rem(23px) + px2rem(18px) * ($i - 1);
-        }
-      }
-
-      tr.#{$ns}Table-tr--#{$i}th {
-        .#{$ns}Table-expandBtn {
-          position: relative;
-          left: px2rem(1px) + (px2rem(18px)) * ($i - 1);
-        }
-
-        .#{$ns}Table-divider2 {
-          left: px2rem(5px) + (px2rem(18px)) * ($i - 1);
-        }
-
-        .#{$ns}Table-divider3 {
-          left: px2rem(5px) + (px2rem(18px)) * ($i - 1);
-        }
-      }
-
-      tr.#{$ns}Table-tr--#{$i}th.is-last .#{$ns}Table-divider3 {
-        height: 50%;
-      }
-
-      tr.#{$ns}Table-tr--#{$i}th.is-last:not(.is-expanded) {
-        .#{$ns}Table-expandCell + td {
-          &::before {
-            height: 50%;
-            bottom: auto;
-          }
-        }
-      }
-    }
-
     > thead > tr > th.#{$ns}Table-checkCell,
     > tbody > tr > td.#{$ns}Table-checkCell {
       width: px2rem(1px);
@@ -620,18 +585,6 @@
 
     > tbody > tr > td.#{$ns}Table-expandCell {
       position: relative;
-
-      @for $i from 1 through 7 {
-        .#{$ns}Table-divider-#{$i} {
-          position: absolute;
-          width: px2rem(1px);
-          top: 0;
-          bottom: 0;
-          height: 100%;
-          background: var(--Table-tree-borderColor);
-          left: px2rem(23px) + px2rem(18px) * ($i - 1);
-        }
-      }
     }
 
     > tbody > tr.is-expanded > td.#{$ns}Table-expandCell {
@@ -655,6 +608,11 @@
       > .#{$ns}TableCell--title {
         display: inline-block;
       }
+    }
+
+    > thead > tr > th.#{$ns}Table-primayCell,
+    > tbody > tr > td.#{$ns}Table-primayCell {
+      white-space: nowrap; // 树形表格展示标题栏，不要换行
     }
   }
 
@@ -899,7 +857,8 @@
     }
   }
 
-  &-expandBtn {
+  &-expandBtn,
+  &-expandBtn2 {
     position: relative;
     z-index: 1;
     color: var(--Table-expandBtn-color);
@@ -931,6 +890,19 @@
     &:hover {
       text-decoration: none;
     }
+  }
+
+  &-expandBtn2 {
+    margin-right: var(--gap-sm);
+  }
+
+  &-indent {
+    display: inline-block;
+  }
+
+  &-expandSpace {
+    display: inline-block;
+    width: px2rem(22px);
   }
 
   &-dragBtn {

--- a/packages/amis/__tests__/event-action/renderers/__snapshots__/crud.test.tsx.snap
+++ b/packages/amis/__tests__/event-action/renderers/__snapshots__/crud.test.tsx.snap
@@ -25,11 +25,10 @@ exports[`doAction:crud reload 1`] = `
           </button>
           <div
             class="cxd-Crud is-loading"
-            style="position: relative;"
           >
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column--2-width: 0px;"
+              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -262,45 +261,45 @@ exports[`doAction:crud reload 1`] = `
                 </div>
                 <span />
               </div>
-            </div>
-            <div
-              class="resize-sensor"
-              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-            >
-              
-  
               <div
-                class="resize-sensor-expand"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
               >
                 
-    
+  
                 <div
-                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-shrink"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
     
-                <div
-                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                />
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
                 
   
-              </div>
-              
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
   
-              <div
-                class="resize-sensor-appear"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-              />
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -335,11 +334,10 @@ exports[`doAction:crud reload with data1 1`] = `
           </button>
           <div
             class="cxd-Crud is-loading"
-            style="position: relative;"
           >
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column--2-width: 0px;"
+              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -572,45 +570,45 @@ exports[`doAction:crud reload with data1 1`] = `
                 </div>
                 <span />
               </div>
-            </div>
-            <div
-              class="resize-sensor"
-              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-            >
-              
-  
               <div
-                class="resize-sensor-expand"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
               >
                 
-    
+  
                 <div
-                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-shrink"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
     
-                <div
-                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                />
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
                 
   
-              </div>
-              
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
   
-              <div
-                class="resize-sensor-appear"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-              />
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -645,11 +643,10 @@ exports[`doAction:crud reload with data2 1`] = `
           </button>
           <div
             class="cxd-Crud is-loading"
-            style="position: relative;"
           >
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column--2-width: 0px;"
+              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -882,45 +879,45 @@ exports[`doAction:crud reload with data2 1`] = `
                 </div>
                 <span />
               </div>
-            </div>
-            <div
-              class="resize-sensor"
-              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-            >
-              
-  
               <div
-                class="resize-sensor-expand"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
               >
                 
-    
+  
                 <div
-                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-shrink"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
     
-                <div
-                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                />
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
                 
   
-              </div>
-              
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
   
-              <div
-                class="resize-sensor-appear"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-              />
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
@@ -51,11 +51,10 @@ exports[`Renderer:input table 1`] = `
                 >
                   <div
                     class="cxd-InputTable cxd-Form-control"
-                    style="position: relative;"
                   >
                     <div
                       class="cxd-Table"
-                      style="--Table-column--2-width: 0px;"
+                      style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
                     >
                       <div
                         class="cxd-Table-contentWrap"
@@ -198,45 +197,45 @@ exports[`Renderer:input table 1`] = `
                         </div>
                         <span />
                       </div>
-                    </div>
-                    <div
-                      class="resize-sensor"
-                      style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-                    >
-                      
-  
                       <div
-                        class="resize-sensor-expand"
-                        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                        class="resize-sensor"
+                        style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
                       >
                         
-    
+  
                         <div
-                          style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                        />
-                        
-  
-                      </div>
-                      
-  
-                      <div
-                        class="resize-sensor-shrink"
-                        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-                      >
-                        
+                          class="resize-sensor-expand"
+                          style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                        >
+                          
     
-                        <div
-                          style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                        />
+                          <div
+                            style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                          />
+                          
+  
+                        </div>
                         
   
-                      </div>
-                      
+                        <div
+                          class="resize-sensor-shrink"
+                          style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                        >
+                          
+    
+                          <div
+                            style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                          />
+                          
   
-                      <div
-                        class="resize-sensor-appear"
-                        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-                      />
+                        </div>
+                        
+  
+                        <div
+                          class="resize-sensor-appear"
+                          style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                        />
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -418,11 +417,10 @@ exports[`Renderer:input table add 1`] = `
         >
           <div
             class="cxd-InputTable cxd-Form-control"
-            style="position: relative;"
           >
             <div
               class="cxd-Table"
-              style="--Table-column--2-width: 0px; --Table-column-2-width: 150px;"
+              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-contentWrap"
@@ -442,7 +440,7 @@ exports[`Renderer:input table add 1`] = `
                       />
                       <col
                         data-index="5"
-                        style="width: 150px;"
+                        style="width: 150px; min-width: 150px;"
                       />
                     </colgroup>
                     <thead>
@@ -603,6 +601,45 @@ exports[`Renderer:input table add 1`] = `
                 </div>
                 <span />
               </div>
+              <div
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
+              >
+                
+  
+                <div
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
+  
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
             </div>
             <div
               class="cxd-InputTable-toolbar"
@@ -618,45 +655,6 @@ exports[`Renderer:input table add 1`] = `
                   新增
                 </span>
               </div>
-            </div>
-            <div
-              class="resize-sensor"
-              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-            >
-              
-  
-              <div
-                class="resize-sensor-expand"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
-    
-                <div
-                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-shrink"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
-    
-                <div
-                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-appear"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-              />
             </div>
           </div>
         </div>
@@ -772,11 +770,10 @@ exports[`Renderer:input-table cell selects delete 1`] = `
           </label>
           <div
             class="cxd-InputTable cxd-Form-control"
-            style="position: relative;"
           >
             <div
               class="cxd-Table"
-              style="--Table-column--2-width: 0px;"
+              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-contentWrap"
@@ -933,45 +930,45 @@ exports[`Renderer:input-table cell selects delete 1`] = `
                 </div>
                 <span />
               </div>
-            </div>
-            <div
-              class="resize-sensor"
-              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-            >
-              
-  
               <div
-                class="resize-sensor-expand"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
               >
                 
-    
+  
                 <div
-                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-shrink"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
     
-                <div
-                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                />
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
                 
   
-              </div>
-              
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
   
-              <div
-                class="resize-sensor-appear"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-              />
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -1185,11 +1182,10 @@ exports[`Renderer:input-table with combo column 1`] = `
         >
           <div
             class="cxd-InputTable cxd-Form-control"
-            style="position: relative;"
           >
             <div
               class="cxd-Table"
-              style="--Table-column--2-width: 0px;"
+              style="--Table-column-3-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-contentWrap"
@@ -1373,45 +1369,45 @@ exports[`Renderer:input-table with combo column 1`] = `
                 </div>
                 <span />
               </div>
-            </div>
-            <div
-              class="resize-sensor"
-              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-            >
-              
-  
               <div
-                class="resize-sensor-expand"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
               >
                 
-    
+  
                 <div
-                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-shrink"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
     
-                <div
-                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                />
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
                 
   
-              </div>
-              
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
   
-              <div
-                class="resize-sensor-appear"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-              />
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
@@ -17,11 +17,10 @@ exports[`1. Renderer:crud basic interval headerToolbar footerToolbar 1`] = `
         >
           <div
             class="cxd-Crud"
-            style="position: relative;"
           >
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column--2-width: 0px;"
+              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -794,45 +793,45 @@ exports[`1. Renderer:crud basic interval headerToolbar footerToolbar 1`] = `
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="resize-sensor"
-              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-            >
-              
-  
               <div
-                class="resize-sensor-expand"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
               >
                 
-    
+  
                 <div
-                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-shrink"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
     
-                <div
-                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                />
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
                 
   
-              </div>
-              
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
   
-              <div
-                class="resize-sensor-appear"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-              />
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -2159,11 +2158,10 @@ exports[`6. Renderer:crud source & alwaysShowPagination 1`] = `
         >
           <div
             class="cxd-Crud"
-            style="position: relative;"
           >
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column--2-width: 0px;"
+              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -2653,45 +2651,45 @@ exports[`6. Renderer:crud source & alwaysShowPagination 1`] = `
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="resize-sensor"
-              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-            >
-              
-  
               <div
-                class="resize-sensor-expand"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
               >
                 
-    
+  
                 <div
-                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-shrink"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
     
-                <div
-                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                />
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
                 
   
-              </div>
-              
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
   
-              <div
-                class="resize-sensor-appear"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-              />
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -2718,7 +2716,6 @@ exports[`13. enderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionL
         >
           <div
             class="cxd-Crud"
-            style="position: relative;"
           >
             <div
               class="cxd-Crud-selection"
@@ -2808,7 +2805,7 @@ exports[`13. enderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionL
             </div>
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column--2-width: 0px;"
+              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative; --Table-column-1-width: 0px;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -3470,6 +3467,45 @@ exports[`13. enderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionL
                 <span />
               </div>
               <div
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
+              >
+                
+  
+                <div
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
+  
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
+              <div
                 class="cxd-Table-toolbar cxd-Table-footToolbar"
               >
                 <div
@@ -3622,45 +3658,6 @@ exports[`13. enderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionL
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="resize-sensor"
-              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-            >
-              
-  
-              <div
-                class="resize-sensor-expand"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
-    
-                <div
-                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-shrink"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
-    
-                <div
-                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-appear"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-              />
             </div>
           </div>
         </div>

--- a/packages/amis/__tests__/renderers/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Pagination.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`Renderer:Pagination 1`] = `
   >
     <div
       class="cxd-PaginationWrapper"
-      style="position: relative;"
     >
       <div
         class="cxd-Pagination-wrap cxd-PaginationWrapper-pager"
@@ -84,7 +83,7 @@ exports[`Renderer:Pagination 1`] = `
       </div>
       <div
         class="cxd-Table"
-        style="--Table-column--2-width: 0px;"
+        style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
       >
         <div
           class="cxd-Table-fixedTop"
@@ -213,45 +212,45 @@ exports[`Renderer:Pagination 1`] = `
           </div>
           <span />
         </div>
-      </div>
-      <div
-        class="resize-sensor"
-        style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-      >
-        
-  
         <div
-          class="resize-sensor-expand"
-          style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+          class="resize-sensor"
+          style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
         >
           
-    
+  
           <div
-            style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-          />
-          
-  
-        </div>
-        
-  
-        <div
-          class="resize-sensor-shrink"
-          style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-        >
-          
+            class="resize-sensor-expand"
+            style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+          >
+            
     
-          <div
-            style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-          />
+            <div
+              style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+            />
+            
+  
+          </div>
           
   
-        </div>
-        
+          <div
+            class="resize-sensor-shrink"
+            style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+          >
+            
+    
+            <div
+              style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+            />
+            
   
-        <div
-          class="resize-sensor-appear"
-          style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-        />
+          </div>
+          
+  
+          <div
+            class="resize-sensor-appear"
+            style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/packages/amis/__tests__/renderers/__snapshots__/Table.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Table.test.tsx.snap
@@ -1,12 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Renderer:table 1`] = `
-<div
-  style="position: relative;"
->
+<div>
   <div
     class="cxd-Table"
-    style="--Table-column--2-width: 0px;"
+    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -327,56 +325,54 @@ exports[`Renderer:table 1`] = `
       </div>
       <span />
     </div>
-  </div>
-  <div
-    class="resize-sensor"
-    style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-  >
-    
-  
     <div
-      class="resize-sensor-expand"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      class="resize-sensor"
+      style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
     >
       
-    
+  
       <div
-        style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-      />
+        class="resize-sensor-expand"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      >
+        
+    
+        <div
+          style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+        />
+        
+  
+      </div>
       
   
-    </div>
-    
-  
-    <div
-      class="resize-sensor-shrink"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-    >
-      
-    
       <div
-        style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-      />
+        class="resize-sensor-shrink"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      >
+        
+    
+        <div
+          style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+        />
+        
+  
+      </div>
       
   
+      <div
+        class="resize-sensor-appear"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+      />
     </div>
-    
-  
-    <div
-      class="resize-sensor-appear"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-    />
   </div>
 </div>
 `;
 
 exports[`Renderer:table align 1`] = `
-<div
-  style="position: relative;"
->
+<div>
   <div
     class="cxd-Table"
-    style="--Table-column--2-width: 0px;"
+    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -720,45 +716,45 @@ exports[`Renderer:table align 1`] = `
       </div>
       <span />
     </div>
-  </div>
-  <div
-    class="resize-sensor"
-    style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-  >
-    
-  
     <div
-      class="resize-sensor-expand"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      class="resize-sensor"
+      style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
     >
       
-    
+  
       <div
-        style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-      />
+        class="resize-sensor-expand"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      >
+        
+    
+        <div
+          style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+        />
+        
+  
+      </div>
       
   
-    </div>
-    
-  
-    <div
-      class="resize-sensor-shrink"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-    >
-      
-    
       <div
-        style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-      />
+        class="resize-sensor-shrink"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      >
+        
+    
+        <div
+          style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+        />
+        
+  
+      </div>
       
   
+      <div
+        class="resize-sensor-appear"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+      />
     </div>
-    
-  
-    <div
-      class="resize-sensor-appear"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-    />
   </div>
 </div>
 `;
@@ -780,11 +776,10 @@ exports[`Renderer:table children 1`] = `
         >
           <div
             class="cxd-Service"
-            style="position: relative;"
           >
             <div
               class="cxd-Table m-b-none"
-              style="--Table-column--2-width: 0px;"
+              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -800,9 +795,6 @@ exports[`Renderer:table children 1`] = `
                     class="cxd-Table-table"
                   >
                     <colgroup>
-                      <col
-                        data-index="2"
-                      />
                       <col
                         data-index="3"
                       />
@@ -827,27 +819,17 @@ exports[`Renderer:table children 1`] = `
                         class=""
                       >
                         <th
-                          class="cxd-Table-expandCell is-sticky is-sticky-left is-sticky-last-left"
-                          data-index="2"
-                          style="left: 0px;"
+                          class=""
+                          data-index="3"
                         >
                           <a
-                            class="cxd-Table-expandBtn"
+                            class="cxd-Table-expandBtn2"
                           >
                             <icon-mock
                               classname="icon icon-right-arrow-bold"
                               icon="right-arrow-bold"
                             />
                           </a>
-                          <div
-                            class="cxd-Table-content-colDragLine"
-                            data-index="2"
-                          />
-                        </th>
-                        <th
-                          class=""
-                          data-index="3"
-                        >
                           <div
                             class="cxd-TableCell--title"
                           >
@@ -973,21 +955,19 @@ exports[`Renderer:table children 1`] = `
                         data-index="0"
                       >
                         <td
-                          class="cxd-Table-expandCell is-sticky is-sticky-left is-sticky-last-left"
-                          style="left: 0px;"
+                          class="cxd-Table-primayCell"
                         >
+                          <span
+                            class="cxd-Table-indent"
+                          />
                           <a
-                            class="cxd-Table-expandBtn"
+                            class="cxd-Table-expandBtn2"
                           >
                             <icon-mock
                               classname="icon icon-right-arrow-bold"
                               icon="right-arrow-bold"
                             />
                           </a>
-                        </td>
-                        <td
-                          class=""
-                        >
                           <span
                             class="cxd-PlainField"
                           >
@@ -1046,21 +1026,19 @@ exports[`Renderer:table children 1`] = `
                         data-index="1"
                       >
                         <td
-                          class="cxd-Table-expandCell is-sticky is-sticky-left is-sticky-last-left"
-                          style="left: 0px;"
+                          class="cxd-Table-primayCell"
                         >
+                          <span
+                            class="cxd-Table-indent"
+                          />
                           <a
-                            class="cxd-Table-expandBtn"
+                            class="cxd-Table-expandBtn2"
                           >
                             <icon-mock
                               classname="icon icon-right-arrow-bold"
                               icon="right-arrow-bold"
                             />
                           </a>
-                        </td>
-                        <td
-                          class=""
-                        >
                           <span
                             class="cxd-PlainField"
                           >
@@ -1119,21 +1097,19 @@ exports[`Renderer:table children 1`] = `
                         data-index="2"
                       >
                         <td
-                          class="cxd-Table-expandCell is-sticky is-sticky-left is-sticky-last-left"
-                          style="left: 0px;"
+                          class="cxd-Table-primayCell"
                         >
+                          <span
+                            class="cxd-Table-indent"
+                          />
                           <a
-                            class="cxd-Table-expandBtn"
+                            class="cxd-Table-expandBtn2"
                           >
                             <icon-mock
                               classname="icon icon-right-arrow-bold"
                               icon="right-arrow-bold"
                             />
                           </a>
-                        </td>
-                        <td
-                          class=""
-                        >
                           <span
                             class="cxd-PlainField"
                           >
@@ -1192,21 +1168,19 @@ exports[`Renderer:table children 1`] = `
                         data-index="3"
                       >
                         <td
-                          class="cxd-Table-expandCell is-sticky is-sticky-left is-sticky-last-left"
-                          style="left: 0px;"
+                          class="cxd-Table-primayCell"
                         >
+                          <span
+                            class="cxd-Table-indent"
+                          />
                           <a
-                            class="cxd-Table-expandBtn"
+                            class="cxd-Table-expandBtn2"
                           >
                             <icon-mock
                               classname="icon icon-right-arrow-bold"
                               icon="right-arrow-bold"
                             />
                           </a>
-                        </td>
-                        <td
-                          class=""
-                        >
                           <span
                             class="cxd-PlainField"
                           >
@@ -1265,21 +1239,19 @@ exports[`Renderer:table children 1`] = `
                         data-index="4"
                       >
                         <td
-                          class="cxd-Table-expandCell is-sticky is-sticky-left is-sticky-last-left"
-                          style="left: 0px;"
+                          class="cxd-Table-primayCell"
                         >
+                          <span
+                            class="cxd-Table-indent"
+                          />
                           <a
-                            class="cxd-Table-expandBtn"
+                            class="cxd-Table-expandBtn2"
                           >
                             <icon-mock
                               classname="icon icon-right-arrow-bold"
                               icon="right-arrow-bold"
                             />
                           </a>
-                        </td>
-                        <td
-                          class=""
-                        >
                           <span
                             class="cxd-PlainField"
                           >
@@ -1337,45 +1309,45 @@ exports[`Renderer:table children 1`] = `
                 </div>
                 <span />
               </div>
-            </div>
-            <div
-              class="resize-sensor"
-              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-            >
-              
-  
               <div
-                class="resize-sensor-expand"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
               >
                 
-    
+  
                 <div
-                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-shrink"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
     
-                <div
-                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                />
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
                 
   
-              </div>
-              
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
   
-              <div
-                class="resize-sensor-appear"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-              />
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -1386,12 +1358,10 @@ exports[`Renderer:table children 1`] = `
 `;
 
 exports[`Renderer:table classNameExpr 1`] = `
-<div
-  style="position: relative;"
->
+<div>
   <div
     class="cxd-Table"
-    style="--Table-column--2-width: 0px;"
+    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -1712,56 +1682,54 @@ exports[`Renderer:table classNameExpr 1`] = `
       </div>
       <span />
     </div>
-  </div>
-  <div
-    class="resize-sensor"
-    style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-  >
-    
-  
     <div
-      class="resize-sensor-expand"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      class="resize-sensor"
+      style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
     >
       
-    
+  
       <div
-        style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-      />
+        class="resize-sensor-expand"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      >
+        
+    
+        <div
+          style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+        />
+        
+  
+      </div>
       
   
-    </div>
-    
-  
-    <div
-      class="resize-sensor-shrink"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-    >
-      
-    
       <div
-        style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-      />
+        class="resize-sensor-shrink"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      >
+        
+    
+        <div
+          style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+        />
+        
+  
+      </div>
       
   
+      <div
+        class="resize-sensor-appear"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+      />
     </div>
-    
-  
-    <div
-      class="resize-sensor-appear"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-    />
   </div>
 </div>
 `;
 
 exports[`Renderer:table column head style className 1`] = `
-<div
-  style="position: relative;"
->
+<div>
   <div
     class="cxd-Table className"
-    style="--Table-column--2-width: 0px; --Table-column-1-width: 0px;"
+    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -2093,45 +2061,45 @@ exports[`Renderer:table column head style className 1`] = `
       </div>
       <span />
     </div>
-  </div>
-  <div
-    class="resize-sensor"
-    style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-  >
-    
-  
     <div
-      class="resize-sensor-expand"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      class="resize-sensor"
+      style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
     >
       
-    
+  
       <div
-        style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-      />
+        class="resize-sensor-expand"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      >
+        
+    
+        <div
+          style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+        />
+        
+  
+      </div>
       
   
-    </div>
-    
-  
-    <div
-      class="resize-sensor-shrink"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-    >
-      
-    
       <div
-        style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-      />
+        class="resize-sensor-shrink"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      >
+        
+    
+        <div
+          style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+        />
+        
+  
+      </div>
       
   
+      <div
+        class="resize-sensor-appear"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+      />
     </div>
-    
-  
-    <div
-      class="resize-sensor-appear"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-    />
   </div>
 </div>
 `;
@@ -2153,11 +2121,10 @@ exports[`Renderer:table combine Renderer:table combineNum only 1`] = `
         >
           <div
             class="cxd-Service"
-            style="position: relative;"
           >
             <div
               class="cxd-Table"
-              style="--Table-column--2-width: 0px;"
+              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -2666,45 +2633,45 @@ exports[`Renderer:table combine Renderer:table combineNum only 1`] = `
                 </div>
                 <span />
               </div>
-            </div>
-            <div
-              class="resize-sensor"
-              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-            >
-              
-  
               <div
-                class="resize-sensor-expand"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
               >
                 
-    
+  
                 <div
-                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-shrink"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
     
-                <div
-                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                />
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
                 
   
-              </div>
-              
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
   
-              <div
-                class="resize-sensor-appear"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-              />
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -2731,11 +2698,10 @@ exports[`Renderer:table combine Renderer:table combineNum with fromIndex 1`] = `
         >
           <div
             class="cxd-Service"
-            style="position: relative;"
           >
             <div
               class="cxd-Table"
-              style="--Table-column--2-width: 0px;"
+              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -3314,45 +3280,45 @@ exports[`Renderer:table combine Renderer:table combineNum with fromIndex 1`] = `
                 </div>
                 <span />
               </div>
-            </div>
-            <div
-              class="resize-sensor"
-              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-            >
-              
-  
               <div
-                class="resize-sensor-expand"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
               >
                 
-    
+  
                 <div
-                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-shrink"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
     
-                <div
-                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                />
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
                 
   
-              </div>
-              
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
   
-              <div
-                class="resize-sensor-appear"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-              />
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -3379,11 +3345,10 @@ exports[`Renderer:table groupName-default 1`] = `
         >
           <div
             class="cxd-Service"
-            style="position: relative;"
           >
             <div
               class="cxd-Table m-b-none"
-              style="--Table-column--2-width: 0px;"
+              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -4096,45 +4061,45 @@ exports[`Renderer:table groupName-default 1`] = `
                 </div>
                 <span />
               </div>
-            </div>
-            <div
-              class="resize-sensor"
-              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-            >
-              
-  
               <div
-                class="resize-sensor-expand"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
               >
                 
-    
+  
                 <div
-                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-shrink"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
     
-                <div
-                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                />
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
                 
   
-              </div>
-              
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
   
-              <div
-                class="resize-sensor-appear"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-              />
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -4161,11 +4126,10 @@ exports[`Renderer:table groupName-middleNoGroupName 1`] = `
         >
           <div
             class="cxd-Service"
-            style="position: relative;"
           >
             <div
               class="cxd-Table m-b-none"
-              style="--Table-column--2-width: 0px;"
+              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -4882,45 +4846,45 @@ exports[`Renderer:table groupName-middleNoGroupName 1`] = `
                 </div>
                 <span />
               </div>
-            </div>
-            <div
-              class="resize-sensor"
-              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-            >
-              
-  
               <div
-                class="resize-sensor-expand"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
               >
                 
-    
+  
                 <div
-                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-shrink"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
     
-                <div
-                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                />
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
                 
   
-              </div>
-              
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
   
-              <div
-                class="resize-sensor-appear"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-              />
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -4947,11 +4911,10 @@ exports[`Renderer:table groupName-startNoGroupName 1`] = `
         >
           <div
             class="cxd-Service"
-            style="position: relative;"
           >
             <div
               class="cxd-Table m-b-none"
-              style="--Table-column--2-width: 0px;"
+              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -5656,45 +5619,45 @@ exports[`Renderer:table groupName-startNoGroupName 1`] = `
                 </div>
                 <span />
               </div>
-            </div>
-            <div
-              class="resize-sensor"
-              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-            >
-              
-  
               <div
-                class="resize-sensor-expand"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
               >
                 
-    
+  
                 <div
-                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-shrink"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
     
-                <div
-                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                />
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
                 
   
-              </div>
-              
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
   
-              <div
-                class="resize-sensor-appear"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-              />
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -5721,11 +5684,10 @@ exports[`Renderer:table groupName-withTpl 1`] = `
         >
           <div
             class="cxd-Service"
-            style="position: relative;"
           >
             <div
               class="cxd-Table m-b-none"
-              style="--Table-column--2-width: 0px;"
+              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -6438,45 +6400,45 @@ exports[`Renderer:table groupName-withTpl 1`] = `
                 </div>
                 <span />
               </div>
-            </div>
-            <div
-              class="resize-sensor"
-              style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-            >
-              
-  
               <div
-                class="resize-sensor-expand"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
               >
                 
-    
+  
                 <div
-                  style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-                />
-                
-  
-              </div>
-              
-  
-              <div
-                class="resize-sensor-shrink"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-              >
-                
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
     
-                <div
-                  style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-                />
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
                 
   
-              </div>
-              
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
   
-              <div
-                class="resize-sensor-appear"
-                style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-              />
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -6487,12 +6449,10 @@ exports[`Renderer:table groupName-withTpl 1`] = `
 `;
 
 exports[`Renderer:table isHead fixed 1`] = `
-<div
-  style="position: relative;"
->
+<div>
   <div
     class="cxd-Table"
-    style="--Table-column--2-width: 0px; --Table-column-1-width: 0px;"
+    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -6824,56 +6784,54 @@ exports[`Renderer:table isHead fixed 1`] = `
       </div>
       <span />
     </div>
-  </div>
-  <div
-    class="resize-sensor"
-    style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-  >
-    
-  
     <div
-      class="resize-sensor-expand"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      class="resize-sensor"
+      style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
     >
       
-    
+  
       <div
-        style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-      />
+        class="resize-sensor-expand"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      >
+        
+    
+        <div
+          style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+        />
+        
+  
+      </div>
       
   
-    </div>
-    
-  
-    <div
-      class="resize-sensor-shrink"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-    >
-      
-    
       <div
-        style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-      />
+        class="resize-sensor-shrink"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      >
+        
+    
+        <div
+          style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+        />
+        
+  
+      </div>
       
   
+      <div
+        class="resize-sensor-appear"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+      />
     </div>
-    
-  
-    <div
-      class="resize-sensor-appear"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-    />
   </div>
 </div>
 `;
 
 exports[`Renderer:table list 1`] = `
-<div
-  style="position: relative;"
->
+<div>
   <div
     class="cxd-Table"
-    style="--Table-column--2-width: 0px;"
+    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; --Table-column-10-width: 0px; --Table-column-11-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-toolbar cxd-Table-headToolbar"
@@ -8058,45 +8016,45 @@ exports[`Renderer:table list 1`] = `
       </div>
       <span />
     </div>
-  </div>
-  <div
-    class="resize-sensor"
-    style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
-  >
-    
-  
     <div
-      class="resize-sensor-expand"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      class="resize-sensor"
+      style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
     >
       
-    
+  
       <div
-        style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
-      />
+        class="resize-sensor-expand"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      >
+        
+    
+        <div
+          style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+        />
+        
+  
+      </div>
       
   
-    </div>
-    
-  
-    <div
-      class="resize-sensor-shrink"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
-    >
-      
-    
       <div
-        style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
-      />
+        class="resize-sensor-shrink"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      >
+        
+    
+        <div
+          style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+        />
+        
+  
+      </div>
       
   
+      <div
+        class="resize-sensor-appear"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+      />
     </div>
-    
-  
-    <div
-      class="resize-sensor-appear"
-      style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
-    />
   </div>
 </div>
 `;

--- a/packages/amis/src/renderers/Table/AutoFilterForm.tsx
+++ b/packages/amis/src/renderers/Table/AutoFilterForm.tsx
@@ -1,0 +1,244 @@
+import {
+  IColumn,
+  ITableStore,
+  RendererProps,
+  createObject,
+  padArr
+} from 'amis-core';
+import {Icon} from 'amis-ui';
+import {observer} from 'mobx-react';
+import React from 'react';
+
+export interface AutoFilterFormProps extends RendererProps {
+  searchFormExpanded: boolean;
+  autoGenerateFilter: any;
+  activedSearchableColumns: Array<IColumn>;
+  searchableColumns: Array<IColumn>;
+  columnsNum: number;
+  onItemToggleExpanded?: (column: IColumn, value: any) => void;
+  onToggleExpanded?: () => void;
+  query?: any;
+
+  onSearchableFromReset?: any;
+  onSearchableFromSubmit?: any;
+  onSearchableFromInit?: any;
+}
+
+export function AutoFilterForm({
+  autoGenerateFilter,
+  searchFormExpanded,
+  activedSearchableColumns,
+  searchableColumns,
+  onItemToggleExpanded,
+  onToggleExpanded,
+  classnames: cx,
+  translate: __,
+  render,
+  data,
+  onSearchableFromReset,
+  onSearchableFromSubmit,
+  onSearchableFromInit
+}: AutoFilterFormProps) {
+  const schema = React.useMemo(() => {
+    const {columnsNum, showBtnToolbar} =
+      typeof autoGenerateFilter === 'boolean'
+        ? {
+            columnsNum: 3,
+            showBtnToolbar: true
+          }
+        : autoGenerateFilter;
+
+    const body: Array<any> = padArr(activedSearchableColumns, columnsNum).map(
+      group => ({
+        type: 'group',
+        body: group.map((column: any) => ({
+          ...(column.searchable === true
+            ? {
+                type: 'input-text',
+                name: column.name,
+                label: column.label
+              }
+            : {
+                type: 'input-text',
+                name: column.name,
+                ...column.searchable
+              }),
+          name: column.searchable?.name ?? column.name,
+          label: column.searchable?.label ?? column.label
+        }))
+      })
+    );
+
+    let showExpander = searchableColumns.length >= columnsNum;
+
+    // todo 以后做动画
+    if (!searchFormExpanded && body.length) {
+      body.splice(1, body.length - 1);
+      body[0].body.splice(columnsNum - 1, body[0].body.length - columnsNum + 1);
+    }
+
+    let lastGroup = body[body.length - 1];
+    if (
+      !Array.isArray(lastGroup?.body) ||
+      lastGroup.body.length >= columnsNum
+    ) {
+      lastGroup = {
+        type: 'group',
+        body: []
+      };
+      body.push(lastGroup);
+    }
+
+    let count = Math.max(columnsNum - lastGroup.body.length - 1);
+    while (count-- > 0) {
+      lastGroup.body.push({
+        type: 'tpl',
+        tpl: ''
+      });
+    }
+    lastGroup.body.push({
+      type: 'container',
+      className: 'ButtonToolbar text-right block',
+      wrapperBody: false,
+      body: [
+        {
+          type: 'dropdown-button',
+          label: __('Table.searchFields'),
+          className: cx('Table-searchableForm-dropdown', 'mr-2'),
+          level: 'link',
+          trigger: 'click',
+          size: 'sm',
+          align: 'right',
+          visible: showBtnToolbar,
+          buttons: searchableColumns.map(column => {
+            return {
+              type: 'checkbox',
+              label: false,
+              className: cx('Table-searchableForm-checkbox'),
+              inputClassName: cx('Table-searchableForm-checkbox-inner'),
+              name: `${
+                column.searchable.strategy === 'jsonql' ? '' : '__search_'
+              }${column.searchable?.name ?? column.name}`,
+              option: column.searchable?.label ?? column.label,
+              value: column.enableSearch,
+              badge: {
+                offset: [-10, 5],
+                visibleOn: `${
+                  column.toggable && !column.toggled && column.enableSearch
+                }`
+              },
+              onChange: (value: boolean) =>
+                onItemToggleExpanded?.(column, value)
+            };
+          })
+        },
+
+        {
+          type: 'submit',
+          label: __('search'),
+          level: 'primary',
+          className: 'w-18'
+        },
+        {
+          type: 'reset',
+          label: __('reset'),
+          className: 'w-18'
+        },
+
+        showExpander
+          ? {
+              children: () => (
+                <a
+                  className={cx(
+                    'Table-SFToggler',
+                    searchFormExpanded ? 'is-expanded' : ''
+                  )}
+                  onClick={onToggleExpanded}
+                >
+                  {__(searchFormExpanded ? 'collapse' : 'expand')}
+                  <span className={cx('Table-SFToggler-arrow')}>
+                    <Icon icon="right-arrow-bold" className="icon" />
+                  </span>
+                </a>
+              )
+            }
+          : null
+      ].filter(item => item)
+    });
+
+    return {
+      type: 'form',
+      api: null,
+      title: '',
+      mode: 'horizontal',
+      submitText: __('search'),
+      body: body,
+      actions: [],
+      canAccessSuperData: false
+    };
+  }, [
+    autoGenerateFilter,
+    activedSearchableColumns,
+    searchableColumns,
+    searchFormExpanded
+  ]);
+
+  return render('searchable-form', schema, {
+    key: 'searchable-form',
+    panelClassName: cx('Table-searchableForm'),
+    actionsClassName: cx('Table-searchableForm-footer'),
+    onReset: onSearchableFromReset,
+    onSubmit: onSearchableFromSubmit,
+    onInit: onSearchableFromInit,
+    formStore: undefined,
+    data
+  });
+}
+
+export default observer(
+  ({
+    store,
+    query,
+    data,
+    ...rest
+  }: Omit<
+    AutoFilterFormProps,
+    | 'activedSearchableColumns'
+    | 'searchableColumns'
+    | 'searchFormExpanded'
+    | 'onItemToggleExpanded'
+    | 'onToggleExpanded'
+  > & {
+    store: ITableStore;
+    query: any;
+  }) => {
+    const onItemToggleExpanded = React.useCallback(
+      (column: IColumn, value: any) => {
+        column.setEnableSearch(value);
+        store.setSearchFormExpanded(true);
+      },
+      []
+    );
+
+    const onToggleExpanded = React.useCallback(() => {
+      store.toggleSearchFormExpanded();
+    }, []);
+
+    const ctx = React.useMemo(
+      () => (query ? createObject(data, query) : data),
+      [query, data]
+    );
+
+    return (
+      <AutoFilterForm
+        {...(rest as any)}
+        activedSearchableColumns={store.activedSearchableColumns}
+        searchableColumns={store.searchableColumns}
+        searchFormExpanded={store.searchFormExpanded}
+        onItemToggleExpanded={onItemToggleExpanded}
+        onToggleExpanded={onToggleExpanded}
+        data={ctx}
+      />
+    );
+  }
+);

--- a/packages/amis/src/renderers/Table/ColGroup.tsx
+++ b/packages/amis/src/renderers/Table/ColGroup.tsx
@@ -9,8 +9,31 @@ export function ColGroup({
   columns: Array<IColumn>;
   store: ITableStore;
 }) {
+  const domRef = React.createRef<HTMLTableColElement>();
+
+  React.useEffect(() => {
+    if (domRef.current) {
+      store.syncTableWidth();
+    }
+  });
+
+  React.useEffect(() => {
+    const table = domRef.current!.parentElement!;
+    const observer = new MutationObserver(() => {
+      store.syncTableWidth();
+    });
+    observer.observe(table, {
+      attributes: true,
+      childList: true,
+      subtree: true
+    });
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
   return (
-    <colgroup>
+    <colgroup ref={domRef}>
       {columns.map(column => {
         const style: any = {};
 
@@ -18,6 +41,10 @@ export function ColGroup({
           style.width = column.width;
         } else if (column.pristine.width) {
           style.width = column.pristine.width;
+        }
+
+        if (store.tableLayout === 'auto' && style.width) {
+          style.minWidth = style.width;
         }
 
         return <col data-index={column.index} style={style} key={column.id} />;

--- a/packages/amis/src/renderers/Table/TableBody.tsx
+++ b/packages/amis/src/renderers/Table/TableBody.tsx
@@ -65,7 +65,7 @@ export interface TableBodyProps extends LocaleProps {
 @observer
 export class TableBody extends React.Component<TableBodyProps> {
   componentDidMount(): void {
-    this.props.store.syncTableWidth();
+    this.props.store.initTableWidth();
   }
 
   renderRows(

--- a/packages/amis/src/renderers/Table/TableContent.tsx
+++ b/packages/amis/src/renderers/Table/TableContent.tsx
@@ -173,8 +173,7 @@ export class TableContent extends React.PureComponent<TableContentProps> {
       store,
       dispatchEvent,
       onEvent,
-      loading,
-      columnWidthReady
+      loading
     } = this.props;
 
     const tableClassName = cx('Table-table', this.props.tableClassName);
@@ -190,7 +189,7 @@ export class TableContent extends React.PureComponent<TableContentProps> {
           ref={tableRef}
           className={cx(
             tableClassName,
-            columnWidthReady ? 'is-layout-fixed' : undefined
+            store.tableLayout === 'fixed' ? 'is-layout-fixed' : undefined
           )}
         >
           <ColGroup columns={columns} store={store} />

--- a/packages/amis/src/renderers/Table/TableRow.tsx
+++ b/packages/amis/src/renderers/Table/TableRow.tsx
@@ -42,6 +42,7 @@ interface TableRowProps extends Pick<RendererProps, 'render'> {
 export class TableRow extends React.PureComponent<
   TableRowProps & {
     expanded: boolean;
+    parentExpanded?: boolean;
     id: string;
     newIndex: number;
     isHover: boolean;
@@ -301,13 +302,13 @@ export class TableRow extends React.PureComponent<
               ...rest,
               rowIndex: itemIndex,
               colIndex: column.index,
-              key: column.index,
+              key: column.id,
               onAction: this.handleAction,
               onQuickChange: this.handleQuickChange,
               onChange: this.handleChange
             })
           ) : (
-            <td key={column.index}>
+            <td key={column.id}>
               <div className={cx('Table-emptyBlock')}>&nbsp;</div>
             </td>
           )
@@ -320,6 +321,7 @@ export class TableRow extends React.PureComponent<
 // 换成 mobx-react-lite 模式
 export default observer((props: TableRowProps) => {
   const item = props.item;
+  const parent = props.parent;
   const store = props.store;
   const columns = props.columns;
   const canAccessSuperData =
@@ -337,6 +339,7 @@ export default observer((props: TableRowProps) => {
       {...props}
       trRef={ref}
       expanded={item.expanded}
+      parentExpanded={parent?.expanded}
       id={item.id}
       newIndex={item.newIndex}
       isHover={item.isHover}

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -68,6 +68,7 @@ import isPlainObject from 'lodash/isPlainObject';
 import omit from 'lodash/omit';
 import ColGroup from './ColGroup';
 import debounce from 'lodash/debounce';
+import AutoFilterForm from './AutoFilterForm';
 
 /**
  * 表格列，不指定类型时默认为文本类型。
@@ -335,6 +336,11 @@ export interface TableSchema extends BaseSchema {
    * 表格自动计算高度
    */
   autoFillHeight?: boolean | AutoFillHeightObject;
+
+  /**
+   * table layout
+   */
+  tableLayout?: 'fixed' | 'auto';
 }
 
 export interface TableProps extends RendererProps, SpinnerExtraProps {
@@ -522,6 +528,15 @@ export default class Table extends React.Component<TableProps, object> {
     leading: false
   });
 
+  updateAutoFillHeightLazy = debounce(
+    this.updateAutoFillHeight.bind(this),
+    250,
+    {
+      trailing: true,
+      leading: false
+    }
+  );
+
   constructor(props: TableProps, context: IScopedContext) {
     super(props);
 
@@ -579,7 +594,8 @@ export default class Table extends React.Component<TableProps, object> {
       autoGenerateFilter,
       loading,
       canAccessSuperData,
-      lazyRenderAfter
+      lazyRenderAfter,
+      tableLayout
     } = props;
 
     let combineNum = props.combineNum;
@@ -610,7 +626,8 @@ export default class Table extends React.Component<TableProps, object> {
       maxKeepItemSelectionLength,
       loading,
       canAccessSuperData,
-      lazyRenderAfter
+      lazyRenderAfter,
+      tableLayout
     });
 
     if (
@@ -665,22 +682,19 @@ export default class Table extends React.Component<TableProps, object> {
     const currentNode = findDOMNode(this) as HTMLElement;
 
     if (this.props.autoFillHeight) {
-      let frame: number;
-      let fn = () => {
-        cancelAnimationFrame(frame);
-        frame = requestAnimationFrame(this.updateAutoFillHeight);
-      };
-      this.toDispose.push(resizeSensor(currentNode.parentElement!, fn));
+      this.toDispose.push(
+        resizeSensor(
+          currentNode.parentElement!,
+          this.updateAutoFillHeightLazy,
+          false,
+          'height'
+        )
+      );
       this.updateAutoFillHeight();
     }
 
     this.toDispose.push(
-      resizeSensor(
-        currentNode.parentElement!,
-        this.updateTableInfoLazy,
-        false,
-        'width'
-      )
+      resizeSensor(currentNode, this.updateTableInfoLazy, false, 'width')
     );
     const {store, autoGenerateFilter, onSearchableFromInit} = this.props;
 
@@ -779,7 +793,9 @@ export default class Table extends React.Component<TableProps, object> {
 
     const tableContentHeight = heightValue
       ? `${heightValue}px`
-      : `${viewportHeight - tableContentTop - tableContentBottom}px`;
+      : `${Math.round(
+          viewportHeight - tableContentTop - tableContentBottom
+        )}px`;
 
     tableContent.style[heightField] = tableContentHeight;
   }
@@ -807,7 +823,8 @@ export default class Table extends React.Component<TableProps, object> {
         'columns',
         'loading',
         'canAccessSuperData',
-        'lazyRenderAfter'
+        'lazyRenderAfter',
+        'tableLayout'
       ],
       prevProps,
       props,
@@ -858,6 +875,7 @@ export default class Table extends React.Component<TableProps, object> {
     this.toDispose = [];
 
     this.updateTableInfoLazy.cancel();
+    this.updateAutoFillHeightLazy.cancel();
     formItem && isAlive(formItem) && formItem.setSubStore(null);
     clearTimeout(this.timer);
 
@@ -1215,7 +1233,7 @@ export default class Table extends React.Component<TableProps, object> {
     if (this.resizeLine) {
       return;
     }
-    this.props.store.syncTableWidth();
+    this.props.store.initTableWidth();
     this.handleOutterScroll();
     callback && setTimeout(callback, 20);
   }
@@ -1542,7 +1560,7 @@ export default class Table extends React.Component<TableProps, object> {
     const store = this.props.store;
     const index = parseInt(this.resizeLine!.getAttribute('data-index')!, 10);
     const column = store.columns[index];
-    this.lineStartWidth = column.width;
+    this.lineStartWidth = column.realWidth || column.width;
     this.resizeLine!.classList.add('is-resizing');
 
     document.addEventListener('mousemove', this.handleColResizeMouseMove);
@@ -1583,167 +1601,29 @@ export default class Table extends React.Component<TableProps, object> {
       onSearchableFromSubmit,
       onSearchableFromInit,
       classnames: cx,
-      autoGenerateFilter,
       translate: __,
       query,
-      data
+      data,
+      autoGenerateFilter
     } = this.props;
-    const {columnsNum, showBtnToolbar} =
-      typeof autoGenerateFilter === 'boolean'
-        ? {
-            columnsNum: 3,
-            showBtnToolbar: true
-          }
-        : autoGenerateFilter;
-    const searchableColumns = store.searchableColumns;
-    const activedSearchableColumns = store.activedSearchableColumns;
 
+    const searchableColumns = store.searchableColumns;
     if (!searchableColumns.length) {
       return null;
     }
-
-    const body: Array<any> = padArr(activedSearchableColumns, columnsNum).map(
-      group => ({
-        type: 'group',
-        body: group.map((column: any) => ({
-          ...(column.searchable === true
-            ? {
-                type: 'input-text',
-                name: column.name,
-                label: column.label
-              }
-            : {
-                type: 'input-text',
-                name: column.name,
-                ...column.searchable
-              }),
-          name: column.searchable?.name ?? column.name,
-          label: column.searchable?.label ?? column.label
-        }))
-      })
-    );
-
-    let showExpander = searchableColumns.length >= columnsNum;
-
-    // todo 以后做动画
-    if (!store.searchFormExpanded && body.length) {
-      body.splice(1, body.length - 1);
-      body[0].body.splice(columnsNum - 1, body[0].body.length - columnsNum + 1);
-    }
-
-    let lastGroup = body[body.length - 1];
-    if (
-      !Array.isArray(lastGroup?.body) ||
-      lastGroup.body.length >= columnsNum
-    ) {
-      lastGroup = {
-        type: 'group',
-        body: []
-      };
-      body.push(lastGroup);
-    }
-
-    let count = Math.max(columnsNum - lastGroup.body.length - 1);
-    while (count-- > 0) {
-      lastGroup.body.push({
-        type: 'tpl',
-        tpl: ''
-      });
-    }
-    lastGroup.body.push({
-      type: 'container',
-      className: 'ButtonToolbar text-right block',
-      wrapperBody: false,
-      body: [
-        {
-          type: 'dropdown-button',
-          label: __('Table.searchFields'),
-          className: cx('Table-searchableForm-dropdown', 'mr-2'),
-          level: 'link',
-          trigger: 'click',
-          size: 'sm',
-          align: 'right',
-          visible: showBtnToolbar,
-          buttons: searchableColumns.map(column => {
-            return {
-              type: 'checkbox',
-              label: false,
-              className: cx('Table-searchableForm-checkbox'),
-              inputClassName: cx('Table-searchableForm-checkbox-inner'),
-              name: `${
-                column.searchable.strategy === 'jsonql' ? '' : '__search_'
-              }${column.searchable?.name ?? column.name}`,
-              option: column.searchable?.label ?? column.label,
-              value: column.enableSearch,
-              badge: {
-                offset: [-10, 5],
-                visibleOn: `${
-                  column.toggable && !column.toggled && column.enableSearch
-                }`
-              },
-              onChange: (value: boolean) => {
-                column.setEnableSearch(value);
-                store.setSearchFormExpanded(true);
-              }
-            };
-          })
-        },
-
-        {
-          type: 'submit',
-          label: __('search'),
-          level: 'primary',
-          className: 'w-18'
-        },
-        {
-          type: 'reset',
-          label: __('reset'),
-          className: 'w-18'
-        },
-
-        showExpander
-          ? {
-              children: () => (
-                <a
-                  className={cx(
-                    'Table-SFToggler',
-                    store.searchFormExpanded ? 'is-expanded' : ''
-                  )}
-                  onClick={store.toggleSearchFormExpanded}
-                >
-                  {__(store.searchFormExpanded ? 'collapse' : 'expand')}
-                  <span className={cx('Table-SFToggler-arrow')}>
-                    <Icon icon="right-arrow-bold" className="icon" />
-                  </span>
-                </a>
-              )
-            }
-          : null
-      ].filter(item => item)
-    });
-
-    return render(
-      'searchable-form',
-      {
-        type: 'form',
-        api: null,
-        title: '',
-        mode: 'horizontal',
-        submitText: __('search'),
-        body: body,
-        actions: [],
-        canAccessSuperData: false
-      },
-      {
-        key: 'searchable-form',
-        panelClassName: cx('Table-searchableForm'),
-        actionsClassName: cx('Table-searchableForm-footer'),
-        onReset: onSearchableFromReset,
-        onSubmit: onSearchableFromSubmit,
-        onInit: onSearchableFromInit,
-        formStore: undefined,
-        data: query ? createObject(data, query) : data
-      }
+    return (
+      <AutoFilterForm
+        store={store}
+        query={query}
+        data={data}
+        translate={__}
+        classnames={cx}
+        render={render}
+        autoGenerateFilter={autoGenerateFilter}
+        onSearchableFromReset={onSearchableFromReset}
+        onSearchableFromSubmit={onSearchableFromSubmit}
+        onSearchableFromInit={onSearchableFromInit}
+      />
     );
   }
 
@@ -1951,7 +1831,30 @@ export default class Table extends React.Component<TableProps, object> {
       );
     }
 
-    let affix = [];
+    const prefix: Array<JSX.Element> = [];
+    const affix: Array<JSX.Element> = [];
+
+    if (column.isPrimary && store.isNested) {
+      (store.footable &&
+        (store.footable.expandAll === false || store.footable.accordion)) ||
+        (store.expandConfig &&
+          (store.expandConfig.expandAll === false ||
+            store.expandConfig.accordion)) ||
+        prefix.push(
+          <a
+            key="expandBtn"
+            className={cx(
+              'Table-expandBtn2',
+              store.allExpanded ? 'is-active' : ''
+            )}
+            // data-tooltip="展开/收起全部"
+            // data-position="top"
+            onClick={store.toggleExpandAll}
+          >
+            <Icon icon="right-arrow-bold" className="icon" />
+          </a>
+        );
+    }
 
     if (column.searchable && column.name && !autoGenerateFilter) {
       affix.push(
@@ -2071,9 +1974,11 @@ export default class Table extends React.Component<TableProps, object> {
           'Table-operationCell': column.type === 'operation'
         })}
       >
+        {prefix}
         <div
+          key="content"
           className={cx(
-            `${ns}TableCell--title`,
+            `TableCell--title`,
             column.pristine.className,
             column.pristine.labelClassName
           )}
@@ -2162,15 +2067,6 @@ export default class Table extends React.Component<TableProps, object> {
           key={props.key}
           className={cx(column.pristine.className, stickyClassName)}
         >
-          {item.depth > 2
-            ? Array.from({length: item.depth - 2}).map((_, index) => (
-                <i key={index} className={cx('Table-divider-' + (index + 1))} />
-              ))
-            : null}
-
-          {item.depth > 1 ? <i className={cx('Table-divider2')} /> : null}
-          {item.depth > 1 ? <i className={cx('Table-divider3')} /> : null}
-
           {item.expandable ? (
             <a
               className={cx(
@@ -2188,7 +2084,35 @@ export default class Table extends React.Component<TableProps, object> {
       );
     }
 
-    let prefix: React.ReactNode = null;
+    let prefix: React.ReactNode[] = [];
+    let affix: React.ReactNode[] = [];
+    let addtionalClassName = '';
+
+    if (column.isPrimary && store.isNested) {
+      addtionalClassName = 'Table-primayCell';
+      prefix.push(
+        <span
+          key="indent"
+          className={cx('Table-indent')}
+          style={item.indentStyle}
+        />
+      );
+      prefix.push(
+        item.expandable ? (
+          <a
+            key="expandBtn2"
+            className={cx('Table-expandBtn2', item.expanded ? 'is-active' : '')}
+            // data-tooltip="展开/收起"
+            // data-position="top"
+            onClick={item.toggleExpanded}
+          >
+            <Icon icon="right-arrow-bold" className="icon" />
+          </a>
+        ) : (
+          <span key="expandSpace" className={cx('Table-expandSpace')} />
+        )
+      );
+    }
 
     if (
       !ignoreDrag &&
@@ -2197,8 +2121,9 @@ export default class Table extends React.Component<TableProps, object> {
       store.draggable &&
       item.draggable
     ) {
-      prefix = (
+      affix.push(
         <a
+          key="dragBtn"
           draggable
           onDragStart={this.handleDragStart}
           className={cx('Table-dragBtn')}
@@ -2226,6 +2151,7 @@ export default class Table extends React.Component<TableProps, object> {
       rowSpan: item.rowSpans[column.name as string],
       quickEditFormRef: this.subFormRef,
       cellPrefix: prefix,
+      cellAffix: affix,
       onImageEnlarge: this.handleImageEnlarge,
       canAccessSuperData,
       row: item,
@@ -2236,7 +2162,11 @@ export default class Table extends React.Component<TableProps, object> {
         store.firstToggledColumnIndex === props.colIndex,
       onQuery: undefined,
       style,
-      className: cx(column.pristine.className, stickyClassName),
+      className: cx(
+        column.pristine.className,
+        stickyClassName,
+        addtionalClassName
+      ),
       /** 给子节点的设置默认值，避免取到env.affixHeader的默认值，导致表头覆盖首行 */
       affixOffsetTop: 0
     };
@@ -2280,9 +2210,30 @@ export default class Table extends React.Component<TableProps, object> {
             <div className={cx('Table-wrapper')}>
               <table
                 ref={this.affixedTableRef}
-                className={cx(tableClassName, 'is-layout-fixed')}
+                className={cx(
+                  tableClassName,
+                  store.tableLayout === 'fixed' ? 'is-layout-fixed' : ''
+                )}
               >
-                <ColGroup columns={store.filteredColumns} store={store} />
+                <colgroup>
+                  {store.filteredColumns.map(column => {
+                    const style: any = {
+                      width: `var(--Table-column-${column.index}-width)`
+                    };
+
+                    if (store.tableLayout === 'auto') {
+                      style.minWidth = style.width;
+                    }
+
+                    return (
+                      <col
+                        data-index={column.index}
+                        style={style}
+                        key={column.id}
+                      />
+                    );
+                  })}
+                </colgroup>
                 <thead>
                   {columnsGroup.length ? (
                     <tr>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a844697</samp>

This pull request implements and improves the table layout mode feature for the `amis` library. It adds a new `tableLayout` property to the `Table` component and the documentation, and modifies the logic and styling of the `TableStore`, `TableBody`, `TableRow`, `ColGroup`, and `TableContent` components. It also fixes some bugs related to the column width and order, and adds a nested table feature with a new `parentExpanded` prop and a `--Table-tree-indent` CSS variable. It updates the example file `Nested.jsx` to demonstrate the new features.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a844697</samp>

> _The table component got a new mode_
> _To handle the layout of the code_
> _With `colgroup` and `realWidth`_
> _And `tableLayout` for the user's wish_
> _The nested rows also nicely showed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a844697</samp>

*  Add a new feature to allow users to choose between `auto` or `fixed` table layout modes for the table component ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-8a30381c7717a1ae36bd67d653324e6d01991200c0a2f1a0124f1e753d0cf380R1849), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL378-R391), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL916-R943), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4R4014), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dL550-L585), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dL623-L634), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dR612-R616), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dL902-R861), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dR895-R907), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-b4960ad44934bf990cfc6e86973e87d97d8ae96dbfa69ee15cad4d013719feb5L12-R36), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-b4960ad44934bf990cfc6e86973e87d97d8ae96dbfa69ee15cad4d013719feb5R46-R49), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL68-R68), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-91ac32323efbbdeeb403a100e73ac57bbc44aa103329f6734c33acb0bd323b25L176-R176), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-91ac32323efbbdeeb403a100e73ac57bbc44aa103329f6734c33acb0bd323b25L193-R192), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-43b60bad2b0604663fde07452d82b7576c0d07c3fea6c0a0d6d24a1dd3b82f49R45), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR338-R342), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL582-R597), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL613-R629), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL810-R826), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1218-R1235), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1954-R1995), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2074-R2118), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2283-R2373))
  * Add a new table property `tableLayout` to the documentation file `./docs/zh-CN/components/table.md` to document the new feature ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-8a30381c7717a1ae36bd67d653324e6d01991200c0a2f1a0124f1e753d0cf380R1849))
  * Add a new property `tableLayout` to the `TableStore` type in the file `./packages/amis-core/src/store/table.ts` to store the table layout mode that is configured by the user or the default value ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL378-R391))
  * Add the `tableLayout` property to the arguments of the `update` method of the `TableStore` type and assign it to the `tableLayout` property of the table store ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL916-R943))
  * Add a new CSS variable `--Table-tree-indent` to the file `./packages/amis-ui/scss/_components.scss` to define the indentation size for the nested table rows ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4R4014))
  * Remove the CSS rules for the selectors `.Table-tr--nth` and `.Table-divider-nth` in the file `./packages/amis-ui/scss/components/_table.scss` to simplify the styling of the nested table rows and remove the hard-coded limits on the depth levels ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dL550-L585), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dL623-L634))
  * Add a new selector `.Table-primayCell` in the file `./packages/amis-ui/scss/components/_table.scss` to set the `white-space: nowrap` property for the primary cell of the nested table ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dR612-R616))
  * Add a new selector `.Table-expandBtn2` in the file `./packages/amis-ui/scss/components/_table.scss` to style the expand button for the nested table rows, which is different from the expand button for the footable rows ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dL902-R861))
  * Add two new selectors `.Table-indent` and `.Table-expandSpace` in the file `./packages/amis-ui/scss/components/_table.scss` to style the indentation and the space for the nested table rows ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dR895-R907))
  * Create a reference to the `colgroup` element and use it to call the `syncTableWidth` method of the table store when the element is mounted or mutated in the `ColGroup` function in the file `./packages/amis/src/renderers/Table/ColGroup.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-b4960ad44934bf990cfc6e86973e87d97d8ae96dbfa69ee15cad4d013719feb5L12-R36))
  * Use the `realWidth` property instead of the `width` property of the column, and set the `minWidth` property when the table layout mode is `auto` for the `col` elements in the `ColGroup` function in the file `./packages/amis/src/renderers/Table/ColGroup.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-b4960ad44934bf990cfc6e86973e87d97d8ae96dbfa69ee15cad4d013719feb5R46-R49))
  * Use the renamed method `initTableWidth` instead of the `syncTableWidth` method to initialize the column widths and the table layout mode when the table component is mounted or updated in the `componentDidMount` lifecycle method of the `TableBody` class in the file `./packages/amis/src/renderers/Table/TableBody.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-dbc4da319071d0962777fb819d399fd26da523ca04fb540f59f927a25f0e05efL68-R68))
  * Remove the unused prop `columnWidthReady` that was previously used to control the table layout mode from the `TableContent` class in the file `./packages/amis/src/renderers/Table/TableContent.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-91ac32323efbbdeeb403a100e73ac57bbc44aa103329f6734c33acb0bd323b25L176-R176))
  * Use the `tableLayout` prop and the table store to determine whether to add the `is-layout-fixed` class name or not for the `table` element in the `TableContent` class in the file `./packages/amis/src/renderers/Table/TableContent.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-91ac32323efbbdeeb403a100e73ac57bbc44aa103329f6734c33acb0bd323b25L193-R192))
  * Add a new prop `parentExpanded` to the `TableRow` class in the file `./packages/amis/src/renderers/Table/TableRow.tsx` to pass the expanded state of the parent row to the child row, so that the child row can be rendered or hidden accordingly ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-43b60bad2b0604663fde07452d82b7576c0d07c3fea6c0a0d6d24a1dd3b82f49R45))
  * Add a new prop `tableLayout` to the `Table` class in the file `./packages/amis/src/renderers/Table/index.tsx` to allow the user to configure the table layout mode as `auto` or `fixed` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR338-R342))
  * Access the `tableLayout` prop that is passed from the parent component in the destructuring assignment of the props in the `Table` class in the file `./packages/amis/src/renderers/Table/index.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL582-R597))
  * Pass the `tableLayout` prop to the table store in the `update` method of the table store in the `Table` class in the file `./packages/amis/src/renderers/Table/index.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL613-R629))
  * Detect the changes in the `tableLayout` prop and update the table store accordingly in the `componentDidUpdate` lifecycle method of the `Table` class in the file `./packages/amis/src/renderers/Table/index.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL810-R826))
  * Use the renamed method `initTableWidth` instead of the `syncTableWidth` method to initialize the column widths and the table layout mode when the table component is mounted or updated in the `updateTableInfo` method of the `Table` class in the file `./packages/amis/src/renderers/Table/index.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1218-R1235))
  * Separate the affix elements from the prefix elements, which are used for different purposes, and render them before and after the content element, respectively, in the `renderHeadCell` method of the `Table` class in the file `./packages/amis/src/renderers/Table/index.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1954-R1995), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2074-R2118))
  * Use the `realWidth` property instead of the `width` property of the column, and set the `minWidth` property when the table layout mode is `auto` for the `colgroup` and `col` elements in the `render` method of the `Table` class in the file `./packages/amis/src/renderers/Table/index.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2283-R2373))
* Add a new feature to sync the real width of the columns with the actual width of the table cells as rendered by the browser, which may change due to resizing, filtering, or dragging ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR64), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL92-R102), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR882-R885), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1005-R1031), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1012-R1057), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1023-R1076), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1043-R1103), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1062-R1115), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR1122-R1136), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1672-R1741), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-b4960ad44934bf990cfc6e86973e87d97d8ae96dbfa69ee15cad4d013719feb5L12-R36), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-b4960ad44934bf990cfc6e86973e87d97d8ae96dbfa69ee15cad4d013719feb5R46-R49), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR530-R538), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL668-R696), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL782-R797), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR877))
  * Add a new property `realWidth` to the `Column` type in the file `./packages/amis-core/src/store/table.ts` to store the actual width of the column as rendered by the browser, which may differ from the `width` property that is set by the user or the default value ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR64))
  * Add a new method `setMinWidth` to the `Column` type in the file `./packages/amis-core/src/store/table.ts` to allow setting the minimum width of the column, which is used in the `auto` table layout mode to prevent the column from shrinking too much ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL92-R102))
  * Add a new method `setRealWidth` to the `Column` type in the file `./packages/amis-core/src/store/table.ts` to allow setting the real width of the column, which is updated when the table width is initialized or synced ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR882-R885))
  * Rename the `syncTableWidth` method to `initTableWidth` in the `TableStore` type in the file `./packages/amis-core/src/store/table.ts` to clarify the difference between this method and the new `syncTableWidth` method that is added later ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1005-R1031))
  * Use an array of HTML strings instead of concatenating them, and use the `isFixed` variable to check the table layout mode for the creation and insertion of the hidden div element in the `initTableWidth` method of the `TableStore` type in the file `./packages/amis-core/src/store/table.ts` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1012-R1057))
  * Use the `isFixed` variable to check the table layout mode, and use the `index` property instead of the `data-index` attribute of the cells for the selection and iteration of the table header cells in the `initTableWidth` method of the `TableStore` type in the file `./packages/amis-core/src/store/table.ts` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1023-R1076))
  * Use the `index` property instead of the `data-index` attribute of the cells, and call the `setMinWidth` method only when the table layout mode is `fixed` for the setting of the `minWidths` object and the calling of the `setMinWidth` method in the `initTableWidth` method of the `TableStore` type in the file `./packages/amis-core/src/store/table.ts` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1043-R1103))
  * Use the `index` property instead of the `data-index` attribute of the cells, and use the `minWidths` object to provide a fallback value for the minimum width for the setting of the `width` property and the calling of the `setWidth` method in the `initTableWidth` method of the `TableStore` type in the file `./packages/amis-core/src/store/table.ts` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1062-R1115))
  * Add a new method `syncTableWidth` to the `TableStore` type in the file `./packages/amis-core/src/store/table.ts` to sync the real width of the columns with the actual width of the table cells as rendered by the browser, which may change due to resizing, filtering, or dragging ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR1122-R1136))
  * Add the `getTable` and `syncTableWidth` methods and modify the `initTableWidth` method in the return value of the `TableStore` type in the file `./packages/amis-core/src/store/table.ts` to expose these methods to the table component and its subcomponents, so that they can access the table element and sync the table width ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1672-R1741))
  * Create a reference to the `colgroup` element and use it to call the `syncTableWidth` method of the table store when the element is mounted or mutated in the `ColGroup` function in the file `./packages/amis/src/renderers/Table/ColGroup.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-b4960ad44934bf990cfc6e86973e87d97d8ae96dbfa69ee15cad4d013719feb5L12-R36))
  * Use the `realWidth` property instead of the `width` property of the column, and set the `minWidth` property when the table layout mode is `auto` for the `col` elements in the `ColGroup` function in the file `./packages/amis/src/renderers/Table/ColGroup.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-b4960ad44934bf990cfc6e86973e87d97d8ae96dbfa69ee15cad4d013719feb5R46-R49))
  * Assign a debounced version of the `updateAutoFillHeight` method to a new variable `updateAutoFillHeightLazy` and use it for the resize sensor that adjusts the table height in the `Table` class in the file `./packages/amis/src/renderers/Table/index.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR530-R538))
  * Use the `currentNode` variable instead of the `currentNode.parentElement` variable for the resize sensor that updates the table info, since the latter may not reflect the actual width of the table element, in the `Table` class in the file `./packages/amis/src/renderers/Table/index.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL668-R696))
  * Use the `Math.round` function to round the height value to the nearest integer, to avoid fractional pixel values that may cause rendering issues, in the `updateAutoFillHeight` method of the `Table` class in the file `./packages/amis/src/renderers/Table/index.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL782-R797))
  * Cancel the execution of the `updateAutoFillHeightLazy` variable after the component is unmounted in the `componentWillUnmount` lifecycle method of the `Table` class in the file `./packages/amis/src/renderers/Table/index.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR877))
* Add a new feature to render the indentation of the nested rows in the table component ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR265-R270), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dR363), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-43b60bad2b0604663fde07452d82b7576c0d07c3fea6c0a0d6d24a1dd3b82f49R324), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-43b60bad2b0604663fde07452d82b7576c0d07c3fea6c0a0d6d24a1dd3b82f49R342), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2165-L2173), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2191-R2253), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2200-R2263), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR2291), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2239-R2306))
  * Add a new getter `indentStyle` to the `Row` type in the file `./packages/amis-core/src/store/table.ts` to return a style object that sets the left padding of the row according to its depth in the nested table ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR265-R270))
  * Add a new CSS property `display: inline-block` to the selector `.Table-expandBtn` in the file `./packages/amis-ui/scss/components/_table.scss` to make the expand button align with the text content of the cell ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dR363))
  * Add a new variable `parent` to the `TableRow` class in the file `./packages/amis/src/renderers/Table/TableRow.tsx` to store the parent row of the current row, which is passed from the props ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-43b60bad2b0604663fde07452d82b7576c0d07c3fea6c0a0d6d24a1dd3b82f49R324))
  * Pass the expanded state of the parent row to the child row in the `parentExpanded` prop of the `TableRow` component in the `TableRow` class in the file `./packages/amis/src/renderers/Table/TableRow.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-43b60bad2b0604663fde07452d82b7576c0d07c3fea6c0a0d6d24a1dd3b82f49R342))
  * Remove the rendering of the divider elements in the `renderCell` method of the `Table` class in the file `./packages/amis/src/renderers/Table/index.tsx` to simplify the rendering of the nested table rows and remove the hard-coded limits on the depth levels ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2165-L2173))
  * Separate the prefix elements from the affix elements, which are used for different purposes, in the `renderCell` method of the `Table` class in the file `./packages/amis/src/renderers/Table/index.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2191-R2253), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2200-R2263))
  * Pass the `affix` variable to the `cellAffix` prop of the `TableCell` component in the `renderCell` method of the `Table` class in the file `./packages/amis/src/renderers/Table/index.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR2291))
  * Pass the `Table-primayCell` class name to the `className` prop of the `TableCell` component, if the column is the primary column of the nested table, in the `renderCell` method of the `Table` class in the file `./packages/amis/src/renderers/Table/index.tsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2239-R2306))
* Fix a bug that prevented the `lazyRenderAfter` property from being updated, and add the support for updating the `tableLayout` property, in the `update` method of the `TableStore` type in the file `./packages/amis-core/src/store/table.ts` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL916-R943))
* Fix a bug that caused the fixed columns to have incorrect left or right styles when the columns are filtered or dragged, by using the `index` property instead of the `rawIndex` property of the column, in the `getColumnStyle` method of the `TableStore` type in the file `./packages/amis-core/src/store/table.ts` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL811-R832), [link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL829-R854))
* Exclude the `__expandme` column from the filtered columns when the table is not nested or dragging, since it is only used for expanding the nested rows, in the `getFilteredColumns` method of the `TableStore` type in the file `./packages/amis-core/src/store/table.ts` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL430-R443))
* Adjust the column width to fit the content better in the example file `./examples/components/CRUD/Nested.jsx` ([link](https://github.com/baidu/amis/pull/8077/files?diff=unified&w=0#diff-c1e292113137100e48b28863e77748e5f3bc137887515cbc8bc714c855ca982dL18-R18))
