### PR TITLE
pref: 源码编辑提示样式优化

### DIFF
--- a/packages/amis-editor-core/scss/style-control/_theme-css-code.scss
+++ b/packages/amis-editor-core/scss/style-control/_theme-css-code.scss
@@ -99,3 +99,10 @@
     }
   }
 }
+
+.cxd-ThemeCssCode-custom-editor {
+  .suggest-widget {
+    width: 230px !important;
+    left: 16px !important;
+  }
+}

--- a/packages/amis-editor-core/scss/style-control/_theme-css-code.scss
+++ b/packages/amis-editor-core/scss/style-control/_theme-css-code.scss
@@ -102,7 +102,12 @@
 
 .cxd-ThemeCssCode-custom-editor {
   .suggest-widget {
-    width: 230px !important;
+    width: auto !important;
     left: 16px !important;
+    right: 0 !important;
+
+    .monaco-sash:first-child {
+      display: none;
+    }
   }
 }

--- a/packages/amis-editor/src/plugin/Image.tsx
+++ b/packages/amis-editor/src/plugin/Image.tsx
@@ -155,7 +155,7 @@ export class ImagePlugin extends BasePlugin {
 
               {
                 name: 'thumbMode',
-                visibleOn: 'imageMode ===  "thumb"',
+                visibleOn: '${!imageMode || imageMode ===  "thumb"}',
                 type: 'select',
                 label: '展示模式',
                 mode: 'horizontal',

--- a/packages/amis-editor/src/renderer/style-control/ThemeCssCode.tsx
+++ b/packages/amis-editor/src/renderer/style-control/ThemeCssCode.tsx
@@ -138,6 +138,7 @@ function ThemeCssCode(props: FormControlProps) {
         </a>
         <div className="ThemeCssCode-editor-wrap" style={{height: '180px'}}>
           <Editor
+            className="ThemeCssCode-custom-editor"
             value={value}
             placeholder={editorPlaceholder}
             language="scss"


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d353857</samp>

This pull request improves the theme CSS code editor and fixes a bug in the image plugin. It adds a custom style for the suggest widget, a class name for the editor component, and a visibility condition for the thumb mode option.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d353857</samp>

> _`theme CSS` styled_
> _suggest widget fits better_
> _autumn bug fixing_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d353857</samp>

* Fix a bug in the image plugin that hid the thumb mode option ([link](https://github.com/baidu/amis/pull/8091/files?diff=unified&w=0#diff-080f970ff41a9d0e1619e4d8d2190127b7b241f179ed33b91f4f0fe48475fd41L158-R158))
* Add a custom style for the suggest widget in the theme CSS code editor ([link](https://github.com/baidu/amis/pull/8091/files?diff=unified&w=0#diff-dec576ef2c582c0ec8c2c343db72684ed6aa1fa777ca881d14887462e883d701R102-R108), [link](https://github.com/baidu/amis/pull/8091/files?diff=unified&w=0#diff-0d09abc7945e56f72384164537e19882a6faf0835c9130a430db6cebad0bc3eaR141))
