### PR TITLE
style: 修复toast组件info和success级别下body字体大小不一致的问题

### DIFF
--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -3501,7 +3501,7 @@
   --Toast--danger-bottom-left-border-radius: var(--borders-radius-3);
   --Toast--danger-bgColor: var(--colors-neutral-fill-11);
   --Toast--info-color: var(--colors-neutral-text-2);
-  --Toast--info-fontSize: var(--fonts-size-7);
+  --Toast--info-fontSize: var(--fonts-size-8);
   --Toast--info-fontWeight: var(--fonts-weight-6);
   --Toast--info-top-border-color: var(--colors-neutral-line-11);
   --Toast--info-top-border-width: var(--borders-width-2);
@@ -3517,7 +3517,6 @@
   --Toast--info-left-border-style: var(--borders-style-2);
   --Toast--info-bgColor: var(--colors-neutral-fill-11);
   --Toast--success-color: var(--colors-neutral-text-2);
-  --Toast--success-fontSize: var(--fonts-weight-6);
   --Toast--success-fontWeight: var(--fonts-weight-6);
   --Toast--success-fontSize: var(--fonts-size-8);
   --Toast--success-fontWeight: var(--fonts-weight-6);


### PR DESCRIPTION
### What
toast组件在不同级别下展示的大小不一致
<img width="785" alt="image" src="https://github.com/baidu/amis/assets/39587710/e24a9978-3923-438a-b449-600313e61547">

对应的代码
```
{
  "type": "page",
  "body": [
    {
      "label": "提示",
      "type": "button",
      "actionType": "toast",
      "toast": {
        "items": [
          {
            "body": "轻提示内容"
          }
        ]
      }
    },
    {
      "label": "提示2",
      "type": "button",
      "actionType": "toast",
      "toast": {
        "items": [
          {
            "level": "success",
            "body": "轻提示内容2"
          }
        ]
      }
    }
  ]
}
```


### Why

因为scss字体设置不一致


### How
将字体统一设置为`--fonts-size-8`

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7c5611b</samp>

* Increase the font size of the info toast to 8 for better readability and consistency ([link](https://github.com/baidu/amis/pull/8270/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4L3504-R3504))
* Remove the redundant font size of the success toast and inherit from the default toast ([link](https://github.com/baidu/amis/pull/8270/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4L3520))
