### PR TITLE
fix:上传文件&图片成功事件数据

### DIFF
--- a/packages/amis-editor/src/plugin/Form/InputFile.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputFile.tsx
@@ -101,7 +101,11 @@ export class FileControlPlugin extends BasePlugin {
               properties: {
                 item: {
                   type: 'object',
-                  title: '远程上传请求成功后返回的结果数据'
+                  title: '上传的文件'
+                },
+                result: {
+                  type: 'object',
+                  title: '远程上传请求成功后返回的响应数据'
                 }
               }
             }

--- a/packages/amis-editor/src/plugin/Form/InputImage.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputImage.tsx
@@ -144,7 +144,11 @@ export class ImageControlPlugin extends BasePlugin {
               properties: {
                 item: {
                   type: 'object',
-                  title: '远程上传请求成功后返回的结果数据'
+                  title: '上传的文件'
+                },
+                result: {
+                  type: 'object',
+                  title: '远程上传请求成功后返回的响应数据'
                 }
               }
             }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0995e8d</samp>

This pull request enhances the `file` and `image` controls in `amis-editor` by adding a new `result` property to the `value` field schema, which exposes the response data of the upload request. It also renames the `item` property to `file` for clarity.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0995e8d</samp>

> _`file` and `image`_
> _get new `result` property_
> _autumn of uploads_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0995e8d</samp>

*  Add `result` property to the schema of the `value` field of the `file` and `image` controls, and rename `item` property to `file` to access and display the upload response data ([link](https://github.com/baidu/amis/pull/8248/files?diff=unified&w=0#diff-1c9e16c95c50830285414ee526feb9fd66b1bebd99774864bd1111174784bf74L104-R108), [link](https://github.com/baidu/amis/pull/8248/files?diff=unified&w=0#diff-196626bf3350bb7e3df1e7beed48ef308ea68210398ca53c8370932f242feae6L147-R151))
