### PR TITLE
fix: 对静态展示时默认值是object等未知情况进行错误边界处理

### DIFF
--- a/packages/amis/package.json
+++ b/packages/amis/package.json
@@ -72,7 +72,8 @@
     "sortablejs": "1.15.0",
     "tslib": "^2.3.1",
     "video-react": "0.15.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "react-error-boundary": "^4.0.11"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",

--- a/packages/amis/src/renderers/Form/StaticHoc.tsx
+++ b/packages/amis/src/renderers/Form/StaticHoc.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import toString from 'lodash/toString';
 import {getPropValue, FormControlProps} from 'amis-core';
+import {ErrorBoundary} from 'react-error-boundary';
 
 function renderCommonStatic(props: any, defaultValue: string) {
   const {type, render, staticSchema} = props;
@@ -135,7 +136,9 @@ export function supportStatic<T extends FormControlProps>() {
 
         return (
           <div className={cx(`${ns}Form-static`, className)}>
-            {React.isValidElement(body) ? body : toString(body)}
+            <ErrorBoundary fallback={<>{toString(body)}</>}>
+              {body}
+            </ErrorBoundary>
           </div>
         );
       }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 079f3c2</samp>

Added error handling for static form renderers in `amis`. This improves the stability and usability of the form by using the `react-error-boundary` package and the `ErrorBoundary` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 079f3c2</samp>

> _Oh, we're the `amis` crew and we sail the web so blue_
> _We render forms with React, but sometimes they go splat_
> _So we added `ErrorBoundary` to catch them when they fall_
> _And show a fallback value, so we don't lose it all_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 079f3c2</samp>

*  Add `react-error-boundary` package as a dependency to handle errors in React components ([link](https://github.com/baidu/amis/pull/8116/files?diff=unified&w=0#diff-b49028542a3bb14de6e47e46a9f09f23ffeff3afea2a17d5ddace75726a33e12L75-R76))
*  Import `ErrorBoundary` component from `react-error-boundary` package in `StaticHoc.tsx` file ([link](https://github.com/baidu/amis/pull/8116/files?diff=unified&w=0#diff-6743296e062555d6d5ef1ffa806450e07b74989e2b2bcc829517a34a8560e918R4))
*  Wrap `body` prop with `ErrorBoundary` component in `supportStatic` function to render fallback string in case of errors ([link](https://github.com/baidu/amis/pull/8116/files?diff=unified&w=0#diff-6743296e062555d6d5ef1ffa806450e07b74989e2b2bcc829517a34a8560e918L138-R141))
