### PR TITLE
fix(amis-editor): theme:common补充hidePaddingAndMargin，支持隐藏内外边距配置项

### DIFF
--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -371,7 +371,6 @@ setSchemaTpl(
         key: item.title,
         body: flatten(item.body)
       }));
-
     return {
       type: 'collapse-group',
       activeKey: collapseGroupBody

--- a/packages/amis-editor/src/tpl/style.tsx
+++ b/packages/amis-editor/src/tpl/style.tsx
@@ -619,15 +619,17 @@ setSchemaTpl(
           visibleOn: visibleOn,
           name: `themeCss.${classname}.boxShadow:${state}`
         })
-      ].concat(
-        extra.map(item => {
-          return {
-            ...item,
-            visibleOn: visibleOn,
-            name: `${item.name}:${state}`
-          };
-        })
-      );
+      ]
+        .filter(item => item)
+        .concat(
+          extra.map(item => {
+            return {
+              ...item,
+              visibleOn: visibleOn,
+              name: `${item.name}:${state}`
+            };
+          })
+        );
     };
     const styles = [
       {

--- a/packages/amis-editor/src/tpl/style.tsx
+++ b/packages/amis-editor/src/tpl/style.tsx
@@ -579,14 +579,17 @@ setSchemaTpl(
     classname?: string;
     title?: string;
     hiddenOn?: string;
+    hidePaddingAndMargin?: boolean;
   }) => {
     const {
       collapsed = false,
       extra = [],
       classname = 'baseControlClassName',
       title = '基本样式',
-      hiddenOn
+      hiddenOn,
+      hidePaddingAndMargin
     } = option;
+    const curHidePaddingAndMargin = hidePaddingAndMargin ?? false;
     const styleStateFunc = (visibleOn: string, state: string) => {
       return [
         getSchemaTpl('theme:border', {
@@ -597,10 +600,12 @@ setSchemaTpl(
           visibleOn: visibleOn,
           name: `themeCss.${classname}.radius:${state}`
         }),
-        getSchemaTpl('theme:paddingAndMargin', {
-          visibleOn: visibleOn,
-          name: `themeCss.${classname}.padding-and-margin:${state}`
-        }),
+        !curHidePaddingAndMargin
+          ? getSchemaTpl('theme:paddingAndMargin', {
+              visibleOn: visibleOn,
+              name: `themeCss.${classname}.padding-and-margin:${state}`
+            })
+          : null,
         getSchemaTpl('theme:colorPicker', {
           visibleOn: visibleOn,
           name: `themeCss.${classname}.background:${state}`,
@@ -672,6 +677,7 @@ setSchemaTpl(
     layoutExtra?: any[];
     classname?: string;
     baseTitle?: string;
+    hidePaddingAndMargin?: boolean;
   }) => {
     let {
       exclude,
@@ -680,7 +686,8 @@ setSchemaTpl(
       baseExtra,
       layoutExtra,
       classname,
-      baseTitle
+      baseTitle,
+      hidePaddingAndMargin
     } = option || {};
 
     const curCollapsed = collapsed ?? false; // 默认都展开
@@ -708,7 +715,8 @@ setSchemaTpl(
         collapsed: curCollapsed,
         extra: baseExtra,
         classname,
-        title: baseTitle
+        title: baseTitle,
+        hidePaddingAndMargin
       }),
       ...extra,
       {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2ab1dcb</samp>

Add `hidePaddingAndMargin` option to style and layout editors. This option lets the user customize the appearance of elements in the amis framework by hiding the padding and margin controls in the editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2ab1dcb</samp>

> _`hidePaddingAndMargin`_
> _New option for style and layout_
> _Autumn leaves fall gently_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2ab1dcb</samp>

*  Add `hidePaddingAndMargin` option to style and layout editor components ([link](https://github.com/baidu/amis/pull/8205/files?diff=unified&w=0#diff-397f3332bd17c52ed7e468360e1cfe462d1d8646110ccd681b48a6deaa608302R582), [link](https://github.com/baidu/amis/pull/8205/files?diff=unified&w=0#diff-397f3332bd17c52ed7e468360e1cfe462d1d8646110ccd681b48a6deaa608302R680))
*  Destructure `hidePaddingAndMargin` option from `option` parameter in `getStyleTpl` and `getLayoutTpl` functions ([link](https://github.com/baidu/amis/pull/8205/files?diff=unified&w=0#diff-397f3332bd17c52ed7e468360e1cfe462d1d8646110ccd681b48a6deaa608302L588-R592), [link](https://github.com/baidu/amis/pull/8205/files?diff=unified&w=0#diff-397f3332bd17c52ed7e468360e1cfe462d1d8646110ccd681b48a6deaa608302L683-R690))
*  Hide padding and margin controls in style editor component based on `hidePaddingAndMargin` option ([link](https://github.com/baidu/amis/pull/8205/files?diff=unified&w=0#diff-397f3332bd17c52ed7e468360e1cfe462d1d8646110ccd681b48a6deaa608302L600-R608))
*  Pass `hidePaddingAndMargin` option to `getStyleTpl` function call in `getLayoutTpl` function ([link](https://github.com/baidu/amis/pull/8205/files?diff=unified&w=0#diff-397f3332bd17c52ed7e468360e1cfe462d1d8646110ccd681b48a6deaa608302L711-R719))
