### PR TITLE
fix: 修复input-table有编辑项时，分页后，在后面页进行项的删除，出现删除项不正确问题

### DIFF
--- a/packages/amis/src/renderers/QuickEdit.tsx
+++ b/packages/amis/src/renderers/QuickEdit.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import {findDOMNode} from 'react-dom';
-import {RendererProps, noop} from 'amis-core';
+import {RendererProps, getRendererByName, noop} from 'amis-core';
 import hoistNonReactStatic from 'hoist-non-react-statics';
 import {ActionObject} from 'amis-core';
 import keycode from 'keycode';
@@ -121,8 +121,10 @@ export const HocQuickEdit =
         this.handleWindowKeyPress = this.handleWindowKeyPress.bind(this);
         this.handleWindowKeyDown = this.handleWindowKeyDown.bind(this);
         this.formRef = this.formRef.bind(this);
+        this.formItemRef = this.formItemRef.bind(this);
         this.handleInit = this.handleInit.bind(this);
         this.handleChange = this.handleChange.bind(this);
+        this.handleFormItemChange = this.handleFormItemChange.bind(this);
 
         this.state = {
           isOpened: false
@@ -150,6 +152,17 @@ export const HocQuickEdit =
           }
 
           quickEditFormRef(ref, colIndex, rowIndex);
+        }
+      }
+      formItemRef(ref: any) {
+        const {quickEditFormItemRef, rowIndex, colIndex} = this.props;
+
+        if (quickEditFormItemRef) {
+          while (ref && ref.getWrappedInstance) {
+            ref = ref.getWrappedInstance();
+          }
+
+          quickEditFormItemRef(ref, colIndex, rowIndex);
         }
       }
 
@@ -331,6 +344,17 @@ export const HocQuickEdit =
 
         onQuickChange(
           values,
+          (quickEdit as QuickEditConfig).saveImmediately,
+          false,
+          quickEdit as QuickEditConfig
+        );
+      }
+
+      handleFormItemChange(value: any) {
+        const {onQuickChange, quickEdit, name} = this.props;
+
+        onQuickChange(
+          {[name!]: value},
           (quickEdit as QuickEditConfig).saveImmediately,
           false,
           quickEdit as QuickEditConfig
@@ -526,6 +550,51 @@ export const HocQuickEdit =
         );
       }
 
+      renderInlineForm() {
+        const {
+          render,
+          classnames: cx,
+          canAccessSuperData,
+          disabled,
+          value,
+          name
+        } = this.props;
+
+        const schema: any = this.buildSchema();
+
+        // 有且只有一个表单项时，直接渲染表单项
+        if (
+          Array.isArray(schema.body) &&
+          schema.body.length === 1 &&
+          !schema.body[0].unique && // 唯一模式还不支持
+          !schema.body[0].value && // 不能有默认值表达式什么的情况
+          schema.body[0].name &&
+          schema.body[0].name === name &&
+          schema.body[0].type &&
+          getRendererByName(schema.body[0].type)?.isFormItem
+        ) {
+          return render('inline-form-item', schema.body[0], {
+            mode: 'normal',
+            value: value || '',
+            onChange: this.handleFormItemChange,
+            ref: this.formItemRef
+          });
+        }
+
+        return render('inline-form', schema, {
+          value: undefined,
+          wrapperComponent: 'div',
+          className: cx('Form--quickEdit'),
+          ref: this.formRef,
+          simpleMode: true,
+          onInit: this.handleInit,
+          onChange: this.handleChange,
+          formLazyChange: false,
+          canAccessSuperData,
+          disabled
+        });
+      }
+
       render() {
         const {
           onQuickChange,
@@ -556,20 +625,7 @@ export const HocQuickEdit =
           (quickEdit as QuickEditConfig).isFormMode
         ) {
           return (
-            <Component {...this.props}>
-              {render('inline-form', this.buildSchema(), {
-                value: undefined,
-                wrapperComponent: 'div',
-                className: cx('Form--quickEdit'),
-                ref: this.formRef,
-                simpleMode: true,
-                onInit: this.handleInit,
-                onChange: this.handleChange,
-                formLazyChange: false,
-                canAccessSuperData,
-                disabled
-              })}
-            </Component>
+            <Component {...this.props}>{this.renderInlineForm()}</Component>
           );
         } else {
           return (


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 495aac8</samp>

Added a new feature to the quick edit component that allows editing a single form item inline. Refactored the rendering logic to use existing helper functions and added event handlers to control the form item state. Modified `QuickEdit.tsx` and related tests.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 495aac8</samp>

> _To edit a single form item_
> _The quick edit component got 'em_
> _It uses `getRendererByName`_
> _And `renderInlineForm` to simplify_
> _The logic for `formItemRef` and `handleFormItemChange` to spot 'em_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 495aac8</samp>

* Import `getRendererByName` function to check renderer type ([link](https://github.com/baidu/amis/pull/8271/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L8-R8))
* Add and bind `formItemRef` and `handleFormItemChange` methods to handle single form item case ([link](https://github.com/baidu/amis/pull/8271/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L124-R127))
* Implement `formItemRef` to pass form item reference to parent prop `quickEditFormItemRef` ([link](https://github.com/baidu/amis/pull/8271/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L155-R168))
* Implement `handleFormItemChange` to call `onQuickChange` prop with value and `saveImmediately` option ([link](https://github.com/baidu/amis/pull/8271/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1R353-R363))
* Add `renderInlineForm` method to render inline form or single form item based on schema and renderer type ([link](https://github.com/baidu/amis/pull/8271/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1R553-R597))
* Use `renderInlineForm` in render method of `QuickEditComponent` class ([link](https://github.com/baidu/amis/pull/8271/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L559-R628))
