### PR TITLE
fix: 修复table rowClassNameExpr一般背景样式不生效问题

### DIFF
--- a/packages/amis-ui/scss/components/_table.scss
+++ b/packages/amis-ui/scss/components/_table.scss
@@ -383,7 +383,7 @@
 
     > tbody > tr {
       position: relative;
-      background: var(--Table-bg);
+      // background: var(--Table-bg);
 
       & + tr {
         border-top: var(--Table-borderWidth) solid var(--Table-borderColor);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e74b267</samp>

Comment out `background` property of table rows in `_table.scss` to fix hover style in dark mode. This improves the visibility and usability of the table component in dark mode.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e74b267</samp>

> _`background` gone_
> _table rows now show hover_
> _dark mode in winter_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e74b267</samp>

* Remove the background property of table rows to fix the hover style in dark mode ([link](https://github.com/baidu/amis/pull/8315/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dL386-R386))
