### PR TITLE
fix: 数字输入框禁用时单位选择也禁用

### DIFF
--- a/packages/amis/src/renderers/Form/InputNumber.tsx
+++ b/packages/amis/src/renderers/Form/InputNumber.tsx
@@ -482,6 +482,7 @@ export default class NumberControl extends React.Component<
               options={this.state.unitOptions || []}
               onChange={this.handleChangeUnit}
               className={`${ns}NumberControl-unit`}
+              disabled={disabled}
             />
           ) : (
             <div


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 15d1893</samp>

Added support for disabling `InputNumber` form items based on schema. Modified `InputNumber.tsx` to accept and use the `disabled` prop.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 15d1893</samp>

> _`InputNumber` has_
> _a new `disabled` prop now_
> _autumn of the form_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 15d1893</samp>

* Add `disabled` prop to `InputNumber` component to support disabling form items based on schema ([link](https://github.com/baidu/amis/pull/8279/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685R485))
