### PR TITLE
fix: 修复inputTable当前页数据删除完无法自动调整到上一页问题

### DIFF
--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -1582,11 +1582,14 @@ export default class FormTable extends React.Component<TableProps, TableState> {
 
     let items = this.state.items;
     let showPager = false;
-    const page = this.state.page || 1;
+    let page = this.state.page || 1;
     let offset = 0;
     let lastPage = 1;
     if (typeof perPage === 'number' && perPage && items.length > perPage) {
       lastPage = Math.ceil(items.length / perPage);
+      if (page > lastPage) {
+        page = lastPage;
+      }
       items = items.slice((page - 1) * perPage, page * perPage);
       showPager = true;
       offset = (page - 1) * perPage;
@@ -1666,7 +1669,8 @@ export default class FormTable extends React.Component<TableProps, TableState> {
                   },
                   {
                     activePage: page,
-                    lastPage: lastPage,
+                    perPage,
+                    total: this.state.items.length,
                     onPageChange: this.handlePageChange,
                     className: 'InputTable-pager'
                   }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a473780</samp>

This pull request improves the pagination functionality and appearance of the `InputTable` renderer. It fixes a bug that could cause invalid page numbers and adds item count information to the pager.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a473780</samp>

> _A bug in the `InputTable` pager_
> _Made the page number sometimes waver_
> _But this pull request_
> _Has fixed and enhanced_
> _The pagination and item saver_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a473780</samp>

* Fix a bug where the page number could exceed the last page when the items array changes ([link](https://github.com/baidu/amis/pull/8327/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1585-R1592))
* Add perPage and total props to the Pagination component to display the number of items and pages in the pager ([link](https://github.com/baidu/amis/pull/8327/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1669-R1673))
