### PR TITLE
fix(amis-editor): 优化canAppendSiblings判定逻辑

### DIFF
--- a/packages/amis-editor-core/src/manager.ts
+++ b/packages/amis-editor-core/src/manager.ts
@@ -1029,12 +1029,7 @@ export class EditorManager {
       return false;
     }
     const regionNode = node.parent as EditorNodeType; // 父级节点
-    if (
-      regionNode &&
-      !regionNode.region &&
-      !regionNode.schema.body &&
-      regionNode.schema?.type !== 'flex'
-    ) {
+    if (regionNode && !regionNode.region && !regionNode.schema.body) {
       return false;
     }
 

--- a/packages/amis-editor-core/src/manager.ts
+++ b/packages/amis-editor-core/src/manager.ts
@@ -1025,15 +1025,19 @@ export class EditorManager {
     const store = this.store;
     const id = store.activeId;
     const node = store.getNodeById(id)!; // 当前选中节点
-    if (!node) {
-      return false;
-    }
     const regionNode = node.parent as EditorNodeType; // 父级节点
-    if (regionNode && !regionNode.region && !regionNode.schema.body) {
+    if (!node || !regionNode || !regionNode.schema) {
       return false;
+    } else if (regionNode.memberImmutable('')) {
+      return false;
+    } else if (
+      regionNode.schema.body ||
+      (regionNode.schema.type === 'flex' && regionNode.schema.items) ||
+      node.schema.columns
+    ) {
+      return true;
     }
-
-    return true;
+    return false;
   }
 
   /**

--- a/packages/amis-editor-core/src/plugin.ts
+++ b/packages/amis-editor-core/src/plugin.ts
@@ -1047,7 +1047,8 @@ export abstract class BasePlugin implements PluginInterface {
         disabledRendererPlugin: plugin.disabledRendererPlugin,
         isBaseComponent: plugin.isBaseComponent,
         isListComponent: plugin.isListComponent,
-        rendererName: plugin.rendererName
+        rendererName: plugin.rendererName,
+        memberImmutable: plugin.memberImmutable
       };
     }
   }

--- a/packages/amis-editor/src/plugin/Cards.tsx
+++ b/packages/amis-editor/src/plugin/Cards.tsx
@@ -305,8 +305,6 @@ export class CardsPlugin extends BasePlugin {
           style: {
             'position': 'static',
             'display': 'block',
-            'overflowY': 'auto',
-            'overflowX': 'auto',
             'paddingTop': '10px',
             'paddingRight': '10px',
             'paddingBottom': '10px',
@@ -348,7 +346,6 @@ export class CardsPlugin extends BasePlugin {
         position: 'static',
         display: 'flex',
         width: '1000%',
-        overflowX: 'auto',
         margin: '0',
         flexWrap: 'nowrap',
         justifyContent: 'space-between'

--- a/packages/amis-editor/src/plugin/Cards.tsx
+++ b/packages/amis-editor/src/plugin/Cards.tsx
@@ -30,6 +30,7 @@ export class CardsPlugin extends BasePlugin {
   name = '卡片列表';
   isBaseComponent = true;
   isListComponent = true;
+  memberImmutable = true;
   description =
     '功能类似于表格，但是用一个个小卡片来展示数据。当前组件需要配置数据源，不自带数据拉取，请优先使用 「CRUD」 组件。';
   docLink = '/amis/zh-CN/components/cards';
@@ -511,7 +512,8 @@ export class CardsPlugin extends BasePlugin {
         wrapperResolve: plugin.wrapperResolve,
         filterProps: plugin.filterProps,
         $schema: plugin.$schema,
-        renderRenderer: plugin.renderRenderer
+        renderRenderer: plugin.renderRenderer,
+        memberImmutable: plugin.memberImmutable
       };
     }
 

--- a/packages/amis-editor/src/plugin/CustomRegion.tsx
+++ b/packages/amis-editor/src/plugin/CustomRegion.tsx
@@ -150,7 +150,8 @@ export class CustomPlugin extends BasePlugin {
         scaffoldForm: plugin.scaffoldForm,
         disabledRendererPlugin: plugin.disabledRendererPlugin,
         isBaseComponent: plugin.isBaseComponent,
-        rendererName: plugin.rendererName
+        rendererName: plugin.rendererName,
+        memberImmutable: plugin.memberImmutable
       };
     }
   }

--- a/packages/amis-editor/src/plugin/Each.tsx
+++ b/packages/amis-editor/src/plugin/Each.tsx
@@ -17,6 +17,7 @@ export class EachPlugin extends BasePlugin {
   name = '循环 Each';
   isBaseComponent = true;
   isListComponent = true;
+  memberImmutable = true;
   description = '功能渲染器，可以基于现有变量循环输出渲染器。';
   tags = ['功能'];
   icon = 'fa fa-repeat';

--- a/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
+++ b/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
@@ -232,7 +232,6 @@ export class FlexPluginBase extends LayoutBasePlugin {
     const isFlexItem = this.manager?.isFlexItem(id);
     const isFlexColumnItem = this.manager?.isFlexColumnItem(id);
     const newColumnSchema = defaultFlexColumnSchema('新的一列');
-    const canAppendSiblings = this.manager?.canAppendSiblings();
 
     const toolbarsTooltips: any = {};
     toolbars.forEach(toolbar => {
@@ -243,11 +242,11 @@ export class FlexPluginBase extends LayoutBasePlugin {
 
     if (
       parent &&
+      (parent.type === 'flex' || parent.type === 'container') &&
       (info.renderer?.name === 'flex' || info.renderer?.name === 'container') &&
       !isFlexItem && // 备注：如果是列级元素就不需要显示了
       !draggableContainer &&
-      !schema?.isFreeContainer &&
-      canAppendSiblings
+      !schema?.isFreeContainer
     ) {
       // 非特殊布局元素（fixed、absolute）支持前后插入追加布局元素功能icon
       if (!toolbarsTooltips['上方插入布局容器']) {
@@ -296,7 +295,12 @@ export class FlexPluginBase extends LayoutBasePlugin {
       }
     }
 
-    if (isFlexItem && !draggableContainer && canAppendSiblings) {
+    if (
+      parent &&
+      (parent.type === 'flex' || parent.type === 'container') &&
+      isFlexItem &&
+      !draggableContainer
+    ) {
       if (
         !toolbarsTooltips[`${isFlexColumnItem ? '上方' : '左侧'}插入列级容器`]
       ) {

--- a/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
+++ b/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
@@ -232,7 +232,7 @@ export class FlexPluginBase extends LayoutBasePlugin {
     const isFlexItem = this.manager?.isFlexItem(id);
     const isFlexColumnItem = this.manager?.isFlexColumnItem(id);
     const newColumnSchema = defaultFlexColumnSchema('新的一列');
-
+    const canAppendSiblings = this.manager?.canAppendSiblings();
     const toolbarsTooltips: any = {};
     toolbars.forEach(toolbar => {
       if (toolbar.tooltip) {
@@ -243,10 +243,10 @@ export class FlexPluginBase extends LayoutBasePlugin {
     // 列表组件中的直接容器元素不支持上下插入布局元素
     if (
       parent &&
-      parent.type !== 'cards' &&
       (info.renderer?.name === 'flex' || info.renderer?.name === 'container') &&
       !draggableContainer &&
-      !schema?.isFreeContainer
+      !schema?.isFreeContainer &&
+      canAppendSiblings
     ) {
       // 非特殊布局元素（fixed、absolute）支持前后插入追加布局元素功能icon
       // 备注：如果是列级元素不需要显示
@@ -300,7 +300,8 @@ export class FlexPluginBase extends LayoutBasePlugin {
       parent &&
       (parent.type === 'flex' || parent.type === 'container') &&
       isFlexItem &&
-      !draggableContainer
+      !draggableContainer &&
+      canAppendSiblings
     ) {
       if (
         !toolbarsTooltips[`${isFlexColumnItem ? '上方' : '左侧'}插入列级容器`]

--- a/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
+++ b/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
@@ -240,16 +240,17 @@ export class FlexPluginBase extends LayoutBasePlugin {
       }
     });
 
+    // 列表组件中的直接容器元素不支持上下插入布局元素
     if (
       parent &&
-      (parent.type === 'flex' || parent.type === 'container') &&
+      parent.type !== 'cards' &&
       (info.renderer?.name === 'flex' || info.renderer?.name === 'container') &&
-      !isFlexItem && // 备注：如果是列级元素就不需要显示了
       !draggableContainer &&
       !schema?.isFreeContainer
     ) {
       // 非特殊布局元素（fixed、absolute）支持前后插入追加布局元素功能icon
-      if (!toolbarsTooltips['上方插入布局容器']) {
+      // 备注：如果是列级元素不需要显示
+      if (!toolbarsTooltips['上方插入布局容器'] && !isFlexItem) {
         toolbars.push(
           {
             iconSvg: 'add-btn',

--- a/packages/amis-editor/src/plugin/List.tsx
+++ b/packages/amis-editor/src/plugin/List.tsx
@@ -35,6 +35,7 @@ export class ListPlugin extends BasePlugin {
   isBaseComponent = true;
   isListComponent = true;
   disabledRendererPlugin = true;
+  memberImmutable = true;
   description =
     '展示一个列表，可以自定标题、副标题，内容及按钮组部分。当前组件需要配置数据源，不自带数据拉取，请优先使用 「CRUD」 组件。';
   docLink = '/amis/zh-CN/components/list';
@@ -403,7 +404,8 @@ export class ListPlugin extends BasePlugin {
         wrapperResolve: plugin.wrapperResolve,
         filterProps: plugin.filterProps,
         $schema: plugin.$schema,
-        renderRenderer: plugin.renderRenderer
+        renderRenderer: plugin.renderRenderer,
+        memberImmutable: plugin.memberImmutable
       };
     }
 

--- a/packages/amis-editor/src/plugin/List2.tsx
+++ b/packages/amis-editor/src/plugin/List2.tsx
@@ -24,6 +24,7 @@ export class List2Plugin extends BasePlugin {
   name = '列表';
   isBaseComponent = true;
   isListComponent = true;
+  memberImmutable = true;
   description =
     '功能类似于表格，但是用一个个小卡片来展示数据。当前组件需要配置数据源，不自带数据拉取，请优先使用 「CRUD」 组件。';
   docLink = '/amis/zh-CN/components/cards';
@@ -448,7 +449,8 @@ export class List2Plugin extends BasePlugin {
         wrapperResolve: plugin.wrapperResolve,
         filterProps: plugin.filterProps,
         $schema: plugin.$schema,
-        renderRenderer: plugin.renderRenderer
+        renderRenderer: plugin.renderRenderer,
+        memberImmutable: plugin.memberImmutable
       };
     }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e209c7d</samp>

This pull request simplifies the code and fixes some bugs in the `amis-editor` and `amis-editor-core` packages. It improves the style and functionality of the `Cards` and `Flex` plugins, and the drag-and-drop feature for nodes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e209c7d</samp>

> _Simplify the code, unleash the power_
> _Drag the nodes, break the chains_
> _Overflow the style, burn the pages_
> _Flex the items, crush the containers_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e209c7d</samp>

*  Simplify the condition for checking whether a node can be dragged ([link](https://github.com/baidu/amis/pull/8083/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fL1032-R1032))
*  Remove redundant style properties for the cards plugin ([link](https://github.com/baidu/amis/pull/8083/files?diff=unified&w=0#diff-6fcd0de29255b9fa752de9b00697c1212b9edfba358ce635621be27559a030b0L308-L309), [link](https://github.com/baidu/amis/pull/8083/files?diff=unified&w=0#diff-6fcd0de29255b9fa752de9b00697c1212b9edfba358ce635621be27559a030b0L351))
*  Remove unused variable canAppendSiblings from the flex plugin base ([link](https://github.com/baidu/amis/pull/8083/files?diff=unified&w=0#diff-0c77368e9183efe6a72ad9cdc7339d1c15ab5f70f8518721c1bda55460262a07L235))
*  Add check for parent node's type being 'flex' or 'container' for showing insert sibling and column container icons in the flex plugin base ([link](https://github.com/baidu/amis/pull/8083/files?diff=unified&w=0#diff-0c77368e9183efe6a72ad9cdc7339d1c15ab5f70f8518721c1bda55460262a07L246-R249), [link](https://github.com/baidu/amis/pull/8083/files?diff=unified&w=0#diff-0c77368e9183efe6a72ad9cdc7339d1c15ab5f70f8518721c1bda55460262a07L299-R303))
