### PR TITLE
fix: InputTable组件上层disabled变化后未更新按钮状态问题

### DIFF
--- a/packages/amis-editor-core/src/component/Preview.tsx
+++ b/packages/amis-editor-core/src/component/Preview.tsx
@@ -618,7 +618,10 @@ class SmartPreview extends React.Component<SmartPreviewProps> {
 
     // 添加弹窗事件或弹窗列表进行弹窗切换后自动选中对应的弹窗
     this.dialogReaction = reaction(
-      () => `${store.root.children[0].type}:${store.root.children[0].id}`,
+      () =>
+        store.root.children?.length
+          ? `${store.root.children[0]?.type}:${store.root.children[0]?.id}`
+          : '',
       info => {
         const type = info.split(':')[0];
         if (type === 'dialog' || type === 'drawer') {

--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -309,15 +309,17 @@ export default class FormTable extends React.Component<TableProps, TableState> {
     this.emitValue = this.emitValue.bind(this);
   }
 
-  componentDidUpdate(nextProps: TableProps) {
+  componentDidUpdate(prevProps: TableProps) {
     const props = this.props;
     let toUpdate: any = null;
 
     // 如果static为true 或 disabled为true，
     // 则删掉正在新增 或 编辑的那一行
+    // Form会向FormItem下发disabled属性，disbaled 属性值也需要同步到
     if (
-      props.$schema.disabled !== nextProps.$schema.disabled ||
-      props.$schema.static !== nextProps.$schema.static
+      prevProps.disabled !== props.disabled ||
+      props.$schema.disabled !== prevProps.$schema.disabled ||
+      props.$schema.static !== prevProps.$schema.static
     ) {
       const items = this.state.items.filter(item => !item.__isPlaceholder);
       toUpdate = {
@@ -328,14 +330,14 @@ export default class FormTable extends React.Component<TableProps, TableState> {
       };
     }
 
-    if (props.columns !== nextProps.columns) {
+    if (props.columns !== prevProps.columns) {
       toUpdate = {
         ...toUpdate,
         columns: this.buildColumns(props)
       };
     }
 
-    if (props.value !== nextProps.value) {
+    if (props.value !== prevProps.value) {
       toUpdate = {
         ...toUpdate,
         items: Array.isArray(props.value) ? props.value.concat() : [],


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2d647fd</samp>

This pull request fixes two bugs: one in the `InputTable` component that affects row editing and adding, and one in the `Preview` component that causes errors when the store root has no children. The changes involve adding or modifying some props and operators in `InputTable.tsx` and `Preview.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2d647fd</samp>

> _To render the schema preview_
> _We need to access the store root's `children`_
> _But sometimes it's empty or undefined_
> _And errors would make the app unwind_
> _So we use optional chaining to prevent mayhem_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2d647fd</samp>

*  Fix a bug that causes errors when the store root has no children in the preview dialog ([link](https://github.com/baidu/amis/pull/8093/files?diff=unified&w=0#diff-d9b508133ad06e8946597f0255a1b4529b6fb9f0c2bf3c170e0fcef582fff0e9L621-R624))
*  Fix a bug that prevents the editing and adding of rows in the input table when the disabled prop is passed from the form ([link](https://github.com/baidu/amis/pull/8093/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL318-R322))
*  Rename the parameter nextProps to prevProps in the `InputTable` component to follow the React convention and improve readability ([link](https://github.com/baidu/amis/pull/8093/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL312-R312), [link](https://github.com/baidu/amis/pull/8093/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL331-R333), [link](https://github.com/baidu/amis/pull/8093/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL338-R340))
