### PR TITLE
fix: 修复steps title展示[object object]问题

### DIFF
--- a/packages/amis-ui/src/components/Steps.tsx
+++ b/packages/amis-ui/src/components/Steps.tsx
@@ -207,9 +207,7 @@ export function Steps(props: StepsProps) {
                     <span
                       className={cx('StepsItem-ellText')}
                       title={
-                        typeof step.title === 'string'
-                          ? String(step.title)
-                          : undefined
+                        typeof step.title === 'string' ? step.title : undefined
                       }
                     >
                       {step.title}
@@ -222,7 +220,7 @@ export function Steps(props: StepsProps) {
                         )}
                         title={
                           typeof step.subTitle === 'string'
-                            ? String(step.subTitle)
+                            ? step.subTitle
                             : undefined
                         }
                       >
@@ -234,7 +232,7 @@ export function Steps(props: StepsProps) {
                     className={cx('StepsItem-description', 'StepsItem-ellText')}
                     title={
                       typeof step.description === 'string'
-                        ? String(step.description)
+                        ? step.description
                         : undefined
                     }
                   >

--- a/packages/amis-ui/src/components/Steps.tsx
+++ b/packages/amis-ui/src/components/Steps.tsx
@@ -206,7 +206,11 @@ export function Steps(props: StepsProps) {
                   >
                     <span
                       className={cx('StepsItem-ellText')}
-                      title={String(step.title)}
+                      title={
+                        typeof step.title === 'string'
+                          ? String(step.title)
+                          : undefined
+                      }
                     >
                       {step.title}
                     </span>
@@ -216,7 +220,11 @@ export function Steps(props: StepsProps) {
                           'StepsItem-subTitle',
                           'StepsItem-ellText'
                         )}
-                        title={String(step.subTitle)}
+                        title={
+                          typeof step.subTitle === 'string'
+                            ? String(step.subTitle)
+                            : undefined
+                        }
                       >
                         {step.subTitle}
                       </span>
@@ -224,7 +232,11 @@ export function Steps(props: StepsProps) {
                   </div>
                   <div
                     className={cx('StepsItem-description', 'StepsItem-ellText')}
-                    title={String(step.description)}
+                    title={
+                      typeof step.description === 'string'
+                        ? String(step.description)
+                        : undefined
+                    }
                   >
                     <span>{step.description}</span>
                   </div>

--- a/packages/amis/__tests__/renderers/__snapshots__/Steps.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Steps.test.tsx.snap
@@ -96,7 +96,6 @@ exports[`Renderer:steps 1`] = `
             </div>
             <div
               class="cxd-StepsItem-description cxd-StepsItem-ellText"
-              title="undefined"
             >
               <span />
             </div>
@@ -140,7 +139,6 @@ exports[`Renderer:steps 1`] = `
             </div>
             <div
               class="cxd-StepsItem-description cxd-StepsItem-ellText"
-              title="undefined"
             >
               <span />
             </div>
@@ -248,7 +246,6 @@ exports[`Renderer:steps 2`] = `
             </div>
             <div
               class="cxd-StepsItem-description cxd-StepsItem-ellText"
-              title="undefined"
             >
               <span />
             </div>
@@ -292,7 +289,6 @@ exports[`Renderer:steps 2`] = `
             </div>
             <div
               class="cxd-StepsItem-description cxd-StepsItem-ellText"
-              title="undefined"
             >
               <span />
             </div>
@@ -345,7 +341,6 @@ exports[`Renderer:steps labelPlacement 1`] = `
             </div>
             <div
               class="cxd-StepsItem-description cxd-StepsItem-ellText"
-              title="undefined"
             >
               <span />
             </div>
@@ -441,7 +436,6 @@ exports[`Renderer:steps labelPlacement 1`] = `
             </div>
             <div
               class="cxd-StepsItem-description cxd-StepsItem-ellText"
-              title="undefined"
             >
               <span />
             </div>
@@ -488,7 +482,6 @@ exports[`Renderer:steps progressDot 1`] = `
             </div>
             <div
               class="cxd-StepsItem-description cxd-StepsItem-ellText"
-              title="undefined"
             >
               <span />
             </div>
@@ -572,7 +565,6 @@ exports[`Renderer:steps progressDot 1`] = `
             </div>
             <div
               class="cxd-StepsItem-description cxd-StepsItem-ellText"
-              title="undefined"
             >
               <span />
             </div>
@@ -625,7 +617,6 @@ exports[`Renderer:steps status 1`] = `
             </div>
             <div
               class="cxd-StepsItem-description cxd-StepsItem-ellText"
-              title="undefined"
             >
               <span />
             </div>
@@ -721,7 +712,6 @@ exports[`Renderer:steps status 1`] = `
             </div>
             <div
               class="cxd-StepsItem-description cxd-StepsItem-ellText"
-              title="undefined"
             >
               <span />
             </div>
@@ -768,7 +758,6 @@ exports[`Renderer:steps with vertical mode 1`] = `
             </div>
             <div
               class="cxd-StepsItem-description cxd-StepsItem-ellText"
-              title="undefined"
             >
               <span />
             </div>
@@ -852,7 +841,6 @@ exports[`Renderer:steps with vertical mode 1`] = `
             </div>
             <div
               class="cxd-StepsItem-description cxd-StepsItem-ellText"
-              title="undefined"
             >
               <span />
             </div>

--- a/packages/amis/__tests__/renderers/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Wizard.test.tsx.snap
@@ -55,7 +55,6 @@ exports[`Renderer:Wizard actionPrevLabel actionNextLabel actionFinishLabel class
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -99,7 +98,6 @@ exports[`Renderer:Wizard actionPrevLabel actionNextLabel actionFinishLabel class
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -247,7 +245,6 @@ exports[`Renderer:Wizard actionPrevLabel actionNextLabel actionFinishLabel class
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -291,7 +288,6 @@ exports[`Renderer:Wizard actionPrevLabel actionNextLabel actionFinishLabel class
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -666,7 +662,6 @@ exports[`Renderer:Wizard dialog 1`] = `
                           </div>
                           <div
                             class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                            title="undefined"
                           >
                             <span />
                           </div>
@@ -710,7 +705,6 @@ exports[`Renderer:Wizard dialog 1`] = `
                           </div>
                           <div
                             class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                            title="undefined"
                           >
                             <span />
                           </div>
@@ -1055,7 +1049,6 @@ exports[`Renderer:Wizard dialog 2`] = `
                           </div>
                           <div
                             class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                            title="undefined"
                           >
                             <span />
                           </div>
@@ -1099,7 +1092,6 @@ exports[`Renderer:Wizard dialog 2`] = `
                           </div>
                           <div
                             class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                            title="undefined"
                           >
                             <span />
                           </div>
@@ -1327,7 +1319,6 @@ exports[`Renderer:Wizard initApi default 1`] = `
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -1371,7 +1362,6 @@ exports[`Renderer:Wizard initApi default 1`] = `
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -1415,7 +1405,6 @@ exports[`Renderer:Wizard initApi default 1`] = `
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -1660,7 +1649,6 @@ exports[`Renderer:Wizard initApi reload 1`] = `
                           </div>
                           <div
                             class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                            title="undefined"
                           >
                             <span />
                           </div>
@@ -1704,7 +1692,6 @@ exports[`Renderer:Wizard initApi reload 1`] = `
                           </div>
                           <div
                             class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                            title="undefined"
                           >
                             <span />
                           </div>
@@ -1935,7 +1922,6 @@ exports[`Renderer:Wizard initApi reload 2`] = `
                           </div>
                           <div
                             class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                            title="undefined"
                           >
                             <span />
                           </div>
@@ -1979,7 +1965,6 @@ exports[`Renderer:Wizard initApi reload 2`] = `
                           </div>
                           <div
                             class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                            title="undefined"
                           >
                             <span />
                           </div>
@@ -2147,7 +2132,6 @@ exports[`Renderer:Wizard initApi reload 3`] = `
                           </div>
                           <div
                             class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                            title="undefined"
                           >
                             <span />
                           </div>
@@ -2191,7 +2175,6 @@ exports[`Renderer:Wizard initApi reload 3`] = `
                           </div>
                           <div
                             class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                            title="undefined"
                           >
                             <span />
                           </div>
@@ -2417,7 +2400,6 @@ exports[`Renderer:Wizard initApi show loading 2`] = `
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -2461,7 +2443,6 @@ exports[`Renderer:Wizard initApi show loading 2`] = `
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -2505,7 +2486,6 @@ exports[`Renderer:Wizard initApi show loading 2`] = `
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -2871,7 +2851,6 @@ exports[`Renderer:Wizard send data 1`] = `
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -2915,7 +2894,6 @@ exports[`Renderer:Wizard send data 1`] = `
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -3066,7 +3044,6 @@ exports[`Renderer:Wizard step initApi 1`] = `
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -3110,7 +3087,6 @@ exports[`Renderer:Wizard step initApi 1`] = `
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -3154,7 +3130,6 @@ exports[`Renderer:Wizard step initApi 1`] = `
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -3418,7 +3393,6 @@ exports[`Renderer:Wizard target 1`] = `
                           </div>
                           <div
                             class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                            title="undefined"
                           >
                             <span />
                           </div>
@@ -3462,7 +3436,6 @@ exports[`Renderer:Wizard target 1`] = `
                           </div>
                           <div
                             class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                            title="undefined"
                           >
                             <span />
                           </div>
@@ -3772,7 +3745,6 @@ exports[`Renderer:Wizard validate 1`] = `
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -3816,7 +3788,6 @@ exports[`Renderer:Wizard validate 1`] = `
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>
@@ -3860,7 +3831,6 @@ exports[`Renderer:Wizard validate 1`] = `
                   </div>
                   <div
                     class="cxd-StepsItem-description cxd-StepsItem-ellText"
-                    title="undefined"
                   >
                     <span />
                   </div>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00778bb</samp>

Improved type safety and tooltip support for `Steps` component. Fixed potential React warnings by checking props in `packages/amis-ui/src/components/Steps.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 00778bb</samp>

> _To avoid warnings from React_
> _And make tooltips work as they should_
> _We added some checks_
> _For `step` props effects_
> _On `title`, `subTitle`, and `description` good_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 00778bb</samp>

*  Add type checks for `step.title`, `step.subTitle`, and `step.description` props to avoid React warnings and ensure tooltip functionality ([link](https://github.com/baidu/amis/pull/8319/files?diff=unified&w=0#diff-b0d86ff73109fb73805fbb6ad3db3d55412c154f48fef6c852a67540780f2b92L209-R213), [link](https://github.com/baidu/amis/pull/8319/files?diff=unified&w=0#diff-b0d86ff73109fb73805fbb6ad3db3d55412c154f48fef6c852a67540780f2b92L219-R227), [link](https://github.com/baidu/amis/pull/8319/files?diff=unified&w=0#diff-b0d86ff73109fb73805fbb6ad3db3d55412c154f48fef6c852a67540780f2b92L227-R239)) in `Steps.tsx`
