### PR TITLE
fix(amis): 修复富文本组件/右侧面板/属性/状态/静态展示属性配置失效问题

### DIFF
--- a/packages/amis-editor/rollup.config.js
+++ b/packages/amis-editor/rollup.config.js
@@ -17,11 +17,15 @@ import path from 'path';
 import svgr from '@svgr/rollup';
 import fs from 'fs';
 import i18nPlugin from 'plugin-react-i18n';
+import moment from 'moment';
 
 const i18nConfig = require('./i18nConfig');
 
 const settings = {
-  globals: {}
+  globals: {},
+  commonConfig: {
+    footer: `window.amisEditorVersionInfo={version:'${version}',buildTime:'${moment().format("YYYY-MM-DD")}'};`,
+  }
 };
 
 const external = id =>
@@ -42,6 +46,7 @@ export default [
     output: [
       {
         ...settings,
+        ...settings.commonConfig,
         dir: path.dirname(main),
         format: 'cjs',
         exports: 'named',
@@ -58,6 +63,7 @@ export default [
     output: [
       {
         ...settings,
+        ...settings.commonConfig,
         dir: path.dirname(module),
         format: 'esm',
         exports: 'named',
@@ -138,6 +144,7 @@ function getPlugins(format = 'esm') {
     license({
       banner: `
         ${name} v${version}
+        build time: <%=moment().format('YYYY-MM-DD')%>
         Copyright 2018<%= moment().format('YYYY') > 2018 ? '-' + moment().format('YYYY') : null %> ${author}
       `
     }),

--- a/packages/amis/rollup.config.js
+++ b/packages/amis/rollup.config.js
@@ -15,9 +15,13 @@ import {
 } from './package.json';
 import path from 'path';
 import svgr from '@svgr/rollup';
+import moment from 'moment';
 
 const settings = {
-  globals: {}
+  globals: {},
+  commonConfig: {
+    footer: `window.amisVersionInfo={version:'${version}',buildTime:'${moment().format("YYYY-MM-DD")}'};`,
+  }
 };
 
 const external = id => {
@@ -61,6 +65,7 @@ export default [
     output: [
       {
         ...settings,
+        ...settings.commonConfig,
         dir: path.dirname(main),
         format: 'cjs',
         exports: 'named',
@@ -78,6 +83,7 @@ export default [
     output: [
       {
         ...settings,
+        ...settings.commonConfig,
         dir: path.dirname(module),
         format: 'esm',
         exports: 'named',
@@ -204,6 +210,7 @@ function getPlugins(format = 'esm') {
     license({
       banner: `
         ${name} v${version}
+        build time: <%=moment().format('YYYY-MM-DD')%>
         Copyright 2018<%= moment().format('YYYY') > 2018 ? '-' + moment().format('YYYY') : null %> ${author}
       `
     })

--- a/packages/amis/src/renderers/Form/InputRichText.tsx
+++ b/packages/amis/src/renderers/Form/InputRichText.tsx
@@ -280,6 +280,7 @@ export default class RichTextControl extends React.Component<
       value,
       onChange,
       disabled,
+      static: isStatic,
       size,
       vendor,
       env,
@@ -289,6 +290,19 @@ export default class RichTextControl extends React.Component<
     } = this.props;
 
     const finnalVendor = vendor || (env.richTextToken ? 'froala' : 'tinymce');
+
+    if (isStatic) {
+      return (
+        <div
+          className={cx(`${ns}RichTextControl`, className, {
+            'is-focused': this.state.focused,
+            'is-disabled': disabled,
+            [`${ns}RichTextControl--border${ucFirst(borderMode)}`]: borderMode
+          })}
+          dangerouslySetInnerHTML={{__html: env.filterHtml(value)}}
+        ></div>
+      );
+    }
 
     return (
       <div


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7544908</samp>

Added build time information to amis and amis-editor packages using `moment`. Added a `static` prop to `InputRichText` renderer to support static rich text rendering.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7544908</samp>

> _`amis-editor`_
> _Adds build time with `moment`_
> _A useful feature_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7544908</samp>

* Import `moment` module and add `footer` option to output bundles of `amis` and `amis-editor` packages to show version and build time information ([link](https://github.com/baidu/amis/pull/8251/files?diff=unified&w=0#diff-a54d5a460cdfe654e8addd3b498b933c1243615c89913bc34c3336eb34410e68L20-R28), [link](https://github.com/baidu/amis/pull/8251/files?diff=unified&w=0#diff-a54d5a460cdfe654e8addd3b498b933c1243615c89913bc34c3336eb34410e68R49), [link](https://github.com/baidu/amis/pull/8251/files?diff=unified&w=0#diff-a54d5a460cdfe654e8addd3b498b933c1243615c89913bc34c3336eb34410e68R66), [link](https://github.com/baidu/amis/pull/8251/files?diff=unified&w=0#diff-a54d5a460cdfe654e8addd3b498b933c1243615c89913bc34c3336eb34410e68R147), [link](https://github.com/baidu/amis/pull/8251/files?diff=unified&w=0#diff-625ea572b75678a7abf95e2462a19fdcd265572b80905d36ab5c001df0904125L18-R24), [link](https://github.com/baidu/amis/pull/8251/files?diff=unified&w=0#diff-625ea572b75678a7abf95e2462a19fdcd265572b80905d36ab5c001df0904125R68), [link](https://github.com/baidu/amis/pull/8251/files?diff=unified&w=0#diff-625ea572b75678a7abf95e2462a19fdcd265572b80905d36ab5c001df0904125R86), [link](https://github.com/baidu/amis/pull/8251/files?diff=unified&w=0#diff-625ea572b75678a7abf95e2462a19fdcd265572b80905d36ab5c001df0904125R213))
* Add `static` prop to `RichTextEditor` component and render rich text value as static content if `isStatic` is true in `InputRichText` renderer ([link](https://github.com/baidu/amis/pull/8251/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15R283), [link](https://github.com/baidu/amis/pull/8251/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15R294-R306))
