### PR TITLE
fix: 修复api适配器回显问题

### DIFF
--- a/packages/amis-editor/src/renderer/APIAdaptorControl.tsx
+++ b/packages/amis-editor/src/renderer/APIAdaptorControl.tsx
@@ -115,6 +115,7 @@ export default class APIAdaptorControl extends React.Component<
           'api-adaptor-control-editor',
           {
             type: 'ae-functionEditorControl',
+            name: 'functionEditorControl',
             placeholder: editorPlaceholder,
             desc: editorDesc,
             allowFullscreen,

--- a/packages/amis-editor/src/renderer/FunctionEditorControl.tsx
+++ b/packages/amis-editor/src/renderer/FunctionEditorControl.tsx
@@ -136,11 +136,11 @@ export default class FunctionEditorControl extends React.Component<
           body: '<span class="mtk1 bracket-highlighting-0">}</span>',
           className: 'ae-FunctionEditorControl-func-footer'
         })}
-        {render('api-function-editor-control-editor/3', {
+        {/* {render('api-function-editor-control-editor/3', {
           type: 'container',
           className: 'cxd-Form-description',
           body: desc
-        })}
+        })} */}
       </>
     );
   }

--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -15,6 +15,7 @@ import reduce from 'lodash/reduce';
 import map from 'lodash/map';
 import omit from 'lodash/omit';
 import keys from 'lodash/keys';
+import type {Schema} from 'amis';
 
 import type {DSField} from '../builder';
 
@@ -451,11 +452,18 @@ setSchemaTpl(
     } = config || {};
     let curRendererSchema = rendererSchema;
 
-    if (useSelectMode && curRendererSchema && curRendererSchema.options) {
-      curRendererSchema = {
-        ...curRendererSchema,
-        type: 'select'
-      };
+    if (useSelectMode && curRendererSchema) {
+      if (typeof curRendererSchema === 'function') {
+        curRendererSchema = (schema: Schema) => ({
+          ...rendererSchema(schema),
+          type: 'select'
+        });
+      } else if (curRendererSchema.options) {
+        curRendererSchema = {
+          ...curRendererSchema,
+          type: 'select'
+        };
+      }
     }
 
     return {


### PR DESCRIPTION
### What
- fix: 修复api适配器回显问题
- fix: 默认值回调函数支持select选项配置

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ae0f7b9</samp>

This pull request improves the API adaptor control in the `amis-editor` by using the `Schema` type from `amis` and removing the unnecessary description container. It also adds a name property to the function editor control schema for identification.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ae0f7b9</samp>

> _`API adaptor`_
> _enhances amis-editor_
> _with schema function_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ae0f7b9</samp>

*  Add a name property to the function editor control schema to identify the control type ([link](https://github.com/baidu/amis/pull/8261/files?diff=unified&w=0#diff-02be4670a1c90d1a68dcd49df72b9908d9c65a69e263db17ab38bbbd4b8e42a0R118))
*  Remove the description container from the function editor control rendering, as it is not needed for the API adaptor control ([link](https://github.com/baidu/amis/pull/8261/files?diff=unified&w=0#diff-2e80072feea753befd007b468061838a09a29ed27379421b32eb8d6dba8bd17bL139-R143))
*  Import the Schema type from amis to define the renderer schema for the API adaptor control (`common.tsx`, [link](https://github.com/baidu/amis/pull/8261/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05R18))
*  Wrap the renderer schema with a function that sets the type to select if the schema is a function, to enable dynamic options rendering for the API adaptor control (`common.tsx`, [link](https://github.com/baidu/amis/pull/8261/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05L454-R467))
