### PR TITLE
fix: 修复编辑器表格在有快速编辑配置时点选不上的问题 Close: #8208

### DIFF
--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -1002,12 +1002,12 @@ export const TableStore = iRendererStore
         const originColumns = self.columns.concat();
         columns = columns.map((item, index) => {
           const origin = item.id
-            ? originColumns.find(column => column.id === item.id)
+            ? originColumns.find(column => column.pristine.id === item.id)
             : originColumns[index];
 
           return {
             ...item,
-            id: guid(),
+            id: origin?.id || guid(),
             index,
             width: origin?.width || 0,
             minWidth: origin?.minWidth || 0,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bf9d6eb</samp>

Fix column id bug in `table.ts`. Use `pristine` property to match columns by id and assign or generate id accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bf9d6eb</samp>

> _`pristine` column id_
> _preserved across updates now_
> _a bug fixed in fall_

### Why

Close: #8208

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bf9d6eb</samp>

* Fix a bug where column id was not preserved when updating columns ([link](https://github.com/baidu/amis/pull/8210/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1005-R1010))
