### PR TITLE
fix:表达式编辑器数组成员快捷操作语句错误问题

### DIFF
--- a/packages/amis-ui/src/components/formula/VariableList.tsx
+++ b/packages/amis-ui/src/components/formula/VariableList.tsx
@@ -198,11 +198,10 @@ function VariableList(props: VariableListProps) {
 
   function handleMemberClick(item: any, option: any, onClose?: any) {
     // todo：暂时只提供一层的快捷操作
-    // const lastPointIdx = option.value.lastIndexOf('.');
-    const firstPointIdx = option.value.indexOf('.');
-    const arr = option.value.substring(0, firstPointIdx);
-    const member = option.value.substring(firstPointIdx + 1);
-
+    const lastPointIdx = option.value.lastIndexOf('.');
+    // const firstPointIdx = option.value.indexOf('.');
+    const arr = option.value.substring(0, lastPointIdx);
+    const member = option.value.substring(lastPointIdx + 1);
     const value = item.value
       .replace('${arr}', arr)
       .replace('${member}', member);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 24fd099</samp>

Fixed a bug in the formula editor component that caused incorrect formula generation when the option value contained multiple dots. Modified the `handleMemberClick` function in `VariableList.tsx` to use the last index of the dot character instead of the first index.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 24fd099</samp>

> _Formula editor_
> _Fixes dot bug with `lastIndexOf`_
> _Winter of errors_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 24fd099</samp>

* Fix a bug in the formula editor component that caused incorrect formula generation when the option value contained multiple dots ([link](https://github.com/baidu/amis/pull/8252/files?diff=unified&w=0#diff-20ccd77f29dae5effdf503856c6589eb936a52ec3ac2f9a852f7c0d4b6b5a562L201-R204))
