### PR TITLE
style: 优化组合条件或\且选择样式 (#8214)

### DIFF
--- a/packages/amis-ui/scss/components/_condition-builder.scss
+++ b/packages/amis-ui/scss/components/_condition-builder.scss
@@ -77,6 +77,10 @@
         box-shadow: none !important;
       }
 
+      &-valueWrap {
+        padding-right: 0;
+      }
+
       &-arrow {
         display: none;
       }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a2e68b</samp>

Remove right padding from condition value input in `condition-builder` component. This change improves the layout and appearance of the `condition-builder` UI widget, which is defined in `_condition-builder.scss`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8a2e68b</samp>

> _`valueWrap` styled_
> _No right padding for input_
> _Condition builder - spring_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a2e68b</samp>

* Remove right padding from value wrap element in condition builder component ([link](https://github.com/baidu/amis/pull/8296/files?diff=unified&w=0#diff-61a730ea77707567de025dccdfaf2f4b2014545a44075936fbc94516e9b9fcdcR80-R83))
