### PR TITLE
styles: 优化combo组件tabs模式下样式问题

### DIFF
--- a/packages/amis-ui/scss/components/form/_combo.scss
+++ b/packages/amis-ui/scss/components/form/_combo.scss
@@ -109,6 +109,13 @@
     }
   }
 
+  .#{$ns}Tabs--radio .is-active &-tab-delBtn {
+    color: var(--Tabs--radio-active-color);
+    &:hover {
+      color: var(--Tabs--radio-active-color);
+    }
+  }
+
   &-tab-delBtn {
     color: var(--combo-multi-delBtn-color);
     cursor: pointer;
@@ -116,8 +123,8 @@
     display: inline-block;
 
     > svg {
-      width: px2rem(11px);
-      height: px2rem(11px);
+      width: px2rem(14px);
+      height: px2rem(14px);
     }
 
     &:hover {

--- a/packages/amis/src/renderers/Form/Combo.tsx
+++ b/packages/amis/src/renderers/Form/Combo.tsx
@@ -1182,7 +1182,7 @@ export default class ComboControl extends React.Component<ComboProps> {
         activeKey={store.activeKey}
         onSelect={this.handleTabSelect}
         additionBtns={
-          !disabled ? (
+          !disabled && addable !== false && store.addable ? (
             <li className={cx(`Tabs-link ComboTabs-addLink`)}>
               {this.renderAddBtn()}
             </li>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f03c8b4</samp>

This pull request enhances the combo form component by improving the style of the delete button in radio mode and adding a condition to hide the add button. The changes affect the files `packages/amis-ui/scss/components/form/_combo.scss` and `packages/amis/src/renderers/Form/Combo.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f03c8b4</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever way to hide or show the `addable` link_
> _That lets the users of the combo form create tabs_
> _As many as they wish, or as few as they think._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f03c8b4</samp>

*  Add a condition to control the visibility of the add button in the combo form component ([link](https://github.com/baidu/amis/pull/8305/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1185-R1185))
*  Change the style of the delete button in the active tab of the combo form component when using the radio mode ([link](https://github.com/baidu/amis/pull/8305/files?diff=unified&w=0#diff-19cf1d528747f83afd11fea7dc0be10a71d0aeef38126bf1f4431617a6bf7914R112-R118))
*  Increase the size of the delete button icon in the combo form component ([link](https://github.com/baidu/amis/pull/8305/files?diff=unified&w=0#diff-19cf1d528747f83afd11fea7dc0be10a71d0aeef38126bf1f4431617a6bf7914L119-R127))
