### PR TITLE
fix(amis): 补充FlexSchema，flex组件增加提示词信息

### DIFF
--- a/packages/amis/src/Schema.ts
+++ b/packages/amis/src/Schema.ts
@@ -1,4 +1,5 @@
 import {PageSchema} from './renderers/Page';
+import {FlexSchema} from './renderers/Flex';
 import {TplSchema} from './renderers/Tpl';
 import {RemarkSchema, SchemaRemark} from './renderers/Remark';
 import {ActionSchema} from './renderers/Action';
@@ -361,6 +362,7 @@ export type SchemaType =
 
 export type SchemaObject =
   | PageSchema
+  | FlexSchema
   | TplSchema
   | RemarkSchema
   | ActionSchema

--- a/packages/amis/src/renderers/Card.tsx
+++ b/packages/amis/src/renderers/Card.tsx
@@ -489,7 +489,7 @@ export class CardRenderer extends React.Component<CardProps> {
     if (childNode.type === 'hbox' || childNode.type === 'grid') {
       return render(region, node, {
         key,
-        itemRender: this.itemRender
+        itemRender: this.itemRender.bind(this)
       }) as JSX.Element;
     }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 88141dd</samp>

Added a new `flex` renderer for flexible layouts. Updated `Schema.ts` to include the new renderer type.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 88141dd</samp>

> _We are the masters of the `flex` renderer_
> _We bend and twist the `SchemaObject` type_
> _We create the layouts of our dreams_
> _We are the `FlexSchema` tribe_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 88141dd</samp>

* Import `FlexSchema` type from `./renderers/Flex` module to define schema for `flex` renderer ([link](https://github.com/baidu/amis/pull/8235/files?diff=unified&w=0#diff-1d70ef86e04744f8ab32d8c9957e4784c6b948efa3fcf7b2557766e973378f23R2))
* Add `FlexSchema` type to `SchemaObject` union type to allow using `flex` renderer in schema definition ([link](https://github.com/baidu/amis/pull/8235/files?diff=unified&w=0#diff-1d70ef86e04744f8ab32d8c9957e4784c6b948efa3fcf7b2557766e973378f23R365))
