### PR TITLE
chore: import类型依赖问题

### DIFF
--- a/packages/amis-editor-core/src/component/Panel/Outline.tsx
+++ b/packages/amis-editor-core/src/component/Panel/Outline.tsx
@@ -3,9 +3,10 @@ import React from 'react';
 import {PanelProps} from '../../plugin';
 import cx from 'classnames';
 import {autobind} from '../../util';
-import {Icon, InputBox, Schema, Tab, Tabs} from 'amis';
+import {Icon, InputBox, Tab, Tabs} from 'amis';
 import {EditorNodeType} from '../../store/node';
 import {isAlive} from 'mobx-state-tree';
+import type {Schema} from 'amis';
 
 @observer
 export class OutlinePanel extends React.Component<PanelProps> {

--- a/packages/amis-editor/src/plugin/CRUD2/BaseCRUD.tsx
+++ b/packages/amis-editor/src/plugin/CRUD2/BaseCRUD.tsx
@@ -16,15 +16,10 @@ import sortBy from 'lodash/sortBy';
 import {toast, autobind, isObject, Icon} from 'amis';
 import {
   BasePlugin,
-  ScaffoldForm,
   EditorManager,
   defaultValue,
   getSchemaTpl,
-  tipedLabel,
-  EditorNodeType,
-  BuildPanelEventContext,
-  RendererPluginEvent,
-  RendererPluginAction
+  tipedLabel
 } from 'amis-editor-core';
 import {
   DSBuilderManager,
@@ -43,6 +38,13 @@ import {FieldSetting} from '../../renderer/FieldSetting';
 
 import type {IFormItemStore, IFormStore} from 'amis-core';
 import type {CRUDScaffoldConfig} from '../../builder/type';
+import type {
+  ScaffoldForm,
+  BuildPanelEventContext,
+  EditorNodeType,
+  RendererPluginEvent,
+  RendererPluginAction
+} from 'amis-editor-core';
 
 /** 需要动态控制的属性 */
 export type CRUD2DynamicControls = Partial<


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 90520a9</samp>

Improved the code readability and reduced the bundle size of the amis-editor and amis-editor-core packages by using type imports instead of regular imports for unused modules and types. Changed the import of `Schema` from 'amis' to a type import in `Outline.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 90520a9</samp>

> _Sing, O Muse, of the cunning coder who refined his code_
> _And reduced the size of his bundle by avoiding `amis`' load_
> _He imported only `Schema` as a type, not as a module_
> _And cleared his BaseCRUD of imports that were superfluous and dull_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 90520a9</samp>

*  Change import of `Schema` to type import in `Outline.tsx` to reduce bundle size ([link](https://github.com/baidu/amis/pull/8113/files?diff=unified&w=0#diff-8b99cb77af146c5d93db0eae96fa971525a3951110615cb271f2ed0e2f31e800L6-R9))
*  Remove regular imports and add type imports of `ScaffoldForm`, `EditorNodeType`, `BuildPanelEventContext`, `RendererPluginEvent`, and `RendererPluginAction` in `BaseCRUD.tsx` to avoid unnecessary imports and clarify type usage ([link](https://github.com/baidu/amis/pull/8113/files?diff=unified&w=0#diff-84800995b352e55dac9d39fc260b3288d628b48ce9ed6a2d34b7338b0e74fa68L19-R22), [link](https://github.com/baidu/amis/pull/8113/files?diff=unified&w=0#diff-84800995b352e55dac9d39fc260b3288d628b48ce9ed6a2d34b7338b0e74fa68R41-R47))
