### PR TITLE
fix: 修复pm分支 inputNumber配置面板在配置校验触发规则没有生效的问题

### DIFF
--- a/packages/amis-editor/src/renderer/FormulaControl.tsx
+++ b/packages/amis-editor/src/renderer/FormulaControl.tsx
@@ -24,7 +24,7 @@ import {FormulaEditor} from 'amis-ui';
 import FormulaPicker, {
   CustomFormulaPickerProps
 } from './textarea-formula/FormulaPicker';
-import {autobind, translateSchema} from 'amis-editor-core';
+import {JSONPipeOut, autobind, translateSchema} from 'amis-editor-core';
 
 import type {
   VariableItem,
@@ -505,7 +505,7 @@ export default class FormulaControl extends React.Component<
       return translateSchema(curRendererSchema, this.appCorpusData);
     }
 
-    return curRendererSchema;
+    return JSONPipeOut(curRendererSchema);
   }
 
   @autobind


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d7994c7</samp>

This pull request enhances the `util.ts` file by fixing a validation bug, adding semicolons, and formatting a function. These changes improve the readability and reliability of the code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d7994c7</samp>

> _Oh we're the coders of the sea, and we work with `util.ts`_
> _We add semicolons and fix bugs, and we make the code robust_
> _Heave away, me hearties, heave away_
> _On the count of three, we run `JSONPipeIn`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d7994c7</samp>

*  Add semicolons to import statements for consistency and code style ([link](https://github.com/baidu/amis/pull/8289/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL11-R15))
*  Exclude `validations` key from `JSONPipeIn` function to avoid validation error ([link](https://github.com/baidu/amis/pull/8289/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL120-R121))
*  Format return statement of `needFillPlaceholder` function for readability and prettier rules ([link](https://github.com/baidu/amis/pull/8289/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL1097-R1101))
