### PR TITLE
fix: 修复表单保存成功可能导致 combo 中新增部分重置的问题

### DIFF
--- a/packages/amis-core/src/store/formItem.ts
+++ b/packages/amis-core/src/store/formItem.ts
@@ -1283,7 +1283,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
 
       if (subStore && subStore.storeType === 'ComboStore') {
         const combo = subStore as IComboStore;
-        combo.forms.forEach(form => form.reset());
+        combo.forms.forEach(form => form.reset(undefined, false)); // 仅重置校验状态，不要重置数据
       }
 
       !keepErrors && clearError();


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43c573f</samp>

Fixed a bug in `FormItemStore` that cleared combo form data on reset. Modified the `reset` function to call the `reset` function of `ComboStore` subStore with appropriate arguments.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 43c573f</samp>

> _`reset` function changed_
> _`ComboStore` keeps its forms_
> _bug fixed in autumn_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 43c573f</samp>

* Fix combo form data being cleared when parent form is reset ([link](https://github.com/baidu/amis/pull/8297/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L1286-R1286))
