### PR TITLE
chore: 调整 schema.children 用法中自定义 validate 上下文信息

### DIFF
--- a/packages/amis-core/src/SchemaRenderer.tsx
+++ b/packages/amis-core/src/SchemaRenderer.tsx
@@ -502,11 +502,20 @@ export class SchemaRenderer extends React.Component<SchemaRendererProps, any> {
 }
 
 class PlaceholderComponent extends React.Component {
+  childRef = React.createRef<any>();
+
+  getWrappedInstance() {
+    return this.childRef.current;
+  }
+
   render() {
     const {renderChildren, ...rest} = this.props as any;
 
     if (typeof renderChildren === 'function') {
-      return renderChildren(rest);
+      return renderChildren({
+        ...rest,
+        ref: this.childRef
+      });
     }
 
     return null;

--- a/packages/amis-core/src/renderers/wrapControl.tsx
+++ b/packages/amis-core/src/renderers/wrapControl.tsx
@@ -320,7 +320,7 @@ export function wrapControl<
 
             const formItem = this.model as IFormItemStore;
             if (formItem && validate) {
-              let finalValidate = promisify(validate.bind(formItem));
+              let finalValidate = promisify(validate.bind(this.control));
               this.hook2 = () => {
                 formItem.clearError('control:valdiate');
                 return finalValidate(

--- a/packages/amis-ui/src/components/FormField.tsx
+++ b/packages/amis-ui/src/components/FormField.tsx
@@ -152,7 +152,7 @@ function FormField(props: FormFieldProps) {
   );
 }
 
-const ThemedFormField = themeable(localeable(FormField));
+const ThemedFormField = themeable(localeable(React.memo(FormField)));
 
 export default ThemedFormField;
 
@@ -176,11 +176,14 @@ export interface ControllerProps
 export function Controller(props: ControllerProps) {
   const {render, name, shouldUnregister, defaultValue, control, wrap, ...rest} =
     props;
-  let rules = {...props.rules};
+  const rules = React.useMemo(() => {
+    const rules = {...props.rules};
 
-  if (rest.isRequired) {
-    rules.required = true;
-  }
+    if (props.isRequired) {
+      rules.required = true;
+    }
+    return rules;
+  }, [props.rules, props.isRequired]);
 
   return (
     <ReactHookFormController

--- a/packages/amis-ui/src/components/InputTable.tsx
+++ b/packages/amis-ui/src/components/InputTable.tsx
@@ -330,7 +330,7 @@ export interface InputTableRowProps {
   formRef: (form: UseFormReturn | null, id: string) => void;
 }
 
-export function InputTableRow({
+export const InputTableRow = React.memo(function InputTableRow({
   value,
   columns,
   index,
@@ -363,6 +363,6 @@ export function InputTableRow({
       ))}
     </>
   );
-}
+});
 
 export default themeable(localeable(InputTable));

--- a/packages/amis-ui/src/hooks/use-sub-form.ts
+++ b/packages/amis-ui/src/hooks/use-sub-form.ts
@@ -34,7 +34,8 @@ const useSubForm = (
   // 监控数值变化，自动同步到上层
   React.useEffect(() => {
     const subscriber = methods.watch((data: any) => {
-      lazyUpdate.current(data);
+      // 因为 watch 只会触发有表单项的数值，而原始数据中可能包含其他属性，所以要合并一下
+      lazyUpdate.current({...defaultValue, ...data});
     });
     return () => subscriber.unsubscribe();
   }, [methods.watch]);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9bedab</samp>

This pull request fixes a bug in the custom validation function of control components and adds a feature to access the instance of schema components dynamically. It modifies the `wrapControl` function in `wrapControl.tsx` and the `PlaceholderComponent` class in `SchemaRenderer.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c9bedab</samp>

> _`wrapControl` fixes_
> _context for validation_
> _autumn bug no more_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c9bedab</samp>

*  Fix the context of the custom validation function for control components ([link](https://github.com/baidu/amis/pull/8175/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL323-R323))
*  Add a way to access the instance of the schema component from the parent component ([link](https://github.com/baidu/amis/pull/8175/files?diff=unified&w=0#diff-337f9a56707dbfa5917084f1e2048555a5ade95f13df3f685076114867426347L505-R518))
