### PR TITLE
fix(amis-editor-core): 构建发版时注入当前版本号信息

### DIFF
--- a/packages/amis-editor-core/rollup.config.js
+++ b/packages/amis-editor-core/rollup.config.js
@@ -22,6 +22,7 @@ import minify from 'postcss-minify';
 import autoprefixer from 'autoprefixer';
 import {terser} from 'rollup-plugin-terser';
 import postcss from 'rollup-plugin-postcss';
+import replace from '@rollup/plugin-replace';
 const cssUrl = require('postcss-url');
 const i18nConfig = require('./i18nConfig');
 
@@ -148,6 +149,10 @@ function getPlugins(format = 'esm') {
     resolve({
       jsnext: true,
       main: true
+    }),
+    replace({
+      preventAssignment: true,
+      __buildVersion: version
     }),
     commonjs({
       sourceMap: false

--- a/packages/amis-editor-core/src/index.ts
+++ b/packages/amis-editor-core/src/index.ts
@@ -37,6 +37,8 @@ import {AvailableRenderersPlugin} from './plugin/AvailableRenderers';
 import ShortcutKey from './component/base/ShortcutKey';
 import WidthDraggableContainer from './component/base/WidthDraggableContainer';
 
+export const version = '__buildVersion';
+
 export default Editor;
 
 export {

--- a/packages/amis-editor/rollup.config.js
+++ b/packages/amis-editor/rollup.config.js
@@ -17,11 +17,15 @@ import path from 'path';
 import svgr from '@svgr/rollup';
 import fs from 'fs';
 import i18nPlugin from 'plugin-react-i18n';
+import moment from 'moment';
 
 const i18nConfig = require('./i18nConfig');
 
 const settings = {
-  globals: {}
+  globals: {},
+  commonConfig: {
+    footer: `window.amisEditorVersionInfo={version:'${version}',buildTime:'${moment().format("YYYY-MM-DD")}'};`,
+  }
 };
 
 const external = id =>
@@ -42,6 +46,7 @@ export default [
     output: [
       {
         ...settings,
+        ...settings.commonConfig,
         dir: path.dirname(main),
         format: 'cjs',
         exports: 'named',
@@ -58,6 +63,7 @@ export default [
     output: [
       {
         ...settings,
+        ...settings.commonConfig,
         dir: path.dirname(module),
         format: 'esm',
         exports: 'named',
@@ -138,6 +144,7 @@ function getPlugins(format = 'esm') {
     license({
       banner: `
         ${name} v${version}
+        build time: <%=moment().format('YYYY-MM-DD')%>
         Copyright 2018<%= moment().format('YYYY') > 2018 ? '-' + moment().format('YYYY') : null %> ${author}
       `
     }),

--- a/packages/amis/rollup.config.js
+++ b/packages/amis/rollup.config.js
@@ -15,9 +15,13 @@ import {
 } from './package.json';
 import path from 'path';
 import svgr from '@svgr/rollup';
+import moment from 'moment';
 
 const settings = {
-  globals: {}
+  globals: {},
+  commonConfig: {
+    footer: `window.amisVersionInfo={version:'${version}',buildTime:'${moment().format("YYYY-MM-DD")}'};`,
+  }
 };
 
 const external = id => {
@@ -61,6 +65,7 @@ export default [
     output: [
       {
         ...settings,
+        ...settings.commonConfig,
         dir: path.dirname(main),
         format: 'cjs',
         exports: 'named',
@@ -78,6 +83,7 @@ export default [
     output: [
       {
         ...settings,
+        ...settings.commonConfig,
         dir: path.dirname(module),
         format: 'esm',
         exports: 'named',
@@ -204,6 +210,7 @@ function getPlugins(format = 'esm') {
     license({
       banner: `
         ${name} v${version}
+        build time: <%=moment().format('YYYY-MM-DD')%>
         Copyright 2018<%= moment().format('YYYY') > 2018 ? '-' + moment().format('YYYY') : null %> ${author}
       `
     })

--- a/packages/amis/src/renderers/Form/InputRichText.tsx
+++ b/packages/amis/src/renderers/Form/InputRichText.tsx
@@ -280,6 +280,7 @@ export default class RichTextControl extends React.Component<
       value,
       onChange,
       disabled,
+      static: isStatic,
       size,
       vendor,
       env,
@@ -289,6 +290,19 @@ export default class RichTextControl extends React.Component<
     } = this.props;
 
     const finnalVendor = vendor || (env.richTextToken ? 'froala' : 'tinymce');
+
+    if (isStatic) {
+      return (
+        <div
+          className={cx(`${ns}RichTextControl`, className, {
+            'is-focused': this.state.focused,
+            'is-disabled': disabled,
+            [`${ns}RichTextControl--border${ucFirst(borderMode)}`]: borderMode
+          })}
+          dangerouslySetInnerHTML={{__html: env.filterHtml(value)}}
+        ></div>
+      );
+    }
 
     return (
       <div


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f172ab</samp>

This pull request adds build information to the output files of the `amis`, `amis-editor`, and `amis-editor-core` packages, and enables rich text rendering in static mode for the `RichTextControl` component. It also updates and cleans up the rollup configurations for the packages and exports the `version` variable from the `amis-editor-core` package.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1f172ab</samp>

> _We are the masters of the code, we shape it as we please_
> _We inject the version and the date, we use the `replace` plugin_
> _We optimize and visualize, we add the `terser` and the `babel`_
> _We unleash the power of the rich text, we render it in static mode_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f172ab</samp>

*  Add build time information to the output files of `amis`, `amis-editor`, and `amis-editor-core` packages ([link](https://github.com/baidu/amis/pull/8253/files?diff=unified&w=0#diff-03e3a6043b801ca44d96d46f7552d08549f78a1dbdd73010b4effe0b0afd4a31R25), [link](https://github.com/baidu/amis/pull/8253/files?diff=unified&w=0#diff-03e3a6043b801ca44d96d46f7552d08549f78a1dbdd73010b4effe0b0afd4a31R153-R156), [link](https://github.com/baidu/amis/pull/8253/files?diff=unified&w=0#diff-6449992cb2efe3e6317741966a096ae7ba3f6ca4f8063fe6ed43ac552479b905R40-R41), [link](https://github.com/baidu/amis/pull/8253/files?diff=unified&w=0#diff-a54d5a460cdfe654e8addd3b498b933c1243615c89913bc34c3336eb34410e68L20-R28), [link](https://github.com/baidu/amis/pull/8253/files?diff=unified&w=0#diff-a54d5a460cdfe654e8addd3b498b933c1243615c89913bc34c3336eb34410e68R49), [link](https://github.com/baidu/amis/pull/8253/files?diff=unified&w=0#diff-a54d5a460cdfe654e8addd3b498b933c1243615c89913bc34c3336eb34410e68R66), [link](https://github.com/baidu/amis/pull/8253/files?diff=unified&w=0#diff-a54d5a460cdfe654e8addd3b498b933c1243615c89913bc34c3336eb34410e68R147), [link](https://github.com/baidu/amis/pull/8253/files?diff=unified&w=0#diff-625ea572b75678a7abf95e2462a19fdcd265572b80905d36ab5c001df0904125L18-R24), [link](https://github.com/baidu/amis/pull/8253/files?diff=unified&w=0#diff-625ea572b75678a7abf95e2462a19fdcd265572b80905d36ab5c001df0904125R68), [link](https://github.com/baidu/amis/pull/8253/files?diff=unified&w=0#diff-625ea572b75678a7abf95e2462a19fdcd265572b80905d36ab5c001df0904125R86), [link](https://github.com/baidu/amis/pull/8253/files?diff=unified&w=0#diff-625ea572b75678a7abf95e2462a19fdcd265572b80905d36ab5c001df0904125R213))
* Add `static` prop to `RichTextControl` component in `InputRichText.tsx` file ([link](https://github.com/baidu/amis/pull/8253/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15R283), [link](https://github.com/baidu/amis/pull/8253/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15R294-R306))
