### PR TITLE
fix(amis-editor): 数据源构造器兼容历史存量Schema

### DIFF
--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -585,8 +585,8 @@ export function JsonGenerateID(json: any) {
     return;
   }
 
-  if (json.type) {
-    //  && !json.id
+  /** 脚手架构建的Schema提前构建好了组件 ID，此时无需生成 ID，避免破坏事件动作 */
+  if (json.type && (!json.__origin || json.__origin !== 'scaffold')) {
     json.id = generateNodeId();
   }
 

--- a/packages/amis-editor/src/builder/DSBuilder.ts
+++ b/packages/amis-editor/src/builder/DSBuilder.ts
@@ -67,7 +67,7 @@ export interface DSBuilderInterface<
   filterByFeat(feat: any): boolean;
 
   /** 根据schema，判断是否匹配当前数据源  */
-  match(schema?: any): boolean;
+  match(schema?: any, key?: string): boolean;
 
   /** 当前上下文中使用的字段 */
   getContextFields(options: T): Promise<any>;
@@ -209,7 +209,7 @@ export abstract class DSBuilder<T extends DSBuilderBaseOptions>
     return feat && this.features.includes(feat);
   }
 
-  abstract match(schema?: any): boolean;
+  abstract match(schema?: any, key?: string): boolean;
 
   abstract getContextFields(options: T): Promise<any>;
 

--- a/packages/amis-editor/src/builder/DSBuilderManager.ts
+++ b/packages/amis-editor/src/builder/DSBuilderManager.ts
@@ -4,7 +4,10 @@
  */
 
 import {builderFactory, DSBuilderInterface} from './DSBuilder';
-import {EditorManager} from 'amis-editor-core';
+
+import type {EditorManager} from 'amis-editor-core';
+import type {GenericSchema} from './type';
+import type {Option} from 'amis-core';
 
 export class DSBuilderManager {
   private builders: Map<string, DSBuilderInterface>;
@@ -42,6 +45,11 @@ export class DSBuilderManager {
     return builder ? builder : this.getDefaultBuilder();
   }
 
+  /**
+   * 获取默认构建器Key
+   *
+   * @returns 返回默认构建器Key
+   */
   getDefaultBuilderKey() {
     const collections = Array.from(this.builders.entries()).filter(
       ([_, builder]) => builder?.disabledOn?.() !== true
@@ -56,6 +64,11 @@ export class DSBuilderManager {
     return defaultKey;
   }
 
+  /**
+   * 获取默认构建器
+   *
+   * @returns {Object} 默认构建器
+   */
   getDefaultBuilder() {
     const collections = Array.from(this.builders.entries()).filter(
       ([_, builder]) => builder?.disabledOn?.() !== true
@@ -70,6 +83,11 @@ export class DSBuilderManager {
     return defaultBuilder;
   }
 
+  /**
+   * 获取可用的构建器列表
+   *
+   * @returns 返回可用构建器的列表
+   */
   getAvailableBuilders() {
     return Array.from(this.builders.entries())
       .filter(([_, builder]) => builder?.disabledOn?.() !== true)
@@ -78,24 +96,65 @@ export class DSBuilderManager {
       });
   }
 
-  getDSSelectorSchema(patch: Record<string, any>) {
+  /**
+   * 获取数据选择器Schema
+   *
+   * @param patch - 需要进行补丁修复的配置对象
+   * @param config - 包含运行上下文和源键的配置对象
+   * @returns 返回一个对象，包含类型、标签、名称、可见性、选项、默认值和pipeIn等属性
+   */
+  getDSSelectorSchema(
+    patch: Record<string, any>,
+    config?: {
+      /** 组件 Schema */
+      schema: GenericSchema;
+      /** 组件数据源 Key */
+      sourceKey: string;
+      /** 获取默认值函数 */
+      getDefautlValue?: (key: string, builder: DSBuilderInterface) => Boolean;
+    }
+  ) {
+    const {schema, sourceKey, getDefautlValue} = config || {};
     const builders = this.getAvailableBuilders();
-    const options = builders.map(([key, builder]) => ({
-      label: builder.name,
-      value: key
-    }));
+    let defaultValue: string | undefined = schema?.dsType;
+    const options: Option[] = [];
+
+    for (const [key, builder] of builders) {
+      if (schema && !defaultValue) {
+        if (
+          getDefautlValue &&
+          typeof getDefautlValue === 'function' &&
+          getDefautlValue(key, builder)
+        ) {
+          defaultValue = key;
+        } else if (builder.match(schema, sourceKey)) {
+          defaultValue = key;
+        }
+      }
+
+      options.push({
+        label: builder.name,
+        value: key
+      });
+    }
 
     return {
       type: 'radios',
       label: '数据来源',
       name: 'dsType',
       visible: options.length > 0,
-      selectFirst: true,
       options: options,
+      ...(defaultValue ? {value: defaultValue} : {}),
       ...patch
     };
   }
 
+  /**
+   * 从构建器中生成集合
+   *
+   * @param callback 回调函数，用于处理每个构建器、构建器键和索引
+   * @returns 返回生成的集合
+   */
   buildCollectionFromBuilders(
     callback: (
       builder: DSBuilderInterface,

--- a/packages/amis-editor/src/builder/constants.ts
+++ b/packages/amis-editor/src/builder/constants.ts
@@ -128,3 +128,7 @@ export const FormOperatorMap: Record<FormOperatorValue, FormOperator> = {
 };
 
 export const ModelDSBuilderKey = 'model-entity';
+
+export const ApiDSBuilderKey = 'api';
+
+export const ApiCenterDSBuilderKey = 'apicenter';

--- a/packages/amis-editor/src/renderer/FieldSetting.tsx
+++ b/packages/amis-editor/src/renderer/FieldSetting.tsx
@@ -439,6 +439,7 @@ export class FieldSetting extends React.Component<
                                   className={'w-full'}
                                   hasError={!!fieldState.error}
                                   searchable
+                                  simpleValue
                                   disabled={false}
                                   clearable={false}
                                   popOverContainer={popOverContainer}
@@ -522,6 +523,7 @@ export class FieldSetting extends React.Component<
                                   className={'w-full'}
                                   hasError={!!fieldState.error}
                                   searchable
+                                  simpleValue
                                   disabled={false}
                                   clearable={false}
                                   popOverContainer={popOverContainer}

--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -1695,6 +1695,7 @@ setSchemaTpl('anchorNavTitle', {
   required: true
 });
 
+/** 给 CRUD2 使用 */
 setSchemaTpl('primaryField', {
   type: 'input-text',
   name: 'primaryField',
@@ -1702,5 +1703,17 @@ setSchemaTpl('primaryField', {
     '主键',
     '每行记录的唯一标识符，通常用于行选择、批量操作等场景。'
   ),
-  pipeIn: defaultValue('id')
+  pipeIn: (value: any, formStore: any) => {
+    const rowSelection = formStore?.data?.rowSelection;
+
+    if (value == null || typeof value !== 'string') {
+      return rowSelection &&
+        rowSelection?.keyField &&
+        typeof rowSelection.keyField === 'string'
+        ? rowSelection?.keyField
+        : 'id';
+    }
+
+    return value;
+  }
 });

--- a/packages/amis-ui/scss/components/_result-box.scss
+++ b/packages/amis-ui/scss/components/_result-box.scss
@@ -126,6 +126,7 @@
     margin-left: px2rem(4px);
     display: flex;
     justify-content: center;
+    align-items: center;
   }
 
   &-singleValue {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 87208af</samp>

This pull request enhances the data source configuration and selection features for various components in the amis-editor, such as CRUD2, Table2, Form, and Service. It also updates the data source builders and schemas to handle different types of api sources, and improves the compatibility, readability, and style of some code and UI elements. It involves changes to several files in the `packages/amis-editor`, `packages/amis-editor-core`, and `packages/amis-ui` directories.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 87208af</samp>

> _`amis-editor`_
> _enhances data sources, `CRUD2`_
> _autumn of refactor_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 87208af</samp>

*  Add `__origin` property to scaffold schemas to skip generating new ids ([link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL588-R589), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-84800995b352e55dac9d39fc260b3288d628b48ce9ed6a2d34b7338b0e74fa68R324-R326), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dR542-R544))
*  Add `key` parameter to `match` method of data source builders to match schema with source key ([link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-d401d093bfcc28e16e58fdc877a0cbe654ad86969ed23118030d66d7d70891c2L97-R99), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-fc44f1f0a3518a0bbaa5eb7eb69bc9f9c2cbf54e001ae7ae430ec8c0806763fcL70-R70), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-fc44f1f0a3518a0bbaa5eb7eb69bc9f9c2cbf54e001ae7ae430ec8c0806763fcL212-R212))
*  Add `config` parameter to `getDSSelectorSchema` method of `DSBuilderManager` to match schema and set default value for selector ([link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-bfee10c2d53f5327044fd5fa75c416d0c8e34005910fc916b41f52578013929fL81-R140), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-bfee10c2d53f5327044fd5fa75c416d0c8e34005910fc916b41f52578013929fL93-R157))
*  Add `generateDSControls` function to plugins to generate data source selector and settings based on `config` parameter ([link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-84800995b352e55dac9d39fc260b3288d628b48ce9ed6a2d34b7338b0e74fa68L518-R526), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dR542-R544), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-6a2f7c2cc26a108293bdd2d7ca6ca8d6b06acbf8e2d17424a50526d6affa6f67L189-R258))
*  Add `ApiDSBuilderKey` and `ApiCenterDSBuilderKey` constants to identify data source builders and their schemas ([link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-888f5e9a2e6476276499952fb7f02cbfda9da6104087f64cb2f7137bbcf45461R131-R134), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-84800995b352e55dac9d39fc260b3288d628b48ce9ed6a2d34b7338b0e74fa68L28-R29), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL28-R29), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-6a2f7c2cc26a108293bdd2d7ca6ca8d6b06acbf8e2d17424a50526d6affa6f67L16-R16))
*  Rename `multiple` to `enableMultiple` in scaffold config of `ApiDSBuilder` to be consistent with other features ([link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-d401d093bfcc28e16e58fdc877a0cbe654ad86969ed23118030d66d7d70891c2L1362-R1376))
*  Replace `rowSelection` with `selectable` and `multiple` properties in CRUD2 schema and panel ([link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-d401d093bfcc28e16e58fdc877a0cbe654ad86969ed23118030d66d7d70891c2L1378-R1389), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-84800995b352e55dac9d39fc260b3288d628b48ce9ed6a2d34b7338b0e74fa68L566-R624), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-ef341bca5195871956dc16f3feee9e62a37cf83eef9503a90d30903c7a99a5dcL897-R935))
*  Change display name and icon of CRUD2 plugin from '增删改查' to '表格2.0' ([link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-84800995b352e55dac9d39fc260b3288d628b48ce9ed6a2d34b7338b0e74fa68L61-R66))
*  Add comments to `DSBuilderManager` methods to explain their functionality ([link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-bfee10c2d53f5327044fd5fa75c416d0c8e34005910fc916b41f52578013929fR48-R52), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-bfee10c2d53f5327044fd5fa75c416d0c8e34005910fc916b41f52578013929fR67-R71), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-bfee10c2d53f5327044fd5fa75c416d0c8e34005910fc916b41f52578013929fR86-R90))
*  Modify condition to check normal api url in `ApiDSBuilder` to handle object with url property ([link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-d401d093bfcc28e16e58fdc877a0cbe654ad86969ed23118030d66d7d70891c2L115-R126))
*  Add `simpleValue` property to `source` control in `FieldSetting` to use simple value mode ([link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-826b212ace06045d989fcddc09c0da1071c579d4e57a23592138ff471bd6b7e0R442), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-826b212ace06045d989fcddc09c0da1071c579d4e57a23592138ff471bd6b7e0R526))
*  Add `align-items` property to `.ae-ResultBox` class to improve appearance of result box component ([link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-21f40f2463597a4f1f9a6a1513592095223ecfd51987e33cd984dd4ab7faa087R129))
*  Rename `isCRUDBody` to `isCRUDContext` in `Table2Plugin` to be consistent with method name ([link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-ef341bca5195871956dc16f3feee9e62a37cf83eef9503a90d30903c7a99a5dcL744-R745), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-ef341bca5195871956dc16f3feee9e62a37cf83eef9503a90d30903c7a99a5dcL758-R765), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-ef341bca5195871956dc16f3feee9e62a37cf83eef9503a90d30903c7a99a5dcL827-R828), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-ef341bca5195871956dc16f3feee9e62a37cf83eef9503a90d30903c7a99a5dcL847-R848))
*  Modify `pipeIn` functions of `feat`, `dsType`, and `primaryField` controls to set default value based on schema properties ([link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL642-R747), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL663-R767), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-ef341bca5195871956dc16f3feee9e62a37cf83eef9503a90d30903c7a99a5dcL897-R935), [link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05L1705-R1718))
*  Add filter function to `body` property of `Table2Plugin` to remove null values from array ([link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-ef341bca5195871956dc16f3feee9e62a37cf83eef9503a90d30903c7a99a5dcL983-R1000))
*  Add comment to `primaryField` function in `common.tsx` to explain its usage for CRUD2 component ([link](https://github.com/baidu/amis/pull/8186/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05R1698))
