### PR TITLE
fix(amis-editor): 数据源构造器 match 规则，分页组件面板控件样式错误问题

### DIFF
--- a/packages/amis-editor-core/scss/control/_crud2-control.scss
+++ b/packages/amis-editor-core/scss/control/_crud2-control.scss
@@ -53,6 +53,7 @@
         display: flex;
         align-items: center;
         justify-content: space-between;
+        margin-right: var(--gap-xs);
 
         & > button {
           color: #151b26;

--- a/packages/amis-editor/src/builder/ApiDSBuilder.ts
+++ b/packages/amis-editor/src/builder/ApiDSBuilder.ts
@@ -98,8 +98,8 @@ export class ApiDSBuilder extends DSBuilder<
     const sourceKey = key && typeof key === 'string' ? key : 'api';
     const apiSchema = schema?.[sourceKey];
 
-    if (schema?.dsType === this.key || apiSchema?.sourceType === this.key) {
-      return true;
+    if (schema?.dsType != null || apiSchema?.sourceType != null) {
+      return schema?.dsType === this.key || apiSchema?.sourceType === this.key;
     }
 
     /**

--- a/packages/amis-editor/src/builder/DSBuilderManager.ts
+++ b/packages/amis-editor/src/builder/DSBuilderManager.ts
@@ -32,11 +32,11 @@ export class DSBuilderManager {
     return this.builders.get(scaffoldConfig.dsType);
   }
 
-  getBuilderBySchema(schema: any) {
+  getBuilderBySchema(schema: any, sourceKey?: string) {
     let builder: DSBuilderInterface | undefined;
 
     for (let [key, value] of Array.from(this.builders.entries())) {
-      if (value.match(schema)) {
+      if (value.match(schema, sourceKey)) {
         builder = value;
         break;
       }

--- a/packages/amis-editor/src/plugin/Pagination.tsx
+++ b/packages/amis-editor/src/plugin/Pagination.tsx
@@ -122,13 +122,12 @@ export class PaginationPlugin extends BasePlugin {
                   {
                     type: 'checkbox',
                     name: 'checked',
-                    className: 'm-t-n-xxs',
-                    inputClassName: 'p-t-none'
+                    inputClassName: 'p-t-none mt-1.5'
                   },
                   {
                     type: 'tpl',
                     name: 'text',
-                    className: 'p-t-xs'
+                    className: 'inline-block pt-1.5'
                   }
                 ],
                 pipeIn: (value: any) => {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f5559f</samp>

This pull request improves the UI and functionality of the amis-editor package, especially for the crud2 control. It adds margin and pagination styles, fixes data source matching logic, and supports multiple data sources in the same schema.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4f5559f</samp>

> _`crud2` gets margin_
> _`ApiDSBuilder` checks null_
> _Autumn of SCSS_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4f5559f</samp>

* Add right margin to crud2 control's toolbar buttons using CSS variable ([link](https://github.com/baidu/amis/pull/8313/files?diff=unified&w=0#diff-b194d220708bca5ab86633f83b4eee1de7120e01e1cd24d21df4e281b434ff18R56))
* Support multiple data sources in crud2 control by passing source key to data source builders ([link](https://github.com/baidu/amis/pull/8313/files?diff=unified&w=0#diff-bfee10c2d53f5327044fd5fa75c416d0c8e34005910fc916b41f52578013929fL35-R39), [link](https://github.com/baidu/amis/pull/8313/files?diff=unified&w=0#diff-d401d093bfcc28e16e58fdc877a0cbe654ad86969ed23118030d66d7d70891c2L101-R102))
* Update pagination plugin's styles using Tailwind CSS classes ([link](https://github.com/baidu/amis/pull/8313/files?diff=unified&w=0#diff-a9ddd77e9761f09529c503212eaa0939fb5f04c01652d1b09117ebf7442e1766L125-R130))
* Add null check for data source type properties in `ApiDSBuilder.match` method ([link](https://github.com/baidu/amis/pull/8313/files?diff=unified&w=0#diff-d401d093bfcc28e16e58fdc877a0cbe654ad86969ed23118030d66d7d70891c2L101-R102))
