### PR TITLE
fix:QuickEdit inline模式时找不到组件问题 Close #7989

### DIFF
--- a/packages/amis/__tests__/renderers/Table.test.tsx
+++ b/packages/amis/__tests__/renderers/Table.test.tsx
@@ -1159,3 +1159,87 @@ test('Renderer:table-each', () => {
     '<div class="cxd-Each"><span class="cxd-TplField"><span><span class="label label-info m-l-sm">a</span></span></span><span class="cxd-TplField"><span><span class="label label-info m-l-sm">b</span></span></span><span class="cxd-TplField"><span><span class="label label-info m-l-sm">c</span></span></span></div>'
   );
 });
+
+test('Renderer:table-column-quickEdit-inline', async () => {
+  const {container, getByText} = render(
+    amisRender(
+      {
+        type: 'table',
+        title: '表格',
+        data: {
+          items: [
+            {
+              engine: 'Trident - wixp4',
+              browser: 'Internet Explorer 4.0',
+              platform: 'Win 95+',
+              version: '4',
+              grade: 'X',
+              badgeText: '默认',
+              id: 1
+            }
+          ]
+        },
+        columns: [
+          {
+            name: 'engine',
+            label: 'Engine',
+            id: 'u:2e5658776790'
+          },
+          {
+            name: 'version',
+            label: 'Version',
+            id: 'u:5c41ffc2ecb0'
+          },
+          {
+            label: '选项',
+            name: 'optionValue',
+            id: 'checkbox_${index}',
+            type: 'switch',
+            quickEdit: {
+              type: 'switch',
+              mode: 'inline',
+              id: 'u:4201a414cde3'
+            }
+          },
+          {
+            label: '操作',
+            type: 'operation',
+            buttons: [
+              {
+                label: '赋值',
+                type: 'button',
+                onEvent: {
+                  click: {
+                    actions: [
+                      {
+                        actionType: 'setValue',
+                        componentId: 'checkbox_${index}',
+                        args: {
+                          value: true
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {},
+      makeEnv({})
+    )
+  );
+
+  await waitFor(() => {
+    expect(getByText('赋值')).toBeInTheDocument();
+    expect(container.querySelector('.cxd-Switch')).toBeInTheDocument();
+    expect(container.querySelector('.is-checked')).not.toBeInTheDocument();
+  });
+
+  fireEvent.click(getByText(/赋值/));
+
+  await waitFor(() => {
+    expect(container.querySelector('.is-checked')).toBeInTheDocument();
+  });
+});

--- a/packages/amis/src/renderers/QuickEdit.tsx
+++ b/packages/amis/src/renderers/QuickEdit.tsx
@@ -391,9 +391,9 @@ export const HocQuickEdit =
       }
 
       buildSchema() {
-        const {quickEdit, name, label, translate: __} = this.props;
-
+        const {quickEdit, name, label, translate: __, id} = this.props;
         let schema;
+        const isline = (quickEdit as QuickEditConfig).mode === 'inline';
 
         if (quickEdit === true) {
           schema = {
@@ -430,7 +430,7 @@ export const HocQuickEdit =
           ) {
             schema = {
               title: '',
-              autoFocus: (quickEdit as QuickEditConfig).mode !== 'inline',
+              autoFocus: !isline,
               ...quickEdit,
               mode: 'normal',
               type: 'form'
@@ -440,13 +440,14 @@ export const HocQuickEdit =
               title: '',
               className: quickEdit.formClassName,
               type: 'form',
-              autoFocus: (quickEdit as QuickEditConfig).mode !== 'inline',
+              autoFocus: !isline,
               mode: 'normal',
               body: [
                 {
                   type: quickEdit.type || 'input-text',
                   name: quickEdit.name || name,
                   ...quickEdit,
+                  ...(isline ? {id: id} : {}),
                   mode: undefined
                 }
               ]
@@ -454,7 +455,6 @@ export const HocQuickEdit =
           }
         }
 
-        const isline = (quickEdit as QuickEditConfig).mode === 'inline';
         const isFormMode = (quickEdit as QuickEditConfig)?.isFormMode;
 
         if (schema) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ecb792</samp>

This pull request adds inline mode and dynamic actions support for the QuickEdit component in `amis`. It also updates the `Table.test.tsx` file to include a test case for the new feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7ecb792</samp>

> _To test the table renderer well_
> _We added a case with a cell_
> _That has a `QuickEdit` switch_
> _Which we can toggle with a click_
> _And `filter` the actions to tell_

### Why

Close: #7989

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7ecb792</samp>

*  Add a new test case for the table renderer with a quick edit switch in inline mode ([link](https://github.com/baidu/amis/pull/8206/files?diff=unified&w=0#diff-ab6375ec2ae128616c420f8f69f82b06b74a43ca22329f77f5246eb808368298R1162-R1245))
*  Import the filter function from amis-core to filter out unsupported actions in inline mode ([link](https://github.com/baidu/amis/pull/8206/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L8-R8))
*  Use the isline variable to set the autoFocus property of the schema and the form component in the QuickEditComponent class ([link](https://github.com/baidu/amis/pull/8206/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L433-R433), [link](https://github.com/baidu/amis/pull/8206/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L443-R443))
*  Add the id property to the QuickEditComponent class and the control component inside the form body to identify and update the component that triggers an action ([link](https://github.com/baidu/amis/pull/8206/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L394-R396), [link](https://github.com/baidu/amis/pull/8206/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1R450))
*  Remove the redundant declaration of the isline variable in the render method of the QuickEditComponent class ([link](https://github.com/baidu/amis/pull/8206/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L457))
