### PR TITLE
fix: 修改组合穿梭器默认脚手架id

### DIFF
--- a/packages/amis-editor/src/plugin/Form/TabsTransfer.tsx
+++ b/packages/amis-editor/src/plugin/Form/TabsTransfer.tsx
@@ -79,7 +79,7 @@ export class TabsTransferPlugin extends BasePlugin {
         children: [
           {
             label: '法师',
-            value: 'fashi',
+            value: 'fashi2',
             children: [
               {
                 label: '诸葛亮',
@@ -89,7 +89,7 @@ export class TabsTransferPlugin extends BasePlugin {
           },
           {
             label: '战士',
-            value: 'zhanshi',
+            value: 'zhanshi2',
             children: [
               {
                 label: '曹操',
@@ -103,7 +103,7 @@ export class TabsTransferPlugin extends BasePlugin {
           },
           {
             label: '打野',
-            value: 'daye',
+            value: 'daye2',
             children: [
               {
                 label: '李白',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cfcee54</samp>

Modified some `TabsTransfer` options in `Form/TabsTransfer.tsx` to test the component and the plugin functionality.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cfcee54</samp>

> _`options` prop changed_
> _Testing `TabsTransfer` now_
> _Autumn leaves fall fast_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cfcee54</samp>

* Changed the values of some options in the `options` prop of the `TabsTransfer` component to test its functionality and the plugin in the amis-editor ([link](https://github.com/baidu/amis/pull/8239/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL82-R82), [link](https://github.com/baidu/amis/pull/8239/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL92-R92), [link](https://github.com/baidu/amis/pull/8239/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL106-R106)) in `packages/amis-editor/src/plugin/Form/TabsTransfer.tsx`
