### PR TITLE
fix:下拉选择上下文支持labelField和valueField

### DIFF
--- a/packages/amis-editor/src/plugin/Form/ButtonGroupSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/ButtonGroupSelect.tsx
@@ -219,11 +219,11 @@ export class ButtonGroupControlPlugin extends BasePlugin {
         type: 'object',
         title: node.schema?.label || node.schema?.name,
         properties: {
-          label: {
+          [node.schema?.labelField || 'label']: {
             type: 'string',
             title: '文本'
           },
-          value: {
+          [node.schema?.valueField || 'value']: {
             type,
             title: '值'
           }

--- a/packages/amis-editor/src/plugin/Form/ChainedSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/ChainedSelect.tsx
@@ -251,11 +251,11 @@ export class ChainedSelectControlPlugin extends BasePlugin {
           type: 'object',
           title: '成员',
           properties: {
-            label: {
+            [node.schema?.labelField || 'label']: {
               type: 'string',
               title: '文本'
             },
-            value: {
+            [node.schema?.valueField || 'value']: {
               type,
               title: '值'
             }

--- a/packages/amis-editor/src/plugin/Form/Checkboxes.tsx
+++ b/packages/amis-editor/src/plugin/Form/Checkboxes.tsx
@@ -245,11 +245,11 @@ export class CheckboxesControlPlugin extends BasePlugin {
         type: 'object',
         title: node.schema?.label || node.schema?.name,
         properties: {
-          label: {
+          [node.schema?.labelField || 'label']: {
             type: 'string',
             title: '文本'
           },
-          value: {
+          [node.schema?.valueField || 'value']: {
             type,
             title: '值'
           }

--- a/packages/amis-editor/src/plugin/Form/InputTag.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTag.tsx
@@ -224,11 +224,11 @@ export class TagControlPlugin extends BasePlugin {
           type: 'object',
           title: '成员',
           properties: {
-            label: {
+            [node.schema?.labelField || 'label']: {
               type: 'string',
               title: '文本'
             },
-            value: {
+            [node.schema?.valueField || 'value']: {
               type,
               title: '值'
             }

--- a/packages/amis-editor/src/plugin/Form/InputText.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputText.tsx
@@ -457,11 +457,11 @@ export class TextControlPlugin extends BasePlugin {
           type: 'object',
           title: node.schema?.label || node.schema?.name,
           properties: {
-            label: {
+            [node.schema?.labelField || 'label']: {
               type: 'string',
               title: '文本'
             },
-            value: {
+            [node.schema?.valueField || 'value']: {
               type,
               title: '值'
             }

--- a/packages/amis-editor/src/plugin/Form/InputTree.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTree.tsx
@@ -667,11 +667,11 @@ export class TreeControlPlugin extends BasePlugin {
         type: 'object',
         title: node.schema?.label || node.schema?.name,
         properties: {
-          label: {
+          [node.schema?.labelField || 'label']: {
             type: 'string',
             title: '文本'
           },
-          value: {
+          [node.schema?.valueField || 'value']: {
             type,
             title: '值'
           }

--- a/packages/amis-editor/src/plugin/Form/ListSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/ListSelect.tsx
@@ -150,11 +150,11 @@ export class ListControlPlugin extends BasePlugin {
         type: 'object',
         title: node.schema?.label || node.schema?.name,
         properties: {
-          label: {
+          [node.schema?.labelField || 'label']: {
             type: 'string',
             title: '文本'
           },
-          value: {
+          [node.schema?.valueField || 'value']: {
             type,
             title: '值'
           }

--- a/packages/amis-editor/src/plugin/Form/NestedSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/NestedSelect.tsx
@@ -384,11 +384,11 @@ export class NestedSelectControlPlugin extends BasePlugin {
         type: 'object',
         title: node.schema?.label || node.schema?.name,
         properties: {
-          label: {
+          [node.schema?.labelField || 'label']: {
             type: 'string',
             title: '文本'
           },
-          value: {
+          [node.schema?.valueField || 'value']: {
             type,
             title: '值'
           }

--- a/packages/amis-editor/src/plugin/Form/Picker.tsx
+++ b/packages/amis-editor/src/plugin/Form/Picker.tsx
@@ -301,11 +301,11 @@ export class PickerControlPlugin extends BasePlugin {
         type: 'object',
         title: node.schema?.label || node.schema?.name,
         properties: {
-          label: {
+          [node.schema?.labelField || 'label']: {
             type: 'string',
             title: '文本'
           },
-          value: {
+          [node.schema?.valueField || 'value']: {
             type,
             title: '值'
           }

--- a/packages/amis-editor/src/plugin/Form/Radios.tsx
+++ b/packages/amis-editor/src/plugin/Form/Radios.tsx
@@ -212,11 +212,11 @@ export class RadiosControlPlugin extends BasePlugin {
         type: 'object',
         title: node.schema?.label || node.schema?.name,
         properties: {
-          label: {
+          [node.schema?.labelField || 'label']: {
             type: 'string',
             title: '文本'
           },
-          value: {
+          [node.schema?.valueField || 'value']: {
             type,
             title: '值'
           }

--- a/packages/amis-editor/src/plugin/Form/Select.tsx
+++ b/packages/amis-editor/src/plugin/Form/Select.tsx
@@ -381,18 +381,18 @@ export class SelectControlPlugin extends BasePlugin {
       title: node.schema?.label || node.schema?.name,
       originalValue: node.schema?.value // 记录原始值，循环引用检测需要
     };
-
+    debugger;
     if (node.schema?.joinValues === false) {
       dataSchema = {
         ...dataSchema,
         type: 'object',
         title: node.schema?.label || node.schema?.name,
         properties: {
-          label: {
+          [node.schema?.labelField || 'label']: {
             type: 'string',
             title: '文本'
           },
-          value: {
+          [node.schema?.valueField || 'value']: {
             type,
             title: '值'
           }

--- a/packages/amis-editor/src/plugin/Form/TabsTransfer.tsx
+++ b/packages/amis-editor/src/plugin/Form/TabsTransfer.tsx
@@ -412,11 +412,11 @@ export class TabsTransferPlugin extends BasePlugin {
           type: 'object',
           title: '成员',
           properties: {
-            label: {
+            [node.schema?.labelField || 'label']: {
               type: 'string',
               title: '文本'
             },
-            value: {
+            [node.schema?.valueField || 'value']: {
               type,
               title: '值'
             }

--- a/packages/amis-editor/src/plugin/Form/Transfer.tsx
+++ b/packages/amis-editor/src/plugin/Form/Transfer.tsx
@@ -412,11 +412,11 @@ export class TransferPlugin extends BasePlugin {
           type: 'object',
           title: '成员',
           properties: {
-            label: {
+            [node.schema?.labelField || 'label']: {
               type: 'string',
               title: '文本'
             },
-            value: {
+            [node.schema?.valueField || 'value']: {
               type,
               title: '值'
             }

--- a/packages/amis-editor/src/plugin/Form/TreeSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/TreeSelect.tsx
@@ -663,11 +663,11 @@ export class TreeSelectControlPlugin extends BasePlugin {
         type: 'object',
         title: node.schema?.label || node.schema?.name,
         properties: {
-          label: {
+          [node.schema?.labelField || 'label']: {
             type: 'string',
             title: '文本'
           },
-          value: {
+          [node.schema?.valueField || 'value']: {
             type,
             title: '值'
           }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6e31c53</samp>

This pull request adds support for custom label and value fields for various form control plugins in `amis-editor`. It allows the user to specify the `labelField` and `valueField` properties in the node schema to define the fields that are used to display and store the values of the form controls, instead of using the fixed `label` and `value` fields. This enhances the flexibility and usability of the form editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6e31c53</samp>

> _Sing, O Muse, of the skillful work of the coder_
> _Who modified the `ControlPlugin` classes with wisdom and order_
> _To let the user define the `labelField` and `valueField` of each option_
> _And thus customize the display and storage of the node schema with precision_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6e31c53</samp>

*  Use `labelField` and `valueField` from node schema to customize label and value fields of options for various form controls ([link](https://github.com/baidu/amis/pull/8268/files?diff=unified&w=0#diff-ff3f4187b50d4f132c5ad5cec4a6ba113c8419508e8475325eebb6d3a482b24eL222-R226), [link](https://github.com/baidu/amis/pull/8268/files?diff=unified&w=0#diff-917a57d1cce34ec40de3b9031528fd56b7ef99391c1d66eab212a15b0c845ee5L254-R258), [link](https://github.com/baidu/amis/pull/8268/files?diff=unified&w=0#diff-4a3c5c6e5498b74e1254ee4f776efe0e8de65ee84a90f59472e29990f67e2978L248-R252), [link](https://github.com/baidu/amis/pull/8268/files?diff=unified&w=0#diff-627192cd96af48f2c73d0e47b271a92ab1873e7017bb7287c09fad69e84c7952L227-R231), [link](https://github.com/baidu/amis/pull/8268/files?diff=unified&w=0#diff-707b783556eac182d54138ee29fd68b050c8998fe310ddee763b7afebeaa1691L460-R464), [link](https://github.com/baidu/amis/pull/8268/files?diff=unified&w=0#diff-55fdd7d5626a1567f50acdbe20595be990fee38dbea26e0ea0e235f7cba3c57fL670-R674), [link](https://github.com/baidu/amis/pull/8268/files?diff=unified&w=0#diff-235237c89adc972d4bf87380300ca947a5a5de87d01b59c1bff98b4c95fa6f27L153-R157), [link](https://github.com/baidu/amis/pull/8268/files?diff=unified&w=0#diff-e4d19f31504ac61326d584930f7e66a1fe15dd8ded2886612df93a0ceaad3227L387-R391), [link](https://github.com/baidu/amis/pull/8268/files?diff=unified&w=0#diff-f2a58f8b179455b31f463e8a24eeab71bfc764efc43a3eaa40b332cc8bc1467eL304-R308), [link](https://github.com/baidu/amis/pull/8268/files?diff=unified&w=0#diff-ba6026b81d4a0bfe6ae014d8852678b351d6972fe75ae94732113ebea70a4435L215-R219), [link](https://github.com/baidu/amis/pull/8268/files?diff=unified&w=0#diff-83d37f4c45d6ac38e41a04b6511b7921d73c2b0a35163df31401c8c0f408e0c4L391-R395), [link](https://github.com/baidu/amis/pull/8268/files?diff=unified&w=0#diff-9dbeed96e9421a665d70145150b206f3f53e42123814c96c4c552c836c877f8dL415-R419), [link](https://github.com/baidu/amis/pull/8268/files?diff=unified&w=0#diff-1407e54f85bb9fa414ee7d73970297153339f0f0d6beb000dd91ac026b73e912L415-R419), [link](https://github.com/baidu/amis/pull/8268/files?diff=unified&w=0#diff-90baebf200b81ed14dd4240db28e6f322004b03cd30f304d5757560f6b7b65ecL666-R670))
* Add `debugger` statement to `SelectControlPlugin` class in `Select.tsx` for debugging purposes ([link](https://github.com/baidu/amis/pull/8268/files?diff=unified&w=0#diff-83d37f4c45d6ac38e41a04b6511b7921d73c2b0a35163df31401c8c0f408e0c4L384-R384))
