### PR TITLE
fix: 修复静态展示staticSchema时react.isValidateElement无法处理数组导致的渲染错误

### DIFF
--- a/packages/amis/package.json
+++ b/packages/amis/package.json
@@ -73,7 +73,8 @@
     "tslib": "^2.3.1",
     "video-react": "0.15.0",
     "xlsx": "^0.18.5",
-    "react-intersection-observer": "9.5.2"
+    "react-intersection-observer": "9.5.2",
+    "react-error-boundary": "^4.0.11"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",

--- a/packages/amis/src/renderers/Form/StaticHoc.tsx
+++ b/packages/amis/src/renderers/Form/StaticHoc.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import toString from 'lodash/toString';
 import {getPropValue, FormControlProps} from 'amis-core';
+import {ErrorBoundary} from 'react-error-boundary';
 
 function renderCommonStatic(props: any, defaultValue: string) {
   const {type, render, staticSchema} = props;
@@ -135,7 +136,9 @@ export function supportStatic<T extends FormControlProps>() {
 
         return (
           <div className={cx(`${ns}Form-static`, className)}>
-            {React.isValidElement(body) ? body : toString(body)}
+            <ErrorBoundary fallback={<>{toString(body)}</>}>
+              {body}
+            </ErrorBoundary>
           </div>
         );
       }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 805a754</samp>

Added `react-error-boundary` package and used it to handle errors in rendering static components in forms. This improves the stability and usability of the form renderer in `amis`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 805a754</samp>

> _Oh we're the coders of the sea, and we work with `react`_
> _We render forms with static comps, but sometimes they go splat_
> _So we added `ErrorBoundary` to catch them when they fall_
> _And now our forms are stable and usable for all_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 805a754</samp>

*  Add `react-error-boundary` package as a dependency to handle errors in rendering static components ([link](https://github.com/baidu/amis/pull/8102/files?diff=unified&w=0#diff-b49028542a3bb14de6e47e46a9f09f23ffeff3afea2a17d5ddace75726a33e12L76-R77))
*  Wrap `body` prop in `ErrorBoundary` component in `supportStatic` function to prevent form crash ([link](https://github.com/baidu/amis/pull/8102/files?diff=unified&w=0#diff-6743296e062555d6d5ef1ffa806450e07b74989e2b2bcc829517a34a8560e918R4),[link](https://github.com/baidu/amis/pull/8102/files?diff=unified&w=0#diff-6743296e062555d6d5ef1ffa806450e07b74989e2b2bcc829517a34a8560e918L138-R141))
*  Use fallback prop as original return value of `supportStatic` function, which converts `body` prop to a string ([link](https://github.com/baidu/amis/pull/8102/files?diff=unified&w=0#diff-6743296e062555d6d5ef1ffa806450e07b74989e2b2bcc829517a34a8560e918L138-R141))
