### PR TITLE
fix: 修复inputNumber配置面板在配置校验触发规则没有生效的问题

### DIFF
--- a/packages/amis-editor/src/renderer/FormulaControl.tsx
+++ b/packages/amis-editor/src/renderer/FormulaControl.tsx
@@ -24,7 +24,7 @@ import {FormulaEditor} from 'amis-ui';
 import FormulaPicker, {
   CustomFormulaPickerProps
 } from './textarea-formula/FormulaPicker';
-import {autobind, translateSchema} from 'amis-editor-core';
+import {JSONPipeOut, autobind, translateSchema} from 'amis-editor-core';
 
 import type {
   VariableItem,
@@ -524,7 +524,7 @@ export default class FormulaControl extends React.Component<
       return translateSchema(curRendererSchema, this.appCorpusData);
     }
 
-    return curRendererSchema;
+    return JSONPipeOut(curRendererSchema);
   }
 
   @autobind


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fdac573</samp>

Fix a bug in `util.ts` that caused form validation to fail due to an extra `$$id` property. Prevent `JSONPipeIn` from modifying the validations object.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fdac573</samp>

> _`JSONPipeIn` calls_
> _skip `validations` key_
> _autumn bug is fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fdac573</samp>

* Fix form validation error by skipping `$$id` property for validations object ([link](https://github.com/baidu/amis/pull/8288/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL132-R133))
