### PR TITLE
feat: 列表类组件支持更新指定行记录 Close #8258

### DIFF
--- a/docs/zh-CN/components/crud.md
+++ b/docs/zh-CN/components/crud.md
@@ -4503,6 +4503,165 @@ value 结构说明：
 ]
 ```
 
+#### 更新指定行记录
+
+可以通过指定`index`或者`condition`来分别更新指定索引的行记录和指定满足条件（条件表达式或者 ConditionBuilder）的行记录，另外`replace`同样生效，即可以完全替换指定行记录，也可以对指定行记录做合并。
+
+```schema
+{
+  type: 'page',
+  data: {
+    i: '3,5'
+  },
+  body: [
+    [
+      {
+        "type": "button",
+        "label": "更新index为3和5的行记录",
+        "onEvent": {
+          "click": {
+            "actions": [
+              {
+                "actionType": "setValue",
+                "componentId": "crud_setvalue_item",
+                "args": {
+                  "value": {
+                    "engine": "amis",
+                    "browser": "Chrome",
+                    "platform": "Mac Pro",
+                    "version": "4",
+                    "grade": "Y",
+                    "badgeText": "你好！",
+                    "id": 1234
+                  },
+                  "index": "${i}"
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "button",
+        "label": "更新index为3和5的行记录(替换)",
+        "onEvent": {
+          "click": {
+            "actions": [
+              {
+                "actionType": "setValue",
+                "componentId": "crud_setvalue_item",
+                "args": {
+                  "value": {
+                    "engine": "amis",
+                    "id": 1234
+                  },
+                  "index": "${i}",
+                  "replace": true
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+          "type": "button",
+          "label": "更新version=7的行记录",
+          "onEvent": {
+            "click": {
+              "actions": [
+                {
+                  "actionType": "setValue",
+                  "componentId": "crud_setvalue_item",
+                  "args": {
+                    "value": {
+                      "engine": "amis",
+                      "browser": "Chrome",
+                      "platform": "Mac Pro",
+                      "version": "4",
+                      "grade": "Y",
+                      "badgeText": "你好！",
+                      "id": 1234
+                    },
+                    "condition": "${version === '7'}"
+                  }
+                }
+              ]
+            }
+          }
+      },
+      {
+        "type": "button",
+        "label": "更新version=4的行记录",
+        "onEvent": {
+          "click": {
+            "actions": [
+              {
+                "actionType": "setValue",
+                "componentId": "crud_setvalue_item",
+                "args": {
+                  "value": {
+                    "engine": "amis",
+                    "browser": "Chrome",
+                    "platform": "Mac Pro",
+                    "version": "4",
+                    "grade": "Y",
+                    "badgeText": "你好！",
+                    "id": 1234
+                  },
+                  "condition": {
+                      conjunction: 'and',
+                      children: [
+                        {
+                          left: {
+                            type: 'field',
+                            field: 'version'
+                          },
+                          op: 'equal',
+                          right: "4"
+                        }
+                      ]
+                    }
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "crud",
+        "id": "crud_setvalue_item",
+        "syncLocation": false,
+        "api": "/api/mock2/sample",
+        "quickSaveApi": "/api/mock2/sample/bulkUpdate",
+        "headerToolbar": [
+          {
+            "type": "tpl",
+            "tpl": "记录总数：${count}"
+          }
+        ],
+        "columns": [
+          {
+            "name": "id",
+            "label": "ID",
+            "id": "u:3db3f2b1b99e"
+          },
+          {
+            "name": "engine",
+            "label": "engine",
+            "id": "u:0b9be99f3403"
+          },
+          {
+            "name": "version",
+            "label": "version",
+            "id": "u:4868d7db0139"
+          }
+        ]
+      }
+  ]
+  ]
+}
+```
+
 #### 行记录中字段赋值
 
 需要通过表达式配置动态`name`或`id`和`componentName`或`componentId`。例如修改`engine`选中状态的同时选中`version`，勾选`id`的同时去掉对`engine`的选中。

--- a/docs/zh-CN/components/form/combo.md
+++ b/docs/zh-CN/components/form/combo.md
@@ -1060,6 +1060,269 @@ combo 还有一个作用是增加层级，比如返回的数据是一个深层�
 }
 ```
 
+#### 更新所有记录
+
+```schema: scope="body"
+{
+  "type": "form",
+  "debug": true,
+  "data": {
+    "combo": [
+      {
+        "select_1": "A",
+        "select_2": "c"
+      },
+      {
+        "select_1": "A",
+        "select_2": "d"
+      },
+      {
+        "select_1": "B",
+        "select_2": "d"
+      }
+    ]
+  },
+  "mode": "horizontal",
+  "api": "/api/mock2/form/saveForm",
+  "body": [
+    {
+      "type": "button",
+      "label": "更新所有记录",
+      "onEvent": {
+        "click": {
+          "actions": [
+            {
+              "componentId": "combo_setvalue_item",
+              "actionType": "setValue",
+              "args": {
+                "value": [
+                  {
+                      "select_1": "B",
+                      "select_2": "a"
+                  },
+                  {
+                      "select_1": "D",
+                      "select_2": "c"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "combo",
+      "label": "组合输入",
+      "name": "combo",
+      "className": "mt-2",
+      "id": "combo_setvalue_item",
+      "multiple": true,
+      "items": [
+        {
+          "type": "select",
+          "label": "选项",
+          "name": "select_1",
+          "options": [
+            {
+              "label": "选项A",
+              "value": "A"
+            },
+            {
+              "label": "选项B",
+              "value": "B"
+            },
+            {
+              "label": "选项C",
+              "value": "C"
+            },
+            {
+              "label": "选项D",
+              "value": "D"
+            }
+          ]
+        },
+        {
+          "type": "select",
+          "name": "select_2",
+          "placeholder": "选项",
+          "options": [
+            {
+              "label": "C",
+              "value": "c"
+            },
+            {
+              "label": "D",
+              "value": "c"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### 更新指定行记录
+
+```schema: scope="body"
+{
+  "type": "form",
+  "debug": true,
+  "data": {
+    "combo": [
+      {
+        "select_1": "A",
+        "select_2": "c"
+      },
+      {
+        "select_1": "A",
+        "select_2": "d"
+      },
+      {
+        "select_1": "B",
+        "select_2": "d"
+      },
+      {
+        "select_1": "C",
+        "select_2": "d"
+      },
+      {
+        "select_1": "D",
+        "select_2": "d"
+      }
+    ]
+  },
+  "mode": "horizontal",
+  "api": "/api/mock2/form/saveForm",
+  "body": [
+    {
+      "type": "button",
+      "label": "更新index为1和3的行记录",
+      "onEvent": {
+        "click": {
+          "actions": [
+            {
+              "componentId": "combo_setvalue_item",
+              "actionType": "setValue",
+              "args": {
+                "value": {
+                    "select_1": "B",
+                    "select_2": "a"
+                },
+                "index": '1,3'
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "button",
+      "label": "更新选项为选项A的行记录",
+      "onEvent": {
+        "click": {
+          "actions": [
+            {
+              "componentId": "combo_setvalue_item",
+              "actionType": "setValue",
+              "args": {
+                "value": {
+                    "select_1": "B",
+                    "select_2": "a"
+                },
+                "condition": "${select_1 === 'A'}"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "button",
+      "label": "更新选项为选项D的行记录",
+      "onEvent": {
+        "click": {
+          "actions": [
+            {
+              "componentId": "combo_setvalue_item",
+              "actionType": "setValue",
+              "args": {
+                "value": {
+                    "select_1": "B",
+                    "select_2": "a"
+                },
+                "condition": {
+                  conjunction: 'and',
+                  children: [
+                    {
+                      left: {
+                        type: 'field',
+                        field: 'select_1'
+                      },
+                      op: 'equal',
+                      right: "D"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "combo",
+      "label": "组合输入",
+      "name": "combo",
+      "className": "mt-2",
+      "id": "combo_setvalue_item",
+      "multiple": true,
+      "items": [
+        {
+          "type": "select",
+          "label": "选项",
+          "name": "select_1",
+          "options": [
+            {
+              "label": "选项A",
+              "value": "A"
+            },
+            {
+              "label": "选项B",
+              "value": "B"
+            },
+            {
+              "label": "选项C",
+              "value": "C"
+            },
+            {
+              "label": "选项D",
+              "value": "D"
+            }
+          ]
+        },
+        {
+          "type": "select",
+          "name": "select_2",
+          "placeholder": "选项",
+          "options": [
+            {
+              "label": "C",
+              "value": "c"
+            },
+            {
+              "label": "D",
+              "value": "c"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
 #### 行记录内表单项联动
 
 在 combo 中行记录内表单项联动需要指定`componentName`为需要联动的表单项名称，以下示例中，当选择指定行内第一个下拉框的值时，将对应的修改所在行内第二个下拉框的值。

--- a/docs/zh-CN/components/form/input-table.md
+++ b/docs/zh-CN/components/form/input-table.md
@@ -1792,6 +1792,8 @@ order: 54
 
 ### setValue
 
+#### 更新列表记录
+
 ```schema: scope="body"
 {
   "type": "form",
@@ -1799,7 +1801,7 @@ order: 54
   "body": [
     {
       "type": "button",
-      "label": "赋值",
+      "label": "更新列表记录",
       "onEvent": {
         "click": {
           "actions": [
@@ -1818,6 +1820,149 @@ order: 54
                     "b": "b-setValue2"
                   }
                 ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "input-table",
+      "label": "表格表单",
+      "id": "setValue-input-table",
+      "name": "table",
+      "columns": [
+        {
+          "name": "a",
+          "label": "A"
+        },
+        {
+          "name": "b",
+          "label": "B"
+        }
+      ],
+      "addable": true,
+      "footerAddBtn": {
+        "label": "新增",
+        "icon": "fa fa-plus",
+        "hidden": true
+      },
+      "strictMode": true,
+      "minLength": 0,
+      "needConfirm": false,
+      "showTableAddBtn": false
+    }
+  ],
+  "data": {
+    "table": [
+      {
+        "id": 1,
+        "a": "a1",
+        "b": "b1"
+      },
+      {
+        "id": 2,
+        "a": "a2",
+        "b": "b2"
+      },
+      {
+        "id": 3,
+        "a": "a3",
+        "b": "b3"
+      },
+      {
+        "id": 4,
+        "a": "a4",
+        "b": "b4"
+      },
+      {
+        "id": 5,
+        "a": "a5",
+        "b": "b5"
+      }
+    ]
+  }
+}
+```
+
+#### 更新指定行记录
+
+可以通过指定`index`或者`condition`来分别更新指定索引的行记录和指定满足条件（条件表达式或者 ConditionBuilder）的行记录。
+
+```schema: scope="body"
+{
+  "type": "form",
+  "api": "/api/mock2/form/saveForm",
+  "body": [
+    {
+      "type": "button",
+      "label": "更新index为1和3的行记录",
+      "onEvent": {
+        "click": {
+          "actions": [
+            {
+              "componentId": "setValue-input-table",
+              "actionType": "setValue",
+              "args": {
+                "value": {
+                    "a": "a-setValue1",
+                    "b": "b-setValue1"
+                },
+                "index": '1,3'
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "button",
+      "label": "更新a=a3的行记录",
+      "onEvent": {
+        "click": {
+          "actions": [
+            {
+              "componentId": "setValue-input-table",
+              "actionType": "setValue",
+              "args": {
+                "value": {
+                    "a": "a-setValue1",
+                    "b": "b-setValue1"
+                },
+                "condition": "${a === 'a3'}"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "button",
+      "label": "更新a=a5的行记录",
+      "onEvent": {
+        "click": {
+          "actions": [
+            {
+              "componentId": "setValue-input-table",
+              "actionType": "setValue",
+              "args": {
+                "value": {
+                    "a": "a-setValue1",
+                    "b": "b-setValue1"
+                },
+                "condition": {
+                  conjunction: 'and',
+                  children: [
+                    {
+                      left: {
+                        type: 'field',
+                        field: 'a'
+                      },
+                      op: 'equal',
+                      right: "a5"
+                    }
+                  ]
+                }
               }
             }
           ]

--- a/docs/zh-CN/components/table.md
+++ b/docs/zh-CN/components/table.md
@@ -2798,6 +2798,8 @@ value 结构说明：
 
 ### setValue
 
+#### 更新列表记录
+
 ```schema: scope="body"
 [
     {
@@ -2892,4 +2894,164 @@ value 结构说明：
       ]
     }
 ]
+```
+
+#### 更新指定行记录
+
+可以通过指定`index`或者`condition`来分别更新指定索引的行记录和指定满足条件（条件表达式或者 ConditionBuilder）的行记录，另外`replace`同样生效，即可以完全替换指定行记录，也可以对指定行记录做合并。
+
+```schema
+{
+    "type": "page",
+    "data": {
+        i: '1,3'
+    },
+    body: [
+    {
+        "type": "button",
+        "label": "更新index为1和3的行记录",
+        "onEvent": {
+          "click": {
+            "actions": [
+              {
+                "actionType": "setValue",
+                "componentId": "table_setvalue_item",
+                "args": {
+                  "value": {
+                    "engine": "amis",
+                    "browser": "Chrome",
+                    "platform": "Mac Pro",
+                    "version": "8",
+                    "grade": "Y",
+                    "badgeText": "你好！",
+                    "id": 1234
+                  },
+                  "index": "${i}"
+                }
+              }
+            ]
+          }
+        }
+    },
+    {
+        "type": "button",
+        "label": "更新index为1和3的行记录(替换)",
+        "onEvent": {
+          "click": {
+            "actions": [
+              {
+                "actionType": "setValue",
+                "componentId": "table_setvalue_item",
+                "args": {
+                  "value": {
+                    "engine": "amis",
+                    "id": 1234
+                  },
+                  "index": "${i}",
+                  "replace": true
+                }
+              }
+            ]
+          }
+        }
+    },
+    {
+        "type": "button",
+        "label": "更新version=7的行记录",
+        "onEvent": {
+          "click": {
+            "actions": [
+              {
+                "actionType": "setValue",
+                "componentId": "table_setvalue_item",
+                "args": {
+                  "value": {
+                    "engine": "amis",
+                    "browser": "Chrome",
+                    "platform": "Mac Pro",
+                    "version": "4",
+                    "grade": "Y",
+                    "badgeText": "你好！",
+                    "id": 1234
+                  },
+                  "condition": "${version === '7'}"
+                }
+              }
+            ]
+          }
+        }
+    },
+    {
+        "type": "button",
+        "label": "更新version=4的行记录",
+        "onEvent": {
+          "click": {
+            "actions": [
+              {
+                "actionType": "setValue",
+                "componentId": "table_setvalue_item",
+                "args": {
+                  "value": {
+                    "engine": "amis",
+                    "browser": "Chrome",
+                    "platform": "Mac Pro",
+                    "version": "4",
+                    "grade": "Y",
+                    "badgeText": "你好！",
+                    "id": 1234
+                  },
+                  "condition": {
+                      conjunction: 'and',
+                      children: [
+                        {
+                          left: {
+                            type: 'field',
+                            field: 'version'
+                          },
+                          op: 'equal',
+                          right: "4"
+                        }
+                      ]
+                    }
+                }
+              }
+            ]
+          }
+        }
+    },
+    {
+      "type": "service",
+      "id": "u:b25a8ef0050b",
+      "api": {
+        "method": "get",
+        "url": "/api/mock2/sample?perPage=5"
+      },
+      "body": [
+        {
+          "type": "table",
+          "id": "table_setvalue_item",
+          "title": "引擎列表",
+          "source": "$rows",
+          "columns": [
+            {
+              "name": "engine",
+              "label": "Engine",
+              "id": "u:4aa2e9034698",
+              "inline": true
+            },
+            {
+              "name": "version",
+              "label": "Version",
+              "id": "u:8b4cb96ca2bf",
+              "inline": true,
+              "tpl": "${version}"
+            }
+          ],
+          "selectable": true,
+          "multiple": true
+        }
+      ]
+    }
+    ]
+}
 ```

--- a/packages/amis-core/src/actions/CmptAction.ts
+++ b/packages/amis-core/src/actions/CmptAction.ts
@@ -13,6 +13,7 @@ export interface ICmptAction extends ListenerAction {
     path?: string; // setValue时，目标变量的path
     value?: string | {[key: string]: string}; // setValue时，目标变量的值
     index?: number; // setValue时，支持更新指定索引的数据，一般用于数组类型
+    condition?: any; // setValue时，支持更新指定条件的数据，一般用于数组类型
   };
 }
 
@@ -74,7 +75,8 @@ export class CmptAction implements RendererAction {
         return component?.setData(
           action.args?.value,
           dataMergeMode === 'override',
-          action.args?.index
+          action.args?.index,
+          action.args?.condition
         );
       } else {
         return component?.props.onChange?.(action.args?.value);

--- a/packages/amis/src/renderers/Form/Combo.tsx
+++ b/packages/amis/src/renderers/Form/Combo.tsx
@@ -7,7 +7,8 @@ import {
   FormBaseControl,
   resolveEventData,
   ApiObject,
-  FormHorizontal
+  FormHorizontal,
+  evalExpressionWithConditionBuilder
 } from 'amis-core';
 import {ActionObject, Api} from 'amis-core';
 import {ComboStore, IComboStore} from 'amis-core';
@@ -1815,13 +1816,37 @@ export default class ComboControl extends React.Component<ComboProps> {
 })
 export class ComboControlRenderer extends ComboControl {
   // 支持更新指定索引的值
-  setData(value: any, replace?: boolean, index?: number) {
+  async setData(
+    value: any,
+    replace?: boolean,
+    index?: number | string,
+    condition?: any
+  ) {
     const {multiple, onChange, submitOnChange} = this.props;
     if (multiple) {
-      if (index !== undefined && ~index) {
-        let newValue = [...this.getValueAsArray()];
-        newValue.splice(index, 1, {...newValue[index], ...value});
-        onChange?.(newValue, submitOnChange, true);
+      let items = [...this.getValueAsArray()];
+      const len = items.length;
+      if (index !== undefined) {
+        const indexs = String(index).split(',');
+        indexs.forEach(i => {
+          const intIndex = Number(i);
+          items.splice(intIndex, 1, {...items[intIndex], ...value}); // 默认merge
+        });
+        onChange?.(items, submitOnChange, true);
+      } else if (condition !== undefined) {
+        for (let i = 0; i < len; i++) {
+          const item = items[i];
+          const isUpdate = await evalExpressionWithConditionBuilder(
+            condition,
+            item
+          );
+
+          if (isUpdate) {
+            items.splice(i, 1, {...items[i], ...value}); // 默认merge
+          }
+        }
+
+        onChange?.(items, submitOnChange, true);
       } else {
         onChange?.(value, submitOnChange, true);
       }

--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -1683,11 +1683,37 @@ export default class FormTable extends React.Component<TableProps, TableState> {
   type: 'input-table'
 })
 export class TableControlRenderer extends FormTable {
-  setData(value: any, replace?: boolean, index?: number) {
-    if (index !== undefined && ~index) {
-      // 如果setValue动作传入了index，更新指定索引的值
-      const items = [...this.state.items];
-      items.splice(index, 1, value);
+  async setData(
+    value: any,
+    replace?: boolean,
+    index?: number | string,
+    condition?: any
+  ) {
+    const len = this.state.items.length;
+    if (index !== undefined) {
+      let items = [...this.state.items];
+      const indexs = String(index).split(',');
+      indexs.forEach(i => {
+        const intIndex = Number(i);
+        items.splice(intIndex, 1, value);
+      });
+      this.setState({items}, () => {
+        this.emitValue();
+      });
+    } else if (condition !== undefined) {
+      let items = [...this.state.items];
+      for (let i = 0; i < len; i++) {
+        const item = items[i];
+        const isUpdate = await evalExpressionWithConditionBuilder(
+          condition,
+          item
+        );
+
+        if (isUpdate) {
+          items.splice(i, 1, value);
+        }
+      }
+
       this.setState({items}, () => {
         this.emitValue();
       });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 774d0d0</samp>

This pull request adds a new feature to the `setValue` action of various components (`input-table`, `table`, `crud`, and `combo`) that allows updating specific rows in the component data based on an index or a condition expression. It also updates the documentation of these components to explain the usage and examples of this feature. It also makes some methods async and imports some helper functions to support the feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 774d0d0</samp>

> _To update rows in `crud` or `combo`_
> _You can use `setValue` with gusto_
> _Just pass an `index` or `condition`_
> _And set the `replace` option_
> _The `setData` method is now async, though_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 774d0d0</samp>

*  Add a new `setValue` action to update the data of the `crud`, `combo`, `input-table`, and `table` components by specifying the `index` or `condition` arguments ([link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653R4506-R4664), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-6095450b85f0a3d4ee5a6887a19d1b926ef9026684f5271078719a0c1e675e31R1063-R1325), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-99a693306fa319133a72b7b8e485f3768df28babc3ded5053f98bf702cd1619eR1795-R1796), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-8a30381c7717a1ae36bd67d653324e6d01991200c0a2f1a0124f1e753d0cf380R2801-R2802), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L2615-R2665), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1818-R1849), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1686-R1719), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2767-R2808))
*  Add a new `replace` argument to the `setValue` action to control whether to merge or overwrite the existing row data in the `crud`, `combo`, and `table` components ([link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653R4506-R4664), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-6095450b85f0a3d4ee5a6887a19d1b926ef9026684f5271078719a0c1e675e31R1063-R1325), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-8a30381c7717a1ae36bd67d653324e6d01991200c0a2f1a0124f1e753d0cf380R2801-R2802), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L2615-R2665), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1818-R1849), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2767-R2808))
*  Add a new property `condition` to the interface `ICmptAction` in `packages/amis-core/src/actions/CmptAction.ts` to support condition expressions or condition builders in the `setValue` action ([link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-9fcca25fc37554994f4168d09ade3ba52487964b8f897e0a9de38442dc6b1ceaR16))
*  Add the `condition` argument to the `setData` method call in the `setValue` action handler in `packages/amis-core/src/actions/CmptAction.ts` ([link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-9fcca25fc37554994f4168d09ade3ba52487964b8f897e0a9de38442dc6b1ceaL77-R79))
*  Add the `evalExpressionWithConditionBuilder` import from `amis-core` to `packages/amis/src/renderers/CRUD.tsx`, `packages/amis/src/renderers/Form/Combo.tsx`, `packages/amis/src/renderers/Form/InputTable.tsx`, and `packages/amis/src/renderers/Table/index.tsx` to evaluate condition expressions or condition builders with data objects ([link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L5-R11), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L10-R11), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL9-R10))
*  Modify the `setData` methods of the classes `CRUDRenderer`, `ComboControlRenderer`, `TableControlRenderer`, and `TableRenderer` in `packages/amis/src/renderers/CRUD.tsx`, `packages/amis/src/renderers/Form/Combo.tsx`, `packages/amis/src/renderers/Form/InputTable.tsx`, and `packages/amis/src/renderers/Table/index.tsx` to be async functions and handle the `index` and `condition` arguments ([link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L2608-R2615), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1818-R1849), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1686-R1719), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2767-R2808))
*  Add the `runSequence` import from `packages/amis-formula/src/evalutorForAsync` to `packages/amis/src/renderers/CRUD.tsx` to run a sequence of actions asynchronously ([link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R67))
*  Modify the label of the button in the example code of the `setValue` action in the `input-table` component documentation from `赋值` to `更新列表记录` ([link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-99a693306fa319133a72b7b8e485f3768df28babc3ded5053f98bf702cd1619eL1802-R1804))
*  Add new sections and subsections to the documentation of the `crud`, `combo`, `input-table`, and `table` components in `docs/zh-CN/components/crud.md`, `docs/zh-CN/components/form/combo.md`, `docs/zh-CN/components/form/input-table.md`, and `docs/zh-CN/components/table.md` to provide examples and explanations of the new `setValue` action and its arguments ([link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653R4506-R4664), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-6095450b85f0a3d4ee5a6887a19d1b926ef9026684f5271078719a0c1e675e31R1063-R1325), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-99a693306fa319133a72b7b8e485f3768df28babc3ded5053f98bf702cd1619eR1795-R1796), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-99a693306fa319133a72b7b8e485f3768df28babc3ded5053f98bf702cd1619eR1888-R2030), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-8a30381c7717a1ae36bd67d653324e6d01991200c0a2f1a0124f1e753d0cf380R2801-R2802), [link](https://github.com/baidu/amis/pull/8278/files?diff=unified&w=0#diff-8a30381c7717a1ae36bd67d653324e6d01991200c0a2f1a0124f1e753d0cf380R2898-R3057))
