### PR TITLE
fix: 修复 requiredOn 问题 Close: #8133

### DIFF
--- a/packages/amis-core/src/store/formItem.ts
+++ b/packages/amis-core/src/store/formItem.ts
@@ -363,7 +363,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
 
       if (
         typeof rules !== 'undefined' ||
-        self.required ||
+        typeof required !== 'undefined' ||
         typeof minLength === 'number' ||
         typeof maxLength === 'number'
       ) {

--- a/packages/amis/__tests__/event-action/renderers/form/form.test.tsx
+++ b/packages/amis/__tests__/event-action/renderers/form/form.test.tsx
@@ -828,7 +828,7 @@ test('doAction:form valdiate requiredOn', async () => {
         submitText: '提交表单',
         body: [
           {
-            type: 'radio',
+            type: 'switch',
             name: 'a',
             label: 'a'
           },
@@ -851,11 +851,11 @@ test('doAction:form valdiate requiredOn', async () => {
   await wait(200);
   expect(onSubmit).toBeCalled();
 
-  expect(container.querySelector('.cxd-Checkbox')!).toBeInTheDocument();
-  fireEvent.click(container.querySelector('.cxd-Checkbox')!);
-  await wait(200);
+  expect(container.querySelector('.cxd-Switch')!).toBeInTheDocument();
+  fireEvent.click(container.querySelector('.cxd-Switch')!);
+  await wait(300);
   fireEvent.click(getByText('提交表单'));
-  await wait(200);
+  await wait(300);
 
   const ul = container.querySelector('.cxd-Form-feedback');
   expect(ul).toBeInTheDocument();
@@ -872,4 +872,17 @@ test('doAction:form valdiate requiredOn', async () => {
     a: true,
     b: '123'
   });
+
+  expect(container.querySelector('.cxd-Form-feedback')).toBeNull();
+
+  fireEvent.change(container.querySelector('input[name="b"]')!, {
+    target: {value: ''}
+  });
+  await wait(300);
+
+  expect(container.querySelector('.cxd-Form-feedback')).toBeInTheDocument();
+  fireEvent.click(container.querySelector('.cxd-Switch')!);
+  await wait(300);
+
+  expect(container.querySelector('.cxd-Form-feedback')).toBeNull();
 });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7401c5a</samp>

This pull request improves the form validation logic in `amis-core` and updates a test case in `amis` accordingly. It fixes a bug that ignored the `required` property of form items and uses a switch component instead of a radio component for testing.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7401c5a</samp>

> _`required` is the law, don't you dare to ignore_
> _We'll validate your form with a switch and a roar_
> _We'll test every case, we'll check every feedback_
> _We'll fix every bug, we're the masters of the stack_

### Why

Close: #8133

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7401c5a</samp>

* Fix a bug in `FormItemStore` that ignored the `required` property when validating the form item ([link](https://github.com/baidu/amis/pull/8135/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L366-R366))
* Modify and update a test case in `form.test.tsx` to use a switch component instead of a radio component for the form item named `a` ([link](https://github.com/baidu/amis/pull/8135/files?diff=unified&w=0#diff-d37e740de8f8efbec12afc96328e13c29c822fa3f90e5c374b03d902d2e93961L831-R831), [link](https://github.com/baidu/amis/pull/8135/files?diff=unified&w=0#diff-d37e740de8f8efbec12afc96328e13c29c822fa3f90e5c374b03d902d2e93961L854-R858))
* Add more assertions to the test case in `form.test.tsx` to verify the form feedback element for the switch component and the input component named `b` ([link](https://github.com/baidu/amis/pull/8135/files?diff=unified&w=0#diff-d37e740de8f8efbec12afc96328e13c29c822fa3f90e5c374b03d902d2e93961R875-R887))
