### PR TITLE
fix: 文字外观去掉vertical-align

### DIFF
--- a/packages/amis-editor/src/plugin/Tpl.tsx
+++ b/packages/amis-editor/src/plugin/Tpl.tsx
@@ -261,7 +261,8 @@ export class TplPlugin extends BasePlugin {
             baseExtra: [
               getSchemaTpl('theme:font', {
                 label: '文字',
-                name: 'themeCss.baseControlClassName.font'
+                name: 'themeCss.baseControlClassName.font',
+                hasVertical: false
               })
             ]
           })


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9956b2b</samp>

Modified the theme editor plugin to use a horizontal font selector component. Changed the `getSchemaTpl` function call in `Tpl.tsx` to pass `hasVertical: false` as an option.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9956b2b</samp>

> _`hasVertical` false_
> _aligns font selector well_
> _autumn of clutter_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9956b2b</samp>

* Added a new property `hasVertical` to the font selector component in the theme editor to control its layout ([link](https://github.com/baidu/amis/pull/8323/files?diff=unified&w=0#diff-0ad9036f99ece8237d04604b822cc6dd71bdf2f44fb3cf34345368349c26b4b6L264-R265))
