### PR TITLE
fix: 修复表单项配置 staticOn 无效的问题 Close: #8072

### DIFF
--- a/packages/amis-core/src/renderers/wrapControl.tsx
+++ b/packages/amis-core/src/renderers/wrapControl.tsx
@@ -836,7 +836,7 @@ export function wrapControl<
             const injectedProps: any = {
               defaultSize: controlWidth,
               disabled: disabled ?? control.disabled,
-              static: control.static ?? defaultStatic,
+              static: this.props.static ?? control.static ?? defaultStatic,
               formItem: this.model,
               formMode: control.mode || formMode,
               ref: this.controlRef,

--- a/packages/amis/__tests__/renderers/Form/static.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/static.test.tsx
@@ -1,8 +1,8 @@
 import React = require('react');
-import {render, cleanup} from '@testing-library/react';
+import {render, cleanup, fireEvent} from '@testing-library/react';
 import '../../../src';
 import {render as amisRender} from '../../../src';
-import {makeEnv} from '../../helper';
+import {makeEnv, wait} from '../../helper';
 import {clearStoresCache} from '../../../src';
 
 afterEach(() => {
@@ -151,4 +151,41 @@ test('Renderer:static', async () => {
     )
   );
   expect(container).toMatchSnapshot();
+});
+
+test('Renderer:staticOn', async () => {
+  const {container, getByText} = render(
+    amisRender(
+      {
+        type: 'form',
+        title: 'The form',
+        body: [
+          {
+            type: 'switch',
+            name: 'a',
+            label: 'a'
+          },
+          {
+            type: 'input-text',
+            name: 'b',
+            value: '123',
+            label: 'b',
+            staticOn: '${a}'
+          }
+        ],
+        submitText: null,
+        actions: []
+      },
+      {},
+      makeEnv()
+    )
+  );
+
+  expect(container.querySelector('input[name="b"]')).toBeInTheDocument();
+  expect(container.querySelector('label.cxd-Switch')).toBeInTheDocument();
+  fireEvent.click(container.querySelector('label.cxd-Switch')!);
+  await wait(200);
+
+  const text = getByText('123');
+  expect(text).toBeInTheDocument();
 });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 62a460e</samp>

This pull request implements a feature to support static rendering of form controls in `amis`. It adds a new prop `static` to the `wrapControl` function and the `input-text` control, and adds tests for the `staticOn` prop that can toggle the static mode based on data or expression.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 62a460e</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever prop, `static`, for the `wrapControl` function,_
> _To render form controls as fixed text or as inputs,_
> _Depending on the data or the expression's junction._

### Why

Close: #8072

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 62a460e</samp>

*  Add `static` prop to `wrapControl` function to enable static rendering of controls ([link](https://github.com/baidu/amis/pull/8084/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL839-R839))
*  Add test coverage for static rendering of form controls in `static.test.tsx` ([link](https://github.com/baidu/amis/pull/8084/files?diff=unified&w=0#diff-7749839c9c92fc7bf94d40efe20a51178ea437cf82474d7d2f3bf9b91e3d94eaL2-R5), [link](https://github.com/baidu/amis/pull/8084/files?diff=unified&w=0#diff-7749839c9c92fc7bf94d40efe20a51178ea437cf82474d7d2f3bf9b91e3d94eaR155-R191))
   - Import `fireEvent` and `wait` to simulate user interactions and wait for updates ([link](https://github.com/baidu/amis/pull/8084/files?diff=unified&w=0#diff-7749839c9c92fc7bf94d40efe20a51178ea437cf82474d7d2f3bf9b91e3d94eaL2-R5))
   - Add test case for `staticOn` prop of `input-text` control, which accepts an expression to determine static rendering ([link](https://github.com/baidu/amis/pull/8084/files?diff=unified&w=0#diff-7749839c9c92fc7bf94d40efe20a51178ea437cf82474d7d2f3bf9b91e3d94eaR155-R191))
