### PR TITLE
fix: 修复部分组件配置面板变更配置后，默认值选项没有更新的问题

### DIFF
--- a/packages/amis-editor/src/plugin/Form/ButtonGroupSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/ButtonGroupSelect.tsx
@@ -10,6 +10,7 @@ import {getSchemaTpl, defaultValue} from 'amis-editor-core';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {ValidatorTag} from '../../validator';
 import {resolveOptionType} from '../../util';
+import type {Schema} from 'amis';
 
 export class ButtonGroupControlPlugin extends BasePlugin {
   static id = 'ButtonGroupControlPlugin';
@@ -126,7 +127,7 @@ export class ButtonGroupControlPlugin extends BasePlugin {
                 getSchemaTpl('label'),
                 getSchemaTpl('multiple'),
                 getSchemaTpl('valueFormula', {
-                  rendererSchema: context?.schema,
+                  rendererSchema: (schema: Schema) => schema,
                   useSelectMode: true, // 改用 Select 设置模式
                   visibleOn: 'this.options && this.options.length > 0'
                 }),

--- a/packages/amis-editor/src/plugin/Form/ChainedSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/ChainedSelect.tsx
@@ -13,6 +13,7 @@ import {
 } from 'amis-editor-core';
 import {ValidatorTag} from '../../validator';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
+import type {Schema} from 'amis';
 
 export class ChainedSelectControlPlugin extends BasePlugin {
   static id = 'ChainedSelectControlPlugin';
@@ -114,7 +115,7 @@ export class ChainedSelectControlPlugin extends BasePlugin {
               getSchemaTpl('label'),
 
               getSchemaTpl('valueFormula', {
-                rendererSchema: context?.schema,
+                rendererSchema: (schema: Schema) => schema,
                 mode: 'vertical', // 改成上下展示模式
                 rendererWrapper: true,
                 label: tipedLabel('默认值', '请填入选项 Options 中 value 值')

--- a/packages/amis-editor/src/plugin/Form/Checkboxes.tsx
+++ b/packages/amis-editor/src/plugin/Form/Checkboxes.tsx
@@ -15,6 +15,7 @@ import {
 } from 'amis-editor-core';
 import {ValidatorTag} from '../../validator';
 
+import type {Schema} from 'amis';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {resolveOptionType} from '../../util';
@@ -166,7 +167,7 @@ export class CheckboxesControlPlugin extends BasePlugin {
                 }
               ],
               getSchemaTpl('valueFormula', {
-                rendererSchema: context?.schema,
+                rendererSchema: (schema: Schema) => schema,
                 useSelectMode: true, // 改用 Select 设置模式
                 visibleOn: 'this.options && this.options.length > 0'
               }),

--- a/packages/amis-editor/src/plugin/Form/InputCity.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputCity.tsx
@@ -13,6 +13,7 @@ import {
   BaseEventContext
 } from 'amis-editor-core';
 import cloneDeep from 'lodash/cloneDeep';
+import type {Schema} from 'amis';
 
 import {formItemControl} from '../../component/BaseControl';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
@@ -118,7 +119,7 @@ export class CityControlPlugin extends BasePlugin {
               }),
               getSchemaTpl('label'),
               getSchemaTpl('valueFormula', {
-                rendererSchema: context?.schema,
+                rendererSchema: (schema: Schema) => schema,
                 rendererWrapper: true,
                 mode: 'vertical' // 改成上下展示模式
               }),

--- a/packages/amis-editor/src/plugin/Form/InputDate.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputDate.tsx
@@ -6,6 +6,7 @@ import {ValidatorTag} from '../../validator';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {FormulaDateType} from '../../renderer/FormulaControl';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
+import type {Schema} from 'amis';
 
 const formatX = [
   {
@@ -347,15 +348,7 @@ export class DateControlPlugin extends BasePlugin {
                   pipeIn: defaultValue(true)
                 }),
                 getSchemaTpl('valueFormula', {
-                  rendererSchema: () => {
-                    const schema = this.manager.store.getSchema(
-                      context.schema?.id,
-                      'id'
-                    );
-                    return {
-                      ...schema
-                    };
-                  },
+                  rendererSchema: (schema: Schema) => schema,
                   placeholder: '请选择静态值',
                   header: '表达式或相对值',
                   DateTimeType: FormulaDateType.IsDate,

--- a/packages/amis-editor/src/plugin/Form/InputDateRange.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputDateRange.tsx
@@ -8,6 +8,7 @@ import {FormulaDateType} from '../../renderer/FormulaControl';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 import {getRendererByName} from 'amis-core';
 import omit from 'lodash/omit';
+import type {Schema} from 'amis';
 
 const formatX = [
   {
@@ -405,11 +406,11 @@ export class DateRangeControlPlugin extends BasePlugin {
                 }),
 
                 getSchemaTpl('valueFormula', {
-                  rendererSchema: {
-                    ...context?.schema,
+                  rendererSchema: (schema: Schema) => ({
+                    ...schema,
                     size: 'full',
                     mode: 'inline'
-                  },
+                  }),
                   mode: 'vertical',
                   header: '表达式或相对值',
                   DateTimeType: FormulaDateType.IsRange,
@@ -419,11 +420,11 @@ export class DateRangeControlPlugin extends BasePlugin {
                   name: 'minDate',
                   header: '表达式或相对值',
                   DateTimeType: FormulaDateType.IsDate,
-                  rendererSchema: {
-                    ...omit(context?.schema, ['shortcuts']),
-                    value: context?.schema.minDate,
+                  rendererSchema: (schema: Schema) => ({
+                    ...omit(schema, ['shortcuts']),
+                    value: schema?.minDate,
                     type: 'input-date'
-                  },
+                  }),
                   placeholder: '请选择静态值',
                   needDeleteProps: ['minDate', 'ranges', 'shortcuts'], // 避免自我限制
                   label: tipedLabel('最小值', dateTooltip)
@@ -432,11 +433,11 @@ export class DateRangeControlPlugin extends BasePlugin {
                   name: 'maxDate',
                   header: '表达式或相对值',
                   DateTimeType: FormulaDateType.IsDate,
-                  rendererSchema: {
-                    ...omit(context?.schema, ['shortcuts']),
-                    value: context?.schema.maxDate,
+                  rendererSchema: (schema: Schema) => ({
+                    ...omit(schema, ['shortcuts']),
+                    value: schema?.maxDate,
                     type: 'input-date'
-                  },
+                  }),
                   placeholder: '请选择静态值',
                   needDeleteProps: ['maxDate', 'ranges', 'shortcuts'], // 避免自我限制
                   label: tipedLabel('最大值', dateTooltip)
@@ -446,11 +447,11 @@ export class DateRangeControlPlugin extends BasePlugin {
                   name: 'minDuration',
                   header: '表达式',
                   DateTimeType: FormulaDateType.NotDate,
-                  rendererSchema: {
-                    ...context?.schema,
-                    value: context?.schema.minDuration,
+                  rendererSchema: (schema: Schema) => ({
+                    ...schema,
+                    value: schema?.minDuration,
                     type: 'input-text'
-                  },
+                  }),
                   placeholder: '请输入相对值',
                   needDeleteProps: ['minDuration'], // 避免自我限制
                   label: tipedLabel('最小跨度', rangTooltip)
@@ -460,11 +461,11 @@ export class DateRangeControlPlugin extends BasePlugin {
                   name: 'maxDuration',
                   header: '表达式',
                   DateTimeType: FormulaDateType.NotDate,
-                  rendererSchema: {
-                    ...context?.schema,
-                    value: context?.schema.maxDuration,
+                  rendererSchema: (schema: Schema) => ({
+                    ...schema,
+                    value: schema?.maxDuration,
                     type: 'input-text'
-                  },
+                  }),
                   placeholder: '请输入相对值',
                   needDeleteProps: ['maxDuration'], // 避免自我限制
                   label: tipedLabel('最大跨度', rangTooltip)

--- a/packages/amis-editor/src/plugin/Form/InputTag.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTag.tsx
@@ -11,6 +11,7 @@ import {
 import {formItemControl} from '../../component/BaseControl';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 import {resolveOptionType} from '../../util';
+import type {Schema} from 'amis';
 
 export class TagControlPlugin extends BasePlugin {
   static id = 'TagControlPlugin';
@@ -31,7 +32,11 @@ export class TagControlPlugin extends BasePlugin {
     type: 'input-tag',
     label: '标签',
     name: 'tag',
-    options: ['红色', '绿色', '蓝色']
+    options: [
+      {label: '红色', value: 'red'},
+      {label: '绿色', value: 'green'},
+      {label: '蓝色', value: 'blue'}
+    ]
   };
   previewSchema: any = {
     type: 'form',
@@ -40,7 +45,7 @@ export class TagControlPlugin extends BasePlugin {
     wrapWithPanel: false,
     body: {
       ...this.scaffold,
-      value: '红色'
+      value: 'red'
     }
   };
 
@@ -168,7 +173,7 @@ export class TagControlPlugin extends BasePlugin {
             getSchemaTpl('clearable'),
             getSchemaTpl('optionsTip'),
             getSchemaTpl('valueFormula', {
-              rendererSchema: context?.schema,
+              rendererSchema: (schema: Schema) => schema,
               mode: 'vertical' // 改成上下展示模式
             }),
             getSchemaTpl('joinValues'),

--- a/packages/amis-editor/src/plugin/Form/InputTree.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTree.tsx
@@ -16,6 +16,7 @@ import {
 import {tipedLabel} from 'amis-editor-core';
 import {ValidatorTag} from '../../validator';
 import {resolveOptionType} from '../../util';
+import type {Schema} from 'amis';
 
 export class TreeControlPlugin extends BasePlugin {
   static id = 'TreeControlPlugin';
@@ -418,10 +419,10 @@ export class TreeControlPlugin extends BasePlugin {
                 hiddenOn: '!data.multiple || !data.autoCheckChildren'
               }),
               getSchemaTpl('valueFormula', {
-                rendererSchema: {
-                  ...context?.schema,
+                rendererSchema: (schema: Schema) => ({
+                  ...schema,
                   type: 'tree-select'
-                },
+                }),
                 visibleOn: 'this.options && this.options.length > 0'
               }),
 

--- a/packages/amis-editor/src/plugin/Form/ListSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/ListSelect.tsx
@@ -5,6 +5,7 @@ import {BasePlugin, BaseEventContext} from 'amis-editor-core';
 import {formItemControl} from '../../component/BaseControl';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 import {resolveOptionType} from '../../util';
+import type {Schema} from 'amis';
 
 export class ListControlPlugin extends BasePlugin {
   static id = 'ListControlPlugin';
@@ -118,7 +119,7 @@ export class ListControlPlugin extends BasePlugin {
             getSchemaTpl('multiple'),
             getSchemaTpl('extractValue'),
             getSchemaTpl('valueFormula', {
-              rendererSchema: context?.schema,
+              rendererSchema: (schema: Schema) => schema,
               mode: 'vertical',
               useSelectMode: true, // 改用 Select 设置模式
               visibleOn: 'this.options && this.options.length > 0'

--- a/packages/amis-editor/src/plugin/Form/NestedSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/NestedSelect.tsx
@@ -9,6 +9,7 @@ import {BasePlugin, BaseEventContext, tipedLabel} from 'amis-editor-core';
 import {ValidatorTag} from '../../validator';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {resolveOptionType} from '../../util';
+import type {Schema} from 'amis';
 
 export class NestedSelectControlPlugin extends BasePlugin {
   static id = 'NestedSelectControlPlugin';
@@ -304,7 +305,7 @@ export class NestedSelectControlPlugin extends BasePlugin {
                 }
               ],
               getSchemaTpl('valueFormula', {
-                rendererSchema: context?.schema
+                rendererSchema: (schema: Schema) => schema
               }),
               getSchemaTpl('hideNodePathLabel'),
               getSchemaTpl('labelRemark'),

--- a/packages/amis-editor/src/plugin/Form/Radios.tsx
+++ b/packages/amis-editor/src/plugin/Form/Radios.tsx
@@ -6,6 +6,7 @@ import {ValidatorTag} from '../../validator';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 import {resolveOptionType} from '../../util';
+import type {Schema} from 'amis';
 
 export class RadiosControlPlugin extends BasePlugin {
   static id = 'RadiosControlPlugin';
@@ -128,7 +129,7 @@ export class RadiosControlPlugin extends BasePlugin {
               }),
               getSchemaTpl('label'),
               getSchemaTpl('valueFormula', {
-                rendererSchema: context?.schema,
+                rendererSchema: (schema: Schema) => schema,
                 useSelectMode: true, // 改用 Select 设置模式
                 visibleOn: 'this.options && this.options.length > 0'
               }),

--- a/packages/amis-editor/src/plugin/Form/Select.tsx
+++ b/packages/amis-editor/src/plugin/Form/Select.tsx
@@ -14,7 +14,7 @@ import {ValidatorTag} from '../../validator';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {resolveOptionType} from '../../util';
 
-import type {RendererProps} from 'amis';
+import type {Schema} from 'amis';
 import type {
   EditorNodeType,
   RendererPluginAction,
@@ -296,15 +296,7 @@ export class SelectControlPlugin extends BasePlugin {
               }),
               getSchemaTpl('checkAll'),
               getSchemaTpl('valueFormula', {
-                rendererSchema: () => {
-                  const schema = this.manager.store.getSchema(
-                    context.schema?.id,
-                    'id'
-                  );
-                  return {
-                    ...schema
-                  };
-                }
+                rendererSchema: (schema: Schema) => schema
               }),
               getSchemaTpl('labelRemark'),
               getSchemaTpl('remark'),

--- a/packages/amis-editor/src/plugin/Form/Transfer.tsx
+++ b/packages/amis-editor/src/plugin/Form/Transfer.tsx
@@ -7,6 +7,7 @@ import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
 import {ValidatorTag} from '../../validator';
 import {tipedLabel} from 'amis-editor-core';
 import {resolveOptionType} from '../../util';
+import type {Schema} from 'amis';
 
 export class TransferPlugin extends BasePlugin {
   static id = 'TransferPlugin';
@@ -184,11 +185,11 @@ export class TransferPlugin extends BasePlugin {
               }),
               getSchemaTpl('label'),
               getSchemaTpl('valueFormula', {
-                rendererSchema: {
-                  ...context?.schema,
+                rendererSchema: (schema: Schema) => ({
+                  ...schema,
                   type: 'select',
                   multiple: true
-                },
+                }),
                 visibleOn: 'data.options.length > 0'
               }),
               getSchemaTpl('labelRemark'),

--- a/packages/amis-editor/src/plugin/Pagination.tsx
+++ b/packages/amis-editor/src/plugin/Pagination.tsx
@@ -20,7 +20,7 @@ export class PaginationPlugin extends BasePlugin {
   name = '分页组件';
   isBaseComponent = true;
   description = '分页组件，可以对列表进行分页展示，提高页面性能';
-  tags = ['容器'];
+  tags = ['展示'];
   icon = 'fa fa-window-minimize';
   lastLayoutSetting = ['pager'];
   layoutOptions = [

--- a/packages/amis-editor/src/renderer/FormulaControl.tsx
+++ b/packages/amis-editor/src/renderer/FormulaControl.tsx
@@ -98,7 +98,7 @@ export interface FormulaControlProps extends FormControlProps {
    * 自定义渲染器:
    * 备注: 可用于设置指定组件类型编辑默认值，支持回调函数，但不支持异步获取
    */
-  rendererSchema?: any; // SchemaObject | Function | undefined;
+  rendererSchema?: any; // SchemaObject | (schema: Schema) => Schema | undefined;
 
   /**
    * 自定义渲染器 是否需要浅色边框包裹，默认不包裹
@@ -240,7 +240,8 @@ export default class FormulaControl extends React.Component<
     }
 
     if (typeof rendererSchema === 'function') {
-      return rendererSchema();
+      const schema = this.props.data ? {...this.props.data} : undefined;
+      return rendererSchema(schema);
     } else {
       return rendererSchema;
     }


### PR DESCRIPTION
### What

- 修复表单类组件，在修改配置面板后默认值没有同步更新的问题
- 修复 InputTag 组件默认schema


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4eb4b19</samp>

> _Sing, O Muse, of the skillful refactorer_
> _Who with `amis`'s `Schema` type did render_
> _The `valueFormula` schema template_
> _More type-safe and readable in every aspect_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4eb4b19</samp>

*  Refactor the `rendererSchema` property of the `valueFormula` schema template to accept a function that returns a schema value, instead of a schema object. This simplifies the logic and avoids using the `context` variable that may be undefined. ([link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-ff3f4187b50d4f132c5ad5cec4a6ba113c8419508e8475325eebb6d3a482b24eR13), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-ff3f4187b50d4f132c5ad5cec4a6ba113c8419508e8475325eebb6d3a482b24eL129-R130), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-917a57d1cce34ec40de3b9031528fd56b7ef99391c1d66eab212a15b0c845ee5R16), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-917a57d1cce34ec40de3b9031528fd56b7ef99391c1d66eab212a15b0c845ee5L117-R118), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-4a3c5c6e5498b74e1254ee4f776efe0e8de65ee84a90f59472e29990f67e2978R18), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-4a3c5c6e5498b74e1254ee4f776efe0e8de65ee84a90f59472e29990f67e2978L169-R170), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-1c7f461a21fc4884ff77f39f4a1346562ddd7d0b598ea8a571581eed4086c56bR16), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-1c7f461a21fc4884ff77f39f4a1346562ddd7d0b598ea8a571581eed4086c56bL121-R122), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-b2fbf87e05b744e08c1257bc524b94cce8950b94797e28818f063fa9d887f7ecR9), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-b2fbf87e05b744e08c1257bc524b94cce8950b94797e28818f063fa9d887f7ecL350-R351), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-627192cd96af48f2c73d0e47b271a92ab1873e7017bb7287c09fad69e84c7952L171-R176), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-55fdd7d5626a1567f50acdbe20595be990fee38dbea26e0ea0e235f7cba3c57fR19), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-55fdd7d5626a1567f50acdbe20595be990fee38dbea26e0ea0e235f7cba3c57fL421-R425), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-235237c89adc972d4bf87380300ca947a5a5de87d01b59c1bff98b4c95fa6f27R8), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-235237c89adc972d4bf87380300ca947a5a5de87d01b59c1bff98b4c95fa6f27L121-R122), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-e4d19f31504ac61326d584930f7e66a1fe15dd8ded2886612df93a0ceaad3227R12), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-e4d19f31504ac61326d584930f7e66a1fe15dd8ded2886612df93a0ceaad3227L307-R308), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-ba6026b81d4a0bfe6ae014d8852678b351d6972fe75ae94732113ebea70a4435R9), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-ba6026b81d4a0bfe6ae014d8852678b351d6972fe75ae94732113ebea70a4435L131-R132), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-83d37f4c45d6ac38e41a04b6511b7921d73c2b0a35163df31401c8c0f408e0c4L17-R17), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-83d37f4c45d6ac38e41a04b6511b7921d73c2b0a35163df31401c8c0f408e0c4L299-R299), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-1407e54f85bb9fa414ee7d73970297153339f0f0d6beb000dd91ac026b73e912R10), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-1407e54f85bb9fa414ee7d73970297153339f0f0d6beb000dd91ac026b73e912L187-R192), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-ce07d539e9ec5eccae74ef6ee3032524b9a77ca3519a9f600cf3065ceaced70bL101-R101), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-ce07d539e9ec5eccae74ef6ee3032524b9a77ca3519a9f600cf3065ceaced70bL243-R244))
* Import the `Schema` type from `amis` to use it in the `rendererSchema` property of the `valueFormula` schema template, instead of the `RendererProps` type or no type. This makes the type more accurate and consistent. ([link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-ff3f4187b50d4f132c5ad5cec4a6ba113c8419508e8475325eebb6d3a482b24eR13), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-917a57d1cce34ec40de3b9031528fd56b7ef99391c1d66eab212a15b0c845ee5R16), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-4a3c5c6e5498b74e1254ee4f776efe0e8de65ee84a90f59472e29990f67e2978R18), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-1c7f461a21fc4884ff77f39f4a1346562ddd7d0b598ea8a571581eed4086c56bR16), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-b2fbf87e05b744e08c1257bc524b94cce8950b94797e28818f063fa9d887f7ecR9), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-57750c096cc98f331f2101f229a6afcb6c830bba8f0b5cdcdc0bf130286c6961R11), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-627192cd96af48f2c73d0e47b271a92ab1873e7017bb7287c09fad69e84c7952R14), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-55fdd7d5626a1567f50acdbe20595be990fee38dbea26e0ea0e235f7cba3c57fR19), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-235237c89adc972d4bf87380300ca947a5a5de87d01b59c1bff98b4c95fa6f27R8), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-e4d19f31504ac61326d584930f7e66a1fe15dd8ded2886612df93a0ceaad3227R12), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-ba6026b81d4a0bfe6ae014d8852678b351d6972fe75ae94732113ebea70a4435R9), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-83d37f4c45d6ac38e41a04b6511b7921d73c2b0a35163df31401c8c0f408e0c4L17-R17), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-1407e54f85bb9fa414ee7d73970297153339f0f0d6beb000dd91ac026b73e912R10))
* Modify the `rendererSchema` function for the `InputDateRange` component to return a modified schema with different properties for different modes and values. This preserves the original logic of customizing the schema for the date range component. ([link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-57750c096cc98f331f2101f229a6afcb6c830bba8f0b5cdcdc0bf130286c6961L408-R413), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-57750c096cc98f331f2101f229a6afcb6c830bba8f0b5cdcdc0bf130286c6961L422-R427), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-57750c096cc98f331f2101f229a6afcb6c830bba8f0b5cdcdc0bf130286c6961L435-R440), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-57750c096cc98f331f2101f229a6afcb6c830bba8f0b5cdcdc0bf130286c6961L449-R454), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-57750c096cc98f331f2101f229a6afcb6c830bba8f0b5cdcdc0bf130286c6961L463-R468))
* Modify the `options` property of the `scaffold` object and the `value` property of the `body` object in the `InputTag` component to use objects with `label` and `value` properties instead of strings. This fixes a bug that prevented the tag component from working properly with the `valueFormula` schema template. ([link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-627192cd96af48f2c73d0e47b271a92ab1873e7017bb7287c09fad69e84c7952L34-R39), [link](https://github.com/baidu/amis/pull/8171/files?diff=unified&w=0#diff-627192cd96af48f2c73d0e47b271a92ab1873e7017bb7287c09fad69e84c7952L43-R48))
