### PR TITLE
chore: 优化 Table 渲染单元格性能

### DIFF
--- a/packages/amis/__tests__/event-action/renderers/__snapshots__/crud.test.tsx.snap
+++ b/packages/amis/__tests__/event-action/renderers/__snapshots__/crud.test.tsx.snap
@@ -259,7 +259,6 @@ exports[`doAction:crud reload 1`] = `
                     class="cxd-Spinner-icon cxd-Spinner-icon--default"
                   />
                 </div>
-                <span />
               </div>
               <div
                 class="resize-sensor"
@@ -568,7 +567,6 @@ exports[`doAction:crud reload with data1 1`] = `
                     class="cxd-Spinner-icon cxd-Spinner-icon--default"
                   />
                 </div>
-                <span />
               </div>
               <div
                 class="resize-sensor"
@@ -877,7 +875,6 @@ exports[`doAction:crud reload with data2 1`] = `
                     class="cxd-Spinner-icon cxd-Spinner-icon--default"
                   />
                 </div>
-                <span />
               </div>
               <div
                 class="resize-sensor"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
@@ -195,7 +195,6 @@ exports[`Renderer:input table 1`] = `
                             </tbody>
                           </table>
                         </div>
-                        <span />
                       </div>
                       <div
                         class="resize-sensor"
@@ -599,7 +598,6 @@ exports[`Renderer:input table add 1`] = `
                     </tbody>
                   </table>
                 </div>
-                <span />
               </div>
               <div
                 class="resize-sensor"
@@ -928,7 +926,6 @@ exports[`Renderer:input-table cell selects delete 1`] = `
                     </tbody>
                   </table>
                 </div>
-                <span />
               </div>
               <div
                 class="resize-sensor"
@@ -1664,7 +1661,6 @@ exports[`Renderer:input-table init display 1`] = `
                     </tbody>
                   </table>
                 </div>
-                <span />
               </div>
               <div
                 class="resize-sensor"
@@ -2103,7 +2099,6 @@ exports[`Renderer:input-table with combo column 1`] = `
                     </tbody>
                   </table>
                 </div>
-                <span />
               </div>
               <div
                 class="resize-sensor"

--- a/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
@@ -487,7 +487,6 @@ exports[`1. Renderer:crud basic interval headerToolbar footerToolbar 1`] = `
                     class="cxd-Spinner-icon cxd-Spinner-icon--default"
                   />
                 </div>
-                <span />
               </div>
               <div
                 class="cxd-Table-toolbar cxd-Table-footToolbar"
@@ -2587,7 +2586,6 @@ exports[`6. Renderer:crud source & alwaysShowPagination 1`] = `
                     </tbody>
                   </table>
                 </div>
-                <span />
               </div>
               <div
                 class="cxd-Table-toolbar cxd-Table-footToolbar"
@@ -3464,7 +3462,6 @@ exports[`13. enderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionL
                     </tbody>
                   </table>
                 </div>
-                <span />
               </div>
               <div
                 class="resize-sensor"

--- a/packages/amis/__tests__/renderers/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Pagination.test.tsx.snap
@@ -210,7 +210,6 @@ exports[`Renderer:Pagination 1`] = `
               </tbody>
             </table>
           </div>
-          <span />
         </div>
         <div
           class="resize-sensor"

--- a/packages/amis/__tests__/renderers/__snapshots__/Table.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Table.test.tsx.snap
@@ -323,7 +323,6 @@ exports[`Renderer:table 1`] = `
           </tbody>
         </table>
       </div>
-      <span />
     </div>
     <div
       class="resize-sensor"
@@ -714,7 +713,6 @@ exports[`Renderer:table align 1`] = `
           </tbody>
         </table>
       </div>
-      <span />
     </div>
     <div
       class="resize-sensor"
@@ -1307,7 +1305,6 @@ exports[`Renderer:table children 1`] = `
                     </tbody>
                   </table>
                 </div>
-                <span />
               </div>
               <div
                 class="resize-sensor"
@@ -1680,7 +1677,6 @@ exports[`Renderer:table classNameExpr 1`] = `
           </tbody>
         </table>
       </div>
-      <span />
     </div>
     <div
       class="resize-sensor"
@@ -2059,7 +2055,6 @@ exports[`Renderer:table column head style className 1`] = `
           </tbody>
         </table>
       </div>
-      <span />
     </div>
     <div
       class="resize-sensor"
@@ -2631,7 +2626,6 @@ exports[`Renderer:table combine Renderer:table combineNum only 1`] = `
                     </tbody>
                   </table>
                 </div>
-                <span />
               </div>
               <div
                 class="resize-sensor"
@@ -3278,7 +3272,6 @@ exports[`Renderer:table combine Renderer:table combineNum with fromIndex 1`] = `
                     </tbody>
                   </table>
                 </div>
-                <span />
               </div>
               <div
                 class="resize-sensor"
@@ -4059,7 +4052,6 @@ exports[`Renderer:table groupName-default 1`] = `
                     </tbody>
                   </table>
                 </div>
-                <span />
               </div>
               <div
                 class="resize-sensor"
@@ -4844,7 +4836,6 @@ exports[`Renderer:table groupName-middleNoGroupName 1`] = `
                     </tbody>
                   </table>
                 </div>
-                <span />
               </div>
               <div
                 class="resize-sensor"
@@ -5617,7 +5608,6 @@ exports[`Renderer:table groupName-startNoGroupName 1`] = `
                     </tbody>
                   </table>
                 </div>
-                <span />
               </div>
               <div
                 class="resize-sensor"
@@ -6398,7 +6388,6 @@ exports[`Renderer:table groupName-withTpl 1`] = `
                     </tbody>
                   </table>
                 </div>
-                <span />
               </div>
               <div
                 class="resize-sensor"
@@ -6782,7 +6771,6 @@ exports[`Renderer:table isHead fixed 1`] = `
           </tbody>
         </table>
       </div>
-      <span />
     </div>
     <div
       class="resize-sensor"
@@ -8014,7 +8002,6 @@ exports[`Renderer:table list 1`] = `
           </tbody>
         </table>
       </div>
-      <span />
     </div>
     <div
       class="resize-sensor"

--- a/packages/amis/src/renderers/Table/Cell.tsx
+++ b/packages/amis/src/renderers/Table/Cell.tsx
@@ -1,0 +1,221 @@
+import {
+  IColumn,
+  IRow,
+  ITableStore,
+  PlainObject,
+  SchemaNode,
+  ThemeProps,
+  resolveVariable
+} from 'amis-core';
+import {BadgeObject, Checkbox, Icon} from 'amis-ui';
+import React from 'react';
+
+export interface CellProps extends ThemeProps {
+  region: string;
+  column: IColumn;
+  item: IRow;
+  props: PlainObject;
+  ignoreDrag?: boolean;
+  render: (
+    region: string,
+    node: SchemaNode,
+    props?: PlainObject
+  ) => JSX.Element;
+  store: ITableStore;
+  multiple: boolean;
+  canAccessSuperData?: boolean;
+  itemBadge?: BadgeObject;
+  onCheck?: (item: IRow) => void;
+  onDragStart?: (e: React.DragEvent) => void;
+  popOverContainer?: any;
+  quickEditFormRef: any;
+  onImageEnlarge?: any;
+}
+
+export default function Cell({
+  region,
+  column,
+  item,
+  props,
+  ignoreDrag,
+  render,
+  store,
+  multiple,
+  itemBadge,
+  classnames: cx,
+  classPrefix: ns,
+  canAccessSuperData,
+  onCheck,
+  onDragStart,
+  popOverContainer,
+  quickEditFormRef,
+  onImageEnlarge
+}: CellProps) {
+  if (column.name && item.rowSpans[column.name] === 0) {
+    return null;
+  }
+
+  const [style, stickyClassName]: any = React.useMemo(() => {
+    const style = {...column.pristine.style};
+    const [stickyStyle, stickyClassName] = store.getStickyStyles(
+      column,
+      store.filteredColumns
+    );
+    return [Object.assign(style, stickyStyle), stickyClassName];
+  }, []);
+
+  const onCheckboxChange = React.useCallback(() => {
+    onCheck?.(item);
+  }, []);
+
+  if (column.type === '__checkme') {
+    return (
+      <td
+        style={style}
+        key={props.key}
+        className={cx(column.pristine.className, stickyClassName)}
+      >
+        <Checkbox
+          classPrefix={ns}
+          type={multiple ? 'checkbox' : 'radio'}
+          checked={item.checked}
+          disabled={item.checkdisable || !item.checkable}
+          onChange={onCheckboxChange}
+        />
+      </td>
+    );
+  } else if (column.type === '__dragme') {
+    return (
+      <td
+        style={style}
+        key={props.key}
+        className={cx(column.pristine.className, stickyClassName, {
+          'is-dragDisabled': !item.draggable
+        })}
+      >
+        {item.draggable ? <Icon icon="drag" className="icon" /> : null}
+      </td>
+    );
+  } else if (column.type === '__expandme') {
+    return (
+      <td
+        style={style}
+        key={props.key}
+        className={cx(column.pristine.className, stickyClassName)}
+      >
+        {item.expandable ? (
+          <a
+            className={cx('Table-expandBtn', item.expanded ? 'is-active' : '')}
+            // data-tooltip="展开/收起"
+            // data-position="top"
+            onClick={item.toggleExpanded}
+          >
+            <Icon icon="right-arrow-bold" className="icon" />
+          </a>
+        ) : null}
+      </td>
+    );
+  }
+
+  let [prefix, affix, addtionalClassName] = React.useMemo(() => {
+    let prefix: React.ReactNode[] = [];
+    let affix: React.ReactNode[] = [];
+    let addtionalClassName = '';
+
+    if (column.isPrimary && store.isNested) {
+      addtionalClassName = 'Table-primayCell';
+      prefix.push(
+        <span
+          key="indent"
+          className={cx('Table-indent')}
+          style={item.indentStyle}
+        />
+      );
+      prefix.push(
+        item.expandable ? (
+          <a
+            key="expandBtn2"
+            className={cx('Table-expandBtn2', item.expanded ? 'is-active' : '')}
+            // data-tooltip="展开/收起"
+            // data-position="top"
+            onClick={item.toggleExpanded}
+          >
+            <Icon icon="right-arrow-bold" className="icon" />
+          </a>
+        ) : (
+          <span key="expandSpace" className={cx('Table-expandSpace')} />
+        )
+      );
+    }
+
+    if (
+      !ignoreDrag &&
+      column.isPrimary &&
+      store.isNested &&
+      store.draggable &&
+      item.draggable
+    ) {
+      affix.push(
+        <a
+          key="dragBtn"
+          draggable
+          onDragStart={onDragStart}
+          className={cx('Table-dragBtn')}
+        >
+          <Icon icon="drag" className="icon" />
+        </a>
+      );
+    }
+    return [prefix, affix, addtionalClassName];
+  }, [item.expandable, item.expanded]);
+  const data = React.useMemo(() => item.locals, [JSON.stringify(item.locals)]);
+
+  const finalCanAccessSuperData =
+    column.pristine.canAccessSuperData ?? canAccessSuperData;
+  const subProps: any = {
+    ...props,
+    // 操作列不下发loading，否则会导致操作栏里面的所有按钮都出现loading
+    loading: column.type === 'operation' ? false : props.loading,
+    btnDisabled: store.dragging,
+    data: data,
+    value: column.name
+      ? resolveVariable(
+          column.name,
+          finalCanAccessSuperData ? item.locals : item.data
+        )
+      : column.value,
+    popOverContainer: popOverContainer,
+    rowSpan: item.rowSpans[column.name as string],
+    quickEditFormRef: quickEditFormRef,
+    cellPrefix: prefix,
+    cellAffix: affix,
+    onImageEnlarge: onImageEnlarge,
+    canAccessSuperData: finalCanAccessSuperData,
+    row: item,
+    itemBadge,
+    showBadge:
+      !props.isHead &&
+      itemBadge &&
+      store.firstToggledColumnIndex === props.colIndex,
+    onQuery: undefined,
+    style,
+    className: cx(
+      column.pristine.className,
+      stickyClassName,
+      addtionalClassName
+    ),
+    /** 给子节点的设置默认值，避免取到env.affixHeader的默认值，导致表头覆盖首行 */
+    affixOffsetTop: 0
+  };
+  delete subProps.label;
+
+  return render(
+    region,
+    {
+      ...column.pristine,
+      column: column.pristine,
+      type: 'cell'
+    },
+    subProps
+  );
+}

--- a/packages/amis/src/renderers/Table/ColGroup.tsx
+++ b/packages/amis/src/renderers/Table/ColGroup.tsx
@@ -13,9 +13,10 @@ export function ColGroup({
 
   React.useEffect(() => {
     if (domRef.current) {
+      store.initTableWidth();
       store.syncTableWidth();
     }
-  });
+  }, []);
 
   React.useEffect(() => {
     const table = domRef.current!.parentElement!;
@@ -37,7 +38,7 @@ export function ColGroup({
       {columns.map(column => {
         const style: any = {};
 
-        if (store.columnWidthReady) {
+        if (store.columnWidthReady && column.width) {
           style.width = column.width;
         } else if (column.pristine.width) {
           style.width = column.pristine.width;

--- a/packages/amis/src/renderers/Table/TableRow.tsx
+++ b/packages/amis/src/renderers/Table/TableRow.tsx
@@ -179,6 +179,7 @@ export class TableRow extends React.PureComponent<
       onEvent,
 
       expanded,
+      parentExpanded,
       id,
       newIndex,
       isHover,
@@ -188,7 +189,9 @@ export class TableRow extends React.PureComponent<
       depth,
       expandable,
       appeard,
+      checkdisable,
       trRef,
+      isNested,
 
       ...rest
     } = this.props;

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -548,7 +548,6 @@ export default class Table extends React.Component<TableProps, object> {
     this.tableRef = this.tableRef.bind(this);
     this.affixedTableRef = this.affixedTableRef.bind(this);
     this.updateTableInfo = this.updateTableInfo.bind(this);
-    this.updateTableInfoRef = this.updateTableInfoRef.bind(this);
     this.handleAction = this.handleAction.bind(this);
     this.handleCheck = this.handleCheck.bind(this);
     this.handleCheckAll = this.handleCheckAll.bind(this);
@@ -1237,13 +1236,6 @@ export default class Table extends React.Component<TableProps, object> {
     this.props.store.initTableWidth();
     this.handleOutterScroll();
     callback && setTimeout(callback, 20);
-  }
-
-  updateTableInfoRef(ref: any) {
-    if (!ref) {
-      return;
-    }
-    this.updateTableInfo();
   }
 
   // 当表格滚动是，需要让 affixHeader 部分的表格也滚动
@@ -2721,13 +2713,6 @@ export default class Table extends React.Component<TableProps, object> {
           onMouseLeave={this.handleMouseLeave}
         >
           {this.renderTableContent()}
-
-          {
-            // 利用这个将 table-layout: auto 转成 table-layout: fixed
-            store.columnWidthReady ? null : (
-              <span ref={this.updateTableInfoRef} />
-            )
-          }
         </div>
 
         {footer}

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -69,6 +69,7 @@ import omit from 'lodash/omit';
 import ColGroup from './ColGroup';
 import debounce from 'lodash/debounce';
 import AutoFilterForm from './AutoFilterForm';
+import Cell from './Cell';
 
 /**
  * 表格列，不指定类型时默认为文本类型。
@@ -2018,168 +2019,31 @@ export default class Table extends React.Component<TableProps, object> {
       classnames: cx,
       checkOnItemClick,
       popOverContainer,
+      canAccessSuperData,
       itemBadge
     } = this.props;
 
-    if (column.name && item.rowSpans[column.name] === 0) {
-      return null;
-    }
-
-    const style: any = {...column.pristine.style};
-    const [stickyStyle, stickyClassName] = store.getStickyStyles(
-      column,
-      store.filteredColumns
-    );
-    Object.assign(style, stickyStyle);
-
-    if (column.type === '__checkme') {
-      return (
-        <td
-          style={style}
-          key={props.key}
-          className={cx(column.pristine.className, stickyClassName)}
-        >
-          <Checkbox
-            classPrefix={ns}
-            type={multiple ? 'checkbox' : 'radio'}
-            checked={item.checked}
-            disabled={item.checkdisable || !item.checkable}
-            onChange={this.handleCheck.bind(this, item)}
-          />
-        </td>
-      );
-    } else if (column.type === '__dragme') {
-      return (
-        <td
-          style={style}
-          key={props.key}
-          className={cx(column.pristine.className, stickyClassName, {
-            'is-dragDisabled': !item.draggable
-          })}
-        >
-          {item.draggable ? <Icon icon="drag" className="icon" /> : null}
-        </td>
-      );
-    } else if (column.type === '__expandme') {
-      return (
-        <td
-          style={style}
-          key={props.key}
-          className={cx(column.pristine.className, stickyClassName)}
-        >
-          {item.expandable ? (
-            <a
-              className={cx(
-                'Table-expandBtn',
-                item.expanded ? 'is-active' : ''
-              )}
-              // data-tooltip="展开/收起"
-              // data-position="top"
-              onClick={item.toggleExpanded}
-            >
-              <Icon icon="right-arrow-bold" className="icon" />
-            </a>
-          ) : null}
-        </td>
-      );
-    }
-
-    let prefix: React.ReactNode[] = [];
-    let affix: React.ReactNode[] = [];
-    let addtionalClassName = '';
-
-    if (column.isPrimary && store.isNested) {
-      addtionalClassName = 'Table-primayCell';
-      prefix.push(
-        <span
-          key="indent"
-          className={cx('Table-indent')}
-          style={item.indentStyle}
-        />
-      );
-      prefix.push(
-        item.expandable ? (
-          <a
-            key="expandBtn2"
-            className={cx('Table-expandBtn2', item.expanded ? 'is-active' : '')}
-            // data-tooltip="展开/收起"
-            // data-position="top"
-            onClick={item.toggleExpanded}
-          >
-            <Icon icon="right-arrow-bold" className="icon" />
-          </a>
-        ) : (
-          <span key="expandSpace" className={cx('Table-expandSpace')} />
-        )
-      );
-    }
-
-    if (
-      !ignoreDrag &&
-      column.isPrimary &&
-      store.isNested &&
-      store.draggable &&
-      item.draggable
-    ) {
-      affix.push(
-        <a
-          key="dragBtn"
-          draggable
-          onDragStart={this.handleDragStart}
-          className={cx('Table-dragBtn')}
-        >
-          <Icon icon="drag" className="icon" />
-        </a>
-      );
-    }
-
-    const canAccessSuperData =
-      column.pristine.canAccessSuperData ?? this.props.canAccessSuperData;
-    const subProps: any = {
-      ...props,
-      // 操作列不下发loading，否则会导致操作栏里面的所有按钮都出现loading
-      loading: column.type === 'operation' ? false : props.loading,
-      btnDisabled: store.dragging,
-      data: item.locals,
-      value: column.name
-        ? resolveVariable(
-            column.name,
-            canAccessSuperData ? item.locals : item.data
-          )
-        : column.value,
-      popOverContainer: this.getPopOverContainer,
-      rowSpan: item.rowSpans[column.name as string],
-      quickEditFormRef: this.subFormRef,
-      cellPrefix: prefix,
-      cellAffix: affix,
-      onImageEnlarge: this.handleImageEnlarge,
-      canAccessSuperData,
-      row: item,
-      itemBadge,
-      showBadge:
-        !props.isHead &&
-        itemBadge &&
-        store.firstToggledColumnIndex === props.colIndex,
-      onQuery: undefined,
-      style,
-      className: cx(
-        column.pristine.className,
-        stickyClassName,
-        addtionalClassName
-      ),
-      /** 给子节点的设置默认值，避免取到env.affixHeader的默认值，导致表头覆盖首行 */
-      affixOffsetTop: 0
-    };
-    delete subProps.label;
-
-    return render(
-      region,
-      {
-        ...column.pristine,
-        column: column.pristine,
-        type: 'cell'
-      },
-      subProps
+    return (
+      <Cell
+        key={props.key}
+        region={region}
+        column={column}
+        item={item}
+        props={props}
+        ignoreDrag={ignoreDrag}
+        render={render}
+        store={store}
+        multiple={multiple}
+        canAccessSuperData={canAccessSuperData}
+        classnames={cx}
+        classPrefix={ns}
+        itemBadge={itemBadge}
+        onCheck={this.handleCheck}
+        onDragStart={this.handleDragStart}
+        popOverContainer={this.getPopOverContainer}
+        quickEditFormRef={this.subFormRef}
+        onImageEnlarge={this.handleImageEnlarge}
+      />
     );
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ee6935</samp>

This pull request introduces a new `Cell` component for rendering table cells in the `amis` library. The `Cell` component handles different types of cells and their styles and elements. The `Table` component is refactored to use the `Cell` component and simplify its code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7ee6935</samp>

> _The `Table` component was a mess_
> _With too much logic to compress_
> _So they made a new `Cell`_
> _To render it well_
> _And the code became easier to assess_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7ee6935</samp>

* Extract the cell rendering logic from the `Table` component and create a new `Cell` component in `Cell.tsx` ([link](https://github.com/baidu/amis/pull/8103/files?diff=unified&w=0#diff-d65258ae6673eb54481e932fd39b426fb60a31ca9cb7430d0cff54fe035efe15R1-R221))
* Use the `Cell` component in the `Table` component and pass the relevant props ([link](https://github.com/baidu/amis/pull/8103/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR72), [link](https://github.com/baidu/amis/pull/8103/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2021-R2047))
