### PR TITLE
fix: picker非内嵌模式初次选中回显问题修复

### DIFF
--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -15,7 +15,6 @@ import {
   getVariable,
   qsstringify,
   qsparse,
-  isArrayChildrenModified,
   isIntegerInRange
 } from 'amis-core';
 import {ScopedContext, IScopedContext} from 'amis-core';
@@ -589,13 +588,9 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     }
 
     let val: any;
-
     if (
       this.props.pickerMode &&
-      isArrayChildrenModified(
-        (val = getPropValue(this.props)),
-        getPropValue(prevProps)
-      ) &&
+      !isEqual((val = getPropValue(this.props)), getPropValue(prevProps)) &&
       !isEqual(val, store.selectedItems.concat())
     ) {
       /**


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cde0fc7</samp>

Use a custom `isEqual` function to compare array objects in `isArrayChildrenModified`. This improves the rendering logic of amis by avoiding unnecessary re-renders or missed updates.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cde0fc7</samp>

> _`isEqual` checks deep_
> _arrays of objects differ_
> _autumn leaves change hue_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cde0fc7</samp>

* Replace strict and loose equality operators with deep comparison function in `isArrayChildrenModified` ([link](https://github.com/baidu/amis/pull/8177/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL339-R341)) to avoid false positives in rendering logic
