### PR TITLE
fix: 日期时间范围选择器的时间选择点击无效问题

### DIFF
--- a/docs/zh-CN/components/form/input-datetime.md
+++ b/docs/zh-CN/components/form/input-datetime.md
@@ -254,7 +254,7 @@ order: 14
 
 可以通过 `disabledDate` 字符函数来控制，比如不允许选择周一、周六、周日
 
-函数签名: `(currentDate: moment.Moment, props: any) => boolean`  
+函数签名: `(currentDate: moment.Moment, props: any) => boolean`
 示例： `"return currentDate.day() == 1 || currentDate.day() == 0 || currentDate.day() == 6"`
 
 ```schema: scope="body"

--- a/packages/amis-ui/src/components/CalendarMobile.tsx
+++ b/packages/amis-ui/src/components/CalendarMobile.tsx
@@ -11,6 +11,7 @@ import {themeable, ThemeProps} from 'amis-core';
 import {LocaleProps, localeable} from 'amis-core';
 import {autobind} from 'amis-core';
 import {ShortCuts} from './DatePicker';
+import type {ViewMode} from './calendar/Calendar';
 
 export interface CalendarMobileProps extends ThemeProps, LocaleProps {
   className?: string;
@@ -25,7 +26,7 @@ export interface CalendarMobileProps extends ThemeProps, LocaleProps {
   maxDuration?: moment.Duration;
   dateFormat?: string;
   embed?: boolean;
-  viewMode?: 'days' | 'months' | 'years' | 'time' | 'quarters';
+  viewMode?: ViewMode;
   close?: () => void;
   confirm?: (startDate?: any, endTime?: any) => void;
   onChange?: (data: any, callback?: () => void) => void;

--- a/packages/amis-ui/src/components/DateRangePicker.tsx
+++ b/packages/amis-ui/src/components/DateRangePicker.tsx
@@ -30,6 +30,7 @@ import Input from './Input';
 import Button from './Button';
 
 import type {PlainObject, ThemeProps, LocaleProps} from 'amis-core';
+import type {ViewMode} from './calendar/Calendar';
 
 export interface DateRangePickerProps extends ThemeProps, LocaleProps {
   className?: string;
@@ -67,7 +68,7 @@ export interface DateRangePickerProps extends ThemeProps, LocaleProps {
   popOverContainer?: any;
   dateFormat?: string;
   embed?: boolean;
-  viewMode?: 'days' | 'months' | 'years' | 'time' | 'quarters';
+  viewMode?: ViewMode;
   borderMode?: 'full' | 'half' | 'none';
   onFocus?: Function;
   onBlur?: Function;
@@ -882,11 +883,22 @@ export class DateRangePicker extends React.Component<
 
   filterDate(
     date: moment.Moment,
-    originValue?: moment.Moment,
-    timeFormat?: string,
-    type: 'start' | 'end' = 'start'
+    options: {
+      type: 'start' | 'end';
+      originValue?: moment.Moment;
+      timeFormat?: string;
+      subControlViewMode?: 'time';
+    } = {type: 'start'}
   ): moment.Moment {
+    const {type, originValue, timeFormat, subControlViewMode} = options || {
+      type: 'start'
+    };
     let value = date.clone();
+
+    /** 日期时间选择器组件支持用户选择时间，如果用户手动选择了时间，则不需要走默认处理 */
+    if (subControlViewMode && subControlViewMode === 'time') {
+      return value;
+    }
 
     // 没有初始值
     if (!originValue) {
@@ -915,18 +927,26 @@ export class DateRangePicker extends React.Component<
     }
   }
 
-  handleStartDateChange(newValue: moment.Moment) {
-    const {timeFormat, minDate, inputFormat, displayFormat, type} = this.props;
-    let {startDate, endDateOpenedFirst} = this.state;
+  /**
+   * @param {Moment} newValue 当前选择的日期时间值
+   * @param {ViewMode=} subControlViewMode 子选择控件的类型，可选参数（'time'），用于区分datetime选择器的触发控件
+   */
+  handleStartDateChange(
+    newValue: moment.Moment,
+    subControlViewMode?: Extract<ViewMode, 'time'>
+  ) {
+    const {minDate, inputFormat, displayFormat, type} = this.props;
+    let {startDate, endDateOpenedFirst, curTimeFormat: timeFormat} = this.state;
     if (minDate && newValue.isBefore(minDate)) {
       newValue = minDate;
     }
-    const date = this.filterDate(
-      newValue,
-      startDate || minDate,
+
+    const date = this.filterDate(newValue, {
+      type: 'start',
+      originValue: startDate || minDate,
       timeFormat,
-      'start'
-    );
+      subControlViewMode
+    });
     const newState = {
       startDate: date,
       startInputValue: date.format(displayFormat || inputFormat)
@@ -944,13 +964,29 @@ export class DateRangePicker extends React.Component<
     this.setState(newState);
   }
 
-  handelEndDateChange(newValue: moment.Moment) {
-    const {embed, timeFormat, inputFormat, displayFormat, type} = this.props;
-    let {startDate, endDate, endDateOpenedFirst} = this.state;
+  /**
+   * @param {Moment} newValue 当前选择的日期时间值
+   * @param {string=} subControlViewMode 子选择控件的类型的类型，可选参数（'time'），用于区分datetime选择器的触发控件
+   */
+  handelEndDateChange(
+    newValue: moment.Moment,
+    subControlViewMode?: Extract<ViewMode, 'time'>
+  ) {
+    const {embed, inputFormat, displayFormat, type} = this.props;
+    let {
+      startDate,
+      endDate,
+      endDateOpenedFirst,
+      curTimeFormat: timeFormat
+    } = this.state;
     newValue = this.getEndDateByDuration(newValue);
     const editState = endDateOpenedFirst ? 'start' : 'end';
-
-    const date = this.filterDate(newValue, endDate, timeFormat, 'end');
+    const date = this.filterDate(newValue, {
+      type: 'end',
+      originValue: endDate,
+      timeFormat,
+      subControlViewMode
+    });
     this.setState(
       {
         endDate: date,

--- a/packages/amis-ui/src/components/calendar/Calendar.tsx
+++ b/packages/amis-ui/src/components/calendar/Calendar.tsx
@@ -16,6 +16,9 @@ import 'moment/locale/zh-cn';
 import 'moment/locale/de';
 import type {RendererEnv} from 'amis-core';
 
+/** 视图模式 */
+export type ViewMode = 'days' | 'months' | 'years' | 'time' | 'quarters';
+
 export type DateType =
   | 'year'
   | 'month'
@@ -48,7 +51,7 @@ interface BaseDatePickerProps {
   className?: string;
   value?: any;
   defaultValue?: any;
-  viewMode?: 'years' | 'months' | 'days' | 'time' | 'quarters';
+  viewMode?: ViewMode;
   dateFormat?: boolean | string;
   inputFormat?: boolean | string;
   displayForamt?: boolean | string;
@@ -63,7 +66,7 @@ interface BaseDatePickerProps {
   onViewModeChange?: (type: string) => void;
   requiredConfirm?: boolean;
   onClose?: () => void;
-  onChange?: (value: any) => void;
+  onChange?: (value: any, viewMode?: Extract<ViewMode, 'time'>) => void;
   isEndDate?: boolean;
   minDate?: moment.Moment;
   maxDate?: moment.Moment;
@@ -480,7 +483,7 @@ class BaseDatePicker extends React.Component<
         inputValue: date.format(state.displayForamt as string)
       });
     }
-    this.props.onChange && this.props.onChange(date);
+    this.props.onChange && this.props.onChange(date, 'time');
   };
 
   setDate = (type: 'month' | 'year' | 'quarters') => {

--- a/packages/amis-ui/src/components/calendar/DaysView.tsx
+++ b/packages/amis-ui/src/components/calendar/DaysView.tsx
@@ -19,8 +19,10 @@ import type {RendererEnv} from 'amis-core';
 import Picker from '../Picker';
 import {PickerOption} from '../PickerColumn';
 import {DateType} from './Calendar';
-import type {TimeScale} from './TimeView';
 import {Icon} from '../icons';
+
+import type {TimeScale} from './TimeView';
+import type {ViewMode} from './Calendar';
 
 interface CustomDaysViewProps extends LocaleProps {
   classPrefix?: string;
@@ -37,7 +39,10 @@ interface CustomDaysViewProps extends LocaleProps {
   isEndDate?: boolean;
   renderDay?: Function;
   onClose?: () => void;
-  onChange: (value: moment.Moment) => void;
+  onChange: (
+    value: moment.Moment,
+    viewMode?: Extract<ViewMode, 'time'>
+  ) => void;
   onConfirm?: (value: number[], types: DateType[]) => void;
   setDateTimeState: (state: any) => void;
   showTime: () => void;
@@ -294,6 +299,7 @@ export class CustomDaysView extends React.Component<CustomDaysViewProps> {
 
   showTime = () => {
     const {selectedDate, viewDate, timeFormat} = this.props;
+
     return (
       <div key="stb" className="rdtShowTime">
         {(selectedDate || viewDate || moment()).format(timeFormat)}
@@ -306,15 +312,16 @@ export class CustomDaysView extends React.Component<CustomDaysViewProps> {
     value: number
   ) => {
     const date = (this.props.selectedDate || this.props.viewDate).clone();
-    date[type](value);
 
+    date[type](value);
+    const updatedDate = date.clone();
     this.props.setDateTimeState({
-      viewDate: date.clone(),
-      selectedDate: date.clone()
+      viewDate: updatedDate,
+      selectedDate: updatedDate
     });
 
     if (!this.props.requiredConfirm) {
-      this.props.onChange(date);
+      this.props.onChange(date, 'time');
     }
   };
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 35797c9</samp>

This pull request enhances the `amis-ui` package by improving the formatting and optimization of the `DaysView` component and fixing two bugs in the `DateRangePicker` component. It also removes an extra space in the `docs/zh-CN/components/form/input-datetime.md` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 35797c9</samp>

> _We're the crew of the `amis-ui` ship_
> _We sail the seas of code and script_
> _We fix the bugs and format the lines_
> _We heave away on the count of three_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 35797c9</samp>

* Fix bug of resetting time part of date when selecting date range for `input-datetime-range` component ([link](https://github.com/baidu/amis/pull/8149/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L889-R896))
* Fix bug of using wrong time format in `handleStartDateChange` and `handleEndDateChange` methods of `DateRangePicker` component ([link](https://github.com/baidu/amis/pull/8149/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L919-R926), [link](https://github.com/baidu/amis/pull/8149/files?diff=unified&w=0#diff-2685ff6ec8d49108794623e40034a6d8a1a41c8a8c15d419ca9b4db3b8c04348L948-R960))
* Optimize code by avoiding cloning date twice in `DaysView` component ([link](https://github.com/baidu/amis/pull/8149/files?diff=unified&w=0#diff-206e06fca060056b2ec3db9f17011b6ceeeb01ac290df0fdeb7d49c7ab7e91d7L309-R315))
* Improve formatting by removing extra space in `input-datetime.md` document ([link](https://github.com/baidu/amis/pull/8149/files?diff=unified&w=0#diff-1df5e88733871e92d86ce0af46616a0c2d8e894285da4e8726c0db67081cfbbcL257-R257))
* Improve formatting by adding empty line in `DaysView.tsx` file ([link](https://github.com/baidu/amis/pull/8149/files?diff=unified&w=0#diff-206e06fca060056b2ec3db9f17011b6ceeeb01ac290df0fdeb7d49c7ab7e91d7R297))
