### PR TITLE
fix(amis-editor): flex组件「弹性设置」配置项变动时不自动添加overflowY和overflowX

### DIFF
--- a/packages/amis-editor/src/tpl/layout.tsx
+++ b/packages/amis-editor/src/tpl/layout.tsx
@@ -581,10 +581,10 @@ setSchemaTpl(
         if (value === '1 1 auto') {
           // 弹性
           if (config?.isFlexColumnItem) {
-            form.setValueByName('style.overflowY', 'auto');
+            // form.setValueByName('style.overflowY', 'auto');
             form.setValueByName('style.height', undefined);
           } else {
-            form.setValueByName('style.overflowX', 'auto');
+            // form.setValueByName('style.overflowX', 'auto');
             form.setValueByName('style.width', undefined);
           }
         } else if (value === '0 0 150px') {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d971be</samp>

Comment out overflow settings in `layout.tsx` to fix layout bug. This allows the layout component to handle different widget sizes and orientations without breaking.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1d971be</samp>

> _`overflow` hidden_
> _buggy layout now fixed_
> _autumn leaves fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1d971be</samp>

* Remove overflow settings from layout style to fix layout breaking bug ([link](https://github.com/baidu/amis/pull/8174/files?diff=unified&w=0#diff-45bfed43c25dfce3e1aae45c4315a2b224141c06f2ca5ecc7a029ea995ac473bL584-R587))
