### PR TITLE
feat: 添加 getChangeLog script 帮助快速生成内部版本差异

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "version": "lerna version",
     "release": "npm run build --workspaces && lerna publish from-package --registry=https://registry.npmjs.org --ignore-scripts",
     "revision": "ts-node ./scripts/generate-revision.ts",
+    "getChangeLog": "ts-node ./scripts/getChangeLog",
     "publish-to-internal": "sh ./publish-to-internal.sh",
     "stylelint": "npx stylelint 'packages/**/*.scss'",
     "typecheck": "tsc --noEmit"

--- a/scripts/getChangeLog.ts
+++ b/scripts/getChangeLog.ts
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import path from 'path';
+import util from 'util';
+import {exec as nodeExec} from 'child_process';
+import {fileURLToPath} from 'url';
+const exec = util.promisify(nodeExec);
+
+const pkg = '@fex/amis';
+const folder = path.join(path.dirname(__filename), '../node_modules');
+
+export async function main(from: string, to: string) {
+  let {stdout: packFromStdout} = await exec(
+    `npm pack ${pkg}@${from} --pack-destination="${folder}"`
+  );
+  const fromFilname = packFromStdout.trim();
+  const fromFolder = `${folder}/amis_${from}`;
+  await exec(`mkdir -p ${fromFolder}`);
+  await exec(`tar -xzvf ${path.join(folder, fromFilname)} -C ${fromFolder}`);
+
+  const fromRevision = JSON.parse(
+    fs.readFileSync(fromFolder + '/package/revision.json', 'utf-8').trim()
+  );
+
+  const {stdout: packToStdout} = await exec(
+    `npm pack ${pkg}@${to} --pack-destination="${folder}"`
+  );
+  const toFilname = packToStdout.trim();
+  const toFolder = `${folder}/amis_${to}`;
+  await exec(`mkdir -p ${toFolder}`);
+  await exec(`tar -xzvf ${path.join(folder, toFilname)} -C ${toFolder}`);
+
+  const toRevision = JSON.parse(
+    fs.readFileSync(toFolder + '/package/revision.json', 'utf-8').trim()
+  );
+
+  const {stdout: logs} = await exec(
+    `git log ${fromRevision.SHA1}...${toRevision.SHA1}^ --oneline`
+  );
+  const lines = logs.split('\n');
+  const commits = lines
+    .map(line => {
+      const [SHA1, ...message] = line.split(' ');
+      const msg = message.join(' ');
+
+      if (msg.startsWith('Merge') || msg.startsWith('bump:')) {
+        return '';
+      }
+
+      return msg;
+    })
+    .filter(item => item);
+  console.log(commits.join('\n'));
+}
+
+main.apply(null, process.argv.slice(2)).catch((err: any) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 955f02d</samp>

This pull request adds a new script `getChangeLog` to the `package.json` file and a new TypeScript file `scripts/getChangeLog.ts` that implements the script. The script generates a changelog for the `@fex/amis` package based on the git history.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 955f02d</samp>

> _`getChangeLog` script_
> _Generates changelog from git_
> _Autumn leaves fall fast_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 955f02d</samp>

* Add a new script `getChangeLog` to generate a changelog from the git history of the `@fex/amis` package ([link](https://github.com/baidu/amis/pull/8162/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R27))
* Create a new TypeScript file `scripts/getChangeLog.ts` that contains the logic for the `getChangeLog` script ([link](https://github.com/baidu/amis/pull/8162/files?diff=unified&w=0#diff-53f8bfa4a4b86d53cb52443688cc0851b860e19b154b628840a0ea0ac930e432R1-R58))
