### PR TITLE
fix: InputTable组件上层disabled变化后未更新按钮状态问题

### DIFF
--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -309,15 +309,17 @@ export default class FormTable extends React.Component<TableProps, TableState> {
     this.emitValue = this.emitValue.bind(this);
   }
 
-  componentDidUpdate(nextProps: TableProps) {
+  componentDidUpdate(prevProps: TableProps) {
     const props = this.props;
     let toUpdate: any = null;
 
     // 如果static为true 或 disabled为true，
     // 则删掉正在新增 或 编辑的那一行
+    // Form会向FormItem下发disabled属性，disbaled 属性值也需要同步到
     if (
-      props.$schema.disabled !== nextProps.$schema.disabled ||
-      props.$schema.static !== nextProps.$schema.static
+      prevProps.disabled !== props.disabled ||
+      props.$schema.disabled !== prevProps.$schema.disabled ||
+      props.$schema.static !== prevProps.$schema.static
     ) {
       const items = this.state.items.filter(item => !item.__isPlaceholder);
       toUpdate = {
@@ -328,14 +330,14 @@ export default class FormTable extends React.Component<TableProps, TableState> {
       };
     }
 
-    if (props.columns !== nextProps.columns) {
+    if (props.columns !== prevProps.columns) {
       toUpdate = {
         ...toUpdate,
         columns: this.buildColumns(props)
       };
     }
 
-    if (props.value !== nextProps.value) {
+    if (props.value !== prevProps.value) {
       toUpdate = {
         ...toUpdate,
         items: Array.isArray(props.value) ? props.value.concat() : [],


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 56745b1</samp>

Fixed a bug in `InputTable` component that affected disabled state and placeholder rows. Refactored the component code to use `prevProps` in `componentDidUpdate`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 56745b1</samp>

> _A bug in the InputTable component_
> _Made the rows and the state inconsistent_
> _So they renamed and used `prevProps`_
> _In `componentDidUpdate` ops_
> _And the placeholder and disabled were fixed in an instant_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 56745b1</samp>

*  Rename `componentDidUpdate` method parameter from `nextProps` to `prevProps` to avoid confusion with local variable ([link](https://github.com/baidu/amis/pull/8094/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL312-R312))
*  Add condition to check if `disabled` prop changed from parent Form component and remove placeholder rows accordingly ([link](https://github.com/baidu/amis/pull/8094/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL318-R322))
*  Update conditions to use `prevProps` instead of `nextProps` for consistency and convention ([link](https://github.com/baidu/amis/pull/8094/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL331-R333), [link](https://github.com/baidu/amis/pull/8094/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL338-R340))
