### PR TITLE
chore: pr #8039 代码丢失重新补上

### DIFF
--- a/examples/sdk-test.html
+++ b/examples/sdk-test.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <title>amis demo</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1"
+    />
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+    <link rel="stylesheet" href="../packages/amis/sdk/sdk.css" />
+    <link rel="stylesheet" href="../packages/amis/sdk/helper.css" />
+    <link rel="stylesheet" href="../packages/amis/sdk/iconfont.css" />
+    <!-- 这是默认主题所需的，如果是其他主题则不需要 -->
+    <!-- 从 1.1.0 开始 sdk.css 将不支持 IE 11，如果要支持 IE11 请引用这个 css，并把前面那个删了 -->
+    <!-- <link rel="stylesheet" href="sdk-ie11.css" /> -->
+    <!-- 不过 amis 开发团队几乎没测试过 IE 11 下的效果，所以可能有细节功能用不了，如果发现请报 issue -->
+    <style>
+      html,
+      body,
+      .app-wrapper {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root" class="app-wrapper"></div>
+    <script src="../packages/amis/sdk/sdk.js"></script>
+    <script type="text/javascript">
+      (function () {
+        let amis = amisRequire('amis/embed');
+        // 通过替换下面这个配置来生成不同页面
+        let amisJSON = {
+          type: 'page',
+          title: '表单页面',
+          body: {
+            type: 'form',
+            mode: 'horizontal',
+            api: '/saveForm',
+            body: [
+              {
+                label: 'Name',
+                type: 'input-text',
+                name: 'name'
+              },
+              {
+                label: 'Email',
+                type: 'input-email',
+                name: 'email'
+              }
+            ]
+          }
+        };
+        let amisScoped = amis.embed('#root', amisJSON);
+      })();
+    </script>
+  </body>
+</html>

--- a/packages/amis/src/renderers/Table/AutoFilterForm.tsx
+++ b/packages/amis/src/renderers/Table/AutoFilterForm.tsx
@@ -19,6 +19,7 @@ export interface AutoFilterFormProps extends RendererProps {
   onToggleExpanded?: () => void;
   query?: any;
 
+  popOverContainer?: any;
   onSearchableFromReset?: any;
   onSearchableFromSubmit?: any;
   onSearchableFromInit?: any;
@@ -37,7 +38,8 @@ export function AutoFilterForm({
   data,
   onSearchableFromReset,
   onSearchableFromSubmit,
-  onSearchableFromInit
+  onSearchableFromInit,
+  popOverContainer
 }: AutoFilterFormProps) {
   const schema = React.useMemo(() => {
     const {columnsNum, showBtnToolbar} =
@@ -191,7 +193,8 @@ export function AutoFilterForm({
     onSubmit: onSearchableFromSubmit,
     onInit: onSearchableFromInit,
     formStore: undefined,
-    data
+    data,
+    popOverContainer
   });
 }
 

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -1616,6 +1616,7 @@ export default class Table extends React.Component<TableProps, object> {
         onSearchableFromReset={onSearchableFromReset}
         onSearchableFromSubmit={onSearchableFromSubmit}
         onSearchableFromInit={onSearchableFromInit}
+        popOverContainer={this.getPopOverContainer}
       />
     );
   }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d5efac</samp>

This pull request adds a new feature to the table renderer that allows customizing the container element for the filter popovers. It also adds a new HTML file `examples/sdk-test.html` that shows how to use the amis SDK to embed a form page. It modifies the `AutoFilterForm` and `Table` components to implement and use the new feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1d5efac</samp>

> _If you want to embed a form page_
> _Using the amis SDK is all the rage_
> _But to filter a table_
> _You need to be able_
> _To set the `popOverContainer` on the stage_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1d5efac</samp>

*  Add a new HTML file `examples/sdk-test.html` that demonstrates how to use the amis SDK to embed a form page in a web page ([link](https://github.com/baidu/amis/pull/8226/files?diff=unified&w=0#diff-9f7e6fd142b15b3db776dddbf3016d683779b1ca281c368ed7fcfc2d7a2c4485L1-R62))
*  Add a new property `popOverContainer` to the `AutoFilterFormProps` interface and the `AutoFilterForm` component to pass a custom container element for the filter popovers ([link](https://github.com/baidu/amis/pull/8226/files?diff=unified&w=0#diff-03a51986279bffed94f6e37c43135adf37dcffbb10d28e1486500b395cfc9982R22), [link](https://github.com/baidu/amis/pull/8226/files?diff=unified&w=0#diff-03a51986279bffed94f6e37c43135adf37dcffbb10d28e1486500b395cfc9982L40-R42), [link](https://github.com/baidu/amis/pull/8226/files?diff=unified&w=0#diff-03a51986279bffed94f6e37c43135adf37dcffbb10d28e1486500b395cfc9982L194-R197))
*  Pass the `getPopOverContainer` method of the `Table` component to the `AutoFilterForm` component as the `popOverContainer` prop to position the popovers relative to the table element and avoid overflow issues ([link](https://github.com/baidu/amis/pull/8226/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR1619))
