### PR TITLE
chore(amis-editor): 编辑器减少主题css变量的重复引入

### DIFF
--- a/packages/amis-editor-core/scss/_mixin.scss
+++ b/packages/amis-editor-core/scss/_mixin.scss
@@ -88,7 +88,7 @@
 }
 
 @mixin panel-sm-content {
-  @extend :root;
+  // @extend :root;
   --fonts-size-7: #{$Editor-right-panel-font-size};
   --Form-input-lineHeight: #{$Editor-right-panel-line-height};
   --InputGroup-select-borderColor: #{$Editor-right-panel-border-color};

--- a/packages/amis-editor-core/src/component/Panel/RightPanels.tsx
+++ b/packages/amis-editor-core/src/component/Panel/RightPanels.tsx
@@ -102,6 +102,7 @@ export class RightPanels extends React.Component<
       <div
         className={cx(
           'editor-right-panel width-draggable',
+          'AMISCSSWrapper',
           panels.length > 1 ? 'mul-tabs-panel' : '',
           isOpenStatus ? '' : 'hidden-status',
           isFixedStatus ? 'fixed-status' : ''

--- a/packages/amis-editor-core/src/component/Preview.tsx
+++ b/packages/amis-editor-core/src/component/Preview.tsx
@@ -515,6 +515,7 @@ export default class Preview extends Component<PreviewProps> {
         onDrop={this.handleDrop}
         className={cx(
           'ae-Preview',
+          'AMISCSSWrapper',
           className,
           isMobile ? 'is-mobile-body hoverShowScrollBar' : 'is-pc-body'
         )}

--- a/packages/amis-editor-core/src/component/ScaffoldModal.tsx
+++ b/packages/amis-editor-core/src/component/ScaffoldModal.tsx
@@ -211,7 +211,7 @@ export class ScaffoldModal extends React.Component<SubEditorProps> {
         contentClassName={scaffoldFormContext?.className}
         show={!!scaffoldFormContext}
         onHide={this.handleCancelClick}
-        className="ae-scaffoldForm-Modal"
+        className="ae-scaffoldForm-Modal AMISCSSWrapper"
         closeOnEsc={!store.scaffoldFormBuzy}
       >
         <div className={cx('Modal-header')}>

--- a/packages/amis-editor/src/component/BaseControl.ts
+++ b/packages/amis-editor/src/component/BaseControl.ts
@@ -429,7 +429,7 @@ export function remarkTpl(config: {
       },
       body: {
         type: 'grid',
-        className: 'pt-4 right-panel-pop',
+        className: 'pt-4 right-panel-pop AMISCSSWrapper',
         gap: 'lg',
         columns: [
           {

--- a/packages/amis-editor/src/plugin/CRUD2/BaseCRUD.tsx
+++ b/packages/amis-editor/src/plugin/CRUD2/BaseCRUD.tsx
@@ -164,7 +164,7 @@ export class BaseCRUDPlugin extends BasePlugin {
           leftFixed: 'sm'
         }
       },
-      className: 'ae-Scaffold-Modal ae-Scaffold-Modal-content', //  ae-formItemControl
+      className: 'ae-Scaffold-Modal ae-Scaffold-Modal-content AMISCSSWrapper', //  ae-formItemControl
       stepsBody: true,
       canSkip: true,
       canRebuild: true,

--- a/packages/amis-editor/src/plugin/Form/Form.tsx
+++ b/packages/amis-editor/src/plugin/Form/Form.tsx
@@ -394,7 +394,7 @@ export class FormPlugin extends BasePlugin {
         }
       },
       canRebuild: true,
-      className: 'ae-Scaffold-Modal ae-Scaffold-Modal-content',
+      className: 'ae-Scaffold-Modal ae-Scaffold-Modal-content AMISCSSWrapper',
       body: [
         {
           type: 'radios',

--- a/packages/amis-editor/src/renderer/APIControl.tsx
+++ b/packages/amis-editor/src/renderer/APIControl.tsx
@@ -524,7 +524,7 @@ export default class APIControl extends React.Component<
 
     return {
       type: 'form',
-      className: 'ae-ApiControl-form',
+      className: 'ae-ApiControl-form AMISCSSWrapper',
       mode: 'horizontal',
       submitOnChange,
       wrapWithPanel: false,

--- a/packages/amis-editor/src/renderer/ActionApiControl.tsx
+++ b/packages/amis-editor/src/renderer/ActionApiControl.tsx
@@ -360,7 +360,7 @@ export default class APIControl extends React.Component<
   renderApiConfigTabs(messageDesc?: string, submitOnChange: boolean = false) {
     return {
       type: 'form',
-      className: 'ae-ApiControl-form',
+      className: 'ae-ApiControl-form AMISCSSWrapper',
       mode: 'horizontal',
       submitOnChange,
       wrapWithPanel: false,

--- a/packages/amis-editor/src/renderer/crud2-control/AddColumnModal.tsx
+++ b/packages/amis-editor/src/renderer/crud2-control/AddColumnModal.tsx
@@ -150,7 +150,7 @@ const AddColumnModal: React.FC<AddColumnModalProps> = props => {
         show={visible}
         onHide={onClose}
         closeOnEsc={false}
-        contentClassName="ae-Scaffold-Modal"
+        contentClassName="ae-Scaffold-Modal AMISCSSWrapper"
       >
         <Modal.Header showCloseButton onClose={onClose}>
           <Modal.Title>添加列</Modal.Title>

--- a/packages/amis-editor/src/renderer/event-control/action-config-dialog.tsx
+++ b/packages/amis-editor/src/renderer/event-control/action-config-dialog.tsx
@@ -363,7 +363,7 @@ export default class ActionDialog extends React.Component<ActionDialogProp> {
             style: {
               borderStyle: 'solid'
             },
-            className: 'action-config-panel'
+            className: 'action-config-panel AMISCSSWrapper'
           }
         ],
         onClose


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c25ce8c</samp>

This pull request adds the `AMISCSSWrapper` class name to various components and renderers that need the AMIS renderer CSS variables to display correctly. This class name is defined in the `_mixin.scss` file and imports the global CSS variables from the `:root` selector. The `@extend :root` directive was commented out in the `panel-sm-content` mixin to avoid conflicts with the global CSS variables.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c25ce8c</samp>

> _`AMISCSSWrapper`_
> _Wraps components in iframe_
> _Style them with variables_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c25ce8c</samp>

*  Add `AMISCSSWrapper` class name to various components and renderers that need the AMIS renderer CSS variables to match the style of the editor ([link](https://github.com/baidu/amis/pull/8192/files?diff=unified&w=0#diff-d3c81e20d56a4882dbecc7a467e1d265e41139cb2fad2f33269ea24f23470373R105), [link](https://github.com/baidu/amis/pull/8192/files?diff=unified&w=0#diff-d9b508133ad06e8946597f0255a1b4529b6fb9f0c2bf3c170e0fcef582fff0e9R518), [link](https://github.com/baidu/amis/pull/8192/files?diff=unified&w=0#diff-85faab9f8c432f5b71f49bdb3e107d8f36edae4199b8cc13dd9b6a2b391b613dL214-R214), [link](https://github.com/baidu/amis/pull/8192/files?diff=unified&w=0#diff-851dba93506fd34484adaa1d720285d572d18ca4392a0c4893fca27c4159fa92L432-R432), [link](https://github.com/baidu/amis/pull/8192/files?diff=unified&w=0#diff-84800995b352e55dac9d39fc260b3288d628b48ce9ed6a2d34b7338b0e74fa68L167-R167), [link](https://github.com/baidu/amis/pull/8192/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL397-R397), [link](https://github.com/baidu/amis/pull/8192/files?diff=unified&w=0#diff-e65abd8ed33a9d63bc29309ed26eb057b2d1f780106822c5eabeeaa220f8c91fL527-R527), [link](https://github.com/baidu/amis/pull/8192/files?diff=unified&w=0#diff-0e3971a496f3279ae50c1ec88e123bcb7043d0e93e188e25070de55d56367a4aL363-R363), [link](https://github.com/baidu/amis/pull/8192/files?diff=unified&w=0#diff-bca893b099ca937943ac72a5ef0208df221f47d9846dba048ff0782f87289317L153-R153), [link](https://github.com/baidu/amis/pull/8192/files?diff=unified&w=0#diff-3d7b0c5e5c5515b4c22895cf1ee4f3be874c4fd89fa5b5445bfcf8e55523e919L366-R366))
