### PR TITLE
fix(amis-core): 修复chart resizeSensor失效问题

### DIFF
--- a/packages/amis-core/src/utils/resize-sensor.ts
+++ b/packages/amis-core/src/utils/resize-sensor.ts
@@ -19,7 +19,7 @@ class EventQueue {
 
   call(type: EventType, ...args: any[]) {
     this.q.forEach(item => {
-      if (item.type === type || type === 'both') {
+      if (item.type === type || item.type === 'both' || type === 'both') {
         item.fn.apply(null, args);
       }
     });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f34a75</samp>

Fixed a bug in the `EventQueue` class that caused unnecessary callback executions in the resize sensor component. This improves the performance and reliability of the `resize-sensor.ts` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0f34a75</samp>

> _`EventQueue` fixed_
> _`item.type` checked for `'both'`_
> _Sensor works in fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0f34a75</samp>

* Fix the `call` method of the `EventQueue` class to check the `item.type` instead of the `type` parameter ([link](https://github.com/baidu/amis/pull/8160/files?diff=unified&w=0#diff-511f35cc92e3e578a9d83468eb7ea91117c33c782ad2f29fb389b1d0ad17c2fbL22-R22)). This prevents unnecessary or incorrect callback executions for the resize sensor component.
