### PR TITLE
fix(amis-editor): 编辑器面板Collapse Header样式错误

### DIFF
--- a/packages/amis-editor-core/scss/control/_formItem-control.scss
+++ b/packages/amis-editor-core/scss/control/_formItem-control.scss
@@ -37,7 +37,8 @@
   }
 }
 
-/* 右侧面板 Collapse 样式覆写，为了提高优先级，用顶层类包裹 */
+/* 面板 Collapse 样式覆写，为了提高优先级，用顶层类包裹 */
+.ae-Outline-panel,
 .ae-Settings-content {
   .ae-formItemControl {
     & > div:last-child {
@@ -52,7 +53,7 @@
       }
     }
 
-    div.ae-formItemControl-header.ae-Collapse-header--right {
+    div.ae-formItemControl-header.ae-Collapse-header {
       width: 100%;
       padding: #{px2rem(6px)} #{px2rem(12px)};
       justify-content: space-between;

--- a/packages/amis-editor/src/component/BaseControl.ts
+++ b/packages/amis-editor/src/component/BaseControl.ts
@@ -202,7 +202,7 @@ export const formItemControl: (
   const supportStatic = SUPPORT_STATIC_FORMITEM_CMPTS.includes(type);
   const collapseProps = {
     type: 'collapse',
-    headingClassName: 'ae-formItemControl-header ae-Collapse-header--right',
+    headingClassName: 'ae-formItemControl-header ae-Collapse-header',
     bodyClassName: 'ae-formItemControl-body'
   };
   // 已经配置了的属性

--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -364,7 +364,7 @@ setSchemaTpl(
       )
       .map(item => ({
         type: 'collapse',
-        headingClassName: 'ae-formItemControl-header ae-Collapse-header--right',
+        headingClassName: 'ae-formItemControl-header ae-Collapse-header',
         bodyClassName: 'ae-formItemControl-body',
         ...item,
         collapsed: item.collapsed ?? false,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19fda17</samp>

This pull request updates the style and class name of the Collapse component in the editor's left and right panels, to make them consistent and responsive. It modifies the SCSS file `packages/amis-editor-core/scss/control/_formItem-control.scss` and the two TSX files `packages/amis-editor/src/component/BaseControl.ts` and `packages/amis-editor/src/tpl/common.tsx` that use the Collapse component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 19fda17</samp>

> _We are the masters of the Collapse_
> _We change the props and the SCSS_
> _We align the panels of the editor_
> _We unleash the power of the selector_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 19fda17</samp>

*  Align the Collapse header to the center for the left and right panels of the editor ([link](https://github.com/baidu/amis/pull/8207/files?diff=unified&w=0#diff-cf5d81915ddfe41869a60d2bb90a8e8d542686d0e6ce7504a8666a1c6a42e931L55-R56), [link](https://github.com/baidu/amis/pull/8207/files?diff=unified&w=0#diff-851dba93506fd34484adaa1d720285d572d18ca4392a0c4893fca27c4159fa92L205-R205), [link](https://github.com/baidu/amis/pull/8207/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05L367-R367))
*  Add the `.ae-Outline-panel` selector to the style override for the Collapse component in the left panel ([link](https://github.com/baidu/amis/pull/8207/files?diff=unified&w=0#diff-cf5d81915ddfe41869a60d2bb90a8e8d542686d0e6ce7504a8666a1c6a42e931L40-R41))
*  Use the same class name `.ae-Collapse-header` for the Collapse header in both panels ([link](https://github.com/baidu/amis/pull/8207/files?diff=unified&w=0#diff-851dba93506fd34484adaa1d720285d572d18ca4392a0c4893fca27c4159fa92L205-R205), [link](https://github.com/baidu/amis/pull/8207/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05L367-R367))
