### PR TITLE
fix: 公式编辑器弹窗，会缓存已删除的内容

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Select.tsx
+++ b/packages/amis-editor/src/plugin/Form/Select.tsx
@@ -381,7 +381,7 @@ export class SelectControlPlugin extends BasePlugin {
       title: node.schema?.label || node.schema?.name,
       originalValue: node.schema?.value // 记录原始值，循环引用检测需要
     };
-    debugger;
+
     if (node.schema?.joinValues === false) {
       dataSchema = {
         ...dataSchema,

--- a/packages/amis-editor/src/renderer/textarea-formula/FormulaPicker.tsx
+++ b/packages/amis-editor/src/renderer/textarea-formula/FormulaPicker.tsx
@@ -4,7 +4,7 @@ import cx from 'classnames';
 import FormulaEditor from 'amis-ui/lib/components/formula/Editor';
 
 export interface FormulaPickerProps {
-  onConfirm: (data: string) => void;
+  onConfirm: (data: string | undefined) => void;
   onClose: () => void;
   variables: any[];
   value?: string;
@@ -23,10 +23,10 @@ export interface CustomFormulaPickerProps extends FormulaPickerProps {
 
 const FormulaPicker: React.FC<FormulaPickerProps> = props => {
   const {variables, variableMode, evalMode = true} = props;
-  const [formula, setFormula] = React.useState('');
+  const [formula, setFormula] = React.useState<string | undefined>(undefined);
   useEffect(() => {
     const {initable, value} = props;
-    if (initable && value) {
+    if (initable) {
       setFormula(value);
     }
   }, [props.value]);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b1ce1e</samp>

This pull request improves the user experience of the formula picker component in the AMIS editor and removes a debugging statement from the select control plugin. It fixes the issue of empty formula inputs not being handled properly and cleans up the code in `Select.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4b1ce1e</samp>

> _`debugger` is gone_
> _`FormulaPicker` improved_
> _Winter code cleanup_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4b1ce1e</samp>

* Remove `debugger` statement from `SelectControlPlugin` class to avoid pausing the execution and opening the developer tools ([link](https://github.com/baidu/amis/pull/8314/files?diff=unified&w=0#diff-83d37f4c45d6ac38e41a04b6511b7921d73c2b0a35163df31401c8c0f408e0c4L384-R384))
* Allow `onConfirm` prop of `FormulaPicker` component to accept `undefined` as a valid value to handle the case when the user clears the formula input ([link](https://github.com/baidu/amis/pull/8314/files?diff=unified&w=0#diff-81d403d78e98e70e6b31027c9eccbe5b094e521ec35bf88ef32825da3467dca8L7-R7))
* Initialize `formula` state of `FormulaPicker` component to `undefined` instead of `''` to match the type of `onConfirm` and `value` props and avoid rendering an empty formula ([link](https://github.com/baidu/amis/pull/8314/files?diff=unified&w=0#diff-81d403d78e98e70e6b31027c9eccbe5b094e521ec35bf88ef32825da3467dca8L26-R29))
