### PR TITLE
chore(editor): 优化editor侧边栏拖拽卡顿问题

### DIFF
--- a/packages/amis-editor-core/src/component/base/WidthDraggableBtn.tsx
+++ b/packages/amis-editor-core/src/component/base/WidthDraggableBtn.tsx
@@ -31,6 +31,8 @@ export class WidthDraggableBtn extends React.Component<WidthDraggableProps> {
     document.addEventListener('mouseup', this.handleResizeMouseUp);
     this.startX = e.clientX;
     this.startWidth = this.dragWrap.offsetWidth;
+    // 拖拽过程中会选中文本，导致卡顿，所以阻止下默认行为
+    e.preventDefault();
   }
 
   handleResizeMouseMove(e: MouseEvent) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0993d19</samp>

Fix slow and choppy resizing of editor panel by disabling text selection during dragging in `WidthDraggableBtn.tsx` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0993d19</samp>

> _`preventDefault`_
> _Editor panel smooth in fall_
> _No more text drag lag_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0993d19</samp>

*  Prevent text selection during dragging to improve editor panel resizing performance ([link](https://github.com/baidu/amis/pull/8309/files?diff=unified&w=0#diff-fbb92f1ea91525eb1d4b23e379b55b37892551ad791f256a4d9065cbf2dc8551R34-R35))
