### PR TITLE
feat(amis-editor): 将style转换为themeCss

### DIFF
--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -2,7 +2,7 @@
  * @file 功能类函数集合。
  */
 import {hasIcon, mapObject, utils} from 'amis';
-import type {Schema, SchemaNode} from 'amis';
+import type {PlainObject, Schema, SchemaNode} from 'amis';
 import {getGlobalData} from 'amis-theme-editor-helper';
 import {isExpression, resolveVariableAndFilter} from 'amis-core';
 import type {VariableItem} from 'amis-ui';
@@ -95,6 +95,11 @@ export function JSONPipeIn(obj: any): any {
   //     toUpdate[`$$${key}`] = obj[key];
   //   }
   // });
+
+  if (obj.type) {
+    // 处理下历史style数据，整理到themCss
+    obj = style2ThemeCss(obj);
+  }
 
   Object.keys(obj).forEach(key => {
     let prop = obj[key];
@@ -1110,6 +1115,64 @@ export function setThemeConfig(config: any) {
 // 获取主题数据和样式选择器数据
 export function getThemeConfig() {
   return {themeConfig, ...themeOptionsData};
+}
+
+/**
+ * 将style转换为组件ThemeCSS格式
+ *
+ * @param data - 组件schema
+ * @returns 处理后的数据
+ */
+export function style2ThemeCss(data: any) {
+  if (!data?.style && isEmpty(data.style)) {
+    return data;
+  }
+  const schemaData = cloneDeep(data);
+  let baseControlClassName: PlainObject = {};
+  const border: PlainObject = {};
+  const paddingAndMargin: PlainObject = {};
+  const font: PlainObject = {};
+  for (let key in schemaData.style) {
+    if (['background', 'radius', 'boxShadow'].includes(key)) {
+      baseControlClassName[key + ':default'] = schemaData.style[key];
+      delete schemaData.style[key];
+    } else if (
+      ['color', 'fontSize', 'fontWeight', 'font-family', 'lineHeight'].includes(
+        key
+      )
+    ) {
+      font[key] = schemaData.style[key];
+      delete schemaData.style[key];
+    } else if (key.includes('border')) {
+      border[key] = schemaData.style[key];
+      delete schemaData.style[key];
+    } else if (key.includes('padding') || key.includes('margin')) {
+      paddingAndMargin[key] = schemaData.style[key];
+      delete schemaData.style[key];
+    }
+  }
+  baseControlClassName = Object.assign(
+    isEmpty(baseControlClassName) ? {} : baseControlClassName,
+    isEmpty(border) ? {} : {'border:default': border},
+    isEmpty(paddingAndMargin)
+      ? {}
+      : {'padding-and-margin:default': paddingAndMargin},
+    isEmpty(font) ? {} : {'font:default': font}
+  );
+  if (isEmpty(baseControlClassName)) {
+    return schemaData;
+  }
+  if (!schemaData.themeCss) {
+    schemaData.themeCss = {
+      baseControlClassName
+    };
+  } else {
+    schemaData.themeCss.baseControlClassName = Object.assign(
+      schemaData.themeCss.baseControlClassName,
+      baseControlClassName
+    );
+  }
+  return schemaData;
 }
 
 /**

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -97,7 +97,7 @@ export function JSONPipeIn(obj: any): any {
   // });
 
   if (obj.type) {
-    // 处理下历史style数据，整理到themCss
+    // 处理下历史style数据，整理到themeCss
     obj = style2ThemeCss(obj);
   }
 
@@ -1127,30 +1127,30 @@ export function style2ThemeCss(data: any) {
   if (!data?.style && isEmpty(data.style)) {
     return data;
   }
-  const schemaData = cloneDeep(data);
+  const style = {...data.style};
   let baseControlClassName: PlainObject = {};
   const border: PlainObject = {};
   const paddingAndMargin: PlainObject = {};
   const font: PlainObject = {};
-  for (let key in schemaData.style) {
+  Object.keys(style).forEach(key => {
     if (['background', 'radius', 'boxShadow'].includes(key)) {
-      baseControlClassName[key + ':default'] = schemaData.style[key];
-      delete schemaData.style[key];
+      baseControlClassName[key + ':default'] = style[key];
+      delete style[key];
     } else if (
       ['color', 'fontSize', 'fontWeight', 'font-family', 'lineHeight'].includes(
         key
       )
     ) {
-      font[key] = schemaData.style[key];
-      delete schemaData.style[key];
+      font[key] = style[key];
+      delete style[key];
     } else if (key.includes('border')) {
-      border[key] = schemaData.style[key];
-      delete schemaData.style[key];
+      border[key] = style[key];
+      delete style[key];
     } else if (key.includes('padding') || key.includes('margin')) {
-      paddingAndMargin[key] = schemaData.style[key];
-      delete schemaData.style[key];
+      paddingAndMargin[key] = style[key];
+      delete style[key];
     }
-  }
+  });
   baseControlClassName = Object.assign(
     isEmpty(baseControlClassName) ? {} : baseControlClassName,
     isEmpty(border) ? {} : {'border:default': border},
@@ -1160,19 +1160,24 @@ export function style2ThemeCss(data: any) {
     isEmpty(font) ? {} : {'font:default': font}
   );
   if (isEmpty(baseControlClassName)) {
-    return schemaData;
+    return data;
   }
-  if (!schemaData.themeCss) {
-    schemaData.themeCss = {
+  let themeCss = {baseControlClassName};
+  if (!data.themeCss) {
+    themeCss = {
       baseControlClassName
     };
   } else {
-    schemaData.themeCss.baseControlClassName = Object.assign(
-      schemaData.themeCss.baseControlClassName,
+    themeCss.baseControlClassName = Object.assign(
+      data.themeCss.baseControlClassName,
       baseControlClassName
     );
   }
-  return schemaData;
+  return {
+    ...data,
+    style,
+    themeCss
+  };
 }
 
 /**


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 05de94c</samp>

Added support for customizing component appearance with `themeCss` in schema. Updated `util.ts` to convert `style` to `themeCss` when importing schema.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 05de94c</samp>

> _We're sailing on the web with our components fine_
> _We've got a new feature to make them all shine_
> _We use `themeCss` to style them as we please_
> _And `style2ThemeCss` to convert with ease_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 05de94c</samp>

*  Import `PlainObject` type from `amis` to annotate schema objects ([link](https://github.com/baidu/amis/pull/8123/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL5-R5))
*  Convert `style` property of schema objects to `themeCss` property using `style2ThemeCss` function ([link](https://github.com/baidu/amis/pull/8123/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aR99-R103))
*  Define and export `style2ThemeCss` function that transforms style properties to themeCss sub-properties and merges existing values ([link](https://github.com/baidu/amis/pull/8123/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aR1121-R1178))
