### PR TITLE
fix: 修复自定义样式id混乱问题

### DIFF
--- a/packages/amis-core/src/components/CustomStyle.tsx
+++ b/packages/amis-core/src/components/CustomStyle.tsx
@@ -1,7 +1,11 @@
 import {useEffect, useRef} from 'react';
 import type {RendererEnv} from '../env';
-import type {InsertCustomStyle} from '../utils/style-helper';
-import {StyleDom} from '../utils/style-helper';
+import {
+  removeCustomStyle,
+  type InsertCustomStyle,
+  insertCustomStyle,
+  insertEditCustomStyle
+} from '../utils/style-helper';
 
 interface CustomStyleProps {
   config: {
@@ -17,37 +21,43 @@ export default function (props: CustomStyleProps) {
   if (!themeCss && !wrapperCustomStyle) {
     return null;
   }
-  const styleDom = useRef(new StyleDom(id || '')).current;
 
   useEffect(() => {
-    if (themeCss && styleDom.id) {
-      styleDom.insertCustomStyle({
+    if (themeCss && id) {
+      insertCustomStyle(
         themeCss,
         classNames,
+        id,
         defaultData,
-        customStyleClassPrefix: env?.customStyleClassPrefix,
-        doc: env.getModalContainer?.().ownerDocument
-      });
+        env?.customStyleClassPrefix,
+        env.getModalContainer?.().ownerDocument
+      );
     }
 
     return () => {
-      styleDom.removeCustomStyle('', env.getModalContainer?.().ownerDocument);
+      if (id) {
+        removeCustomStyle('', id, env.getModalContainer?.().ownerDocument);
+      }
     };
   }, [themeCss]);
 
   useEffect(() => {
-    if (wrapperCustomStyle && styleDom.id) {
-      styleDom.insertEditCustomStyle(
+    if (wrapperCustomStyle && id) {
+      insertEditCustomStyle(
         wrapperCustomStyle,
+        id,
         env.getModalContainer?.().ownerDocument
       );
     }
 
     return () => {
-      styleDom.removeCustomStyle(
-        'wrapperCustomStyle',
-        env.getModalContainer?.().ownerDocument
-      );
+      if (id) {
+        removeCustomStyle(
+          'wrapperCustomStyle',
+          id,
+          env.getModalContainer?.().ownerDocument
+        );
+      }
     };
   }, [wrapperCustomStyle]);
 

--- a/packages/amis-core/src/utils/style-helper.ts
+++ b/packages/amis-core/src/utils/style-helper.ts
@@ -342,55 +342,15 @@ export interface InsertCustomStyle {
   doc?: Document;
 }
 
-export class StyleDom {
-  id: string;
-  constructor(id: string) {
-    this.id = id;
-  }
-  /**
-   * 插入自定义样式
-   *
-   * @param {InsertCustomStyle} params - 插入自定义样式的参数
-   * @param {string} params.themeCss - 主题样式
-   * @param {string} params.classNames - 自定义样式类名
-   * @param {string} params.defaultData - 默认数据
-   * @param {string} params.customStyleClassPrefix - 自定义样式类名前缀
-   */
-  insertCustomStyle({
-    themeCss,
-    classNames,
-    defaultData,
-    customStyleClassPrefix,
-    doc
-  }: Omit<InsertCustomStyle, 'id'>) {
-    insertCustomStyle(
-      themeCss,
-      classNames,
-      this.id,
-      defaultData,
-      customStyleClassPrefix,
-      doc
-    );
-  }
-
-  /**
-   * 插入外层自定义样式
-   *
-   * @param wrapperCustomStyle 自定义样式
-   */
-  insertEditCustomStyle(wrapperCustomStyle: any, doc?: Document) {
-    insertEditCustomStyle(wrapperCustomStyle, this.id, doc);
-  }
-  /**
-   * 移除自定义样式
-   */
-  removeCustomStyle(type?: string, doc?: Document) {
-    const style = (doc || document).getElementById(
-      (type ? type + '-' : '') + this.id.replace('u:', '')
-    );
-    if (style) {
-      style.remove();
-    }
+/**
+ * 移除自定义样式
+ */
+export function removeCustomStyle(type: string, id: string, doc?: Document) {
+  const style = (doc || document).getElementById(
+    (type ? type + '-' : '') + id.replace('u:', '')
+  );
+  if (style) {
+    style.remove();
   }
 }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c2b0c7b</samp>

The pull request refactors the `CustomStyle` component and removes the `StyleDom` class. This improves the performance and simplicity of applying custom styles in `amis-core`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c2b0c7b</samp>

> _`StyleDom` is gone_
> _`CustomStyle` refactored_
> _Spring cleaning the code_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c2b0c7b</samp>

*  Simplify the logic of the `CustomStyle` component by using helper functions instead of a class instance ([link](https://github.com/baidu/amis/pull/8189/files?diff=unified&w=0#diff-64f487ea8bb551e6157d95133fcf65572d6990b062dd31bf6502543a77ad9fb5L3-R8), [link](https://github.com/baidu/amis/pull/8189/files?diff=unified&w=0#diff-64f487ea8bb551e6157d95133fcf65572d6990b062dd31bf6502543a77ad9fb5L20-R48), [link](https://github.com/baidu/amis/pull/8189/files?diff=unified&w=0#diff-64f487ea8bb551e6157d95133fcf65572d6990b062dd31bf6502543a77ad9fb5L47-R60))
*  Remove the unused `StyleDom` class from the `style-helper` module to reduce the module size ([link](https://github.com/baidu/amis/pull/8189/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL345-R354))
