### PR TITLE
fix: 修复由 #8034 引发的 combo select autofill 失效问题

### DIFF
--- a/packages/amis-core/src/WithStore.tsx
+++ b/packages/amis-core/src/WithStore.tsx
@@ -246,7 +246,7 @@ export function HocStoreFactory(renderer: {
                       ...props.data
                     }
                   : syncDataFromSuper(
-                      store.data,
+                      props.data,
                       (props.data as any).__super,
                       (prevProps.data as any).__super,
                       store,

--- a/packages/amis/__tests__/renderers/Form/combo.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/combo.test.tsx
@@ -913,3 +913,59 @@ test('Renderer:combo with removable & deleteBtn & deleteApi & deleteConfirmText'
   await wait(300);
   expect(fetcher).toHaveBeenCalled();
 });
+
+test('Renderer:select autofill in combo', async () => {
+  const {container, submitBtn, findByText, onSubmit, baseElement} = await setup(
+    [
+      {
+        type: 'combo',
+        name: 'combo',
+        label: 'combo',
+        className: 'removableFalse',
+        removable: false,
+        multiple: true,
+        items: [
+          {
+            name: 'a',
+            type: 'select',
+            autoFill: {
+              type: '${type}'
+            },
+            options: [
+              {
+                label: 'A',
+                value: 'a',
+                type: '1'
+              },
+              {
+                label: 'B',
+                value: 'b',
+                type: '2'
+              }
+            ]
+          }
+        ],
+        value: [{}]
+      }
+    ],
+    {
+      // 不加这个，就会报错 fetcher is required
+      session: 'test-case-2'
+    }
+  );
+
+  fireEvent.click(await findByText('请选择'));
+
+  await waitFor(() => {
+    expect(container.querySelector('.cxd-Select-popover')).toBeInTheDocument();
+  });
+
+  fireEvent.click(await findByText('A'));
+  await wait(500);
+  fireEvent.click(submitBtn);
+  await wait(1000);
+  expect(onSubmit).toHaveBeenCalled();
+  expect(onSubmit.mock.calls[0][0]).toMatchObject({
+    combo: [{type: '1', a: 'a'}]
+  });
+});

--- a/packages/amis/src/renderers/Form/Combo.tsx
+++ b/packages/amis/src/renderers/Form/Combo.tsx
@@ -7,8 +7,7 @@ import {
   FormBaseControl,
   resolveEventData,
   ApiObject,
-  FormHorizontal,
-  SimpleMap
+  FormHorizontal
 } from 'amis-core';
 import {ActionObject, Api} from 'amis-core';
 import {ComboStore, IComboStore} from 'amis-core';
@@ -374,7 +373,7 @@ export default class ComboControl extends React.Component<ComboProps> {
     setted: boolean;
   }> = [];
 
-  keys: SimpleMap<any, Record<string, any> | string> = new SimpleMap();
+  keys: Array<string> = [];
   dragTip?: HTMLElement;
   sortable?: Sortable;
   defaultValue?: any;
@@ -463,7 +462,6 @@ export default class ComboControl extends React.Component<ComboProps> {
     this.toDispose = [];
     this.memoizedFormatValue.cache.clear?.();
     this.makeFormRef.cache.clear?.();
-    this.keys.dispose();
   }
 
   /** 解析props中的变量，目前支持'minLength' | 'maxLength' */
@@ -517,12 +515,13 @@ export default class ComboControl extends React.Component<ComboProps> {
     }
 
     let value = this.getValueAsArray();
-    this.keys.set(itemValue, guid());
 
     if (addattop === true) {
+      this.keys.unshift(guid());
       value.unshift(itemValue);
     } else {
       value.push(itemValue);
+      this.keys.push(guid());
     }
 
     if (flat && joinValues) {
@@ -570,13 +569,14 @@ export default class ComboControl extends React.Component<ComboProps> {
             ...(condition.scaffold || scaffold)
           }
     );
-    this.keys.set(value[value.length - 1], guid());
+    this.keys.push(guid());
 
     if (flat && joinValues) {
       value = value.join(delimiter || ',');
     }
 
     if (addattop === true) {
+      this.keys.unshift(this.keys.pop()!);
       value.unshift(value.pop());
     }
 
@@ -621,13 +621,14 @@ export default class ComboControl extends React.Component<ComboProps> {
             ...scaffold
           }
     );
-    this.keys.set(value[value.length - 1], guid());
+    this.keys.push(guid());
 
     if (flat && joinValues) {
       value = value.join(delimiter || ',');
     }
 
     if (addattop === true) {
+      this.keys.unshift(this.keys.pop()!);
       value.unshift(value.pop());
     }
 
@@ -691,7 +692,7 @@ export default class ComboControl extends React.Component<ComboProps> {
       }
     }
 
-    this.keys.delete(value[key]);
+    this.keys.splice(key, 1);
     value.splice(key, 1);
 
     if (flat && joinValues) {
@@ -952,6 +953,7 @@ export default class ComboControl extends React.Component<ComboProps> {
           }
           const newValue = value.concat();
           newValue.splice(e.newIndex, 0, newValue.splice(e.oldIndex, 1)[0]);
+          this.keys.splice(e.newIndex, 0, this.keys.splice(e.oldIndex, 1)[0]);
           this.props.onChange(newValue, submitOnChange, true);
         }
       }
@@ -1231,8 +1233,8 @@ export default class ComboControl extends React.Component<ComboProps> {
             Array.isArray(finnalControls) &&
             finnalControls.some((item: any) => item.unique);
 
-          if (!this.keys.has(value)) {
-            this.keys.set(value, guid());
+          if (!this.keys[index]) {
+            this.keys.splice(index, 0, guid());
           }
 
           return (
@@ -1242,7 +1244,7 @@ export default class ComboControl extends React.Component<ComboProps> {
                   __('{{index}}', {index: (data as any).index + 1}),
                 data
               )}
-              key={this.keys.get(value)!}
+              key={this.keys[index]}
               toolbar={toolbar}
               eventKey={index}
               // 不能按需渲染，因为 unique 会失效。
@@ -1532,14 +1534,14 @@ export default class ComboControl extends React.Component<ComboProps> {
                     ]
                   : items;
 
-              if (!this.keys.has(value)) {
-                this.keys.set(value, guid());
+              if (!this.keys[index]) {
+                this.keys.splice(index, 1, guid());
               }
 
               return (
                 <div
                   className={cx(`Combo-item`, itemClassName)}
-                  key={this.keys.get(value)}
+                  key={this.keys[index]}
                 >
                   {!isStatic && !disabled && draggable && thelist.length > 1 ? (
                     <div className={cx('Combo-itemDrager')}>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b5a71d2</samp>

This pull request improves the combo renderer by using a simpler data structure for the items and adding a new autofill feature for the type field. It also updates the test suite to cover the new functionality. The affected files are `Combo.tsx` and `combo.test.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b5a71d2</samp>

> _The combo renderer had a flaw_
> _When using the prepend option, it would draw_
> _The items out of order_
> _So the coder did sort her_
> _`keys` array and added a test for `autofill`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b5a71d2</samp>

*  Replace the SimpleMap type with an array of strings for the keys property of the combo renderer class, which stores the unique identifiers for each combo item value ([link](https://github.com/baidu/amis/pull/8090/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L10-R10),[link](https://github.com/baidu/amis/pull/8090/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L377-R376))
*  Update the logic of adding, removing, and reordering item values and keys in the combo renderer, by using the array methods of push, unshift, splice, and move, instead of the SimpleMap methods of set, delete, and has ([link](https://github.com/baidu/amis/pull/8090/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L466),[link](https://github.com/baidu/amis/pull/8090/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L520-R524),[link](https://github.com/baidu/amis/pull/8090/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L573-R572),[link](https://github.com/baidu/amis/pull/8090/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829R579),[link](https://github.com/baidu/amis/pull/8090/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L624-R624),[link](https://github.com/baidu/amis/pull/8090/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829R631),[link](https://github.com/baidu/amis/pull/8090/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L694-R695),[link](https://github.com/baidu/amis/pull/8090/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829R956))
*  Update the logic of rendering combo items with single or multiple controls, by using the keys array to access and update the corresponding keys for each item value, instead of the SimpleMap methods of get and set ([link](https://github.com/baidu/amis/pull/8090/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1234-R1237),[link](https://github.com/baidu/amis/pull/8090/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1245-R1247),[link](https://github.com/baidu/amis/pull/8090/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1535-R1538),[link](https://github.com/baidu/amis/pull/8090/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1542-R1544))
*  Add a new test case for the combo renderer in `packages/amis/__tests__/renderers/Form/combo.test.tsx`, which checks if the select component inside the combo can autofill the type field based on the selected option ([link](https://github.com/baidu/amis/pull/8090/files?diff=unified&w=0#diff-1689fddd6fe92bb44bae574b18fd1bf4ed54d85a41bc725b29e9c8498291ffafR916-R971))
