### PR TITLE
chore:补充发送请求动作silent单测

### DIFF
--- a/docs/zh-CN/concepts/event-action.md
+++ b/docs/zh-CN/concepts/event-action.md
@@ -288,7 +288,7 @@ run action ajax
 
 #### 静默模式
 
-当配置`options.silent: true`时，请求完成后不会弹出提示信息。
+当配置`silent: true`时，请求完成后不会弹出提示信息。
 
 ```schema
 {
@@ -316,9 +316,7 @@ run action ajax
                   success: '成功了！欧耶',
                   failed: '失败了呢。。'
                 },
-              },
-              options: {
-                silent: true,
+                silent: true
               },
               data: {
                 age: 18

--- a/packages/amis/__tests__/event-action/ajax.test.tsx
+++ b/packages/amis/__tests__/event-action/ajax.test.tsx
@@ -633,3 +633,131 @@ test('EventAction:ajax data3', async () => {
     expect(fetcher.mock.calls[3][0].data).toMatchObject({});
   });
 });
+
+test('EventAction:ajax silent', async () => {
+  const notify = jest.fn();
+  const fetcher = jest.fn().mockImplementation(() => {
+    return Promise.resolve({
+      data: {
+        status: 0,
+        msg: 'ok'
+      }
+    });
+  });
+  const {getByText, container}: any = render(
+    amisRender(
+      {
+        type: 'page',
+        body: [
+          {
+            type: 'button',
+            label: '发送请求1',
+            level: 'primary',
+            onEvent: {
+              click: {
+                actions: [
+                  {
+                    actionType: 'ajax',
+                    api: {
+                      url: '/api/xxx1',
+                      method: 'post',
+                      silent: true
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            type: 'button',
+            label: '发送请求2',
+            level: 'primary',
+            onEvent: {
+              click: {
+                actions: [
+                  {
+                    actionType: 'ajax',
+                    api: {
+                      url: '/api/xxx2',
+                      method: 'post',
+                      silent: false
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            type: 'button',
+            label: '发送请求3',
+            level: 'primary',
+            onEvent: {
+              click: {
+                actions: [
+                  {
+                    actionType: 'ajax',
+                    api: {
+                      url: '/api/xxx3',
+                      method: 'post'
+                    },
+                    options: {
+                      silent: true
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            type: 'button',
+            label: '发送请求4',
+            level: 'primary',
+            onEvent: {
+              click: {
+                actions: [
+                  {
+                    actionType: 'ajax',
+                    api: {
+                      url: '/api/xxx4',
+                      method: 'post'
+                    },
+                    options: {
+                      silent: false
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {},
+      makeEnv({
+        fetcher,
+        notify
+      })
+    )
+  );
+
+  await waitFor(() => {
+    expect(getByText('发送请求1')).toBeInTheDocument();
+    expect(getByText('发送请求2')).toBeInTheDocument();
+    expect(getByText('发送请求3')).toBeInTheDocument();
+    expect(getByText('发送请求4')).toBeInTheDocument();
+  });
+
+  fireEvent.click(getByText(/发送请求1/));
+  fireEvent.click(getByText(/发送请求2/));
+  fireEvent.click(getByText(/发送请求3/));
+  fireEvent.click(getByText(/发送请求4/));
+
+  await waitFor(() => {
+    expect(fetcher).toHaveBeenCalledTimes(4);
+    debugger;
+    expect(fetcher.mock.calls[0][0].url).toEqual('/api/xxx1');
+    expect(fetcher.mock.calls[1][0].url).toEqual('/api/xxx2');
+    expect(fetcher.mock.calls[2][0].url).toEqual('/api/xxx3');
+    expect(fetcher.mock.calls[3][0].url).toEqual('/api/xxx4');
+    expect(notify).toBeCalledTimes(2);
+  });
+});

--- a/packages/amis/__tests__/renderers/CRUD.test.tsx
+++ b/packages/amis/__tests__/renderers/CRUD.test.tsx
@@ -1092,6 +1092,7 @@ describe('18. inner events', () => {
 });
 
 test('19. fetchInitData silent true', async () => {
+  const notify = jest.fn();
   const fetcher = jest.fn().mockImplementationOnce(() => {
     return new Promise(resolve =>
       resolve({
@@ -1105,27 +1106,47 @@ test('19. fetchInitData silent true', async () => {
   const {container} = render(
     amisRender(
       {
-        type: 'crud',
-        api: {
-          method: 'get',
-          url: '/api/mock/sample',
-          silent: true
-        },
-        columns: [
+        type: 'page',
+        body: [
           {
-            name: 'engine',
-            label: 'Rendering engine'
+            type: 'crud',
+            api: {
+              method: 'get',
+              url: '/api/mock/sample',
+              silent: true
+            },
+            columns: [
+              {
+                name: 'engine',
+                label: 'Rendering engine'
+              }
+            ]
+          },
+          {
+            type: 'crud',
+            api: {
+              method: 'get',
+              url: '/api/mock/sample',
+              silent: false
+            },
+            columns: [
+              {
+                name: 'engine',
+                label: 'Rendering engine'
+              }
+            ]
           }
         ]
       },
       {},
       {
-        fetcher
+        fetcher,
+        notify
       }
     )
   );
 
   await waitFor(() => {
-    expect(container.querySelector('.cxd-Toast')).not.toBeInTheDocument();
+    expect(notify).toBeCalledTimes(1);
   });
 });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad8bcb3</samp>

Improved the documentation and testing of the `silent` property for ajax actions. Fixed outdated code examples in `docs/zh-CN/concepts/event-action.md` and added a new test case in `packages/amis/__tests__/event-action/ajax.test.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ad8bcb3</samp>

> _No sound, no trace, no feedback_
> _We unleash the silent attack_
> _With ajax actions we strike_
> _The deprecated code we despise_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ad8bcb3</samp>

* Correct the documentation and schema for the silent mode of ajax actions ([link](https://github.com/baidu/amis/pull/8198/files?diff=unified&w=0#diff-9802ca5a2390dc6e213b3d844669c50fb10948dad8ad72a0d360c886731fbd3dL291-R291), [link](https://github.com/baidu/amis/pull/8198/files?diff=unified&w=0#diff-9802ca5a2390dc6e213b3d844669c50fb10948dad8ad72a0d360c886731fbd3dL319-R320))
* Add a test case for the silent mode of ajax actions ([link](https://github.com/baidu/amis/pull/8198/files?diff=unified&w=0#diff-8dd27b935bfdaa3bd00b58e4ca95436585071c4ba796dde88cf5bb5caec1fe6dR636-R690))
