### PR TITLE
修复静态展示staticSchema时react.isValidateElement无法处理数组导致的渲染错误

### DIFF
--- a/docs/zh-CN/components/form/input-formula.md
+++ b/docs/zh-CN/components/form/input-formula.md
@@ -232,7 +232,7 @@ order: 21
 
 ## 变量展示模式
 
-设置不同`variableMode`字段切换变量展示模式，树形结构：
+设置不同`variableMode`字段切换变量展示模式，配置`isExpandVariable: true`可以默认展开变量树，树形结构：
 
 ```schema: scope="body"
 {
@@ -245,6 +245,7 @@ order: 21
       "label": "公式",
       "variableMode": "tree",
       "evalMode": true,
+      "isExpandVariable": true,
       "variables": [
         {
           "label": "表单字段",
@@ -384,6 +385,78 @@ Tab 结构：
       "label": "公式",
       "evalMode": true,
       "value": "SUM(1, 2)",
+      "variables": [
+        {
+          "label": "表单字段",
+          "children": [
+            {
+              "label": "文章名",
+              "value": "name",
+              "tag": "文本"
+            },
+            {
+              "label": "作者",
+              "value": "author",
+              "tag": "文本"
+            },
+            {
+              "label": "售价",
+              "value": "price",
+              "tag": "数字"
+            },
+            {
+              "label": "出版时间",
+              "value": "time",
+              "tag": "时间"
+            },
+            {
+              "label": "版本号",
+              "value": "version",
+              "tag": "数字"
+            },
+            {
+              "label": "出版社",
+              "value": "publisher",
+              "tag": "文本"
+            }
+          ]
+        },
+        {
+          "label": "流程字段",
+          "children": [
+            {
+              "label": "联系电话",
+              "value": "telphone"
+            },
+            {
+              "label": "地址",
+              "value": "addr"
+            }
+          ]
+        }
+      ],
+    }
+  ]
+}
+```
+
+## 源码模式
+
+当配置`isCodeMode`为 true 时，默认开启源码模式，关闭源码模式时为高亮模式。
+
+```schema: scope="body"
+{
+  "type": "form",
+  "debug": true,
+  "body": [
+    {
+      "type": "input-formula",
+      "name": "formula",
+      "allowInput": false,
+      "label": "公式",
+      "evalMode": true,
+      "value": "SUM(1, 2)",
+      "isCodeMode": true,
       "variables": [
         {
           "label": "表单字段",
@@ -590,6 +663,8 @@ Tab 结构：
 | variableMode      | `string`                                                                                   | `list`         | 可配置成 `tabs` 或者 `tree` 默认为列表，支持分组。                             |
 | functions         | `Object[]`                                                                                 | -              | 可以不设置，默认就是 amis-formula 里面定义的函数，如果扩充了新的函数则需要指定 |
 | inputMode         | `'button' \| 'input-button' \| 'input-group'`                                              | -              | 控件的展示模式                                                                 |
+| isCodeMode        | `boolean`                                                                                  | `false`        | 使用源码模式                                                                   |
+| isExpandVariable  | `boolean`                                                                                  | `false`        | variableMode 为 tree 时，展开变量树                                            |
 | icon              | `string`                                                                                   | -              | 按钮图标，例如`fa fa-list`                                                     |
 | btnLabel          | `string`                                                                                   | `'公示编辑'`   | 按钮文本，`inputMode`为`button`时生效                                          |
 | level             | `'info' \| 'success' \| 'warning' \| 'danger' \| 'link' \| 'primary' \| 'dark' \| 'light'` | `default`      | 按钮样式                                                                       |

--- a/packages/amis-ui/scss/base/_normalize.scss
+++ b/packages/amis-ui/scss/base/_normalize.scss
@@ -38,17 +38,6 @@ h1 {
      ========================================================================== */
 
 /**
-   * 1. Add the correct box sizing in Firefox.
-   * 2. Show the overflow in Edge and IE.
-   */
-
-hr {
-  box-sizing: content-box; // 1
-  height: 0; // 2
-  overflow: visible; //2
-}
-
-/**
    * 1. Correct the inheritance and scaling of font size in all browsers.
    * 2. Correct the odd `em` font sizing in all browsers.
    */

--- a/packages/amis-ui/src/components/formula/Editor.tsx
+++ b/packages/amis-ui/src/components/formula/Editor.tsx
@@ -91,6 +91,16 @@ export interface FormulaEditorProps extends ThemeProps, LocaleProps {
    * 编辑器配置
    */
   editorOptions?: any;
+
+  /**
+   * 是否源码模式
+   */
+  isCodeMode?: boolean;
+
+  /**
+   * variableMode为tree时，是否展开变量
+   */
+  isExpandVariable?: boolean;
 }
 
 export interface FunctionsProps {
@@ -119,8 +129,8 @@ export class FormulaEditor extends React.Component<
 > {
   state: FormulaState = {
     focused: false,
-    isCodeMode: false,
-    expandTree: false,
+    isCodeMode: this.props.isCodeMode ?? false,
+    expandTree: this.props.isExpandVariable ?? false,
     normalizeVariables: [],
     functions: []
   };

--- a/packages/amis-ui/src/components/formula/Picker.tsx
+++ b/packages/amis-ui/src/components/formula/Picker.tsx
@@ -629,6 +629,8 @@ export class FormulaPicker extends React.Component<
                 value={editorValue}
                 onChange={this.handleEditorChange}
                 selfVariableName={this.props.selfVariableName}
+                isCodeMode={this.props.isCodeMode}
+                isExpandVariable={this.props.isExpandVariable}
               />
             </Modal.Body>
             <Modal.Footer>

--- a/packages/amis/package.json
+++ b/packages/amis/package.json
@@ -73,7 +73,8 @@
     "tslib": "^2.3.1",
     "video-react": "0.15.0",
     "xlsx": "^0.18.5",
-    "react-intersection-observer": "9.5.2"
+    "react-intersection-observer": "9.5.2",
+    "react-error-boundary": "^4.0.11"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",

--- a/packages/amis/src/renderers/Form/InputFormula.tsx
+++ b/packages/amis/src/renderers/Form/InputFormula.tsx
@@ -126,6 +126,16 @@ export interface InputFormulaControlSchema extends FormBaseControlSchema {
    * 输入框的类型
    */
   inputSettings?: FormulaPickerInputSettings;
+
+  /**
+   * 是否源码模式
+   */
+  isCodeMode?: boolean;
+
+  /**
+   * variableMode为tree时，是否展开变量
+   */
+  isExpandVariable?: boolean;
 }
 
 export interface InputFormulaProps
@@ -206,7 +216,9 @@ export class InputFormulaRenderer extends React.Component<InputFormulaProps> {
       popOverContainer,
       env,
       inputSettings,
-      mobileUI
+      mobileUI,
+      isCodeMode,
+      isExpandVariable
     } = this.props;
     let {variables, functions} = this.props;
 
@@ -251,6 +263,8 @@ export class InputFormulaRenderer extends React.Component<InputFormulaProps> {
         selfVariableName={selfVariableName}
         mixedMode={mixedMode}
         mobileUI={mobileUI}
+        isCodeMode={isCodeMode}
+        isExpandVariable={isExpandVariable}
       />
     );
   }

--- a/packages/amis/src/renderers/Form/StaticHoc.tsx
+++ b/packages/amis/src/renderers/Form/StaticHoc.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import toString from 'lodash/toString';
 import {getPropValue, FormControlProps} from 'amis-core';
+import {ErrorBoundary} from 'react-error-boundary';
 
 function renderCommonStatic(props: any, defaultValue: string) {
   const {type, render, staticSchema} = props;
@@ -135,7 +136,9 @@ export function supportStatic<T extends FormControlProps>() {
 
         return (
           <div className={cx(`${ns}Form-static`, className)}>
-            {React.isValidElement(body) ? body : toString(body)}
+            <ErrorBoundary fallback={<>{toString(body)}</>}>
+              {body}
+            </ErrorBoundary>
           </div>
         );
       }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8f5095b</samp>

This pull request adds two new configuration options to the `input-formula` component: `isCodeMode` and `isExpandVariable`, which allow users to customize the display and editing of the formula and the variable tree. It also adds error handling to the `static` hoc renderer by using the `react-error-boundary` package, and removes some redundant CSS rules for the `hr` element.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8f5095b</samp>

> _We're sailing on the code sea, with `input-formula` in our sails_
> _We're adding props and fixing bugs, and hoping nothing fails_
> _We're heaving on the `isCodeMode` and `isExpandVariable`_
> _One, two, three, pull! Make the formula picker more flexible_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8f5095b</samp>

*  Add two new configuration options `isCodeMode` and `isExpandVariable` to the `input-formula` renderer and component, which allow users to switch between the source code mode and the highlight mode of the formula editor, and to control whether the variable tree is expanded by default when the `variableMode` is set to `tree` ([link](https://github.com/baidu/amis/pull/8100/files?diff=unified&w=0#diff-e79f60f5c6132f261e5685efac74ebb51170f6f457b9b6a20b85e124d8fbd066L235-R235), [link](https://github.com/baidu/amis/pull/8100/files?diff=unified&w=0#diff-e79f60f5c6132f261e5685efac74ebb51170f6f457b9b6a20b85e124d8fbd066R248), [link](https://github.com/baidu/amis/pull/8100/files?diff=unified&w=0#diff-e79f60f5c6132f261e5685efac74ebb51170f6f457b9b6a20b85e124d8fbd066R443-R514), [link](https://github.com/baidu/amis/pull/8100/files?diff=unified&w=0#diff-e79f60f5c6132f261e5685efac74ebb51170f6f457b9b6a20b85e124d8fbd066R666-R667), [link](https://github.com/baidu/amis/pull/8100/files?diff=unified&w=0#diff-893fd27e1fa6dd194d6e17f9bb62a1a3144bdf0e24063ef0426990e28d7b7c19R94-R103), [link](https://github.com/baidu/amis/pull/8100/files?diff=unified&w=0#diff-893fd27e1fa6dd194d6e17f9bb62a1a3144bdf0e24063ef0426990e28d7b7c19L122-R133), [link](https://github.com/baidu/amis/pull/8100/files?diff=unified&w=0#diff-a91de98202f6b9b02dd68acc182e85cefc52df9fc5002c2c6ac80593972a4611R632-R633), [link](https://github.com/baidu/amis/pull/8100/files?diff=unified&w=0#diff-913fb8d07888e592949feed6847e6997721160c1df681059970998dbe0f0bb45R129-R138), [link](https://github.com/baidu/amis/pull/8100/files?diff=unified&w=0#diff-913fb8d07888e592949feed6847e6997721160c1df681059970998dbe0f0bb45L209-R221), [link](https://github.com/baidu/amis/pull/8100/files?diff=unified&w=0#diff-913fb8d07888e592949feed6847e6997721160c1df681059970998dbe0f0bb45R266-R267)).
