### PR TITLE
styles: 优化图片上传\表单label样式

### DIFF
--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -1645,7 +1645,7 @@
   --Form-description-fontWeight: var(--fonts-weight-6);
   --Form-description-lineHeight: var(--fonts-lineHeight-2);
   --Form-description-gap: var(--sizes-size-3);
-  --Form-item-onError-color: var(--colors-error-5);
+  --Form-item-onError-color: var(--colors-neutral-text-4);
   --Form-item-onError-borderColor: var(--colors-error-5);
   --Form-item-onError-bg: var(--colors-neutral-fill-11);
   --Form-feedBack-color: var(--colors-error-5);

--- a/packages/amis-ui/scss/components/form/_image.scss
+++ b/packages/amis-ui/scss/components/form/_image.scss
@@ -170,33 +170,6 @@
     margin: 30px 0 0 var(--Tooltip--attr-gap);
   }
 
-  &-dropzone:focus &-addBtn:not(.is-invalid) {
-    border-color: var(--inputImage-base-hover-top-border-color)
-      var(--inputImage-base-hover-right-border-color)
-      var(--inputImage-base-hover-bottom-border-color)
-      var(--inputImage-base-hover-left-border-color);
-    background: var(--ImageControl-addBtn-onHover-bg);
-    color: var(--ImageControl-addBtn-onHover-color);
-
-    > svg {
-      color: var(--inputImage-base-hover-icon-color);
-    }
-  }
-
-  &-dropzone:hover {
-    &-addBtn:not(.is-disabled):not(.is-invalid) {
-      border-color: var(--inputImage-base-hover-top-border-color)
-        var(--inputImage-base-hover-right-border-color)
-        var(--inputImage-base-hover-bottom-border-color)
-        var(--inputImage-base-hover-left-border-color);
-      background: var(--ImageControl-addBtn-onHover-bg);
-      color: var(--ImageControl-addBtn-onHover-color);
-      .#{$ns}ImageControl-addBtn-text {
-        color: var(--ImageControl-addBtn-onHover-color);
-      }
-    }
-  }
-
   &-itemList {
     display: inline;
   }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 83e6cc7</samp>

This pull request updates the SCSS files for the form and image components in the `amis-ui` package. It improves the error text color in the form items and removes redundant hover and focus styles for the image control add button.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 83e6cc7</samp>

> _`--Form-item` text_
> _Contrasts better with new color_
> _Winter clarity_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 83e6cc7</samp>

* Improve the contrast and readability of the error text in the form items by changing the color variable from `--colors-error-5` to `--colors-neutral-text-4` ([link](https://github.com/baidu/amis/pull/8318/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4L1648-R1648))
* Remove the redundant hover and focus styles for the `--ImageControl-addBtn` element from the `_image.scss` file, and rely on the inherited button styles from the `_button.scss` file ([link](https://github.com/baidu/amis/pull/8318/files?diff=unified&w=0#diff-1e04d824cf7a90eb58a506188df26e9c0a680b051f4a5520f9ed4c722868407aL173-L199))
