### PR TITLE
fix: 组合穿梭器 可检索功能无效问题 & 配置面板调整

### DIFF
--- a/packages/amis-editor/src/plugin/Form/TabsTransfer.tsx
+++ b/packages/amis-editor/src/plugin/Form/TabsTransfer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {EditorNodeType, getSchemaTpl} from 'amis-editor-core';
+import {EditorNodeType, getSchemaTpl, tipedLabel} from 'amis-editor-core';
 import {registerEditorPlugin} from 'amis-editor-core';
 import {BasePlugin, BaseEventContext} from 'amis-editor-core';
 
@@ -24,16 +24,15 @@ export class TabsTransferPlugin extends BasePlugin {
   scaffold = {
     label: '组合穿梭器',
     type: 'tabs-transfer',
-    name: 'a',
-    sortable: true,
-    searchable: true,
+    name: 'tabsTransfer',
+    selectMode: 'tree',
     options: [
       {
         label: '成员',
-        selectMode: 'tree',
         children: [
           {
             label: '法师',
+            value: 'fashi',
             children: [
               {
                 label: '诸葛亮',
@@ -43,6 +42,7 @@ export class TabsTransferPlugin extends BasePlugin {
           },
           {
             label: '战士',
+            value: 'zhanshi',
             children: [
               {
                 label: '曹操',
@@ -56,6 +56,7 @@ export class TabsTransferPlugin extends BasePlugin {
           },
           {
             label: '打野',
+            value: 'daye',
             children: [
               {
                 label: '李白',
@@ -75,10 +76,10 @@ export class TabsTransferPlugin extends BasePlugin {
       },
       {
         label: '用户',
-        selectMode: 'chained',
         children: [
           {
             label: '法师',
+            value: 'fashi',
             children: [
               {
                 label: '诸葛亮',
@@ -88,6 +89,7 @@ export class TabsTransferPlugin extends BasePlugin {
           },
           {
             label: '战士',
+            value: 'zhanshi',
             children: [
               {
                 label: '曹操',
@@ -101,6 +103,7 @@ export class TabsTransferPlugin extends BasePlugin {
           },
           {
             label: '打野',
+            value: 'daye',
             children: [
               {
                 label: '李白',
@@ -280,19 +283,11 @@ export class TabsTransferPlugin extends BasePlugin {
                 required: true
               }),
               getSchemaTpl('label'),
-
-              getSchemaTpl('searchable'),
-
-              getSchemaTpl('api', {
-                label: '检索接口',
-                name: 'searchApi'
-              }),
-
               {
-                label: '查询时勾选展示模式',
-                name: 'searchResultMode',
+                label: '左侧选项展示',
+                name: 'selectMode',
                 type: 'select',
-                mode: 'normal',
+                value: 'tree',
                 options: [
                   {
                     label: '列表形式',
@@ -312,22 +307,33 @@ export class TabsTransferPlugin extends BasePlugin {
                   }
                 ]
               },
-
-              getSchemaTpl('sortable'),
-
-              {
-                label: '左侧选项标题',
-                name: 'selectTitle',
-                type: 'input-text',
-                inputClassName: 'is-inline '
-              },
-
               {
                 label: '右侧结果标题',
                 name: 'resultTitle',
                 type: 'input-text',
-                inputClassName: 'is-inline '
-              }
+                inputClassName: 'is-inline ',
+                placeholder: '已选项'
+              },
+              getSchemaTpl('sortable'),
+              getSchemaTpl('searchable', {
+                onChange: (value: any, origin: any, item: any, form: any) => {
+                  if (!value) {
+                    form.setValues({
+                      searchApi: undefined
+                    });
+                  }
+                }
+              }),
+
+              getSchemaTpl('apiControl', {
+                label: tipedLabel(
+                  '检索接口',
+                  '可以通过接口获取检索结果，检索值可以通过变量\\${term}获取，如："https://xxx/search?name=\\${term}"'
+                ),
+                mode: 'normal',
+                name: 'searchApi',
+                visibleOn: '!!searchable'
+              })
             ]
           },
           {
@@ -337,7 +343,14 @@ export class TabsTransferPlugin extends BasePlugin {
                 $ref: 'options',
                 name: 'options'
               },
-              getSchemaTpl('source'),
+              getSchemaTpl('apiControl', {
+                label: tipedLabel(
+                  '获取选项接口',
+                  '可以通过接口获取动态选项，一次拉取全部'
+                ),
+                mode: 'normal',
+                name: 'source'
+              }),
               getSchemaTpl(
                 'loadingConfig',
                 {
@@ -347,15 +360,11 @@ export class TabsTransferPlugin extends BasePlugin {
               ),
               getSchemaTpl('joinValues'),
               getSchemaTpl('delimiter'),
-              getSchemaTpl('extractValue'),
-              getSchemaTpl('autoFillApi', {
-                visibleOn:
-                  '!this.autoFill || this.autoFill.scene && this.autoFill.action'
-              }),
-              getSchemaTpl('autoFill', {
-                visibleOn:
-                  '!this.autoFill || !this.autoFill.scene && !this.autoFill.action'
-              })
+              getSchemaTpl('extractValue')
+              // getSchemaTpl('autoFillApi', {
+              //   visibleOn:
+              //     '!this.autoFill || this.autoFill.scene && this.autoFill.action'
+              // })
             ]
           },
           {

--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -1017,18 +1017,21 @@ setSchemaTpl('borderMode', {
   pipeIn: defaultValue('full')
 });
 
-setSchemaTpl('searchable', () =>
+setSchemaTpl('searchable', (schema: object = {}) =>
   getSchemaTpl('switch', {
     label: '可检索',
-    name: 'searchable'
+    name: 'searchable',
+    ...schema
   })
 );
 
-setSchemaTpl('sortable', {
-  type: 'switch',
-  label: '可排序',
-  name: 'sortable'
-});
+setSchemaTpl('sortable', (schema: object = {}) =>
+  getSchemaTpl('switch', {
+    label: '可排序',
+    name: 'sortable',
+    ...schema
+  })
+);
 
 setSchemaTpl('onlyLeaf', {
   type: 'switch',

--- a/packages/amis-ui/src/components/TabsTransfer.tsx
+++ b/packages/amis-ui/src/components/TabsTransfer.tsx
@@ -52,6 +52,8 @@ export interface TabsTransferProps
   activeKey: number;
   onlyChildren?: boolean;
   ctx?: Record<string, any>;
+  selectMode?: 'table' | 'list' | 'tree' | 'chained' | 'associated';
+  searchable?: boolean;
 }
 
 export interface TabsTransferState {
@@ -167,12 +169,13 @@ export class TabsTransfer extends React.Component<
       itemHeight,
       virtualThreshold,
       onlyChildren,
+      selectMode,
       loadingConfig,
       valueField = 'value',
       labelField = 'label'
     } = this.props;
     const options = searchResult || [];
-    const mode = searchResultMode;
+    const mode = searchResultMode || selectMode; // 没有配置时默认和左侧选项展示形式一致
 
     return mode === 'table' ? (
       <TableCheckboxes
@@ -268,7 +271,8 @@ export class TabsTransfer extends React.Component<
       classnames: cx,
       translate: __,
       ctx,
-      mobileUI
+      mobileUI,
+      searchable
     } = this.props;
     const showOptions = options.filter(item => item.visible !== false);
 
@@ -297,7 +301,7 @@ export class TabsTransfer extends React.Component<
             )}
             className="TabsTransfer-tab"
           >
-            {option.searchable ? (
+            {option.searchable || searchable ? (
               <div
                 className={cx('TabsTransfer-search', {'is-mobile': mobileUI})}
               >
@@ -348,8 +352,9 @@ export class TabsTransfer extends React.Component<
       valueField = 'value',
       labelField = 'label'
     } = this.props;
+    const selectMode = option.selectMode || this.props.selectMode;
 
-    return option.selectMode === 'table' ? (
+    return selectMode === 'table' ? (
       <TableCheckboxes
         className={cx('Transfer-checkboxes')}
         columns={option.columns as any}
@@ -366,7 +371,7 @@ export class TabsTransfer extends React.Component<
         valueField={valueField}
         labelField={labelField}
       />
-    ) : option.selectMode === 'tree' ? (
+    ) : selectMode === 'tree' ? (
       <Tree
         loadingConfig={loadingConfig}
         className={cx('Transfer-checkboxes')}
@@ -395,7 +400,7 @@ export class TabsTransfer extends React.Component<
         valueField={valueField}
         labelField={labelField}
       />
-    ) : option.selectMode === 'chained' ? (
+    ) : selectMode === 'chained' ? (
       <ChainedCheckboxes
         className={cx('Transfer-checkboxes')}
         options={option.children || []}
@@ -420,7 +425,7 @@ export class TabsTransfer extends React.Component<
         valueField={valueField}
         labelField={labelField}
       />
-    ) : option.selectMode === 'associated' ? (
+    ) : selectMode === 'associated' ? (
       <AssociatedCheckboxes
         className={cx('Transfer-checkboxes')}
         options={option.children || []}

--- a/packages/amis/src/renderers/Form/TabsTransfer.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransfer.tsx
@@ -289,6 +289,8 @@ export class TabsTransferRenderer extends BaseTabsTransferRenderer<TabsTransferP
       sortable,
       loading,
       searchResultMode,
+      selectMode,
+      searchable,
       showArrow,
       deferLoad,
       leftDeferLoad,
@@ -325,6 +327,8 @@ export class TabsTransferRenderer extends BaseTabsTransferRenderer<TabsTransferP
           onLeftDeferLoad={leftDeferLoad}
           selectTitle={selectTitle}
           resultTitle={resultTitle}
+          selectMode={selectMode}
+          searchable={searchable}
           optionItemRender={menuTpl ? this.optionItemRender : undefined}
           resultItemRender={valueTpl ? this.resultItemRender : undefined}
           onTabChange={this.onTabChange}


### PR DESCRIPTION
### What
1. 解决组合穿梭器配置面板，可检索功能不生效问题
2. 去除左侧选项标题配置（在组合穿梭框左侧面板没有实际用到）
3. 去掉“查询时勾选展示模式”配置项，新增“左侧选项展示”配置，查询展示模式和左侧选项展示形式保持一致
4. 去除自动填充配置项（配置了没有用）
5. 配置项位置调整
6. 组合穿梭器默认schema调整（1. 去除options中的selectMode，从外部定义左侧展示类型，否则用户除了改schema没有其他办法； 2. 补充value值，否则在table下选中值不会生效；3. 可检索、可排序默认为false，与amis文档保持一致）

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 81e58d3</samp>

*  Import `tipedLabel` function to create labels with tooltips for some schema properties ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL2-R2))
* Change the `name` property of the `TabsTransferPlugin` from `a` to `tabsTransfer` to match the type and avoid conflicts ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL27-R35))
* Add the `selectMode` property to the plugin schema to allow users to choose the display mode of the left options ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL27-R35), [link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL283-R290))
* Remove the `sortable` and `searchable` properties from the plugin schema as they are now inherited from the `BasePlugin` ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL27-R35))
* Change the `children` property of the first option to an array to match the expected format of the `Tree` component ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL27-R35))
* Add the `value` property to the children of the first option to provide unique identifiers for the `Tree` component ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dR45), [link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dR59))
* Remove the `selectMode` property from the second option as it is now inherited from the plugin schema ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL78-R82))
* Change the `children` property of the second option to an array to match the expected format of the `ChainedCheckboxes` component ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL78-R82))
* Add the `value` property to the children of the second option to provide unique identifiers for the `ChainedCheckboxes` component ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dR92), [link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dR106))
* Add the `searchResultMode` schema template to allow users to choose the display mode of the right results when searching ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL315-R336))
* Remove the `selectTitle` schema template as it is not used by the `TabsTransfer` component ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL315-R336))
* Modify the `resultTitle` schema template to add a placeholder `已选项` to indicate the default title of the right results ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL315-R336))
* Replace the `source` schema template by an `apiControl` schema template to allow users to configure an API to fetch dynamic options ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL340-R353))
* Comment out the `autoFillApi` and `autoFill` schema templates as they are not supported by the `TabsTransfer` component ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL350-R367))
* Modify the `searchable` and `sortable` schema templates to accept an optional schema object as an argument and spread it to the `switch` schema template ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05L1020-R1034))
* Add the `selectMode` and `searchable` properties to the `TabsTransferProps` interface to pass them from the renderer to the component ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644R55-R56))
* Modify the `mode` variable to use the `searchResultMode` or the `selectMode` props if they are defined, otherwise use the `selectMode` of the option ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644L175-R178))
* Add the `searchable` prop to the destructuring assignment of the props object in the `TabsTransfer` component ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644L271-R275))
* Modify the condition for rendering the search input to use the `searchable` prop or the `option.searchable` property if they are defined, otherwise use `false` ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644L300-R304))
* Define the `selectMode` variable to use the `option.selectMode` or the `selectMode` prop if they are defined, otherwise use `list` ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644L351-R357))
* Modify the conditions for rendering the `Tree`, `ChainedCheckboxes`, and `AssociatedCheckboxes` components to use the `selectMode` variable instead of the `option.selectMode` property ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644L369-R374), [link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644L398-R403), [link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-7795f33137230cb1bb370e31db60385e814b4a25fa8a1e517cf212cb40251644L423-R428))
* Add the `selectMode` and `searchable` props to the destructuring assignment of the props object in the `TabsTransferRenderer` class ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-36d4a19803ba21094b5aee307abb8b8c5cad04fcb3c373082cddf1566b591f21R292-R293))
* Pass the `selectMode` and `searchable` props to the `TabsTransfer` component in the `TabsTransferRenderer` class ([link](https://github.com/baidu/amis/pull/8180/files?diff=unified&w=0#diff-36d4a19803ba21094b5aee307abb8b8c5cad04fcb3c373082cddf1566b591f21R330-R331))
