### PR TITLE
fix: 修复 cards 里面再用 crud 报错导致 无限刷新问题

### DIFF
--- a/packages/amis-core/src/SchemaRenderer.tsx
+++ b/packages/amis-core/src/SchemaRenderer.tsx
@@ -64,7 +64,8 @@ export const RENDERER_TRANSMISSION_OMIT_PROPS = [
   'label',
   'renderLabel',
   'trackExpression',
-  'editorSetting'
+  'editorSetting',
+  'updatePristineAfterStoreDataReInit'
 ];
 
 const componentCache: SimpleMap = new SimpleMap();

--- a/packages/amis-core/src/WithStore.tsx
+++ b/packages/amis-core/src/WithStore.tsx
@@ -207,7 +207,8 @@ export function HocStoreFactory(renderer: {
                 ...(store.hasRemoteData ? store.data : null), // todo 只保留 remote 数据
                 ...this.formatData(props.defaultData),
                 ...this.formatData(props.data)
-              })
+              }),
+              props.updatePristineAfterStoreDataReInit === false
             );
           }
         } else if (
@@ -234,7 +235,8 @@ export function HocStoreFactory(renderer: {
                       store,
                       props.syncSuperStore === true
                     )
-              )
+              ),
+              props.updatePristineAfterStoreDataReInit === false
             );
           } else if (props.data && (props.data as any).__super) {
             store.initData(
@@ -252,10 +254,14 @@ export function HocStoreFactory(renderer: {
                       store,
                       false
                     )
-              )
+              ),
+              props.updatePristineAfterStoreDataReInit === false
             );
           } else {
-            store.initData(createObject(props.scope, props.data));
+            store.initData(
+              createObject(props.scope, props.data),
+              props.updatePristineAfterStoreDataReInit === false
+            );
           }
         } else if (
           !props.trackExpression &&
@@ -278,8 +284,9 @@ export function HocStoreFactory(renderer: {
                 ...store.data
               }),
 
-              store.storeType === 'FormStore' &&
-                prevProps.store?.storeType === 'CRUDStore'
+              props.updatePristineAfterStoreDataReInit === false ||
+                (store.storeType === 'FormStore' &&
+                  prevProps.store?.storeType === 'CRUDStore')
             );
           }
           // nextProps.data.__super !== props.data.__super) &&
@@ -295,7 +302,8 @@ export function HocStoreFactory(renderer: {
             createObject(props.scope, {
               // ...nextProps.data,
               ...store.data
-            })
+            }),
+            props.updatePristineAfterStoreDataReInit === false
           );
         }
       }

--- a/packages/amis-ui/src/components/Combo.tsx
+++ b/packages/amis-ui/src/components/Combo.tsx
@@ -210,17 +210,18 @@ export function Combo({
     rules: finalRules
   });
 
-  const {trigger} = useFormContext();
+  const {trigger, setValue} = useFormContext();
 
   // useFieldArray 的 update 会更新行 id，导致重新渲染
   // 正在编辑中的元素失去焦点，所以自己写一个
   const lightUpdate = React.useCallback(
     (index: number, value: any) => {
-      const arr = control._getFieldArray(name);
-      arr[index] = {...value};
-      control._updateFieldArray(name, arr);
-      trigger(name);
-      control._subjects.watch.next({});
+      // const arr = control._getFieldArray(name);
+      // arr[index] = {...value};
+      // control._updateFieldArray(name, arr);
+      // trigger(name);
+      // control._subjects.watch.next({});
+      setValue(`${name}.${index}`, value);
     },
     [control]
   );

--- a/packages/amis/src/renderers/Cards.tsx
+++ b/packages/amis/src/renderers/Cards.tsx
@@ -279,7 +279,7 @@ export default class Cards extends React.Component<GridProps, object> {
     }
 
     updateItems && store.initItems(items);
-    typeof props.selected !== 'undefined' &&
+    Array.isArray(props.selected) &&
       store.updateSelected(props.selected, props.valueField);
     return updateItems;
   }

--- a/packages/amis/src/renderers/Form/Combo.tsx
+++ b/packages/amis/src/renderers/Form/Combo.tsx
@@ -1719,7 +1719,8 @@ export default class ComboControl extends React.Component<ComboProps> {
           ref: this.makeFormRef(0),
           onInit: this.handleSingleFormInit,
           canAccessSuperData,
-          formStore: undefined
+          formStore: undefined,
+          updatePristineAfterStoreDataReInit: false
         }
       );
     } else if (multiple && index !== undefined && index >= 0) {
@@ -1750,7 +1751,8 @@ export default class ComboControl extends React.Component<ComboProps> {
           value: undefined,
           formItemValue: undefined,
           formStore: undefined,
-          ...(tabsMode ? {} : {lazyLoad})
+          ...(tabsMode ? {} : {lazyLoad}),
+          updatePristineAfterStoreDataReInit: false
         }
       );
     }

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -673,7 +673,7 @@ export default class Table extends React.Component<TableProps, object> {
     }
 
     updateRows && store.initRows(rows, props.getEntryId, props.reUseRow);
-    typeof props.selected !== 'undefined' &&
+    Array.isArray(props.selected) &&
       store.updateSelected(props.selected, props.valueField);
     return updateRows;
   }

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -552,7 +552,7 @@ export default class Table2 extends React.Component<Table2Props, object> {
     let selectedRowKeys: Array<string | number> = [];
     const keyField = store.keyField;
     // selectedRowKeysExpr比selectedRowKeys优先级高
-    if (typeof props.selected !== 'undefined') {
+    if (Array.isArray(props.selected)) {
       selectedRowKeys = props.selected.map((item: any) => item[keyField]) || [];
     } else {
       if (props.rowSelection && props.rowSelection.selectedRowKeysExpr) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1889fa9</samp>

This pull request adds a new prop `updatePristineAfterStoreDataReInit` to control the pristine state of store data in various components, and fixes some type errors related to the `selected` prop in the `Combo`, `Cards`, `Table`, and `Table2` components. These changes improve the performance, reliability, and consistency of the data management and rendering logic in the `amis` library.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1889fa9</samp>

> _`updatePristine` prop_
> _controls form store and items_
> _changing with the wind_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1889fa9</samp>

*  Add a new prop `updatePristineAfterStoreDataReInit` to control the pristine state update of form stores ([link](https://github.com/baidu/amis/pull/8184/files?diff=unified&w=0#diff-337f9a56707dbfa5917084f1e2048555a5ade95f13df3f685076114867426347L67-R68), [link](https://github.com/baidu/amis/pull/8184/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1722-R1723), [link](https://github.com/baidu/amis/pull/8184/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1753-R1755))
*  Pass the `updatePristineAfterStoreDataReInit` prop to the `store.initData` method in different scenarios of store data initialization or update in `WithStore.tsx` ([link](https://github.com/baidu/amis/pull/8184/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL210-R211), [link](https://github.com/baidu/amis/pull/8184/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL237-R239), [link](https://github.com/baidu/amis/pull/8184/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL255-R264), [link](https://github.com/baidu/amis/pull/8184/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL281-R289), [link](https://github.com/baidu/amis/pull/8184/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL298-R306))
*  Modify the condition for passing the second argument to the `store.initData` method to cover more general cases of pristine state update ([link](https://github.com/baidu/amis/pull/8184/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL281-R289))
*  Replace the logic of updating a field array value with the `setValue` function from the `useFormContext` hook in `Combo.tsx` to improve efficiency and avoid unnecessary re-rendering ([link](https://github.com/baidu/amis/pull/8184/files?diff=unified&w=0#diff-36f970680bec71e24902089b8d0de6bad7530541f5b387a0b69dbb612f9f0dc4L213-R213), [link](https://github.com/baidu/amis/pull/8184/files?diff=unified&w=0#diff-36f970680bec71e24902089b8d0de6bad7530541f5b387a0b69dbb612f9f0dc4L219-R224))
*  Add type checks for the `props.selected` prop in `Cards.tsx`, `Table.tsx`, and `Table2.tsx` to avoid errors and inconsistencies when the prop is not an array ([link](https://github.com/baidu/amis/pull/8184/files?diff=unified&w=0#diff-83895e4b0993db67cbfb774b8539e7625318f250de1b4a848611cabedf9e828bL282-R282), [link](https://github.com/baidu/amis/pull/8184/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL676-R676), [link](https://github.com/baidu/amis/pull/8184/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L555-R555))
