### PR TITLE
feat: style2themecss仅处理部分组件

### DIFF
--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -1124,7 +1124,11 @@ export function getThemeConfig() {
  * @returns 处理后的数据
  */
 export function style2ThemeCss(data: any) {
-  if (!data?.style && isEmpty(data.style)) {
+  if (
+    !data?.style ||
+    isEmpty(data.style) ||
+    !['tpl', 'page', 'container', 'chart', 'flex', 'grid'].includes(data.type)
+  ) {
     return data;
   }
   const style = {...data.style};


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f882e39</samp>

Fixed a bug in the theme editor that caused some components to lose their styles. Added a type check in `style2ThemeCss` to skip style conversion for unsupported components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f882e39</samp>

> _`style2ThemeCss` checks_
> _`type` before conversion_
> _autumn bug is fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f882e39</samp>

* Fix a bug where some components lose their styles when using the theme editor ([link](https://github.com/baidu/amis/pull/8134/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL1127-R1131))
