### PR TITLE
editor: 修复编辑器移动端预览主题\图标不生效问题 Close: #8055

### DIFF
--- a/packages/amis-core/src/components/CustomStyle.tsx
+++ b/packages/amis-core/src/components/CustomStyle.tsx
@@ -25,22 +25,22 @@ export default function (props: CustomStyleProps) {
       classNames,
       defaultData,
       customStyleClassPrefix: env?.customStyleClassPrefix,
-      doc: env.getModalDocument?.()
+      doc: env.getModalContainer?.().ownerDocument
     });
     return () => {
-      styleDom.removeCustomStyle('', env.getModalDocument?.());
+      styleDom.removeCustomStyle('', env.getModalContainer?.().ownerDocument);
     };
   }, [config.themeCss]);
 
   useEffect(() => {
     styleDom.insertEditCustomStyle(
       wrapperCustomStyle,
-      env.getModalDocument?.()
+      env.getModalContainer?.().ownerDocument
     );
     return () => {
       styleDom.removeCustomStyle(
         'wrapperCustomStyle',
-        env.getModalDocument?.()
+        env.getModalContainer?.().ownerDocument
       );
     };
   }, [config.wrapperCustomStyle]);

--- a/packages/amis-core/src/components/CustomStyle.tsx
+++ b/packages/amis-core/src/components/CustomStyle.tsx
@@ -12,8 +12,8 @@ interface CustomStyleProps {
 }
 
 export default function (props: CustomStyleProps) {
-  const {themeCss, classNames, id, defaultData, wrapperCustomStyle} =
-    props.config;
+  const {config, env} = props;
+  const {themeCss, classNames, id, defaultData, wrapperCustomStyle} = config;
   if (!themeCss && !wrapperCustomStyle) {
     return null;
   }
@@ -24,19 +24,26 @@ export default function (props: CustomStyleProps) {
       themeCss,
       classNames,
       defaultData,
-      customStyleClassPrefix: props.env?.customStyleClassPrefix
+      customStyleClassPrefix: env?.customStyleClassPrefix,
+      doc: env.getModalDocument?.()
     });
     return () => {
-      styleDom.removeCustomStyle();
+      styleDom.removeCustomStyle('', env.getModalDocument?.());
     };
-  }, [props.config.themeCss]);
+  }, [config.themeCss]);
 
   useEffect(() => {
-    styleDom.insertEditCustomStyle(wrapperCustomStyle);
+    styleDom.insertEditCustomStyle(
+      wrapperCustomStyle,
+      env.getModalDocument?.()
+    );
     return () => {
-      styleDom.removeCustomStyle('wrapperCustomStyle');
+      styleDom.removeCustomStyle(
+        'wrapperCustomStyle',
+        env.getModalDocument?.()
+      );
     };
-  }, [props.config.wrapperCustomStyle]);
+  }, [config.wrapperCustomStyle]);
 
   return null;
 }

--- a/packages/amis-core/src/env.tsx
+++ b/packages/amis-core/src/env.tsx
@@ -72,6 +72,7 @@ export interface RendererEnv {
   ) => null | RendererConfig;
   copy?: (contents: string, format?: any) => void;
   getModalContainer?: () => HTMLElement;
+  getModalDocument?: () => Document;
   theme: ThemeInstance;
   affixOffsetTop: number;
   affixOffsetBottom: number;

--- a/packages/amis-core/src/env.tsx
+++ b/packages/amis-core/src/env.tsx
@@ -72,7 +72,6 @@ export interface RendererEnv {
   ) => null | RendererConfig;
   copy?: (contents: string, format?: any) => void;
   getModalContainer?: () => HTMLElement;
-  getModalDocument?: () => Document;
   theme: ThemeInstance;
   affixOffsetTop: number;
   affixOffsetBottom: number;

--- a/packages/amis-core/src/utils/style-helper.ts
+++ b/packages/amis-core/src/utils/style-helper.ts
@@ -43,18 +43,19 @@ interface extra {
   suf?: string;
 }
 
-export function findOrCreateStyle(id: string) {
-  let varStyleTag = document.getElementById(id);
+export function findOrCreateStyle(id: string, doc?: Document) {
+  doc = doc || document;
+  let varStyleTag = doc.getElementById(id);
   if (!varStyleTag) {
-    varStyleTag = document.createElement('style');
+    varStyleTag = doc.createElement('style');
     varStyleTag.id = id;
-    document.body.appendChild(varStyleTag);
+    doc.body.appendChild(varStyleTag);
   }
   return varStyleTag;
 }
 
-export function insertStyle(style: string, id: string) {
-  const varStyleTag = findOrCreateStyle(id);
+export function insertStyle(style: string, id: string, doc?: Document) {
+  const varStyleTag = findOrCreateStyle(id, doc);
 
   // bca-disable-line
   varStyleTag.innerHTML = style;
@@ -273,7 +274,8 @@ export function insertCustomStyle(
   classNames?: CustomStyleClassName[],
   id?: string,
   defaultData?: any,
-  customStyleClassPrefix?: string
+  customStyleClassPrefix?: string,
+  doc?: Document
 ) {
   if (!themeCss) {
     return;
@@ -284,7 +286,7 @@ export function insertCustomStyle(
     value = customStyleClassPrefix
       ? `${customStyleClassPrefix} ${value}`
       : value;
-    insertStyle(value, id?.replace('u:', '') || uuid());
+    insertStyle(value, id?.replace('u:', '') || uuid(), doc);
   }
 }
 
@@ -331,7 +333,11 @@ function traverseStyle(style: any, path: string, result: any) {
 /**
  * 设置源码编辑自定义样式
  */
-export function insertEditCustomStyle(customStyle: any, id?: string) {
+export function insertEditCustomStyle(
+  customStyle: any,
+  id?: string,
+  doc?: Document
+) {
   let styles: any = {};
   traverseStyle(customStyle, '', styles);
 
@@ -358,7 +364,8 @@ export function insertEditCustomStyle(customStyle: any, id?: string) {
   }
   insertStyle(
     content,
-    'wrapperCustomStyle-' + (id?.replace('u:', '') || uuid())
+    'wrapperCustomStyle-' + (id?.replace('u:', '') || uuid()),
+    doc
   );
 }
 
@@ -368,6 +375,7 @@ export interface InsertCustomStyle {
   id?: string;
   defaultData?: any;
   customStyleClassPrefix?: string;
+  doc?: Document;
 }
 
 export class StyleDom {
@@ -388,14 +396,16 @@ export class StyleDom {
     themeCss,
     classNames,
     defaultData,
-    customStyleClassPrefix
+    customStyleClassPrefix,
+    doc
   }: InsertCustomStyle) {
     insertCustomStyle(
       themeCss,
       classNames,
       this.id,
       defaultData,
-      customStyleClassPrefix
+      customStyleClassPrefix,
+      doc
     );
   }
 
@@ -404,14 +414,14 @@ export class StyleDom {
    *
    * @param wrapperCustomStyle 自定义样式
    */
-  insertEditCustomStyle(wrapperCustomStyle: any) {
-    insertEditCustomStyle(wrapperCustomStyle, this.id);
+  insertEditCustomStyle(wrapperCustomStyle: any, doc?: Document) {
+    insertEditCustomStyle(wrapperCustomStyle, this.id, doc);
   }
   /**
    * 移除自定义样式
    */
-  removeCustomStyle(type?: string) {
-    const style = document.getElementById(
+  removeCustomStyle(type?: string, doc?: Document) {
+    const style = (doc || document).getElementById(
       (type ? type + '-' : '') + this.id.replace('u:', '')
     );
     if (style) {

--- a/packages/amis-editor-core/src/component/IFramePreview.tsx
+++ b/packages/amis-editor-core/src/component/IFramePreview.tsx
@@ -79,12 +79,6 @@ export default class IFramePreview extends React.Component<IFramePreviewProps> {
   }
 
   @autobind
-  getModalDocument() {
-    const store = this.props.store;
-    return store.getDoc();
-  }
-
-  @autobind
   isMobile() {
     return true;
   }
@@ -114,8 +108,7 @@ export default class IFramePreview extends React.Component<IFramePreviewProps> {
             session: `${env.session}-iframe-preview`,
             useMobileUI: true,
             isMobile: this.isMobile,
-            getModalContainer: this.getModalContainer,
-            getModalDocument: this.getModalDocument
+            getModalContainer: this.getModalContainer
           }
         )}
         <InnerSvgSpirit />

--- a/packages/amis-editor-core/src/component/IFramePreview.tsx
+++ b/packages/amis-editor-core/src/component/IFramePreview.tsx
@@ -1,6 +1,6 @@
 import {observer} from 'mobx-react';
 import {EditorStoreType} from '../store/editor';
-import React from 'react';
+import React, {memo} from 'react';
 import {EditorManager} from '../manager';
 import Frame, {useFrame} from 'react-frame-component';
 import {
@@ -79,6 +79,12 @@ export default class IFramePreview extends React.Component<IFramePreviewProps> {
   }
 
   @autobind
+  getModalDocument() {
+    const store = this.props.store;
+    return store.getDoc();
+  }
+
+  @autobind
   isMobile() {
     return true;
   }
@@ -108,9 +114,11 @@ export default class IFramePreview extends React.Component<IFramePreviewProps> {
             session: `${env.session}-iframe-preview`,
             useMobileUI: true,
             isMobile: this.isMobile,
-            getModalContainer: this.getModalContainer
+            getModalContainer: this.getModalContainer,
+            getModalDocument: this.getModalDocument
           }
         )}
+        <InnerSvgSpirit />
       </Frame>
     );
   }
@@ -219,3 +227,19 @@ function InnerComponent({
 
   return null;
 }
+
+const InnerSvgSpirit = memo(() => {
+  // @ts-ignore 这里取的是平台的变量
+  let spiriteIcons = window.spiriteIcons;
+  if (spiriteIcons) {
+    return (
+      <div
+        id="amis-icon-manage-mount-node"
+        style={{display: 'none'}}
+        dangerouslySetInnerHTML={{__html: spiriteIcons}}
+      ></div>
+    );
+  } else {
+    return null;
+  }
+});


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c2ad72c</samp>

This pull request enhances the editor's features and compatibility with custom styles. It refactors the `CustomStyle` component and the `style-helper.ts` module to support different document objects, such as the modal dialog. It also adds the icon picker feature to the `IFramePreview` component and extends the `RendererEnv` interface with a `getModalDocument` method.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c2ad72c</samp>

> _We are the masters of style, we bend the document to our will_
> _We unleash the power of the modal, we make the editor thrill_
> _We render the icons of the platform, we show them in the iframe_
> _We are the custom style warriors, we set the code on fire_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c2ad72c</samp>

*  Refactor `CustomStyle` component to destructure `config` and `env` props ([link](https://github.com/baidu/amis/pull/8088/files?diff=unified&w=0#diff-64f487ea8bb551e6157d95133fcf65572d6990b062dd31bf6502543a77ad9fb5L15-R16))
*  Add `doc` parameter to `styleDom` methods and pass it from `CustomStyle` component ([link](https://github.com/baidu/amis/pull/8088/files?diff=unified&w=0#diff-64f487ea8bb551e6157d95133fcf65572d6990b062dd31bf6502543a77ad9fb5L27-R46), [link](https://github.com/baidu/amis/pull/8088/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdR378), [link](https://github.com/baidu/amis/pull/8088/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL391-R400), [link](https://github.com/baidu/amis/pull/8088/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL398-R408), [link](https://github.com/baidu/amis/pull/8088/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL407-R424))
*  Extend `RendererEnv` interface to include `getModalDocument` method ([link](https://github.com/baidu/amis/pull/8088/files?diff=unified&w=0#diff-62f2e14b837dfa7b7f5f94ee2a856825f211639ddf0f85d783c666dbcd7f8d0dR75))
*  Modify `style-helper` functions to accept `doc` parameter and use it to create or find style elements ([link](https://github.com/baidu/amis/pull/8088/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL46-R58), [link](https://github.com/baidu/amis/pull/8088/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL276-R278), [link](https://github.com/baidu/amis/pull/8088/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL287-R289), [link](https://github.com/baidu/amis/pull/8088/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL334-R340), [link](https://github.com/baidu/amis/pull/8088/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL361-R368))
*  Update `IFramePreview` component to import `memo` function and pass `getModalDocument` method to `env` prop ([link](https://github.com/baidu/amis/pull/8088/files?diff=unified&w=0#diff-acafbdd055d55bdea83368e433e85e8c5d1831c9af33a8e21501cd24ac33128cL3-R3), [link](https://github.com/baidu/amis/pull/8088/files?diff=unified&w=0#diff-acafbdd055d55bdea83368e433e85e8c5d1831c9af33a8e21501cd24ac33128cR82-R87), [link](https://github.com/baidu/amis/pull/8088/files?diff=unified&w=0#diff-acafbdd055d55bdea83368e433e85e8c5d1831c9af33a8e21501cd24ac33128cL111-R121))
*  Add `InnerSvgSpirit` component to render svg icons in iframe document ([link](https://github.com/baidu/amis/pull/8088/files?diff=unified&w=0#diff-acafbdd055d55bdea83368e433e85e8c5d1831c9af33a8e21501cd24ac33128cR230-R245))
