### PR TITLE
fix: 修复inputTable中inputDate组件初始化值是Invalid Date导致的必填校验失效问题

### DIFF
--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -624,14 +624,18 @@ export default class FormTable extends React.Component<TableProps, TableState> {
               column.type === 'input-quarter' ||
               column.type === 'input-year')
           ) {
-            const date = filterDate(column.value, data, column.format || 'X');
-            setVariable(
-              value,
-              column.name,
-              (column.utc ? moment.utc(date) : date).format(
-                column.format || 'X'
-              )
-            );
+            if (
+              !(typeof column.value === 'string' && column.value.trim() === '')
+            ) {
+              const date = filterDate(column.value, data, column.format || 'X');
+              setVariable(
+                value,
+                column.name,
+                (column.utc ? moment.utc(date) : date).format(
+                  column.format || 'X'
+                )
+              );
+            }
           } else {
             /** 如果value值设置为表达式，则忽略 */
             if (!isExpression(column.value)) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5cc87a6</samp>

Fix a bug in `InputTable` component where empty string values would cause date input errors. Add a condition to skip date filtering for empty strings in `packages/amis/src/renderers/Form/InputTable.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5cc87a6</samp>

> _`InputTable` cells_
> _Empty strings break the date_
> _Check before filter_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5cc87a6</samp>

* Fix a bug where empty string column values would cause invalid date input errors in `InputTable` component ([link](https://github.com/baidu/amis/pull/8276/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL627-R638))
