### PR TITLE
fix: InputTable 修复性能优化后在需要用到父级数据的时候没有及时更新的问题 Close: #8188

### DIFF
--- a/packages/amis-core/src/utils/helper.ts
+++ b/packages/amis-core/src/utils/helper.ts
@@ -20,7 +20,8 @@ import {autobindMethod} from './autobind';
 import {
   isPureVariable,
   resolveVariable,
-  resolveVariableAndFilter
+  resolveVariableAndFilter,
+  tokenize
 } from './tpl-builtin';
 import {
   cloneObject,
@@ -1896,13 +1897,17 @@ export function hashCode(s: string): number {
  */
 export function JSONTraverse(
   json: any,
-  mapper: (value: any, key: string | number, host: Object) => any
+  mapper: (value: any, key: string | number, host: Object) => any,
+  maxDeep: number = Number.MAX_VALUE
 ) {
+  if (maxDeep <= 0) {
+    return;
+  }
   Object.keys(json).forEach(key => {
     const value: any = json[key];
     if (!isObservable(value)) {
       if (isPlainObject(value) || Array.isArray(value)) {
-        JSONTraverse(value, mapper);
+        JSONTraverse(value, mapper, maxDeep - 1);
       } else {
         mapper(value, key, json);
       }
@@ -2072,4 +2077,100 @@ export function differenceFromAll<T>(
   differenceFromAllCache.options = options;
   differenceFromAllCache.res = res;
   return res;
+}
+
+/**
+ * 基于 schema 自动提取 trackExpression
+ * 可能会不准确，建议用户自己配置
+ * @param schema
+ * @returns
+ */
+export function buildTrackExpression(schema: any) {
+  if (!isPlainObject(schema) && !Array.isArray(schema)) {
+    return '';
+  }
+
+  const trackExpressions: Array<string> = [];
+  JSONTraverse(
+    schema,
+    (value, key: string) => {
+      if (typeof value !== 'string') {
+        return;
+      }
+
+      if (key === 'name') {
+        trackExpressions.push(isPureVariable(value) ? value : `\${${value}}`);
+      } else if (key === 'source') {
+        trackExpressions.push(value);
+      } else if (
+        key.endsWith('On') ||
+        key === 'condition' ||
+        key === 'trackExpression'
+      ) {
+        trackExpressions.push(
+          value.startsWith('${') ? value : `<script>${value}</script>`
+        );
+      } else if (value.includes('$')) {
+        trackExpressions.push(value);
+      }
+    },
+    10 // 最多遍历 10 层
+  );
+
+  return trackExpressions.join('|');
+}
+
+export function evalTrackExpression(
+  expression: string,
+  data: Record<string, any>
+) {
+  if (typeof expression !== 'string') {
+    return '';
+  }
+
+  const parts: Array<{
+    type: 'text' | 'script';
+    value: string;
+  }> = [];
+  while (true) {
+    // 这个是自动提取的时候才会用到，用户配置不要用到这个语法
+    const idx = expression.indexOf('<script>');
+    if (idx === -1) {
+      break;
+    }
+    const endIdx = expression.indexOf('</script>');
+    if (endIdx === -1) {
+      throw new Error(
+        'Invalid trackExpression miss end script token `</script>`'
+      );
+    }
+    if (idx) {
+      parts.push({
+        type: 'text',
+        value: expression.substring(0, idx)
+      });
+    }
+
+    parts.push({
+      type: 'script',
+      value: expression.substring(idx + 8, endIdx)
+    });
+    expression = expression.substring(endIdx + 9);
+  }
+
+  expression &&
+    parts.push({
+      type: 'text',
+      value: expression
+    });
+
+  return parts
+    .map(item => {
+      if (item.type === 'text') {
+        return tokenize(item.value, data);
+      }
+
+      return evalExpression(item.value, data);
+    })
+    .join('');
 }

--- a/packages/amis/src/renderers/Table/Cell.tsx
+++ b/packages/amis/src/renderers/Table/Cell.tsx
@@ -5,7 +5,9 @@ import {
   PlainObject,
   SchemaNode,
   ThemeProps,
-  resolveVariable
+  resolveVariable,
+  buildTrackExpression,
+  evalTrackExpression
 } from 'amis-core';
 import {BadgeObject, Checkbox, Icon} from 'amis-ui';
 import React from 'react';
@@ -168,7 +170,20 @@ export default function Cell({
     }
     return [prefix, affix, addtionalClassName];
   }, [item.expandable, item.expanded]);
-  const data = React.useMemo(() => item.locals, [JSON.stringify(item.locals)]);
+
+  // 根据条件缓存 data，避免孩子重复渲染
+  const hasCustomTrackExpression =
+    typeof column.pristine.trackExpression !== 'undefined';
+  const trackExpression = hasCustomTrackExpression
+    ? column.pristine.trackExpression
+    : React.useMemo(() => buildTrackExpression(column.pristine), []);
+  const data = React.useMemo(
+    () => item.locals,
+    [
+      hasCustomTrackExpression ? '' : JSON.stringify(item.locals),
+      evalTrackExpression(trackExpression, item.locals)
+    ]
+  );
 
   const finalCanAccessSuperData =
     column.pristine.canAccessSuperData ?? canAccessSuperData;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 640866c</samp>

This pull request adds a new feature to `amis` that allows users to specify track expressions in schemas to monitor data or condition changes. It implements the logic for parsing and evaluating track expressions in `amis-core` and applies it to table cells in `amis`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 640866c</samp>

> _We're sailing on the data sea, with schemas and expressions_
> _We track the changes as they come, with `trackExpression` functions_
> _Heave ho, me hearties, heave ho, on the count of three_
> _We import and we traverse, with `tokenize` and `JSONTraverse`_

### Why

Close: #8188

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 640866c</samp>

* Import and use `tokenize` function to replace variables in strings ([link](https://github.com/baidu/amis/pull/8193/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL23-R24))
* Add `maxDeep` parameter to `JSONTraverse` function to limit traversal depth ([link](https://github.com/baidu/amis/pull/8193/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1899-R1910))
* Add `buildTrackExpression` and `evalTrackExpression` functions to extract and evaluate track expressions from schemas ([link](https://github.com/baidu/amis/pull/8193/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aR2081-R2176), [link](https://github.com/baidu/amis/pull/8193/files?diff=unified&w=0#diff-d65258ae6673eb54481e932fd39b426fb60a31ca9cb7430d0cff54fe035efe15L8-R10))
* Use track expressions to track data changes and re-render table cells in `Cell.tsx` ([link](https://github.com/baidu/amis/pull/8193/files?diff=unified&w=0#diff-d65258ae6673eb54481e932fd39b426fb60a31ca9cb7430d0cff54fe035efe15L171-R182))
