### PR TITLE
fix: 修复 InputTable 列表单项受控模式回显数字问题 Close: #8070

### DIFF
--- a/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
@@ -1033,6 +1033,742 @@ exports[`Renderer:input-table cell selects delete 1`] = `
 </div>
 `;
 
+exports[`Renderer:input-table init display 1`] = `
+<div>
+  <div
+    class="cxd-Panel cxd-Panel--default cxd-Panel--form"
+    style="position: relative;"
+  >
+    <div
+      class="cxd-Panel-heading"
+    >
+      <h3
+        class="cxd-Panel-title"
+      >
+        <span
+          class="cxd-TplField"
+        >
+          <span>
+            表单
+          </span>
+        </span>
+      </h3>
+    </div>
+    <div
+      class="cxd-Panel-body"
+    >
+      <form
+        class="cxd-Form cxd-Form--normal"
+        novalidate=""
+      >
+        <input
+          style="display: none;"
+          type="submit"
+        />
+        <div
+          class="cxd-Form-item cxd-Form-item--normal"
+          data-role="form-item"
+        >
+          <label
+            class="cxd-Form-label"
+          >
+            <span>
+              <span
+                class="cxd-TplField"
+              >
+                <span>
+                  数字
+                </span>
+              </span>
+            </span>
+          </label>
+          <div
+            class="cxd-NumberControl cxd-Form-control"
+          >
+            <div
+              class="cxd-Number cxd-Number--borderFull"
+            >
+              <div
+                class="cxd-Number-handler-wrap"
+              >
+                <span
+                  aria-disabled="false"
+                  aria-label="Increase Value"
+                  class="cxd-Number-handler cxd-Number-handler-up"
+                  role="button"
+                  unselectable="on"
+                >
+                  <span
+                    class="cxd-Number-handler-up-inner"
+                    unselectable="on"
+                  />
+                </span>
+                <span
+                  aria-disabled="false"
+                  aria-label="Decrease Value"
+                  class="cxd-Number-handler cxd-Number-handler-down"
+                  role="button"
+                  unselectable="on"
+                >
+                  <span
+                    class="cxd-Number-handler-down-inner"
+                    unselectable="on"
+                  />
+                </span>
+              </div>
+              <div
+                class="cxd-Number-input-wrap"
+              >
+                <input
+                  aria-valuenow="0"
+                  autocomplete="off"
+                  class="cxd-Number-input"
+                  role="spinbutton"
+                  step="1"
+                  value="0"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="cxd-Form-item cxd-Form-item--normal"
+          data-role="form-item"
+        >
+          <label
+            class="cxd-Form-label"
+          >
+            <span>
+              <span
+                class="cxd-TplField"
+              >
+                <span>
+                  表格表单
+                </span>
+              </span>
+            </span>
+          </label>
+          <div
+            class="cxd-InputTable cxd-Form-control"
+          >
+            <div
+              class="cxd-Table"
+              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; position: relative;"
+            >
+              <div
+                class="cxd-Table-contentWrap"
+              >
+                <div
+                  class="cxd-Table-content"
+                >
+                  <table
+                    class="cxd-Table-table"
+                  >
+                    <colgroup>
+                      <col
+                        data-index="3"
+                      />
+                      <col
+                        data-index="4"
+                      />
+                      <col
+                        data-index="5"
+                      />
+                      <col
+                        data-index="6"
+                      />
+                    </colgroup>
+                    <thead>
+                      <tr
+                        class=""
+                      >
+                        <th
+                          class=""
+                          data-index="3"
+                        >
+                          <div
+                            class="cxd-TableCell--title"
+                          >
+                            <span
+                              class="cxd-TplField"
+                            >
+                              <span>
+                                名称
+                              </span>
+                            </span>
+                          </div>
+                          <div
+                            class="cxd-Table-content-colDragLine"
+                            data-index="3"
+                          />
+                        </th>
+                        <th
+                          class=""
+                          data-index="4"
+                        >
+                          <div
+                            class="cxd-TableCell--title"
+                          >
+                            <span
+                              class="cxd-TplField"
+                            >
+                              <span>
+                                分数
+                              </span>
+                            </span>
+                          </div>
+                          <div
+                            class="cxd-Table-content-colDragLine"
+                            data-index="4"
+                          />
+                        </th>
+                        <th
+                          class=""
+                          data-index="5"
+                        >
+                          <div
+                            class="cxd-TableCell--title"
+                          >
+                            <span
+                              class="cxd-TplField"
+                            >
+                              <span>
+                                分数(不在quickEdit里面)
+                              </span>
+                            </span>
+                          </div>
+                          <div
+                            class="cxd-Table-content-colDragLine"
+                            data-index="5"
+                          />
+                        </th>
+                        <th
+                          class=""
+                          data-index="6"
+                        >
+                          <div
+                            class="cxd-TableCell--title"
+                          >
+                            <span
+                              class="cxd-TplField"
+                            >
+                              <span>
+                                等级
+                              </span>
+                            </span>
+                          </div>
+                          <div
+                            class="cxd-Table-content-colDragLine"
+                            data-index="6"
+                          />
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr
+                        class="cxd-Table-tr--odd cxd-Table-tr--1th"
+                        data-id="1"
+                        data-index="0"
+                      >
+                        <td
+                          class=""
+                        >
+                          <div
+                            class="cxd-Form-item cxd-Form-item--normal"
+                            data-role="form-item"
+                          >
+                            <div
+                              class="cxd-Form-control cxd-TextControl"
+                            >
+                              <div
+                                class="cxd-TextControl-input"
+                              >
+                                <input
+                                  autocomplete="off"
+                                  class=""
+                                  name="name"
+                                  placeholder=""
+                                  size="10"
+                                  type="text"
+                                  value="AAA"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td
+                          class=""
+                        >
+                          <div
+                            class="cxd-Form-item cxd-Form-item--normal"
+                            data-role="form-item"
+                          >
+                            <div
+                              class="cxd-NumberControl cxd-Form-control"
+                            >
+                              <div
+                                class="cxd-Number no-steps cxd-Number--borderFull"
+                              >
+                                <div
+                                  class="cxd-Number-handler-wrap"
+                                >
+                                  <span
+                                    aria-disabled="false"
+                                    aria-label="Increase Value"
+                                    class="cxd-Number-handler cxd-Number-handler-up"
+                                    role="button"
+                                    unselectable="on"
+                                  >
+                                    <span
+                                      class="cxd-Number-handler-up-inner"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    aria-disabled="false"
+                                    aria-label="Decrease Value"
+                                    class="cxd-Number-handler cxd-Number-handler-down"
+                                    role="button"
+                                    unselectable="on"
+                                  >
+                                    <span
+                                      class="cxd-Number-handler-down-inner"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                </div>
+                                <div
+                                  class="cxd-Number-input-wrap"
+                                >
+                                  <input
+                                    aria-valuenow="234"
+                                    autocomplete="off"
+                                    class="cxd-Number-input"
+                                    role="spinbutton"
+                                    step="1"
+                                    value="234"
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td
+                          class=""
+                        >
+                          <div
+                            class="cxd-NumberControl cxd-Form-control"
+                          >
+                            <div
+                              class="cxd-Number no-steps cxd-Number--borderFull"
+                            >
+                              <div
+                                class="cxd-Number-handler-wrap"
+                              >
+                                <span
+                                  aria-disabled="false"
+                                  aria-label="Increase Value"
+                                  class="cxd-Number-handler cxd-Number-handler-up"
+                                  role="button"
+                                  unselectable="on"
+                                >
+                                  <span
+                                    class="cxd-Number-handler-up-inner"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                <span
+                                  aria-disabled="false"
+                                  aria-label="Decrease Value"
+                                  class="cxd-Number-handler cxd-Number-handler-down"
+                                  role="button"
+                                  unselectable="on"
+                                >
+                                  <span
+                                    class="cxd-Number-handler-down-inner"
+                                    unselectable="on"
+                                  />
+                                </span>
+                              </div>
+                              <div
+                                class="cxd-Number-input-wrap"
+                              >
+                                <input
+                                  aria-valuenow="234"
+                                  autocomplete="off"
+                                  class="cxd-Number-input"
+                                  role="spinbutton"
+                                  step="1"
+                                  value="234"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td
+                          class=""
+                        >
+                          <div
+                            class="cxd-Form-item cxd-Form-item--normal"
+                            data-role="form-item"
+                          >
+                            <div
+                              class="cxd-NumberControl cxd-Form-control"
+                            >
+                              <div
+                                class="cxd-Number no-steps cxd-Number--borderFull"
+                              >
+                                <div
+                                  class="cxd-Number-handler-wrap"
+                                >
+                                  <span
+                                    aria-disabled="false"
+                                    aria-label="Increase Value"
+                                    class="cxd-Number-handler cxd-Number-handler-up"
+                                    role="button"
+                                    unselectable="on"
+                                  >
+                                    <span
+                                      class="cxd-Number-handler-up-inner"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    aria-disabled="false"
+                                    aria-label="Decrease Value"
+                                    class="cxd-Number-handler cxd-Number-handler-down"
+                                    role="button"
+                                    unselectable="on"
+                                  >
+                                    <span
+                                      class="cxd-Number-handler-down-inner"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                </div>
+                                <div
+                                  class="cxd-Number-input-wrap"
+                                >
+                                  <input
+                                    aria-valuenow="1"
+                                    autocomplete="off"
+                                    class="cxd-Number-input"
+                                    role="spinbutton"
+                                    step="1"
+                                    value="1"
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr
+                        class="cxd-Table-tr--even cxd-Table-tr--1th"
+                        data-id="2"
+                        data-index="1"
+                      >
+                        <td
+                          class=""
+                        >
+                          <div
+                            class="cxd-Form-item cxd-Form-item--normal"
+                            data-role="form-item"
+                          >
+                            <div
+                              class="cxd-Form-control cxd-TextControl"
+                            >
+                              <div
+                                class="cxd-TextControl-input"
+                              >
+                                <input
+                                  autocomplete="off"
+                                  class=""
+                                  name="name"
+                                  placeholder=""
+                                  size="10"
+                                  type="text"
+                                  value="BBB"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td
+                          class=""
+                        >
+                          <div
+                            class="cxd-Form-item cxd-Form-item--normal"
+                            data-role="form-item"
+                          >
+                            <div
+                              class="cxd-NumberControl cxd-Form-control"
+                            >
+                              <div
+                                class="cxd-Number no-steps cxd-Number--borderFull"
+                              >
+                                <div
+                                  class="cxd-Number-handler-wrap"
+                                >
+                                  <span
+                                    aria-disabled="false"
+                                    aria-label="Increase Value"
+                                    class="cxd-Number-handler cxd-Number-handler-up"
+                                    role="button"
+                                    unselectable="on"
+                                  >
+                                    <span
+                                      class="cxd-Number-handler-up-inner"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    aria-disabled="false"
+                                    aria-label="Decrease Value"
+                                    class="cxd-Number-handler cxd-Number-handler-down"
+                                    role="button"
+                                    unselectable="on"
+                                  >
+                                    <span
+                                      class="cxd-Number-handler-down-inner"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                </div>
+                                <div
+                                  class="cxd-Number-input-wrap"
+                                >
+                                  <input
+                                    aria-valuenow="0"
+                                    autocomplete="off"
+                                    class="cxd-Number-input"
+                                    role="spinbutton"
+                                    step="1"
+                                    value="0"
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td
+                          class=""
+                        >
+                          <div
+                            class="cxd-NumberControl cxd-Form-control"
+                          >
+                            <div
+                              class="cxd-Number no-steps cxd-Number--borderFull"
+                            >
+                              <div
+                                class="cxd-Number-handler-wrap"
+                              >
+                                <span
+                                  aria-disabled="false"
+                                  aria-label="Increase Value"
+                                  class="cxd-Number-handler cxd-Number-handler-up"
+                                  role="button"
+                                  unselectable="on"
+                                >
+                                  <span
+                                    class="cxd-Number-handler-up-inner"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                <span
+                                  aria-disabled="false"
+                                  aria-label="Decrease Value"
+                                  class="cxd-Number-handler cxd-Number-handler-down"
+                                  role="button"
+                                  unselectable="on"
+                                >
+                                  <span
+                                    class="cxd-Number-handler-down-inner"
+                                    unselectable="on"
+                                  />
+                                </span>
+                              </div>
+                              <div
+                                class="cxd-Number-input-wrap"
+                              >
+                                <input
+                                  aria-valuenow="0"
+                                  autocomplete="off"
+                                  class="cxd-Number-input"
+                                  role="spinbutton"
+                                  step="1"
+                                  value="0"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td
+                          class=""
+                        >
+                          <div
+                            class="cxd-Form-item cxd-Form-item--normal"
+                            data-role="form-item"
+                          >
+                            <div
+                              class="cxd-NumberControl cxd-Form-control"
+                            >
+                              <div
+                                class="cxd-Number no-steps cxd-Number--borderFull"
+                              >
+                                <div
+                                  class="cxd-Number-handler-wrap"
+                                >
+                                  <span
+                                    aria-disabled="false"
+                                    aria-label="Increase Value"
+                                    class="cxd-Number-handler cxd-Number-handler-up"
+                                    role="button"
+                                    unselectable="on"
+                                  >
+                                    <span
+                                      class="cxd-Number-handler-up-inner"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    aria-disabled="false"
+                                    aria-label="Decrease Value"
+                                    class="cxd-Number-handler cxd-Number-handler-down"
+                                    role="button"
+                                    unselectable="on"
+                                  >
+                                    <span
+                                      class="cxd-Number-handler-down-inner"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                </div>
+                                <div
+                                  class="cxd-Number-input-wrap"
+                                >
+                                  <input
+                                    aria-valuenow="0"
+                                    autocomplete="off"
+                                    class="cxd-Number-input"
+                                    role="spinbutton"
+                                    step="1"
+                                    value="0"
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <span />
+              </div>
+              <div
+                class="resize-sensor"
+                style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
+              >
+                
+  
+                <div
+                  class="resize-sensor-expand"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+                  />
+                  
+  
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-shrink"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+                >
+                  
+    
+                  <div
+                    style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+                  />
+                  
+  
+                </div>
+                
+  
+                <div
+                  class="resize-sensor-appear"
+                  style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div
+      class="cxd-Panel-footerWrap"
+    >
+      <div
+        class="cxd-Panel-btnToolbar cxd-Panel-footer"
+      >
+        <button
+          class="cxd-Button cxd-Button--primary cxd-Button--size-default"
+          type="submit"
+        >
+          <span>
+            提交
+          </span>
+        </button>
+      </div>
+    </div>
+    <div
+      class="resize-sensor"
+      style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px; overflow: scroll; z-index: -1; visibility: hidden;"
+    >
+      
+  
+      <div
+        class="resize-sensor-expand"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      >
+        
+    
+        <div
+          style="position: absolute; left: 0px; top: 0px; width: 10px; height: 10px;"
+        />
+        
+  
+      </div>
+      
+  
+      <div
+        class="resize-sensor-shrink"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;"
+      >
+        
+    
+        <div
+          style="position: absolute; left: 0; top: 0; width: 200%; height: 200%"
+        />
+        
+  
+      </div>
+      
+  
+      <div
+        class="resize-sensor-appear"
+        style="position: absolute; left: 0; top: 0; right: 0; bottom: 0; overflow: scroll; z-index: -1; visibility: hidden;animation-name: apearSensor; animation-duration: 0.2s;"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Renderer:input-table verifty 1`] = `
 <div>
   <div

--- a/packages/amis/__tests__/renderers/Form/inputTable.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/inputTable.test.tsx
@@ -540,3 +540,110 @@ test('Renderer:input-table doaction:additem', async () => {
     ]
   });
 });
+
+test('Renderer:input-table init display', async () => {
+  const onSubmit = jest.fn();
+  const {container, findByRole, findByText} = render(
+    amisRender(
+      {
+        type: 'form',
+        body: [
+          {
+            type: 'input-number',
+            name: 'aaa',
+            label: '数字',
+            id: 'u:2cf54f983323',
+            keyboard: true
+          },
+          {
+            addable: false,
+            footerAddBtn: {
+              icon: 'fa fa-plus',
+              label: '新增'
+            },
+            columns: [
+              {
+                quickEdit: {
+                  name: 'name',
+                  id: 'u:0d991cdb83f7',
+                  type: 'input-text'
+                },
+                name: 'name',
+                id: 'u:c03a3961b816',
+                label: '名称'
+              },
+              {
+                quickEdit: {
+                  name: 'score',
+                  id: 'u:fdd06fcb43ea',
+                  type: 'input-number',
+                  showSteps: false
+                },
+                name: 'score',
+                id: 'u:5cf9b284569d',
+                label: '分数'
+              },
+              {
+                quickEdit: false,
+                name: 'score',
+                id: 'u:8b9930874658',
+                label: '分数(不在quickEdit里面)',
+                type: 'input-number',
+                showSteps: false
+              },
+              {
+                quickEdit: {
+                  name: 'level',
+                  id: 'u:69f5cbdadbb0',
+                  type: 'input-number',
+                  showSteps: false
+                },
+                name: 'level',
+                id: 'u:3bd7b1d50f2d',
+                label: '等级'
+              }
+            ],
+            minLength: 0,
+            strictMode: true,
+            needConfirm: false,
+            name: 'tableList',
+            id: 'u:bda697db0d7e',
+            label: '表格表单',
+            type: 'input-table'
+          }
+        ],
+        id: 'u:1affe4fb299e',
+        actions: [
+          {
+            type: 'submit',
+            label: '提交',
+            primary: true,
+            id: 'u:6cde77348a96'
+          }
+        ],
+        data: {
+          aaa: 0,
+          tableList: [
+            {
+              score: 234,
+              level: 1,
+              name: 'AAA'
+            },
+            {
+              score: 0,
+              level: 0,
+              name: 'BBB'
+            }
+          ]
+        },
+        title: '表单'
+      },
+      {onSubmit},
+      makeEnv({})
+    )
+  );
+
+  await wait(200);
+  replaceReactAriaIds(container);
+  expect(container).toMatchSnapshot();
+});

--- a/packages/amis/src/renderers/QuickEdit.tsx
+++ b/packages/amis/src/renderers/QuickEdit.tsx
@@ -575,7 +575,7 @@ export const HocQuickEdit =
         ) {
           return render('inline-form-item', schema.body[0], {
             mode: 'normal',
-            value: value || '',
+            value: value ?? '',
             onChange: this.handleFormItemChange,
             ref: this.formItemRef
           });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6dcd74c</samp>

This pull request adds a test case for the `input-table` renderer and fixes a bug in the `QuickEdit` component. The bug caused 0 values to be replaced with empty strings in inline editing, which could lead to validation errors and data loss. The fix uses a more robust way of checking for null or undefined values.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6dcd74c</samp>

> _`input-table` test_
> _renders and edits the form_
> _autumn bug is fixed_

### Why

Close: #8070 

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6dcd74c</samp>

* Fix bug in QuickEdit component that caused 0 values to be replaced with empty strings ([link](https://github.com/baidu/amis/pull/8092/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L578-R578))
* Add test case for input-table renderer to check initial display and quick edit features ([link](https://github.com/baidu/amis/pull/8092/files?diff=unified&w=0#diff-0395cc761c8c4e57b39b245df042d9bd80835c94138ffd602a2a44993d9a9592R543-R649))
