### PR TITLE
fix(amis&amis-editor): 构建时注入版本信息，确保运行时能获取到amis和amis-editor版本信息

### DIFF
--- a/packages/amis-editor/rollup.config.js
+++ b/packages/amis-editor/rollup.config.js
@@ -17,11 +17,15 @@ import path from 'path';
 import svgr from '@svgr/rollup';
 import fs from 'fs';
 import i18nPlugin from 'plugin-react-i18n';
+import moment from 'moment';
 
 const i18nConfig = require('./i18nConfig');
 
 const settings = {
-  globals: {}
+  globals: {},
+  commonConfig: {
+    footer: `window.amisEditorVersionInfo={version:'${version}',buildTime:'${moment().format("YYYY-MM-DD")}'};`,
+  }
 };
 
 const external = id =>
@@ -42,6 +46,7 @@ export default [
     output: [
       {
         ...settings,
+        ...settings.commonConfig,
         dir: path.dirname(main),
         format: 'cjs',
         exports: 'named',
@@ -58,6 +63,7 @@ export default [
     output: [
       {
         ...settings,
+        ...settings.commonConfig,
         dir: path.dirname(module),
         format: 'esm',
         exports: 'named',
@@ -138,6 +144,7 @@ function getPlugins(format = 'esm') {
     license({
       banner: `
         ${name} v${version}
+        build time: <%=moment().format('YYYY-MM-DD')%>
         Copyright 2018<%= moment().format('YYYY') > 2018 ? '-' + moment().format('YYYY') : null %> ${author}
       `
     }),

--- a/packages/amis/rollup.config.js
+++ b/packages/amis/rollup.config.js
@@ -15,9 +15,13 @@ import {
 } from './package.json';
 import path from 'path';
 import svgr from '@svgr/rollup';
+import moment from 'moment';
 
 const settings = {
-  globals: {}
+  globals: {},
+  commonConfig: {
+    footer: `window.amisVersionInfo={version:'${version}',buildTime:'${moment().format("YYYY-MM-DD")}'};`,
+  }
 };
 
 const external = id => {
@@ -61,6 +65,7 @@ export default [
     output: [
       {
         ...settings,
+        ...settings.commonConfig,
         dir: path.dirname(main),
         format: 'cjs',
         exports: 'named',
@@ -78,6 +83,7 @@ export default [
     output: [
       {
         ...settings,
+        ...settings.commonConfig,
         dir: path.dirname(module),
         format: 'esm',
         exports: 'named',
@@ -204,6 +210,7 @@ function getPlugins(format = 'esm') {
     license({
       banner: `
         ${name} v${version}
+        build time: <%=moment().format('YYYY-MM-DD')%>
         Copyright 2018<%= moment().format('YYYY') > 2018 ? '-' + moment().format('YYYY') : null %> ${author}
       `
     })


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5bbbec2</samp>

This pull request adds version and build time information to the output files of the `amis` and `amis-editor` packages. It uses the `moment` module to format the build time and refactors the rollup configurations to avoid repetition.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5bbbec2</samp>

> _Sing, O Muse, of the skillful amis-editor_
> _That with the help of moment, the swift-footed module,_
> _Stamped the version and the time of the glorious build_
> _On the output files, the cjs, esm, and umd bundles._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5bbbec2</samp>

* Import `moment` module and add `commonConfig` object to store `footer` property with version and build time information for both `amis` and `amis-editor` packages ([link](https://github.com/baidu/amis/pull/8250/files?diff=unified&w=0#diff-a54d5a460cdfe654e8addd3b498b933c1243615c89913bc34c3336eb34410e68L20-R28), [link](https://github.com/baidu/amis/pull/8250/files?diff=unified&w=0#diff-625ea572b75678a7abf95e2462a19fdcd265572b80905d36ab5c001df0904125L18-R24))
* Spread `commonConfig` object into output options of cjs and esm bundles for both `amis` and `amis-editor` packages to append `footer` to generated files ([link](https://github.com/baidu/amis/pull/8250/files?diff=unified&w=0#diff-a54d5a460cdfe654e8addd3b498b933c1243615c89913bc34c3336eb34410e68R49), [link](https://github.com/baidu/amis/pull/8250/files?diff=unified&w=0#diff-a54d5a460cdfe654e8addd3b498b933c1243615c89913bc34c3336eb34410e68R66), [link](https://github.com/baidu/amis/pull/8250/files?diff=unified&w=0#diff-625ea572b75678a7abf95e2462a19fdcd265572b80905d36ab5c001df0904125R68), [link](https://github.com/baidu/amis/pull/8250/files?diff=unified&w=0#diff-625ea572b75678a7abf95e2462a19fdcd265572b80905d36ab5c001df0904125R86))
* Add build time to banner of umd bundles for both `amis` and `amis-editor` packages using `moment` module and template syntax ([link](https://github.com/baidu/amis/pull/8250/files?diff=unified&w=0#diff-a54d5a460cdfe654e8addd3b498b933c1243615c89913bc34c3336eb34410e68R147), [link](https://github.com/baidu/amis/pull/8250/files?diff=unified&w=0#diff-625ea572b75678a7abf95e2462a19fdcd265572b80905d36ab5c001df0904125R213))
