### PR TITLE
fix(amis-editor): Tree静态选项控件删除校验逻辑错误, 值从props.value获取

### DIFF
--- a/packages/amis-editor/src/renderer/TreeOptionControl.tsx
+++ b/packages/amis-editor/src/renderer/TreeOptionControl.tsx
@@ -80,13 +80,12 @@ export default class TreeOptionControl extends React.Component<
   }
 
   transformOptions(props: OptionControlProps) {
-    const {
-      data: {options}
-    } = props;
-    if (!options || !options.length) {
+    const {value} = props;
+
+    if (!value || !Array.isArray(value) || !value.length) {
       return [{...defaultOption}];
     }
-    return options;
+    return value;
   }
 
   /**
@@ -231,10 +230,12 @@ export default class TreeOptionControl extends React.Component<
   @autobind
   handleDelete(pathStr: string, index: number) {
     const options = cloneDeep(this.state.options);
-    if (options.length === 1) {
-      toast.warning('至少保留一个节点', {closeButton: true});
+
+    if (!pathStr.includes('-') && options.length === 1) {
+      toast.warning('至少保留一个根节点', {closeButton: true});
       return;
     }
+
     const path = pathStr.split('-');
     if (path.length === 1) {
       options.splice(index, 1);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a167218</samp>

Fixed bugs in the `TreeOptionControl` component for editing tree options in `amis-editor`. The component now updates the tree options correctly and shows the appropriate warning message when deleting nodes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a167218</samp>

> _Sing, O Muse, of the valiant coder who fixed the bugs_
> _That plagued the `TreeOptionControl`, the skillful maker of trees_
> _Who by his cunning resolved the errors that hindered the updates_
> _And silenced the false alarms that vexed the deleters of nodes_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a167218</samp>

* Fix bug where adding or deleting nodes would not update the tree options correctly by using the `value` prop instead of the `options` prop as the source of the tree options in the `transformOptions` method ([link](https://github.com/baidu/amis/pull/8078/files?diff=unified&w=0#diff-cc8fe36e00110e9ad28c6e6ea10e6cd2093a714526d785f0320a88a39a522c5fL83-R88))
* Fix bug where deleting a child node would trigger a warning that is only intended for the root nodes by checking if the pathStr parameter contains a dash before comparing the length of the options array in the `handleDelete` method ([link](https://github.com/baidu/amis/pull/8078/files?diff=unified&w=0#diff-cc8fe36e00110e9ad28c6e6ea10e6cd2093a714526d785f0320a88a39a522c5fL234-R238))
* Clarify the warning message for deleting root nodes by changing it to "至少保留一个根节点" (at least keep one root node) in the `TreeOptionControl.tsx` file ([link](https://github.com/baidu/amis/pull/8078/files?diff=unified&w=0#diff-cc8fe36e00110e9ad28c6e6ea10e6cd2093a714526d785f0320a88a39a522c5fL234-R238))
