### PR TITLE
fix: TreeSelect组件单选模式开启searchable绑定值后输入框仍然存在问题

### DIFF
--- a/packages/amis/__tests__/renderers/Tree.test.tsx
+++ b/packages/amis/__tests__/renderers/Tree.test.tsx
@@ -530,3 +530,76 @@ test('Tree: item disabled', async () => {
     transfer: ''
   });
 });
+
+test('Tree: single value mode should not render input when searchable enabled and default value settled', async () => {
+  const {container} = render(
+    amisRender({
+      type: 'container',
+      body: [
+        {
+          "type": "tree-select",
+          "name": "tree",
+          "label": "Tree",
+          "searchable": true,
+          "value": 2,
+          "inputClassName": "single",
+          "options": [
+            {
+              "label": "Folder A",
+              "value": 1,
+              "children": [
+                {
+                  "label": "file A",
+                  "value": 2
+                },
+                {
+                  "label": "file B",
+                  "value": 3
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "tree-select",
+          "name": "tree2",
+          "label": "Tree2",
+          "searchable": true,
+          "value": "2,4",
+          "multiple": true,
+          "inputClassName": "multiple",
+          "options": [
+            {
+              "label": "Folder A",
+              "value": 1,
+              "children": [
+                {
+                  "label": "file A",
+                  "value": 2
+                },
+                {
+                  "label": "file B",
+                  "value": 3
+                }
+              ]
+            },
+            {
+              "label": "file C",
+              "value": 4
+            }
+          ]
+        }
+      ]
+    },
+    {},
+    makeEnv({})
+  ));
+
+  const singleModeInput = container.querySelector('.single .cxd-ResultBox-value-input');
+  const multipleModeInput = container.querySelector('.multiple .cxd-ResultBox-value-input');
+
+  /** 单选模式且已选值，不应该再有 input */
+  expect(singleModeInput).not.toBeInTheDocument();
+  /** 多选模式始终都有 input */
+  expect(multipleModeInput).toBeInTheDocument();
+})

--- a/packages/amis/src/renderers/Form/TreeSelect.tsx
+++ b/packages/amis/src/renderers/Form/TreeSelect.tsx
@@ -695,8 +695,13 @@ export default class TreeSelectControl extends React.Component<
       env,
       loadingConfig
     } = this.props;
-
     const {isOpened} = this.state;
+    const resultValue = multiple
+      ? selectedOptions
+      : selectedOptions.length
+      ? this.renderItem(selectedOptions[0])
+      : '';
+
     return (
       <div ref={this.container} className={cx(`TreeSelectControl`, className)}>
         <ResultBox
@@ -716,13 +721,7 @@ export default class TreeSelectControl extends React.Component<
             'is-opened': this.state.isOpened,
             'is-disabled': disabled
           })}
-          result={
-            multiple
-              ? selectedOptions
-              : selectedOptions.length
-              ? this.renderItem(selectedOptions[0])
-              : ''
-          }
+          result={resultValue}
           onResultClick={this.handleOutClick}
           value={this.state.inputValue}
           onChange={this.handleInputChange}
@@ -733,7 +732,11 @@ export default class TreeSelectControl extends React.Component<
           onBlur={this.handleBlur}
           onKeyDown={this.handleInputKeyDown}
           clearable={clearable}
-          allowInput={!mobileUI && (searchable || isEffectiveApi(autoComplete))}
+          allowInput={
+            !mobileUI &&
+            (searchable || isEffectiveApi(autoComplete)) &&
+            (multiple || !resultValue)
+          }
           hasDropDownArrow
           readOnly={mobileUI}
           mobileUI={mobileUI}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9aa85d9</samp>

This pull request improves the TreeSelect component and its test case. It refactors the component code to use a variable for the result value and to simplify the input logic based on the `multiple` and `result` props. It also adds a test case to verify that the component renders the input element correctly depending on the mode and the default value.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9aa85d9</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The TreeSelect component, a wondrous form control_
> _That lets the user choose from branches intertwined_
> _With options manifold, and stores the chosen goal._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9aa85d9</samp>

*  Modify the `TreeSelect` component to conditionally allow input based on the value mode and the default value ([link](https://github.com/baidu/amis/pull/8152/files?diff=unified&w=0#diff-9e1b32863ebd5d805fac50e10de5eb0f6e2cd1c3385b3674813bf1994426ae95L736-R739))
*  Refactor the `TreeSelect` component to store the rendered result value in a variable and reuse it in the render method ([link](https://github.com/baidu/amis/pull/8152/files?diff=unified&w=0#diff-9e1b32863ebd5d805fac50e10de5eb0f6e2cd1c3385b3674813bf1994426ae95L698-R704), [link](https://github.com/baidu/amis/pull/8152/files?diff=unified&w=0#diff-9e1b32863ebd5d805fac50e10de5eb0f6e2cd1c3385b3674813bf1994426ae95L719-R724))
*  Add a test case for the `TreeSelect` component to check the input rendering logic in single and multiple value modes ([link](https://github.com/baidu/amis/pull/8152/files?diff=unified&w=0#diff-4d7700aaaa14921467975840001b3ea0a4f4970f4a54acd391b2bbb5e4071e47R533-R605))
