### PR TITLE
feat: export-excel 初步支持总结行 Closes #2911

### DIFF
--- a/examples/components/CRUD/ExportCSVExcel.jsx
+++ b/examples/components/CRUD/ExportCSVExcel.jsx
@@ -213,6 +213,39 @@ export default {
         name: 'num',
         label: 'num'
       }
+    ],
+    prefixRow: [
+      {
+        type: 'text',
+        text: '前置总计',
+        colSpan: 2
+      },
+      {
+        type: 'tpl',
+        tpl: '${items|pick:engine.version|sum}'
+      }
+    ],
+    affixRow: [
+      [
+        {
+          type: 'text',
+          text: '总计1'
+        },
+        {
+          type: 'tpl',
+          tpl: '${items|pick:engine.version|sum}'
+        }
+      ],
+      [
+        {
+          type: 'text',
+          text: '总计2'
+        },
+        {
+          type: 'tpl',
+          tpl: '${items|pick:engine.version|sum}'
+        }
+      ]
     ]
   }
 };


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9371ca3</samp>

This pull request enhances the Excel export feature of the table renderer by allowing custom summary rows. It adds a new function `renderSummary` to `packages/amis/src/renderers/Table/exportExcel.ts` and uses it with the `prefixRow` and `affixRow` props. It also updates the `ExportCSVExcel` component in `examples/components/CRUD/ExportCSVExcel.jsx` to demonstrate the usage of the summary rows.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9371ca3</samp>

> _Oh we're the crew of the `ExportCSVExcel`_
> _And we work hard to make our tables swell_
> _We can add a `prefixRow` and an `affixRow`_
> _To show the summary of our data well_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9371ca3</samp>

*  Add `prefixRow` and `affixRow` properties to the `exportExcel` action in the `ExportCSVExcel` component to enable custom summary rows in Excel exports ([link](https://github.com/baidu/amis/pull/8286/files?diff=unified&w=0#diff-77b473f79a97cfa505ba4f7f306487c5a1d3fda83053e968d30ac472a7f9e936R216-R248))
* Implement a new function `renderSummary` in the `exportExcel.ts` module to output the summary rows to the worksheet according to a schema ([link](https://github.com/baidu/amis/pull/8286/files?diff=unified&w=0#diff-8814befa6c6247c465ab39fa28f3db15c2280e238d8254286fa1f29d29500c51R156-R206))
* Modify the `exportExcel` function in the `exportExcel.ts` module to accept the `prefixRow` and `affixRow` properties from the props and pass them to the `renderSummary` function ([link](https://github.com/baidu/amis/pull/8286/files?diff=unified&w=0#diff-8814befa6c6247c465ab39fa28f3db15c2280e238d8254286fa1f29d29500c51L161-R220))
* Call the `renderSummary` function with the `prefixRow` schema before looping through the table data and update the row index accordingly ([link](https://github.com/baidu/amis/pull/8286/files?diff=unified&w=0#diff-8814befa6c6247c465ab39fa28f3db15c2280e238d8254286fa1f29d29500c51R326-R327))
* Call the `renderSummary` function with the `affixRow` schema after looping through the table data ([link](https://github.com/baidu/amis/pull/8286/files?diff=unified&w=0#diff-8814befa6c6247c465ab39fa28f3db15c2280e238d8254286fa1f29d29500c51R514-R516))
