### PR TITLE
feat:  外观样式在组件运行时加载className

### DIFF
--- a/packages/amis-core/src/components/CustomStyle.tsx
+++ b/packages/amis-core/src/components/CustomStyle.tsx
@@ -20,30 +20,36 @@ export default function (props: CustomStyleProps) {
   const styleDom = useRef(new StyleDom(id || '')).current;
 
   useEffect(() => {
-    styleDom.insertCustomStyle({
-      themeCss,
-      classNames,
-      defaultData,
-      customStyleClassPrefix: env?.customStyleClassPrefix,
-      doc: env.getModalContainer?.().ownerDocument
-    });
+    if (themeCss && styleDom.id) {
+      styleDom.insertCustomStyle({
+        themeCss,
+        classNames,
+        defaultData,
+        customStyleClassPrefix: env?.customStyleClassPrefix,
+        doc: env.getModalContainer?.().ownerDocument
+      });
+    }
+
     return () => {
       styleDom.removeCustomStyle('', env.getModalContainer?.().ownerDocument);
     };
-  }, [config.themeCss]);
+  }, [themeCss]);
 
   useEffect(() => {
-    styleDom.insertEditCustomStyle(
-      wrapperCustomStyle,
-      env.getModalContainer?.().ownerDocument
-    );
+    if (wrapperCustomStyle && styleDom.id) {
+      styleDom.insertEditCustomStyle(
+        wrapperCustomStyle,
+        env.getModalContainer?.().ownerDocument
+      );
+    }
+
     return () => {
       styleDom.removeCustomStyle(
         'wrapperCustomStyle',
         env.getModalContainer?.().ownerDocument
       );
     };
-  }, [config.wrapperCustomStyle]);
+  }, [wrapperCustomStyle]);
 
   return null;
 }

--- a/packages/amis-core/src/renderers/Item.tsx
+++ b/packages/amis-core/src/renderers/Item.tsx
@@ -34,7 +34,7 @@ import {wrapControl} from './wrapControl';
 import debounce from 'lodash/debounce';
 import {isApiOutdated, isEffectiveApi} from '../utils/api';
 import {findDOMNode} from 'react-dom';
-import {dataMapping} from '../utils';
+import {dataMapping, setThemeClassName} from '../utils';
 import Overlay from '../components/Overlay';
 import PopOver from '../components/PopOver';
 import CustomStyle from '../components/CustomStyle';
@@ -501,10 +501,15 @@ export interface FormItemConfig extends FormItemBasicConfig {
 }
 
 const getItemLabelClassName = (props: FormItemProps) => {
-  const {staticLabelClassName, labelClassName} = props;
+  const {staticLabelClassName, labelClassName, id, themeCss} = props;
   return props.static && staticLabelClassName
     ? staticLabelClassName
-    : labelClassName;
+    : `${labelClassName || ''} ${setThemeClassName(
+        'labelClassName',
+        id,
+        themeCss,
+        'item'
+      )}`;
 };
 
 const getItemInputClassName = (props: FormItemProps) => {
@@ -912,6 +917,12 @@ export class FormItemWrap extends React.Component<FormItemProps> {
               controlSize !== 'full'
           },
           model?.errClassNames,
+          setThemeClassName(
+            'wrapperCustomStyle',
+            rest.id,
+            rest.wrapperCustomStyle,
+            'item'
+          ),
           getItemInputClassName(this.props)
         )
       });
@@ -956,7 +967,8 @@ export class FormItemWrap extends React.Component<FormItemProps> {
         static: isStatic,
         staticClassName,
         id,
-        wrapperCustomStyle
+        wrapperCustomStyle,
+        themeCss
       } = props;
 
       // 强制不渲染 label 的话
@@ -983,9 +995,12 @@ export class FormItemWrap extends React.Component<FormItemProps> {
               [`is-required`]: required
             },
             model?.errClassNames,
-            wrapperCustomStyle
-              ? `wrapperCustomStyle-${id?.replace('u:', '')}-item`
-              : ''
+            setThemeClassName(
+              'wrapperCustomStyle',
+              id,
+              wrapperCustomStyle,
+              'item'
+            )
           )}
           style={style}
         >
@@ -1076,7 +1091,16 @@ export class FormItemWrap extends React.Component<FormItemProps> {
 
             {renderDescription !== false && description
               ? render('description', description, {
-                  className: cx(`Form-description`, descriptionClassName)
+                  className: cx(
+                    `Form-description`,
+                    descriptionClassName,
+                    setThemeClassName(
+                      'descriptionClassName',
+                      id,
+                      themeCss,
+                      'item'
+                    )
+                  )
                 })
               : null}
           </div>
@@ -1109,7 +1133,10 @@ export class FormItemWrap extends React.Component<FormItemProps> {
         mobileUI,
         translate: __,
         static: isStatic,
-        staticClassName
+        staticClassName,
+        themeCss,
+        wrapperCustomStyle,
+        id
       } = props;
 
       description = description || desc;
@@ -1124,7 +1151,13 @@ export class FormItemWrap extends React.Component<FormItemProps> {
               'is-error': model && !model.valid,
               [`is-required`]: required
             },
-            model?.errClassNames
+            model?.errClassNames,
+            setThemeClassName(
+              'wrapperCustomStyle',
+              id,
+              wrapperCustomStyle,
+              'item'
+            )
           )}
           style={style}
         >
@@ -1194,7 +1227,16 @@ export class FormItemWrap extends React.Component<FormItemProps> {
 
               {renderDescription !== false && description
                 ? render('description', description, {
-                    className: cx(`Form-description`, descriptionClassName)
+                    className: cx(
+                      `Form-description`,
+                      descriptionClassName,
+                      setThemeClassName(
+                        'descriptionClassName',
+                        id,
+                        themeCss,
+                        'item'
+                      )
+                    )
                   })
                 : null}
             </div>
@@ -1235,10 +1277,18 @@ export class FormItemWrap extends React.Component<FormItemProps> {
                   ))}
                 </ul>
               ) : null}
-
               {renderDescription !== false && description
                 ? render('description', description, {
-                    className: cx(`Form-description`, descriptionClassName)
+                    className: cx(
+                      `Form-description`,
+                      descriptionClassName,
+                      setThemeClassName(
+                        'descriptionClassName',
+                        id,
+                        themeCss,
+                        'item'
+                      )
+                    )
                   })
                 : null}
             </>
@@ -1272,7 +1322,10 @@ export class FormItemWrap extends React.Component<FormItemProps> {
         mobileUI,
         translate: __,
         static: isStatic,
-        staticClassName
+        staticClassName,
+        themeCss,
+        wrapperCustomStyle,
+        id
       } = props;
       const labelWidth = props.labelWidth || props.formLabelWidth;
       description = description || desc;
@@ -1287,7 +1340,13 @@ export class FormItemWrap extends React.Component<FormItemProps> {
               'is-error': model && !model.valid,
               [`is-required`]: required
             },
-            model?.errClassNames
+            model?.errClassNames,
+            setThemeClassName(
+              'wrapperCustomStyle',
+              id,
+              wrapperCustomStyle,
+              'item'
+            )
           )}
           style={style}
         >
@@ -1359,7 +1418,16 @@ export class FormItemWrap extends React.Component<FormItemProps> {
 
             {renderDescription !== false && description
               ? render('description', description, {
-                  className: cx(`Form-description`, descriptionClassName)
+                  className: cx(
+                    `Form-description`,
+                    descriptionClassName,
+                    setThemeClassName(
+                      'descriptionClassName',
+                      id,
+                      themeCss,
+                      'item'
+                    )
+                  )
                 })
               : null}
           </div>
@@ -1392,7 +1460,10 @@ export class FormItemWrap extends React.Component<FormItemProps> {
         mobileUI,
         translate: __,
         static: isStatic,
-        staticClassName
+        staticClassName,
+        wrapperCustomStyle,
+        themeCss,
+        id
       } = props;
       const labelWidth = props.labelWidth || props.formLabelWidth;
       description = description || desc;
@@ -1407,7 +1478,13 @@ export class FormItemWrap extends React.Component<FormItemProps> {
               'is-error': model && !model.valid,
               [`is-required`]: required
             },
-            model?.errClassNames
+            model?.errClassNames,
+            setThemeClassName(
+              'wrapperCustomStyle',
+              id,
+              wrapperCustomStyle,
+              'item'
+            )
           )}
           style={style}
         >
@@ -1478,7 +1555,16 @@ export class FormItemWrap extends React.Component<FormItemProps> {
 
           {description && renderDescription !== false
             ? render('description', description, {
-                className: cx(`Form-description`, descriptionClassName)
+                className: cx(
+                  `Form-description`,
+                  descriptionClassName,
+                  setThemeClassName(
+                    'descriptionClassName',
+                    id,
+                    themeCss,
+                    'item'
+                  )
+                )
               })
             : null}
         </div>
@@ -1496,8 +1582,6 @@ export class FormItemWrap extends React.Component<FormItemProps> {
       css,
       themeCss,
       id,
-      labelClassName,
-      descriptionClassName,
       wrapperCustomStyle,
       env
     } = this.props;
@@ -1536,12 +1620,10 @@ export class FormItemWrap extends React.Component<FormItemProps> {
             themeCss: themeCss || css,
             classNames: [
               {
-                key: 'labelClassName',
-                value: labelClassName
+                key: 'labelClassName'
               },
               {
-                key: 'descriptionClassName',
-                value: descriptionClassName
+                key: 'descriptionClassName'
               }
             ],
             wrapperCustomStyle,

--- a/packages/amis-core/src/renderers/Item.tsx
+++ b/packages/amis-core/src/renderers/Item.tsx
@@ -38,6 +38,7 @@ import {dataMapping, setThemeClassName} from '../utils';
 import Overlay from '../components/Overlay';
 import PopOver from '../components/PopOver';
 import CustomStyle from '../components/CustomStyle';
+import classNames from 'classnames';
 
 export type LabelAlign = 'right' | 'left';
 
@@ -504,12 +505,10 @@ const getItemLabelClassName = (props: FormItemProps) => {
   const {staticLabelClassName, labelClassName, id, themeCss} = props;
   return props.static && staticLabelClassName
     ? staticLabelClassName
-    : `${labelClassName || ''} ${setThemeClassName(
-        'labelClassName',
-        id,
-        themeCss,
-        'item'
-      )}`;
+    : classNames(
+        labelClassName,
+        setThemeClassName('labelClassName', id, themeCss, 'item')
+      );
 };
 
 const getItemInputClassName = (props: FormItemProps) => {

--- a/packages/amis-editor-core/src/store/editor.ts
+++ b/packages/amis-editor-core/src/store/editor.ts
@@ -18,7 +18,6 @@ import {
   stringRegExp,
   needDefaultWidth,
   guid,
-  addStyleClassName,
   appTranslate,
   JSONGetByPath,
   getDialogActions
@@ -1427,22 +1426,12 @@ export const MainStore = types
         if (diff) {
           const result = patchDiff(origin, diff);
           this.traceableSetSchema(
-            JSONUpdate(
-              self.schema,
-              id,
-              addStyleClassName(JSONPipeIn(result)),
-              true
-            ),
+            JSONUpdate(self.schema, id, JSONPipeIn(result), true),
             noTrace
           );
         } else {
           this.traceableSetSchema(
-            JSONUpdate(
-              self.schema,
-              id,
-              addStyleClassName(JSONPipeIn(value)),
-              replace
-            ),
+            JSONUpdate(self.schema, id, JSONPipeIn(value), replace),
             noTrace
           );
         }

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -589,6 +589,11 @@ export function reGenerateID(
     else if (key === 'componentId' && isNodeIdFormat) {
       host.componentId = reIds[value] ?? value;
     }
+    // 处理className
+    else if (typeof value === 'string' && /[C|c]lassName/.test(key)) {
+      const oldId = /-(.*)/.exec(value)?.[1] || '';
+      host[key] = value.replace(oldId, reIds['u:' + oldId].replace('u:', ''));
+    }
 
     return value;
   });

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -591,8 +591,10 @@ export function reGenerateID(
     }
     // 处理className
     else if (typeof value === 'string' && /[C|c]lassName/.test(key)) {
-      const oldId = /-(.*)/.exec(value)?.[1] || '';
-      host[key] = value.replace(oldId, reIds['u:' + oldId].replace('u:', ''));
+      const oldId = /-(.*)/.exec(value)?.[1];
+      if (oldId) {
+        host[key] = value.replace(oldId, reIds['u:' + oldId].replace('u:', ''));
+      }
     }
 
     return value;

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -207,33 +207,6 @@ export function JSONPipeOut(
   return obj;
 }
 
-/**
- * 如果存在themeCss属性，则给对应的className加上name
- */
-export function addStyleClassName(obj: Schema) {
-  const themeCss = obj.type === 'page' ? obj.themeCss : obj.themeCss || obj.css;
-  // page暂时不做处理
-  if (!themeCss) {
-    return obj;
-  }
-  let toUpdate: any = {};
-  Object.keys(themeCss).forEach(key => {
-    if (key !== '$$id') {
-      let classname = `${key}-${obj.id.replace('u:', '')}`;
-      if (!obj[key]) {
-        toUpdate[key] = classname;
-      } else if (!~obj[key].indexOf(classname)) {
-        toUpdate[key] = obj[key] + ' ' + classname;
-      }
-    }
-  });
-  obj = cleanUndefined({
-    ...obj,
-    ...toUpdate
-  });
-  return obj;
-}
-
 export function JSONGetByPath(
   json: any,
   paths: Array<string>,
@@ -588,13 +561,6 @@ export function reGenerateID(
     // 组件ID，给新的id内容
     else if (key === 'componentId' && isNodeIdFormat) {
       host.componentId = reIds[value] ?? value;
-    }
-    // 处理className
-    else if (typeof value === 'string' && /[C|c]lassName/.test(key)) {
-      const oldId = /-(.*)/.exec(value)?.[1];
-      if (oldId) {
-        host[key] = value.replace(oldId, reIds['u:' + oldId].replace('u:', ''));
-      }
     }
 
     return value;

--- a/packages/amis-editor/src/plugin/Form/InputImage.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputImage.tsx
@@ -499,7 +499,7 @@ export class ImageControlPlugin extends BasePlugin {
                   returnSvg: true
                 },
                 getSchemaTpl('theme:select', {
-                  name: `${IconCssClassName}.font-size`,
+                  name: `${IconCssClassName}.iconSize`,
                   label: '图标大小',
                   editorThemePath: `${editorPath}.default.body.icon-size`
                 }),

--- a/packages/amis/src/renderers/Action.tsx
+++ b/packages/amis/src/renderers/Action.tsx
@@ -9,7 +9,8 @@ import {
   Renderer,
   RendererProps,
   ScopedContext,
-  uuid
+  uuid,
+  setThemeClassName
 } from 'amis-core';
 import {filter} from 'amis-core';
 import {BadgeObject, Button, SpinnerExtraProps} from 'amis-ui';
@@ -780,7 +781,10 @@ export class Action extends React.Component<ActionProps, ActionState> {
         cx={cx}
         icon={icon}
         className="Button-icon"
-        classNameProp={iconClassName}
+        classNameProp={cx(
+          iconClassName,
+          setThemeClassName('iconClassName', id, themeCss || css)
+        )}
       />
     );
     const rightIconElement = (
@@ -788,7 +792,10 @@ export class Action extends React.Component<ActionProps, ActionState> {
         cx={cx}
         icon={rightIcon}
         className="Button-icon"
-        classNameProp={rightIconClassName}
+        classNameProp={cx(
+          rightIconClassName,
+          setThemeClassName('iconClassName', id, themeCss || css)
+        )}
       />
     );
 
@@ -796,10 +803,14 @@ export class Action extends React.Component<ActionProps, ActionState> {
       <>
         <Button
           loadingConfig={loadingConfig}
-          className={cx(className, {
-            [activeClassName || 'is-active']: isActive,
-            [`wrapperCustomStyle-${id?.replace('u:', '')}`]: wrapperCustomStyle
-          })}
+          className={cx(
+            className,
+            setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle),
+            setThemeClassName('className', id, themeCss || css),
+            {
+              [activeClassName || 'is-active']: isActive
+            }
+          )}
           style={style}
           size={size}
           level={
@@ -836,7 +847,6 @@ export class Action extends React.Component<ActionProps, ActionState> {
             classNames: [
               {
                 key: 'className',
-                value: className,
                 weights: {
                   hover: {
                     suf: ':not(:disabled):not(.is-disabled)'
@@ -846,7 +856,6 @@ export class Action extends React.Component<ActionProps, ActionState> {
               },
               {
                 key: 'iconClassName',
-                value: iconClassName,
                 weights: {
                   default: {
                     important: true

--- a/packages/amis/src/renderers/Carousel.tsx
+++ b/packages/amis/src/renderers/Carousel.tsx
@@ -5,7 +5,7 @@ import Transition, {
   EXITING,
   EXITED
 } from 'react-transition-group/Transition';
-import {Renderer, RendererProps} from 'amis-core';
+import {Renderer, RendererProps, setThemeClassName} from 'amis-core';
 import {resolveVariableAndFilter} from 'amis-core';
 import {
   autobind,
@@ -462,9 +462,7 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
       id,
       wrapperCustomStyle,
       env,
-      themeCss,
-      baseControlClassName,
-      galleryControlClassName
+      themeCss
     } = this.props;
     const {options, current, nextAnimation} = this.state;
 
@@ -616,10 +614,8 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
           `Carousel Carousel--${controlsTheme}`,
           {['Carousel-arrow--always']: !!alwaysShowArrow},
           className,
-          baseControlClassName,
-          wrapperCustomStyle
-            ? `wrapperCustomStyle-${id?.replace('u:', '')}`
-            : ''
+          setThemeClassName('baseControlClassName', id, themeCss),
+          setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
         )}
         style={carouselStyles}
       >
@@ -628,7 +624,10 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
         {dots ? this.renderDots() : null}
         {arrows ? (
           <div
-            className={cx('Carousel-leftArrow', galleryControlClassName)}
+            className={cx(
+              'Carousel-leftArrow',
+              setThemeClassName('galleryControlClassName', id, themeCss)
+            )}
             onClick={this.prev}
           >
             {icons && icons.prev ? (
@@ -648,7 +647,10 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
         ) : null}
         {arrows ? (
           <div
-            className={cx('Carousel-rightArrow', galleryControlClassName)}
+            className={cx(
+              'Carousel-rightArrow',
+              setThemeClassName('galleryControlClassName', id, themeCss)
+            )}
             onClick={this.next}
           >
             {icons && icons.next ? (
@@ -673,12 +675,10 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
             themeCss,
             classNames: [
               {
-                key: 'baseControlClassName',
-                value: baseControlClassName
+                key: 'baseControlClassName'
               },
               {
                 key: 'galleryControlClassName',
-                value: galleryControlClassName,
                 weights: {
                   default: {
                     suf: ' svg',

--- a/packages/amis/src/renderers/Chart.tsx
+++ b/packages/amis/src/renderers/Chart.tsx
@@ -7,7 +7,8 @@ import {
   RendererProps,
   loadScript,
   buildStyle,
-  CustomStyle
+  CustomStyle,
+  setThemeClassName
 } from 'amis-core';
 import {ServiceStore, IServiceStore} from 'amis-core';
 
@@ -611,10 +612,8 @@ export class Chart extends React.Component<ChartProps> {
         className={cx(
           `${ns}Chart`,
           className,
-          baseControlClassName,
-          wrapperCustomStyle
-            ? `wrapperCustomStyle-${id?.replace('u:', '')}`
-            : ''
+          setThemeClassName('baseControlClassName', id, themeCss),
+          setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
         )}
         style={styleVar}
       >
@@ -632,8 +631,7 @@ export class Chart extends React.Component<ChartProps> {
             themeCss,
             classNames: [
               {
-                key: 'baseControlClassName',
-                value: baseControlClassName
+                key: 'baseControlClassName'
               }
             ]
           }}

--- a/packages/amis/src/renderers/Container.tsx
+++ b/packages/amis/src/renderers/Container.tsx
@@ -7,7 +7,8 @@ import {
   buildStyle,
   isPureVariable,
   resolveVariableAndFilter,
-  CustomStyle
+  CustomStyle,
+  setThemeClassName
 } from 'amis-core';
 import {DndContainer as DndWrapper} from 'amis-ui';
 import {BaseSchema, SchemaClassName, SchemaCollection} from '../Schema';
@@ -213,10 +214,8 @@ export default class Container<T> extends React.Component<
           'Container',
           size && size !== 'none' ? `Container--${size}` : '',
           className,
-          baseControlClassName,
-          wrapperCustomStyle
-            ? `wrapperCustomStyle-${id?.replace('u:', '')}`
-            : ''
+          setThemeClassName('baseControlClassName', id, themeCss),
+          setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
         )}
         onClick={this.handleClick}
         onMouseEnter={this.handleMouseEnter}
@@ -231,8 +230,7 @@ export default class Container<T> extends React.Component<
             themeCss,
             classNames: [
               {
-                key: 'baseControlClassName',
-                value: baseControlClassName
+                key: 'baseControlClassName'
               }
             ]
           }}

--- a/packages/amis/src/renderers/Dialog.tsx
+++ b/packages/amis/src/renderers/Dialog.tsx
@@ -5,7 +5,8 @@ import {
   filterTarget,
   isPureVariable,
   resolveVariableAndFilter,
-  setVariable
+  setVariable,
+  setThemeClassName
 } from 'amis-core';
 import {Renderer, RendererProps} from 'amis-core';
 import {SchemaNode, Schema, ActionObject} from 'amis-core';
@@ -569,14 +570,7 @@ export default class Dialog extends React.Component<DialogProps> {
       popOverContainer,
       inDesign,
       themeCss,
-      css,
       id,
-      dialogClassName,
-      dialogMaskClassName,
-      dialogHeaderClassName,
-      dialogTitleClassName,
-      dialogBodyClassName,
-      dialogFooterClassName,
       ...rest
     } = {
       ...this.props,
@@ -594,8 +588,12 @@ export default class Dialog extends React.Component<DialogProps> {
         size={size}
         height={height}
         width={width}
-        modalClassName={dialogClassName}
-        modalMaskClassName={dialogMaskClassName}
+        modalClassName={setThemeClassName('dialogClassName', id, themeCss)}
+        modalMaskClassName={setThemeClassName(
+          'dialogMaskClassName',
+          id,
+          themeCss
+        )}
         backdrop="static"
         onHide={this.handleSelfClose}
         keyboard={closeOnEsc && !store.loading}
@@ -619,7 +617,7 @@ export default class Dialog extends React.Component<DialogProps> {
             className={cx(
               'Modal-header',
               headerClassName,
-              dialogHeaderClassName
+              setThemeClassName('dialogHeaderClassName', id, themeCss)
             )}
           >
             {showCloseButton !== false && !store.loading ? (
@@ -636,7 +634,12 @@ export default class Dialog extends React.Component<DialogProps> {
                 />
               </a>
             ) : null}
-            <div className={cx('Modal-title', dialogTitleClassName)}>
+            <div
+              className={cx(
+                'Modal-title',
+                setThemeClassName('dialogTitleClassName', id, themeCss)
+              )}
+            >
               {filter(__(title), store.formData)}
             </div>
           </div>
@@ -645,7 +648,7 @@ export default class Dialog extends React.Component<DialogProps> {
             className={cx(
               'Modal-header',
               headerClassName,
-              dialogHeaderClassName
+              setThemeClassName('dialogHeaderClassName', id, themeCss)
             )}
           >
             {showCloseButton !== false && !store.loading ? (
@@ -685,7 +688,11 @@ export default class Dialog extends React.Component<DialogProps> {
 
         {(!store.entered && lazyRender) || (lazySchema && !body) ? (
           <div
-            className={cx('Modal-body', bodyClassName, dialogBodyClassName)}
+            className={cx(
+              'Modal-body',
+              bodyClassName,
+              setThemeClassName('dialogBodyClassName', id, themeCss)
+            )}
             role="dialog-body"
           >
             <Spinner overlay show size="lg" loadingConfig={loadingConfig} />
@@ -693,37 +700,35 @@ export default class Dialog extends React.Component<DialogProps> {
         ) : body ? (
           // dialog-body 用于在 editor 中定位元素
           <div
-            className={cx('Modal-body', bodyClassName, dialogBodyClassName)}
+            className={cx(
+              'Modal-body',
+              bodyClassName,
+              setThemeClassName('dialogBodyClassName', id, themeCss)
+            )}
             role="dialog-body"
           >
             {this.renderBody(body, 'body')}
             <CustomStyle
               config={{
-                themeCss: themeCss || css,
+                themeCss: themeCss,
                 classNames: [
                   {
-                    key: 'dialogClassName',
-                    value: dialogClassName
+                    key: 'dialogClassName'
                   },
                   {
-                    key: 'dialogMaskClassName',
-                    value: dialogMaskClassName
+                    key: 'dialogMaskClassName'
                   },
                   {
-                    key: 'dialogHeaderClassName',
-                    value: dialogHeaderClassName
+                    key: 'dialogHeaderClassName'
                   },
                   {
-                    key: 'dialogTitleClassName',
-                    value: dialogTitleClassName
+                    key: 'dialogTitleClassName'
                   },
                   {
-                    key: 'dialogBodyClassName',
-                    value: dialogBodyClassName
+                    key: 'dialogBodyClassName'
                   },
                   {
-                    key: 'dialogFooterClassName',
-                    value: dialogFooterClassName
+                    key: 'dialogFooterClassName'
                   }
                 ],
                 id: id

--- a/packages/amis/src/renderers/Drawer.tsx
+++ b/packages/amis/src/renderers/Drawer.tsx
@@ -4,7 +4,8 @@ import {
   IScopedContext,
   filterTarget,
   isPureVariable,
-  resolveVariableAndFilter
+  resolveVariableAndFilter,
+  setThemeClassName
 } from 'amis-core';
 import {Renderer, RendererProps} from 'amis-core';
 import {SchemaNode, Schema, ActionObject} from 'amis-core';
@@ -500,12 +501,17 @@ export default class Drawer extends React.Component<DrawerProps> {
       classnames: cx,
       showErrorMsg,
       footerClassName,
-      drawerFooterClassName
+      id,
+      themeCss
     } = this.props;
 
     return (
       <div
-        className={cx('Drawer-footer', footerClassName, drawerFooterClassName)}
+        className={cx(
+          'Drawer-footer',
+          footerClassName,
+          setThemeClassName('drawerFooterClassName', id, themeCss)
+        )}
       >
         {store.loading || store.error ? (
           <div className={cx('Drawer-info')}>
@@ -575,14 +581,7 @@ export default class Drawer extends React.Component<DrawerProps> {
       loadingConfig,
       popOverContainer,
       themeCss,
-      css,
       id,
-      drawerClassName,
-      drawerMaskClassName,
-      drawerHeaderClassName,
-      drawerTitleClassName,
-      drawerBodyClassName,
-      drawerFooterClassName,
       ...rest
     } = {
       ...this.props,
@@ -598,8 +597,12 @@ export default class Drawer extends React.Component<DrawerProps> {
         classPrefix={ns}
         className={className}
         style={style}
-        drawerClassName={drawerClassName}
-        drawerMaskClassName={drawerMaskClassName}
+        drawerClassName={setThemeClassName('drawerClassName', id, themeCss)}
+        drawerMaskClassName={setThemeClassName(
+          'drawerMaskClassName',
+          id,
+          themeCss
+        )}
         size={size}
         onHide={this.handleSelfClose}
         disabled={store.loading}
@@ -621,11 +624,16 @@ export default class Drawer extends React.Component<DrawerProps> {
           className={cx(
             'Drawer-header',
             headerClassName,
-            drawerHeaderClassName
+            setThemeClassName('drawerHeaderClassName', id, themeCss)
           )}
         >
           {title ? (
-            <div className={cx('Drawer-title', drawerTitleClassName)}>
+            <div
+              className={cx(
+                'Drawer-title',
+                setThemeClassName('drawerTitleClassName', id, themeCss)
+              )}
+            >
               {render('title', title, {
                 data: store.formData,
                 onConfirm: this.handleDrawerConfirm,
@@ -646,44 +654,46 @@ export default class Drawer extends React.Component<DrawerProps> {
 
         {!store.entered ? (
           <div
-            className={cx('Drawer-body', bodyClassName, drawerBodyClassName)}
+            className={cx(
+              'Drawer-body',
+              bodyClassName,
+              setThemeClassName('drawerBodyClassName', id, themeCss)
+            )}
           >
             <Spinner overlay show size="lg" loadingConfig={loadingConfig} />
           </div>
         ) : body ? (
           // dialog-body 用于在 editor 中定位元素
           <div
-            className={cx('Drawer-body', bodyClassName, drawerBodyClassName)}
+            className={cx(
+              'Drawer-body',
+              bodyClassName,
+              setThemeClassName('drawerBodyClassName', id, themeCss)
+            )}
             role="dialog-body"
           >
             {this.renderBody(body, 'body')}
             <CustomStyle
               config={{
-                themeCss: themeCss || css,
+                themeCss: themeCss,
                 classNames: [
                   {
-                    key: 'drawerClassName',
-                    value: drawerClassName
+                    key: 'drawerClassName'
                   },
                   {
-                    key: 'drawerMaskClassName',
-                    value: drawerMaskClassName
+                    key: 'drawerMaskClassName'
                   },
                   {
-                    key: 'drawerHeaderClassName',
-                    value: drawerHeaderClassName
+                    key: 'drawerHeaderClassName'
                   },
                   {
-                    key: 'drawerTitleClassName',
-                    value: drawerTitleClassName
+                    key: 'drawerTitleClassName'
                   },
                   {
-                    key: 'drawerBodyClassName',
-                    value: drawerBodyClassName
+                    key: 'drawerBodyClassName'
                   },
                   {
-                    key: 'drawerFooterClassName',
-                    value: drawerFooterClassName
+                    key: 'drawerFooterClassName'
                   }
                 ],
                 id: id

--- a/packages/amis/src/renderers/Flex.tsx
+++ b/packages/amis/src/renderers/Flex.tsx
@@ -3,7 +3,13 @@
  */
 
 import React from 'react';
-import {buildStyle, Renderer, RendererProps, CustomStyle} from 'amis-core';
+import {
+  buildStyle,
+  Renderer,
+  RendererProps,
+  CustomStyle,
+  setThemeClassName
+} from 'amis-core';
 import {Schema} from 'amis-core';
 import {BaseSchema, SchemaCollection, SchemaObject} from '../Schema';
 
@@ -105,7 +111,6 @@ export default class Flex extends React.Component<FlexProps, object> {
       wrapperCustomStyle,
       env,
       themeCss,
-      baseControlClassName,
       classnames: cx
     } = this.props;
     const styleVar = buildStyle(style, data);
@@ -132,10 +137,8 @@ export default class Flex extends React.Component<FlexProps, object> {
         className={cx(
           'Flex',
           className,
-          baseControlClassName,
-          wrapperCustomStyle
-            ? ` wrapperCustomStyle-${id?.replace('u:', '')}`
-            : ''
+          setThemeClassName('baseControlClassName', id, themeCss),
+          setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
         )}
       >
         {(Array.isArray(items) ? items : items ? [items] : []).map(
@@ -152,8 +155,7 @@ export default class Flex extends React.Component<FlexProps, object> {
             themeCss,
             classNames: [
               {
-                key: 'baseControlClassName',
-                value: baseControlClassName
+                key: 'baseControlClassName'
               }
             ]
           }}

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -6,7 +6,8 @@ import {
   prettyBytes,
   resolveEventData,
   CustomStyle,
-  setThemeClassName
+  setThemeClassName,
+  PlainObject
 } from 'amis-core';
 // import 'cropperjs/dist/cropper.css';
 const Cropper = React.lazy(() => import('react-cropper'));
@@ -358,6 +359,23 @@ export interface FileX extends File {
 
 export type InputImageRendererEvent = 'change' | 'success' | 'fail' | 'remove';
 export type InputImageRendererAction = 'clear';
+
+function formatIconThemeCss(themeCss: any) {
+  let addBtnControlClassName: PlainObject = {};
+  ['default', 'hover', 'active'].forEach(key => {
+    addBtnControlClassName[`color:${key}`] =
+      themeCss?.addBtnControlClassName?.[`icon-color:${key}`];
+  });
+  for (let key in addBtnControlClassName) {
+    if (!addBtnControlClassName[key]) {
+      delete addBtnControlClassName[key];
+    }
+  }
+  if (!isEmpty(addBtnControlClassName)) {
+    return {addBtnControlClassName};
+  }
+  return;
+}
 
 export default class ImageControl extends React.Component<
   ImageProps,
@@ -1945,6 +1963,12 @@ export default class ImageControl extends React.Component<
                               id,
                               themeCss
                             ),
+                            setThemeClassName(
+                              'addBtnControlClassName',
+                              id,
+                              formatIconThemeCss(themeCss),
+                              'icon'
+                            ),
                             error ? 'is-invalid' : ''
                           )}
                           style={frameImageStyle}
@@ -2034,6 +2058,31 @@ export default class ImageControl extends React.Component<
               }
             ],
             id
+          }}
+          env={env}
+        />
+        <CustomStyle
+          config={{
+            themeCss: formatIconThemeCss(themeCss),
+            classNames: [
+              {
+                key: 'addBtnControlClassName',
+                weights: {
+                  default: {
+                    inner: 'svg'
+                  },
+                  hover: {
+                    suf: ':not(:disabled):not(.is-disabled)',
+                    inner: 'svg'
+                  },
+                  active: {
+                    suf: ':not(:disabled):not(.is-disabled)',
+                    inner: 'svg'
+                  }
+                }
+              }
+            ],
+            id: id && id + '-icon'
           }}
           env={env}
         />

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -5,7 +5,8 @@ import {
   FormBaseControl,
   prettyBytes,
   resolveEventData,
-  CustomStyle
+  CustomStyle,
+  setThemeClassName
 } from 'amis-core';
 // import 'cropperjs/dist/cropper.css';
 const Cropper = React.lazy(() => import('react-cropper'));
@@ -1561,9 +1562,6 @@ export default class ImageControl extends React.Component<
       maxSize,
       render,
       themeCss,
-      inputImageControlClassName,
-      addBtnControlClassName,
-      iconControlClassName,
       id,
       translate: __,
       draggable,
@@ -1592,7 +1590,11 @@ export default class ImageControl extends React.Component<
 
     return (
       <div
-        className={cx(`ImageControl`, className, inputImageControlClassName)}
+        className={cx(
+          `ImageControl`,
+          className,
+          setThemeClassName('inputImageControlClassName', id, themeCss)
+        )}
       >
         {cropFile ? (
           <div className={cx('ImageControl-cropperWrapper')}>
@@ -1938,7 +1940,11 @@ export default class ImageControl extends React.Component<
                             },
                             fixedSize ? 'ImageControl-fixed-size' : '',
                             fixedSize ? fixedSizeClassName : '',
-                            addBtnControlClassName,
+                            setThemeClassName(
+                              'addBtnControlClassName',
+                              id,
+                              themeCss
+                            ),
                             error ? 'is-invalid' : ''
                           )}
                           style={frameImageStyle}
@@ -1950,7 +1956,11 @@ export default class ImageControl extends React.Component<
                             className="icon"
                             iconContent={cx(
                               ':ImageControl-addBtn-icon',
-                              iconControlClassName
+                              setThemeClassName(
+                                'iconControlClassName',
+                                id,
+                                themeCss
+                              )
                             )}
                           />
                           <span className={cx('ImageControl-addBtn-text')}>
@@ -2001,12 +2011,10 @@ export default class ImageControl extends React.Component<
             themeCss,
             classNames: [
               {
-                key: 'inputImageControlClassName',
-                value: inputImageControlClassName
+                key: 'inputImageControlClassName'
               },
               {
                 key: 'addBtnControlClassName',
-                value: addBtnControlClassName,
                 weights: {
                   hover: {
                     suf: ':not(:disabled):not(.is-disabled)'
@@ -2018,7 +2026,6 @@ export default class ImageControl extends React.Component<
               },
               {
                 key: 'iconControlClassName',
-                value: iconControlClassName,
                 weights: {
                   default: {
                     suf: ' svg'

--- a/packages/amis/src/renderers/Form/InputNumber.tsx
+++ b/packages/amis/src/renderers/Form/InputNumber.tsx
@@ -5,7 +5,9 @@ import {
   FormControlProps,
   FormBaseControl,
   resolveEventData,
-  CustomStyle
+  CustomStyle,
+  formatInputThemeCss,
+  setThemeClassName
 } from 'amis-core';
 import cx from 'classnames';
 import {NumberInput, Select} from 'amis-ui';
@@ -54,17 +56,17 @@ export interface NumberControlSchema extends FormBaseControlSchema {
    * 是否显示上下点击按钮
    */
   showSteps?: boolean;
-  
+
   /**
    * 边框模式，全边框，还是半边框，或者没边框。
    */
   borderMode?: 'full' | 'half' | 'none';
-  
+
   /**
    * 前缀
    */
   prefix?: string;
-  
+
   /**
    * 后缀
    */
@@ -106,47 +108,47 @@ export interface NumberProps extends FormControlProps {
   max?: number | string;
   min?: number | string;
   step?: number;
-  
+
   /**
    *  精度
    */
   precision?: number;
-  
+
   /**
    * 边框模式，全边框，还是半边框，或者没边框。
    */
   borderMode?: 'full' | 'half' | 'none';
-  
+
   /**
    * 前缀
    */
   prefix?: string;
-  
+
   /**
    * 后缀
    */
   suffix?: string;
-  
+
   /**
    * 是否千分分隔
    */
   kilobitSeparator?: boolean;
-  
+
   /**
    * 只读
    */
   readOnly?: boolean;
-  
+
   /**
    * 启用键盘行为，即通过上下方向键控制是否生效
    */
   keyboard?: boolean;
-  
+
   /**
    * 输入框为基础输入框还是加强输入框
    */
   displayMode?: 'base' | 'enhance';
-  
+
   /**
    * 是否是大数，如果是的话输入输出都将是字符串
    */
@@ -440,7 +442,16 @@ export default class NumberControl extends React.Component<
         )}
       >
         <NumberInput
-          inputControlClassName={inputControlClassName}
+          inputControlClassName={cx(
+            inputControlClassName,
+            setThemeClassName(inputControlClassName, id, themeCss || css),
+            setThemeClassName(
+              inputControlClassName,
+              id,
+              themeCss || css,
+              'inner'
+            )
+          )}
           inputRef={this.inputRef}
           value={finalValue}
           resetValue={resetValue}
@@ -492,15 +503,44 @@ export default class NumberControl extends React.Component<
             classNames: [
               {
                 key: 'inputControlClassName',
-                value: inputControlClassName,
                 weights: {
                   active: {
-                    pre: `${inputControlClassName}.focused, `
+                    pre: `inputControlClassName-${id?.replace(
+                      'u:',
+                      ''
+                    )}.focused, `
                   }
                 }
               }
             ],
             id
+          }}
+          env={env}
+        />
+        <CustomStyle
+          config={{
+            themeCss: formatInputThemeCss(themeCss || css),
+            classNames: [
+              {
+                key: 'inputControlClassName',
+                weights: {
+                  default: {
+                    inner: 'input'
+                  },
+                  hover: {
+                    inner: 'input'
+                  },
+                  active: {
+                    pre: `inputControlClassName-${id?.replace(
+                      'u:',
+                      ''
+                    )}.focused, `,
+                    inner: 'input'
+                  }
+                }
+              }
+            ],
+            id: id && id + '-inner'
           }}
           env={env}
         />

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -8,7 +8,9 @@ import {
   CustomStyle,
   getValueByPath,
   PopOver,
-  Overlay
+  Overlay,
+  formatInputThemeCss,
+  setThemeClassName
 } from 'amis-core';
 import {ActionObject} from 'amis-core';
 import Downshift, {StateChangeOptions} from 'downshift';
@@ -694,7 +696,10 @@ export default class TextControl extends React.PureComponent<
       minLength,
       translate: __,
       loadingConfig,
-      popOverContainer
+      popOverContainer,
+      themeCss,
+      css,
+      id
     } = this.props;
     let type = this.props.type?.replace(/^(?:native|input)\-/, '');
 
@@ -750,6 +755,13 @@ export default class TextControl extends React.PureComponent<
               className={cx(
                 `TextControl-input TextControl-input--withAC`,
                 inputControlClassName,
+                setThemeClassName('inputControlClassName', id, themeCss || css),
+                setThemeClassName(
+                  'inputControlClassName',
+                  id,
+                  themeCss || css,
+                  'inner'
+                ),
                 inputOnly ? className : '',
                 {
                   'is-opened': isOpen,
@@ -927,7 +939,10 @@ export default class TextControl extends React.PureComponent<
       data,
       showCounter,
       maxLength,
-      minLength
+      minLength,
+      themeCss,
+      css,
+      id
     } = this.props;
 
     const type = this.props.type?.replace(/^(?:native|input)\-/, '');
@@ -939,6 +954,13 @@ export default class TextControl extends React.PureComponent<
           {
             [`TextControl-input--border${ucFirst(borderMode)}`]: borderMode
           },
+          setThemeClassName('inputControlClassName', id, themeCss || css),
+          setThemeClassName(
+            'inputControlClassName',
+            id,
+            themeCss || css,
+            'inner'
+          ),
           inputControlClassName,
           inputOnly ? className : ''
         )}
@@ -1030,7 +1052,10 @@ export default class TextControl extends React.PureComponent<
       readOnly,
       inputOnly,
       static: isStatic,
-      addOnClassName
+      addOnClassName,
+      themeCss,
+      css,
+      id
     } = this.props;
 
     const addOn: any =
@@ -1047,13 +1072,25 @@ export default class TextControl extends React.PureComponent<
       addOn && !isStatic ? (
         addOn.actionType ||
         ~['button', 'submit', 'reset', 'action'].indexOf(addOn.type) ? (
-          <div className={cx(`${ns}TextControl-button`, addOnClassName)}>
+          <div
+            className={cx(
+              `${ns}TextControl-button`,
+              addOnClassName,
+              setThemeClassName('addOnClassName', id, themeCss || css, 'addOn')
+            )}
+          >
             {render('addOn', addOn, {
               disabled
             })}
           </div>
         ) : (
-          <div className={cx(`${ns}TextControl-addOn`, addOnClassName)}>
+          <div
+            className={cx(
+              `${ns}TextControl-addOn`,
+              addOnClassName,
+              setThemeClassName('addOnClassName', id, themeCss || css, 'addOn')
+            )}
+          >
             {iconElement}
             {addOn.label ? filter(addOn.label, data) : null}
           </div>
@@ -1087,23 +1124,6 @@ export default class TextControl extends React.PureComponent<
    * 处理input的自定义样式
    */
   @autobind
-  formatInputThemeCss() {
-    const {themeCss, css} = this.props;
-    if (!themeCss && !css) {
-      return;
-    }
-    const inputFontThemeCss: any = {inputControlClassName: {}};
-    const inputControlClassNameObject =
-      (themeCss || css)?.inputControlClassName || {};
-    for (let key in inputControlClassNameObject) {
-      if (~key.indexOf('font')) {
-        inputFontThemeCss.inputControlClassName[key] =
-          inputControlClassNameObject[key];
-      }
-    }
-    return inputFontThemeCss;
-  }
-
   @supportStatic()
   render(): JSX.Element {
     const {
@@ -1112,9 +1132,7 @@ export default class TextControl extends React.PureComponent<
       autoComplete,
       themeCss,
       css,
-      inputControlClassName,
       id,
-      addOnClassName,
       env,
       classPrefix: ns
     } = this.props;
@@ -1132,10 +1150,12 @@ export default class TextControl extends React.PureComponent<
             classNames: [
               {
                 key: 'inputControlClassName',
-                value: inputControlClassName,
                 weights: {
                   active: {
-                    pre: `${ns}TextControl.is-focused > .${inputControlClassName}, `
+                    pre: `${ns}TextControl.is-focused > .inputControlClassName-${id?.replace(
+                      'u:',
+                      ''
+                    )}, `
                   }
                 }
               }
@@ -1146,11 +1166,10 @@ export default class TextControl extends React.PureComponent<
         />
         <CustomStyle
           config={{
-            themeCss: this.formatInputThemeCss(),
+            themeCss: formatInputThemeCss(themeCss || css),
             classNames: [
               {
                 key: 'inputControlClassName',
-                value: inputControlClassName,
                 weights: {
                   default: {
                     inner: 'input'
@@ -1159,7 +1178,10 @@ export default class TextControl extends React.PureComponent<
                     inner: 'input'
                   },
                   active: {
-                    pre: `${ns}TextControl.is-focused > .${inputControlClassName}, `,
+                    pre: `${ns}TextControl.is-focused > .inputControlClassName-${id?.replace(
+                      'u:',
+                      ''
+                    )}, `,
                     inner: 'input'
                   }
                 }
@@ -1175,8 +1197,7 @@ export default class TextControl extends React.PureComponent<
             themeCss: themeCss || css,
             classNames: [
               {
-                key: 'addOnClassName',
-                value: addOnClassName
+                key: 'addOnClassName'
               }
             ],
             id: id && id + '-addOn'

--- a/packages/amis/src/renderers/Grid.tsx
+++ b/packages/amis/src/renderers/Grid.tsx
@@ -4,7 +4,8 @@ import {
   Renderer,
   RendererProps,
   buildStyle,
-  CustomStyle
+  CustomStyle,
+  setThemeClassName
 } from 'amis-core';
 import pick from 'lodash/pick';
 import {BaseSchema, SchemaClassName, SchemaCollection} from '../Schema';
@@ -211,8 +212,7 @@ export default class Grid<T> extends React.Component<GridProps & T, object> {
       id,
       wrapperCustomStyle,
       env,
-      themeCss,
-      baseControlClassName
+      themeCss
     } = this.props;
     const styleVar = buildStyle(style, data);
     return (
@@ -225,10 +225,8 @@ export default class Grid<T> extends React.Component<GridProps & T, object> {
             [`Grid--h${ucFirst(hAlign)}`]: hAlign
           },
           className,
-          baseControlClassName,
-          wrapperCustomStyle
-            ? `wrapperCustomStyle-${id?.replace('u:', '')}`
-            : ''
+          setThemeClassName('baseControlClassName', id, themeCss),
+          setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
         )}
         style={styleVar}
       >
@@ -241,8 +239,7 @@ export default class Grid<T> extends React.Component<GridProps & T, object> {
             themeCss,
             classNames: [
               {
-                key: 'baseControlClassName',
-                value: baseControlClassName
+                key: 'baseControlClassName'
               }
             ]
           }}

--- a/packages/amis/src/renderers/IFrame.tsx
+++ b/packages/amis/src/renderers/IFrame.tsx
@@ -5,7 +5,8 @@ import {
   Renderer,
   RendererProps,
   runActions,
-  CustomStyle
+  CustomStyle,
+  setThemeClassName
 } from 'amis-core';
 import {filter} from 'amis-core';
 import {autobind, createObject} from 'amis-core';
@@ -264,10 +265,8 @@ export default class IFrame extends React.Component<IFrameProps, object> {
           className={cx(
             'IFrame',
             className,
-            baseControlClassName,
-            wrapperCustomStyle
-              ? ` wrapperCustomStyle-${id?.replace('u:', '')}`
-              : ''
+            setThemeClassName('baseControlClassName', id, themeCss),
+            setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
           )}
           frameBorder={frameBorder}
           style={style}
@@ -285,8 +284,7 @@ export default class IFrame extends React.Component<IFrameProps, object> {
             themeCss,
             classNames: [
               {
-                key: 'baseControlClassName',
-                value: baseControlClassName
+                key: 'baseControlClassName'
               }
             ]
           }}

--- a/packages/amis/src/renderers/Icon.tsx
+++ b/packages/amis/src/renderers/Icon.tsx
@@ -5,7 +5,8 @@ import {
   filter,
   autobind,
   createObject,
-  CustomStyle
+  CustomStyle,
+  setThemeClassName
 } from 'amis-core';
 import {BaseSchema, SchemaTpl} from '../Schema';
 import {
@@ -70,8 +71,8 @@ export class Icon extends React.Component<IconProps, object> {
       data,
       id,
       themeCss,
-      css,
-      env
+      env,
+      wrapperCustomStyle
     } = this.props;
     let icon = this.props.icon;
 
@@ -87,14 +88,18 @@ export class Icon extends React.Component<IconProps, object> {
           onClick={this.handleClick}
           onMouseEnter={this.handleMouseEnter}
           onMouseLeave={this.handleMouseLeave}
+          className={cx(
+            className,
+            setThemeClassName('baseControlClassName', id, themeCss),
+            setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
+          )}
         />
         <CustomStyle
           config={{
-            themeCss: themeCss || css,
+            themeCss: themeCss,
             classNames: [
               {
-                key: 'className',
-                value: className
+                key: 'className'
               }
             ],
             id

--- a/packages/amis/src/renderers/Image.tsx
+++ b/packages/amis/src/renderers/Image.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import {Renderer, RendererProps, CustomStyle} from 'amis-core';
+import {
+  Renderer,
+  RendererProps,
+  CustomStyle,
+  setThemeClassName
+} from 'amis-core';
 import {filter} from 'amis-core';
 import {themeable, ThemeProps} from 'amis-core';
 import {autobind, getPropValue} from 'amis-core';
@@ -240,10 +245,8 @@ export class ImageThumb extends React.Component<
       translate: __,
       overlays,
       imageMode,
-      imageControlClassName,
-      titleControlClassName,
-      desControlClassName,
-      iconControlClassName
+      id,
+      themeCss
     } = this.props;
 
     const {imageLoading} = this.state;
@@ -278,7 +281,11 @@ export class ImageThumb extends React.Component<
               data-position="bottom"
               target="_blank"
               onClick={this.handleEnlarge}
-              className={iconControlClassName}
+              className={setThemeClassName(
+                'iconControlClassName',
+                id,
+                themeCss
+              )}
             >
               <Icon
                 icon="view"
@@ -297,7 +304,7 @@ export class ImageThumb extends React.Component<
           'Image',
           imageMode === 'original' ? 'Image--original' : 'Image--thumb',
           className,
-          imageControlClassName
+          setThemeClassName('imageControlClassName', id, themeCss)
         )}
         style={href ? undefined : style} // 避免重复设置style
       >
@@ -335,7 +342,10 @@ export class ImageThumb extends React.Component<
           <div key="caption" className={cx('Image-info')}>
             {title ? (
               <div
-                className={cx('Image-title', titleControlClassName)}
+                className={cx(
+                  'Image-title',
+                  setThemeClassName('titleControlClassName', id, themeCss)
+                )}
                 title={title}
               >
                 {title}
@@ -343,7 +353,10 @@ export class ImageThumb extends React.Component<
             ) : null}
             {caption ? (
               <div
-                className={cx('Image-caption', desControlClassName)}
+                className={cx(
+                  'Image-caption',
+                  setThemeClassName('titleControlClassName', id, themeCss)
+                )}
                 title={caption}
               >
                 {caption}
@@ -437,8 +450,8 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
       showToolbar,
       toolbarActions,
       imageGallaryClassName,
-      galleryControlClassName,
-      enlargeWithGallary
+      id,
+      themeCss
     } = this.props;
 
     onImageEnlarge &&
@@ -452,10 +465,11 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
           thumbRatio,
           showToolbar,
           toolbarActions,
-          imageGallaryClassName: galleryControlClassName
-            ? imageGallaryClassName + ' ' + galleryControlClassName
-            : imageGallaryClassName,
-          enlargeWithGallary
+          imageGallaryClassName: `${imageGallaryClassName} ${setThemeClassName(
+            'imageGallaryClassName',
+            id,
+            themeCss
+          )} ${setThemeClassName('galleryControlClassName', id, themeCss)}`
         },
         this.props
       );
@@ -514,9 +528,7 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
             ? 'ImageField--original'
             : 'ImageField--thumb',
           className,
-          wrapperCustomStyle
-            ? `wrapperCustomStyle-${id?.replace('u:', '')}`
-            : ''
+          setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
         )}
         style={style}
         onClick={this.handleClick}
@@ -538,10 +550,26 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
             enlargeAble={enlargeAble && value !== defaultImage}
             onEnlarge={this.handleEnlarge}
             imageMode={imageMode}
-            imageControlClassName={imageControlClassName}
-            titleControlClassName={titleControlClassName}
-            desControlClassName={desControlClassName}
-            iconControlClassName={iconControlClassName}
+            imageControlClassName={setThemeClassName(
+              'imageControlClassName',
+              id,
+              themeCss
+            )}
+            titleControlClassName={setThemeClassName(
+              'titleControlClassName',
+              id,
+              themeCss
+            )}
+            desControlClassName={setThemeClassName(
+              'desControlClassName',
+              id,
+              themeCss
+            )}
+            iconControlClassName={setThemeClassName(
+              'iconControlClassName',
+              id,
+              themeCss
+            )}
           />
         ) : (
           <span className="text-muted">{placeholder}</span>
@@ -553,24 +581,19 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
             themeCss,
             classNames: [
               {
-                key: 'imageControlClassName',
-                value: imageControlClassName
+                key: 'imageControlClassName'
               },
               {
-                key: 'titleControlClassName',
-                value: titleControlClassName
+                key: 'titleControlClassName'
               },
               {
-                key: 'desControlClassName',
-                value: desControlClassName
+                key: 'desControlClassName'
               },
               {
-                key: 'iconControlClassName',
-                value: iconControlClassName
+                key: 'iconControlClassName'
               },
               {
-                key: 'galleryControlClassName',
-                value: galleryControlClassName
+                key: 'galleryControlClassName'
               }
             ]
           }}

--- a/packages/amis/src/renderers/Image.tsx
+++ b/packages/amis/src/renderers/Image.tsx
@@ -245,8 +245,10 @@ export class ImageThumb extends React.Component<
       translate: __,
       overlays,
       imageMode,
-      id,
-      themeCss
+      titleControlClassName,
+      iconControlClassName,
+      imageControlClassName,
+      desControlClassName
     } = this.props;
 
     const {imageLoading} = this.state;
@@ -281,11 +283,7 @@ export class ImageThumb extends React.Component<
               data-position="bottom"
               target="_blank"
               onClick={this.handleEnlarge}
-              className={setThemeClassName(
-                'iconControlClassName',
-                id,
-                themeCss
-              )}
+              className={iconControlClassName}
             >
               <Icon
                 icon="view"
@@ -304,7 +302,7 @@ export class ImageThumb extends React.Component<
           'Image',
           imageMode === 'original' ? 'Image--original' : 'Image--thumb',
           className,
-          setThemeClassName('imageControlClassName', id, themeCss)
+          imageControlClassName
         )}
         style={href ? undefined : style} // 避免重复设置style
       >
@@ -342,10 +340,7 @@ export class ImageThumb extends React.Component<
           <div key="caption" className={cx('Image-info')}>
             {title ? (
               <div
-                className={cx(
-                  'Image-title',
-                  setThemeClassName('titleControlClassName', id, themeCss)
-                )}
+                className={cx('Image-title', titleControlClassName)}
                 title={title}
               >
                 {title}
@@ -353,10 +348,7 @@ export class ImageThumb extends React.Component<
             ) : null}
             {caption ? (
               <div
-                className={cx(
-                  'Image-caption',
-                  setThemeClassName('titleControlClassName', id, themeCss)
-                )}
+                className={cx('Image-caption', desControlClassName)}
                 title={caption}
               >
                 {caption}
@@ -508,11 +500,6 @@ export class ImageField extends React.Component<ImageFieldProps, object> {
       wrapperCustomStyle,
       id,
       themeCss,
-      imageControlClassName,
-      titleControlClassName,
-      desControlClassName,
-      iconControlClassName,
-      galleryControlClassName,
       env
     } = this.props;
 

--- a/packages/amis/src/renderers/Images.tsx
+++ b/packages/amis/src/renderers/Images.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import {Renderer, RendererProps, CustomStyle} from 'amis-core';
+import {
+  Renderer,
+  RendererProps,
+  CustomStyle,
+  setThemeClassName
+} from 'amis-core';
 import {filter} from 'amis-core';
 import {
   resolveVariable,
@@ -227,10 +232,8 @@ export class ImagesField extends React.Component<ImagesProps> {
         className={cx(
           'ImagesField',
           className,
-          imagesControlClassName,
-          wrapperCustomStyle
-            ? `wrapperCustomStyle-${id?.replace('u:', '')}`
-            : ''
+          setThemeClassName('imagesControlClassName', id, themeCss),
+          setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
         )}
         style={style}
       >
@@ -258,11 +261,15 @@ export class ImagesField extends React.Component<ImagesProps> {
                 enlargeWithGallary={enlargeWithGallary}
                 onEnlarge={this.handleEnlarge}
                 showToolbar={showToolbar}
-                imageGallaryClassName={
-                  galleryControlClassName
-                    ? imageGallaryClassName + ' ' + galleryControlClassName
-                    : imageGallaryClassName
-                }
+                imageGallaryClassName={`${imageGallaryClassName} ${setThemeClassName(
+                  'imageGallaryClassName',
+                  id,
+                  themeCss
+                )} ${setThemeClassName(
+                  'galleryControlClassName',
+                  id,
+                  themeCss
+                )}`}
                 toolbarActions={toolbarActions}
               />
             ))}
@@ -286,12 +293,10 @@ export class ImagesField extends React.Component<ImagesProps> {
             themeCss,
             classNames: [
               {
-                key: 'imagesControlClassName',
-                value: imagesControlClassName
+                key: 'imagesControlClassName'
               },
               {
-                key: 'galleryControlClassName',
-                value: galleryControlClassName
+                key: 'galleryControlClassName'
               }
             ]
           }}

--- a/packages/amis/src/renderers/Page.tsx
+++ b/packages/amis/src/renderers/Page.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Renderer, RendererProps, filterTarget} from 'amis-core';
+import {
+  Renderer,
+  RendererProps,
+  filterTarget,
+  setThemeClassName
+} from 'amis-core';
 import {observer} from 'mobx-react';
 import {ServiceStore, IServiceStore} from 'amis-core';
 import {
@@ -782,8 +787,6 @@ export default class Page extends React.Component<PageProps> {
       remark,
       remarkPlacement,
       headerClassName,
-      headerControlClassName,
-      toolbarControlClassName,
       toolbarClassName,
       toolbar,
       render,
@@ -793,7 +796,9 @@ export default class Page extends React.Component<PageProps> {
       env,
       classnames: cx,
       regions,
-      translate: __
+      translate: __,
+      id,
+      themeCss
     } = this.props;
 
     const subProps = {
@@ -807,7 +812,11 @@ export default class Page extends React.Component<PageProps> {
     ) {
       header = (
         <div
-          className={cx(`Page-header`, headerClassName, headerControlClassName)}
+          className={cx(
+            `Page-header`,
+            headerClassName,
+            setThemeClassName('headerControlClassName', id, themeCss)
+          )}
         >
           {title ? (
             <h2 className={cx('Page-title')}>
@@ -837,7 +846,7 @@ export default class Page extends React.Component<PageProps> {
           className={cx(
             `Page-toolbar`,
             toolbarClassName,
-            toolbarControlClassName
+            setThemeClassName('toolbarControlClassName', id, themeCss)
           )}
         >
           {render('toolbar', toolbar || '', subProps)}
@@ -880,12 +889,7 @@ export default class Page extends React.Component<PageProps> {
       id,
       wrapperCustomStyle,
       env,
-      themeCss,
-      baseControlClassName,
-      bodyControlClassName,
-      headerControlClassName,
-      toolbarControlClassName,
-      asideControlClassName
+      themeCss
     } = this.props;
 
     const subProps = {
@@ -908,7 +912,11 @@ export default class Page extends React.Component<PageProps> {
           {this.renderHeader()}
           {/* role 用于 editor 定位 Spinner */}
           <div
-            className={cx(`Page-body`, bodyClassName, bodyControlClassName)}
+            className={cx(
+              `Page-body`,
+              bodyClassName,
+              setThemeClassName('bodyControlClassName', id, themeCss)
+            )}
             role="page-body"
           >
             <Spinner
@@ -943,10 +951,8 @@ export default class Page extends React.Component<PageProps> {
           `Page`,
           hasAside ? `Page--withSidebar` : '',
           className,
-          baseControlClassName,
-          wrapperCustomStyle
-            ? `wrapperCustomStyle-${id?.replace('u:', '')}`
-            : ''
+          setThemeClassName('baseControlClassName', id, themeCss),
+          setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
         )}
         onClick={this.handleClick}
         style={styleVar}
@@ -957,7 +963,7 @@ export default class Page extends React.Component<PageProps> {
               `Page-aside`,
               asideResizor ? 'relative' : 'Page-aside--withWidth',
               asideClassName,
-              asideControlClassName
+              setThemeClassName('asideControlClassName', id, themeCss)
             )}
           >
             <div className={cx(`Page-asideInner`)} ref={this.asideInner}>
@@ -1035,7 +1041,6 @@ export default class Page extends React.Component<PageProps> {
             classNames: [
               {
                 key: 'baseControlClassName',
-                value: baseControlClassName,
                 weights: {
                   default: {
                     important: true
@@ -1049,20 +1054,16 @@ export default class Page extends React.Component<PageProps> {
                 }
               },
               {
-                key: 'bodyControlClassName',
-                value: bodyControlClassName
+                key: 'bodyControlClassName'
               },
               {
-                key: 'headerControlClassName',
-                value: headerControlClassName
+                key: 'headerControlClassName'
               },
               {
-                key: 'toolbarControlClassName',
-                value: toolbarControlClassName
+                key: 'toolbarControlClassName'
               },
               {
-                key: 'asideControlClassName',
-                value: asideControlClassName
+                key: 'asideControlClassName'
               }
             ]
           }}

--- a/packages/amis/src/renderers/TableView.tsx
+++ b/packages/amis/src/renderers/TableView.tsx
@@ -7,7 +7,8 @@ import {
   Renderer,
   RendererProps,
   resolveMappingObject,
-  CustomStyle
+  CustomStyle,
+  setThemeClassName
 } from 'amis-core';
 import {BaseSchema, SchemaObject} from '../Schema';
 
@@ -283,10 +284,8 @@ export default class TableView extends React.Component<TableViewProps, object> {
         className={cx(
           'TableView',
           className,
-          baseControlClassName,
-          wrapperCustomStyle
-            ? `wrapperCustomStyle-${id?.replace('u:', '')}`
-            : ''
+          setThemeClassName('baseControlClassName', id, themeCss),
+          setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
         )}
         style={{width: width, borderCollapse: 'collapse'}}
       >
@@ -300,8 +299,7 @@ export default class TableView extends React.Component<TableViewProps, object> {
             themeCss,
             classNames: [
               {
-                key: 'baseControlClassName',
-                value: baseControlClassName
+                key: 'baseControlClassName'
               }
             ]
           }}

--- a/packages/amis/src/renderers/TooltipWrapper.tsx
+++ b/packages/amis/src/renderers/TooltipWrapper.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import {Renderer, RendererProps, CustomStyle} from 'amis-core';
+import {
+  Renderer,
+  RendererProps,
+  CustomStyle,
+  setThemeClassName
+} from 'amis-core';
 import {BaseSchema, SchemaCollection} from '../Schema';
 import {filter} from 'amis-core';
 import {escapeHtml} from 'amis-core';
@@ -191,8 +196,7 @@ export default class TooltipWrapper extends React.Component<
       inline,
       style,
       data,
-      wrap,
-      baseControlClassName,
+      themeCss,
       wrapperCustomStyle,
       id
     } = this.props;
@@ -208,10 +212,8 @@ export default class TooltipWrapper extends React.Component<
           {
             'TooltipWrapper--inline': inline
           },
-          baseControlClassName,
-          wrapperCustomStyle
-            ? `wrapperCustomStyle-${id?.replace('u:', '')}`
-            : ''
+          setThemeClassName('baseControlClassName', id, themeCss),
+          setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
         )}
         style={buildStyle(style, data)}
       >
@@ -262,9 +264,11 @@ export default class TooltipWrapper extends React.Component<
           ? container
           : popOverContainer || env?.getModalContainer,
       tooltipTheme,
-      tooltipClassName: tooltipControlClassName
-        ? tooltipClassName + ' ' + tooltipControlClassName
-        : tooltipClassName,
+      tooltipClassName: `${tooltipClassName} ${setThemeClassName(
+        'tooltipControlClassName',
+        id,
+        themeCss
+      )}`,
       mouseEnterDelay,
       mouseLeaveDelay,
       offset,
@@ -290,12 +294,10 @@ export default class TooltipWrapper extends React.Component<
             themeCss,
             classNames: [
               {
-                key: 'baseControlClassName',
-                value: baseControlClassName
+                key: 'baseControlClassName'
               },
               {
-                key: 'tooltipControlClassName',
-                value: tooltipControlClassName
+                key: 'tooltipControlClassName'
               }
             ]
           }}

--- a/packages/amis/src/renderers/TooltipWrapper.tsx
+++ b/packages/amis/src/renderers/TooltipWrapper.tsx
@@ -247,9 +247,7 @@ export default class TooltipWrapper extends React.Component<
       popOverContainer,
       wrapperCustomStyle,
       id,
-      themeCss,
-      baseControlClassName,
-      tooltipControlClassName
+      themeCss
     } = this.props;
 
     const tooltipObj: TooltipObject = {
@@ -264,11 +262,10 @@ export default class TooltipWrapper extends React.Component<
           ? container
           : popOverContainer || env?.getModalContainer,
       tooltipTheme,
-      tooltipClassName: `${tooltipClassName} ${setThemeClassName(
-        'tooltipControlClassName',
-        id,
-        themeCss
-      )}`,
+      tooltipClassName: cx(
+        tooltipClassName,
+        setThemeClassName('tooltipControlClassName', id, themeCss)
+      ),
       mouseEnterDelay,
       mouseLeaveDelay,
       offset,

--- a/packages/amis/src/renderers/Tpl.tsx
+++ b/packages/amis/src/renderers/Tpl.tsx
@@ -4,7 +4,8 @@ import {
   createObject,
   Renderer,
   RendererProps,
-  CustomStyle
+  CustomStyle,
+  setThemeClassName
 } from 'amis-core';
 import {filter, asyncFilter} from 'amis-core';
 import isEmpty from 'lodash/isEmpty';
@@ -199,8 +200,7 @@ export class Tpl extends React.Component<TplProps, TplState> {
       id,
       wrapperCustomStyle,
       env,
-      themeCss,
-      baseControlClassName
+      themeCss
     } = this.props;
     const Component = wrapperComponent || (inline ? 'span' : 'div');
     const {content} = this.state;
@@ -218,10 +218,8 @@ export class Tpl extends React.Component<TplProps, TplState> {
         className={cx(
           'TplField',
           className,
-          baseControlClassName,
-          wrapperCustomStyle
-            ? `wrapperCustomStyle-${id?.replace('u:', '')}`
-            : ''
+          setThemeClassName('baseControlClassName', id, themeCss),
+          setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
         )}
         style={buildStyle(style, data)}
         {...(showNativeTitle ? {title: this.getTitle(content)} : {})}
@@ -241,8 +239,7 @@ export class Tpl extends React.Component<TplProps, TplState> {
             themeCss,
             classNames: [
               {
-                key: 'baseControlClassName',
-                value: baseControlClassName
+                key: 'baseControlClassName'
               }
             ]
           }}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 916964f</samp>

Fix the issue of class names not being updated when copying components in the AMIS editor. Add a branch to `reGenerateID` function in `util.ts` to handle the `className` and `classname` keys.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 916964f</samp>

> _`reGenerateID`_
> _Copies components with care_
> _Autumn of classes_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 916964f</samp>

* Add a branch to handle class names in `reGenerateID` function ([link](https://github.com/baidu/amis/pull/8104/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aR592-R596))
