### PR TITLE
fix moment version to  2.19.4

### DIFF
--- a/packages/amis-formula/package.json
+++ b/packages/amis-formula/package.json
@@ -48,7 +48,7 @@
   "homepage": "https://github.com/aisuda/amis-tpl#readme",
   "dependencies": {
     "lodash": "^4.17.15",
-    "moment": "^2.29.4",
+    "moment": "^2.19.4",
     "tslib": "^2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
修复 moment 版本

### What
![image](https://github.com/baidu/amis/assets/15613121/07482e20-68a4-46bf-b7ad-a7093040a55c)

copilot: 修复 amis-formula 包中的moment 版本差异问题 使之与其他包一致

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1a42b8f</samp>

> _`moment` downgraded_
> _IE11 needs old code_
> _winter of browsers_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1a42b8f</samp>

*  Downgrade `moment` dependency version to fix IE11 compatibility issue ([link](https://github.com/baidu/amis/pull/8095/files?diff=unified&w=0#diff-2a1582dd8536cd65b762f9cd79719e90b98bdc38b808db0aaf783039f53d4153L51-R51))
