### PR TITLE
fix: 修复嵌套模式当列隐藏时不显示展开按钮问题 Close: #8301

### DIFF
--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -51,7 +51,6 @@ export const Column = types
     toggable: true,
     expandable: false,
     checkdisable: false,
-    isPrimary: false,
     searchable: types.maybe(types.frozen()),
     enableSearch: true,
     sortable: false,
@@ -67,6 +66,13 @@ export const Column = types
     remark: types.optional(types.frozen(), undefined),
     className: types.union(types.string, types.frozen())
   })
+  .views(self => ({
+    get isPrimary() {
+      const table = getParent(self, 2) as any;
+
+      return table.filteredColumns[0]?.id === self.id;
+    }
+  }))
   .actions(self => ({
     toggleToggle(min = 1) {
       self.toggled = !self.toggled;
@@ -1016,7 +1022,6 @@ export const TableStore = iRendererStore
             pristine: item.pristine || item,
             toggled: item.toggled !== false,
             breakpoint: item.breakpoint,
-            isPrimary: index === PARTITION_INDEX,
             /** 提前映射变量，方便后续view中使用 */
             label: isPureVariable(item.label)
               ? resolveVariableAndFilter(item.label, self.data)

--- a/packages/amis/src/renderers/Table/Cell.tsx
+++ b/packages/amis/src/renderers/Table/Cell.tsx
@@ -169,7 +169,7 @@ export default function Cell({
       );
     }
     return [prefix, affix, addtionalClassName];
-  }, [item.expandable, item.expanded]);
+  }, [item.expandable, item.expanded, column.isPrimary]);
 
   // 根据条件缓存 data，避免孩子重复渲染
   const hasCustomTrackExpression =


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a4a7fcd</samp>

This pull request improves the handling of primary keys in table columns by using a computed view instead of a fixed property. It also updates the `Cell` component to depend on the `column.isPrimary` view for rendering.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a4a7fcd</samp>

> _`isPrimary` view_
> _cuts through column logic_
> _like autumnal wind_

### Why

Close: #8301

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a4a7fcd</samp>

*  Remove `isPrimary` property from `Column` type and replace it with a computed view that checks the first column in the filtered columns array of the parent table ([link](https://github.com/baidu/amis/pull/8302/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL54), [link](https://github.com/baidu/amis/pull/8302/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR69-R75), [link](https://github.com/baidu/amis/pull/8302/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1019))
*  Add `column.isPrimary` dependency to `useMemo` hook in `Cell` component to re-render the cell element when the primary key status of the column changes ([link](https://github.com/baidu/amis/pull/8302/files?diff=unified&w=0#diff-d65258ae6673eb54481e932fd39b426fb60a31ca9cb7430d0cff54fe035efe15L172-R172))
