### PR TITLE
feat: 「页面设计器」组件搜索框支持不输入"-"进行搜索

### DIFF
--- a/packages/amis-editor-core/src/component/base/SearchCustomRendererPanel.tsx
+++ b/packages/amis-editor-core/src/component/base/SearchCustomRendererPanel.tsx
@@ -43,6 +43,8 @@ export default class SearchCustomRendererPanel extends React.Component<
       <SearchPanel
         allResult={customRenderersByOrder}
         externalKeyword={defaultKeyword}
+        immediateChange
+        closeAutoComplete
         searchPanelUUID={this.localStorageKey}
         onChange={changeCustomRenderersKeywords}
         onTagChange={changeCustomRenderersTag}

--- a/packages/amis-editor-core/src/store/editor.ts
+++ b/packages/amis-editor-core/src/store/editor.ts
@@ -702,7 +702,8 @@ export const MainStore = types
               key =>
                 resolveVariable(key, item) &&
                 regular &&
-                regular.test(resolveVariable(key, item))
+                (regular.test(resolveVariable(key, item)) ||
+                  regular.test(resolveVariable(key, item)?.replaceAll('-', '')))
             )
           ) {
             const tags = Array.isArray(item.tags)


### PR DESCRIPTION
### What

1. 组件搜索框支持不输入"-"进行搜索，如搜索input-number组件时，可以通过inputnumber进行搜索，更贴近amis文档
2. 自定义组件面板搜索组件添加"immediateChange"，"closeAutoComplete"配置，和系统组件搜索交互保持一致
3. 修复组件SearchPanel组件搜索结果为空的问题（虽然没有开启相应的配置，但代码处理有问题）

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6ed6cb8</samp>

* Enhance the search function for custom renderers by adding a new property `searchKeywords` and allowing matching with or without hyphens in the keywords ([link](https://github.com/baidu/amis/pull/8316/files?diff=unified&w=0#diff-365208d299ca70361fad5cb92a9e35bd9f1cdeec4664471fcd68447536fab80eL206-R210), [link](https://github.com/baidu/amis/pull/8316/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8L705-R706))
* Improve the user experience of searching for custom renderers in the editor by triggering the search function on every keystroke and closing the autocomplete dropdown when the input is blurred ([link](https://github.com/baidu/amis/pull/8316/files?diff=unified&w=0#diff-178ae0bdd085623fa7401d9c72c0580b155f1eaaa108b17dd464be8498da02baR46-R47))
* Refactor the search function to use `resolveVariable` to access the custom renderers' properties and avoid unnecessary duplication of the search results by tag ([link](https://github.com/baidu/amis/pull/8316/files?diff=unified&w=0#diff-365208d299ca70361fad5cb92a9e35bd9f1cdeec4664471fcd68447536fab80eL3-R3), [link](https://github.com/baidu/amis/pull/8316/files?diff=unified&w=0#diff-365208d299ca70361fad5cb92a9e35bd9f1cdeec4664471fcd68447536fab80eL193-L195), [link](https://github.com/baidu/amis/pull/8316/files?diff=unified&w=0#diff-365208d299ca70361fad5cb92a9e35bd9f1cdeec4664471fcd68447536fab80eL217-R219))
