### PR TITLE
feat: 树组件支持配置虚拟渲染时的高度\宽度\可见区外缓冲渲染数

### DIFF
--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -128,6 +128,9 @@ interface TreeSelectorProps extends ThemeProps, LocaleProps, SpinnerExtraProps {
   createTip?: string;
   // 是否开启虚拟滚动
   virtualThreshold?: number;
+  virtualContainerHeight?: number;
+  virtualContainerWidth?: number;
+  virtualOverscanCount?: number;
   itemHeight?: number;
   onAdd?: (
     idx?: number | Array<number>,
@@ -1417,11 +1420,23 @@ export class TreeSelector extends React.Component<
 
   @autobind
   renderList(list: Options, value: any[]) {
-    const {virtualThreshold, itemHeight = 32} = this.props;
+    const {
+      virtualThreshold,
+      itemHeight = 32,
+      virtualContainerHeight,
+      virtualContainerWidth,
+      virtualOverscanCount
+    } = this.props;
     if (virtualThreshold && list.length > virtualThreshold) {
       return (
         <VirtualList
-          height={list.length > 8 ? 266 : list.length * itemHeight}
+          height={
+            list.length > 8
+              ? virtualContainerHeight || 266
+              : list.length * itemHeight
+          }
+          width={virtualContainerWidth}
+          overscanCount={virtualOverscanCount}
           itemCount={list.length}
           prefix={this.renderCheckAll()}
           itemSize={itemHeight}

--- a/packages/amis/src/renderers/Form/InputTree.tsx
+++ b/packages/amis/src/renderers/Form/InputTree.tsx
@@ -372,6 +372,9 @@ export default class TreeControl extends React.Component<TreeProps, TreeState> {
       translate: __,
       data,
       virtualThreshold,
+      virtualContainerWidth,
+      virtualContainerHeight,
+      virtualOverscanCount,
       itemHeight,
       loadingConfig,
       menuTpl,
@@ -438,6 +441,13 @@ export default class TreeControl extends React.Component<TreeProps, TreeState> {
         onDeferLoad={deferLoad}
         onExpandTree={expandTreeOptions}
         virtualThreshold={virtualThreshold}
+        virtualContainerWidth={virtualContainerWidth}
+        virtualContainerHeight={virtualContainerHeight}
+        virtualOverscanCount={
+          toNumber(virtualOverscanCount) > 0
+            ? toNumber(virtualOverscanCount)
+            : undefined
+        }
         itemHeight={toNumber(itemHeight) > 0 ? toNumber(itemHeight) : undefined}
         itemRender={menuTpl ? this.renderOptionItem : undefined}
         enableDefaultIcon={enableDefaultIcon}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 322f11f</samp>

This pull request enhances the `TreeSelector` and `InputTree` components with virtual scrolling, expand all, and node rendering customization features. It adds new props to the `TreeSelectorProps` interface and passes them to the `Tree` and `VirtualList` components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 322f11f</samp>

> _`TreeSelector` grows_
> _Adding props and features_
> _Virtual, expand_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 322f11f</samp>

*  Add `virtualContainerHeight`, `virtualContainerWidth`, and `virtualOverscanCount` props to customize the size and performance of the virtualized list component that renders the tree options ([link](https://github.com/baidu/amis/pull/8216/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7R131-R133), [link](https://github.com/baidu/amis/pull/8216/files?diff=unified&w=0#diff-527e78ca6789f4f47200b93123fe7f7884acc6890540c2616a3bc4cf4f41cd2bR375-R377))
*  Use the new props to set the height and width of the `VirtualList` component and pass the `overscanCount` prop to control how many extra items are rendered outside the visible area of the list in the `renderList` method of the `TreeSelector` component ([link](https://github.com/baidu/amis/pull/8216/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1420-R1439))
*  Add a prefix prop to the `VirtualList` component to render the check all option in the `TreeSelector` component ([link](https://github.com/baidu/amis/pull/8216/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1420-R1439))
*  Pass the new props to the `TreeSelector` component inside the `InputTree` component, which is a form input that allows selecting tree options ([link](https://github.com/baidu/amis/pull/8216/files?diff=unified&w=0#diff-527e78ca6789f4f47200b93123fe7f7884acc6890540c2616a3bc4cf4f41cd2bR444-R450))
*  Convert the `virtualOverscanCount` prop to a number and check if it is positive before passing it to the `TreeSelector` component in the `InputTree` component ([link](https://github.com/baidu/amis/pull/8216/files?diff=unified&w=0#diff-527e78ca6789f4f47200b93123fe7f7884acc6890540c2616a3bc4cf4f41cd2bR444-R450))
