### PR TITLE
fix:Select值不变时不应触发change Close #8179

### DIFF
--- a/packages/amis-ui/src/components/Select.tsx
+++ b/packages/amis-ui/src/components/Select.tsx
@@ -675,7 +675,10 @@ export class Select extends React.Component<SelectProps, SelectState> {
         simpleValue ? selection.map(item => item[valueField]) : selection
       );
     } else {
-      onChange(simpleValue ? selectItem[valueField] : selectItem);
+      // Downshift里面的判断修改后的值是否相等时，没有区分是否多选，且用的是！==，所以这里拦截一下
+      (!selection.length ||
+        selection[0][valueField] !== selectItem[valueField]) &&
+        onChange(simpleValue ? selectItem[valueField] : selectItem);
     }
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9f1beac</samp>

Fix a bug in `Select` component that triggers `onChange` when the value does not change. Add a comment to explain the reason for the condition.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9f1beac</samp>

> _`onChange` prop checked_
> _No call if value unchanged_
> _Downshift bug in spring_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9f1beac</samp>

*  Prevent calling `onChange` when value is unchanged in single-select mode ([link](https://github.com/baidu/amis/pull/8211/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL678-R681))
