### PR TITLE
Fix input date of input table empty value required validate fail

### DIFF
--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -128,6 +128,9 @@ interface TreeSelectorProps extends ThemeProps, LocaleProps, SpinnerExtraProps {
   createTip?: string;
   // 是否开启虚拟滚动
   virtualThreshold?: number;
+  virtualContainerHeight?: number;
+  virtualContainerWidth?: number;
+  virtualOverscanCount?: number;
   itemHeight?: number;
   onAdd?: (
     idx?: number | Array<number>,
@@ -1417,11 +1420,23 @@ export class TreeSelector extends React.Component<
 
   @autobind
   renderList(list: Options, value: any[]) {
-    const {virtualThreshold, itemHeight = 32} = this.props;
+    const {
+      virtualThreshold,
+      itemHeight = 32,
+      virtualContainerHeight,
+      virtualContainerWidth,
+      virtualOverscanCount
+    } = this.props;
     if (virtualThreshold && list.length > virtualThreshold) {
       return (
         <VirtualList
-          height={list.length > 8 ? 266 : list.length * itemHeight}
+          height={
+            list.length > 8
+              ? virtualContainerHeight || 266
+              : list.length * itemHeight
+          }
+          width={virtualContainerWidth}
+          overscanCount={virtualOverscanCount}
           itemCount={list.length}
           prefix={this.renderCheckAll()}
           itemSize={itemHeight}

--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -624,14 +624,18 @@ export default class FormTable extends React.Component<TableProps, TableState> {
               column.type === 'input-quarter' ||
               column.type === 'input-year')
           ) {
-            const date = filterDate(column.value, data, column.format || 'X');
-            setVariable(
-              value,
-              column.name,
-              (column.utc ? moment.utc(date) : date).format(
-                column.format || 'X'
-              )
-            );
+            if (
+              !(typeof column.value === 'string' && column.value.trim() === '')
+            ) {
+              const date = filterDate(column.value, data, column.format || 'X');
+              setVariable(
+                value,
+                column.name,
+                (column.utc ? moment.utc(date) : date).format(
+                  column.format || 'X'
+                )
+              );
+            }
           } else {
             /** 如果value值设置为表达式，则忽略 */
             if (!isExpression(column.value)) {

--- a/packages/amis/src/renderers/Form/InputTree.tsx
+++ b/packages/amis/src/renderers/Form/InputTree.tsx
@@ -372,6 +372,9 @@ export default class TreeControl extends React.Component<TreeProps, TreeState> {
       translate: __,
       data,
       virtualThreshold,
+      virtualContainerWidth,
+      virtualContainerHeight,
+      virtualOverscanCount,
       itemHeight,
       loadingConfig,
       menuTpl,
@@ -438,6 +441,13 @@ export default class TreeControl extends React.Component<TreeProps, TreeState> {
         onDeferLoad={deferLoad}
         onExpandTree={expandTreeOptions}
         virtualThreshold={virtualThreshold}
+        virtualContainerWidth={virtualContainerWidth}
+        virtualContainerHeight={virtualContainerHeight}
+        virtualOverscanCount={
+          toNumber(virtualOverscanCount) > 0
+            ? toNumber(virtualOverscanCount)
+            : undefined
+        }
         itemHeight={toNumber(itemHeight) > 0 ? toNumber(itemHeight) : undefined}
         itemRender={menuTpl ? this.renderOptionItem : undefined}
         enableDefaultIcon={enableDefaultIcon}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 36eccdd</samp>

This pull request improves the `TreeSelector` and `InputTree` components by adding props for virtualized list customization, and fixes a date value bug in the `InputTable` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 36eccdd</samp>

> _`InputTable` fixed_
> _`TreeSelector` improved_
> _`InputTree` follows_

### Why
![0262b5ffd2e8eafc68f046425c8bd79f](https://github.com/baidu/amis/assets/16409259/9ea9fa0e-7ab3-4c69-8e86-b89ad2a32dc5)


<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 36eccdd</samp>

*  Add optional props to customize the size and performance of the virtualized list component that renders the tree options in `TreeSelector` and `InputTree` components ([link](https://github.com/baidu/amis/pull/8274/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7R131-R133), [link](https://github.com/baidu/amis/pull/8274/files?diff=unified&w=0#diff-527e78ca6789f4f47200b93123fe7f7884acc6890540c2616a3bc4cf4f41cd2bR375-R377))
*  Use the new props to set the height, width, and overscan count of the virtual list in `TreeSelector` ([link](https://github.com/baidu/amis/pull/8274/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1420-R1439))
*  Pass the new props to the `TreeSelector` component in `InputTree` and validate the overscan count prop ([link](https://github.com/baidu/amis/pull/8274/files?diff=unified&w=0#diff-527e78ca6789f4f47200b93123fe7f7884acc6890540c2616a3bc4cf4f41cd2bR444-R450))
*  Fix a bug in `InputTable` that sets the date value to the current timestamp if the column value is an empty string ([link](https://github.com/baidu/amis/pull/8274/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL627-R638))
