### PR TITLE
fix: 对静态展示时默认值是object等未知情况进行错误边界处理

### DIFF
--- a/packages/amis/package.json
+++ b/packages/amis/package.json
@@ -73,7 +73,8 @@
     "tslib": "^2.3.1",
     "video-react": "0.15.0",
     "xlsx": "^0.18.5",
-    "react-intersection-observer": "9.5.2"
+    "react-intersection-observer": "9.5.2",
+    "react-error-boundary": "^4.0.11"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",

--- a/packages/amis/src/renderers/Form/StaticHoc.tsx
+++ b/packages/amis/src/renderers/Form/StaticHoc.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import toString from 'lodash/toString';
 import {getPropValue, FormControlProps} from 'amis-core';
+import {ErrorBoundary} from 'react-error-boundary';
 
 function renderCommonStatic(props: any, defaultValue: string) {
   const {type, render, staticSchema} = props;
@@ -135,7 +136,9 @@ export function supportStatic<T extends FormControlProps>() {
 
         return (
           <div className={cx(`${ns}Form-static`, className)}>
-            {React.isValidElement(body) ? body : toString(body)}
+            <ErrorBoundary fallback={<>{toString(body)}</>}>
+              {body}
+            </ErrorBoundary>
           </div>
         );
       }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 40cd9c1</samp>

Added error handling for static components in `amis` package. Used `react-error-boundary` package and `ErrorBoundary` component to catch and display errors in `body` prop of `supportStatic` function.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 40cd9c1</samp>

> _Oh we're the coders of the sea, and we handle errors gracefully_
> _We use `react-error-boundary` to catch what we can't foresee_
> _And when the `body` prop is bad, we don't let it make us sad_
> _We render a fallback with `ErrorBoundary` and carry on our work so gladly_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 40cd9c1</samp>

*  Add `react-error-boundary` package as a dependency to handle errors in rendering static components ([link](https://github.com/baidu/amis/pull/8115/files?diff=unified&w=0#diff-b49028542a3bb14de6e47e46a9f09f23ffeff3afea2a17d5ddace75726a33e12L76-R77))
*  Wrap `body` prop in `ErrorBoundary` component in `supportStatic` function to prevent app from crashing if `body` prop is not a valid React element or throws an error ([link](https://github.com/baidu/amis/pull/8115/files?diff=unified&w=0#diff-6743296e062555d6d5ef1ffa806450e07b74989e2b2bcc829517a34a8560e918R4), [link](https://github.com/baidu/amis/pull/8115/files?diff=unified&w=0#diff-6743296e062555d6d5ef1ffa806450e07b74989e2b2bcc829517a34a8560e918L138-R141))
*  Import `ErrorBoundary` component from `react-error-boundary` package in `StaticHoc.tsx` ([link](https://github.com/baidu/amis/pull/8115/files?diff=unified&w=0#diff-6743296e062555d6d5ef1ffa806450e07b74989e2b2bcc829517a34a8560e918R4))
