### PR TITLE
chore: 当页面中没有对应id元素时才删除改id的样式

### DIFF
--- a/packages/amis-core/src/components/CustomStyle.tsx
+++ b/packages/amis-core/src/components/CustomStyle.tsx
@@ -15,12 +15,30 @@ interface CustomStyleProps {
   env: RendererEnv;
 }
 
+export const styleIdCount = new Map();
+
 export default function (props: CustomStyleProps) {
   const {config, env} = props;
   const {themeCss, classNames, id, defaultData, wrapperCustomStyle} = config;
   if (!themeCss && !wrapperCustomStyle) {
     return null;
   }
+
+  useEffect(() => {
+    if (styleIdCount.has(id)) {
+      styleIdCount.set(id, styleIdCount.get(id) + 1);
+    } else if (id) {
+      styleIdCount.set(id, 1);
+    }
+    return () => {
+      if (styleIdCount.has(id)) {
+        styleIdCount.set(id, styleIdCount.get(id) - 1);
+        if (styleIdCount.get(id) === 0) {
+          styleIdCount.delete(id);
+        }
+      }
+    };
+  }, [id]);
 
   useEffect(() => {
     if (themeCss && id) {
@@ -35,7 +53,7 @@ export default function (props: CustomStyleProps) {
     }
 
     return () => {
-      if (id) {
+      if (id && !styleIdCount.get(id)) {
         removeCustomStyle('', id, env.getModalContainer?.().ownerDocument);
       }
     };
@@ -51,7 +69,7 @@ export default function (props: CustomStyleProps) {
     }
 
     return () => {
-      if (id) {
+      if (id && !styleIdCount.get(id)) {
         removeCustomStyle(
           'wrapperCustomStyle',
           id,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcade43</samp>

This pull request improves the management of custom styles in `amis-core` by using a reference count mechanism. It prevents custom styles from being removed when they are still used by some components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bcade43</samp>

> _`styleIdCount` map_
> _tracks custom styles usage_
> _autumn leaves don't fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bcade43</samp>

*  Add a map to keep track of custom style usage counts and prevent removing styles that are still in use by other components ([link](https://github.com/baidu/amis/pull/8213/files?diff=unified&w=0#diff-64f487ea8bb551e6157d95133fcf65572d6990b062dd31bf6502543a77ad9fb5R18-R19), [link](https://github.com/baidu/amis/pull/8213/files?diff=unified&w=0#diff-64f487ea8bb551e6157d95133fcf65572d6990b062dd31bf6502543a77ad9fb5R28-R43), [link](https://github.com/baidu/amis/pull/8213/files?diff=unified&w=0#diff-64f487ea8bb551e6157d95133fcf65572d6990b062dd31bf6502543a77ad9fb5L38-R56), [link](https://github.com/baidu/amis/pull/8213/files?diff=unified&w=0#diff-64f487ea8bb551e6157d95133fcf65572d6990b062dd31bf6502543a77ad9fb5L54-R72))
