### PR TITLE
fix: 修复 combo 表单项中存在同名表单项时内部表单项值被覆盖的问题

### DIFF
--- a/packages/amis-core/src/WithStore.tsx
+++ b/packages/amis-core/src/WithStore.tsx
@@ -247,6 +247,10 @@ export function HocStoreFactory(renderer: {
                       ...store.data,
                       ...props.data
                     }
+                  : // combo 不需要同步，如果要同步，在 Combo.tsx 里面已经实现了相关逻辑
+                  // 目前主要的问题是，如果 combo 中表单项名字和 combo 本身的名字一样，会导致里面的值会被覆盖成数组
+                  props.store?.storeType === 'ComboStore'
+                  ? undefined
                   : syncDataFromSuper(
                       props.data,
                       (props.data as any).__super,

--- a/packages/amis/__tests__/renderers/Form/combo.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/combo.test.tsx
@@ -970,3 +970,35 @@ test('Renderer:select autofill in combo', async () => {
     combo: [{type: '1', a: 'a'}]
   });
 });
+
+// 10. combo 内部表单项与 combo 同名时，原来会出现内部表单项的值变成数组的情况
+test('Renderer:combo 内部表单项与 combo 同名', async () => {
+  const {container, submitBtn, findByText, onSubmit, baseElement} = await setup(
+    [
+      {
+        type: 'combo',
+        name: 'a',
+        label: 'combo',
+        className: 'removableFalse',
+        removable: false,
+        multiple: true,
+        items: [
+          {
+            name: 'a',
+            type: 'input-text',
+            label: 'A'
+          }
+        ],
+        value: [{}]
+      }
+    ]
+  );
+
+  const input = container.querySelector('input[name="a"]') as HTMLInputElement;
+  fireEvent.change(input, {target: {value: '1'}});
+  await wait(400);
+
+  fireEvent.change(input, {target: {value: '123'}});
+  await wait(400);
+  expect(input.value).toBe('123');
+});


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 455a752</samp>

This pull request fixes a bug in the `Combo` renderer that causes the value of a sub-form item with the same name as the combo renderer to be overwritten by an array. It also adds a test case to ensure the bug is resolved.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 455a752</samp>

> _`ComboStore` bug fixed_
> _Sub-form value stays intact_
> _Autumn leaves don't sync_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 455a752</samp>

*  Prevent combo renderer from syncing value with parent form when store type is `ComboStore` ([link](https://github.com/baidu/amis/pull/8300/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acR250-R253))
* Add test case for combo renderer with sub-form item that has the same name as the combo renderer ([link](https://github.com/baidu/amis/pull/8300/files?diff=unified&w=0#diff-1689fddd6fe92bb44bae574b18fd1bf4ed54d85a41bc725b29e9c8498291ffafR973-R1004))
