### PR TITLE
fix(amis-editor): 导出CRUD2/utils

### DIFF
--- a/packages/amis-editor/src/plugin/index.ts
+++ b/packages/amis-editor/src/plugin/index.ts
@@ -13,6 +13,7 @@ export * from './Tabs'; // 选项卡
 // 数据容器
 export * from './CRUD'; // 增删改查
 export * from './CRUD2/CRUDTable'; // 增删改查v2.0
+export * from './CRUD2/utils';
 export * from './Form/Form'; // 表单
 export * from './Service'; // 服务service
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 26cdf9d</samp>

Export CRUD2 utilities from `packages/amis-editor/src/plugin/index.ts`. This enables other plugins or components to use the new CRUD2 schema features for CRUD operations.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 26cdf9d</samp>

> _`CRUD2` exports utils_
> _New way to work with amis_
> _Autumn of schemas_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 26cdf9d</samp>

* Export CRUD2 utilities from `packages/amis-editor/src/plugin/index.ts` ([link](https://github.com/baidu/amis/pull/8322/files?diff=unified&w=0#diff-932f531ae9519592dd3c4d5b344142b81879a4366812780b429dfa5a17fc675bR16)) to enable other plugins or components to use the new CRUD features
