### PR TITLE
fix: 修复在 toolbar 中的 form 值变化回显不正确的问题、inputTable当前页数据删除完无法自动调整到上一页问题 

### DIFF
--- a/packages/amis-core/src/WithStore.tsx
+++ b/packages/amis-core/src/WithStore.tsx
@@ -245,6 +245,10 @@ export function HocStoreFactory(renderer: {
                       ...store.data,
                       ...props.data
                     }
+                  : // combo 不需要同步，如果要同步，在 Combo.tsx 里面已经实现了相关逻辑
+                  // 目前主要的问题是，如果 combo 中表单项名字和 combo 本身的名字一样，会导致里面的值会被覆盖成数组
+                  props.store?.storeType === 'ComboStore'
+                  ? undefined
                   : syncDataFromSuper(
                       store.data,
                       (props.data as any).__super,

--- a/packages/amis-core/src/WithStore.tsx
+++ b/packages/amis-core/src/WithStore.tsx
@@ -246,7 +246,7 @@ export function HocStoreFactory(renderer: {
                       ...props.data
                     }
                   : syncDataFromSuper(
-                      props.data,
+                      store.data,
                       (props.data as any).__super,
                       (prevProps.data as any).__super,
                       store,

--- a/packages/amis/__tests__/renderers/Form/combo.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/combo.test.tsx
@@ -970,3 +970,35 @@ test('Renderer:select autofill in combo', async () => {
     combo: [{type: '1', a: 'a'}]
   });
 });
+
+// 10. combo 内部表单项与 combo 同名时，原来会出现内部表单项的值变成数组的情况
+test('Renderer:combo 内部表单项与 combo 同名', async () => {
+  const {container, submitBtn, findByText, onSubmit, baseElement} = await setup(
+    [
+      {
+        type: 'combo',
+        name: 'a',
+        label: 'combo',
+        className: 'removableFalse',
+        removable: false,
+        multiple: true,
+        items: [
+          {
+            name: 'a',
+            type: 'input-text',
+            label: 'A'
+          }
+        ],
+        value: [{}]
+      }
+    ]
+  );
+
+  const input = container.querySelector('input[name="a"]') as HTMLInputElement;
+  fireEvent.change(input, {target: {value: '1'}});
+  await wait(400);
+
+  fireEvent.change(input, {target: {value: '123'}});
+  await wait(400);
+  expect(input.value).toBe('123');
+});

--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -1527,11 +1527,14 @@ export default class FormTable extends React.Component<TableProps, TableState> {
 
     let items = this.state.items;
     let showPager = false;
-    const page = this.state.page || 1;
+    let page = this.state.page || 1;
     let offset = 0;
     let lastPage = 1;
     if (typeof perPage === 'number' && perPage && items.length > perPage) {
       lastPage = Math.ceil(items.length / perPage);
+      if (page > lastPage) {
+        page = lastPage;
+      }
       items = items.slice((page - 1) * perPage, page * perPage);
       showPager = true;
       offset = (page - 1) * perPage;
@@ -1611,7 +1614,8 @@ export default class FormTable extends React.Component<TableProps, TableState> {
                   },
                   {
                     activePage: page,
-                    lastPage: lastPage,
+                    perPage,
+                    total: this.state.items.length,
                     onPageChange: this.handlePageChange,
                     className: 'InputTable-pager'
                   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,7 +62,8 @@ export default defineConfig({
     }),
     monacoEditorPlugin({}),
     replace({
-      __editor_i18n: !!I18N
+      __editor_i18n: !!I18N,
+      preventAssignment: true
     })
   ].filter(n => n),
   optimizeDeps: {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 338a745</samp>

This pull request fixes two bugs in the InputTable and WithStore components and adds a configuration option to the vite build tool. The changes improve the usability and performance of the amis library.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 338a745</samp>

> _This pull request has some changes to make_
> _To fix some bugs and warnings that we don't want to take_
> _It syncs with the `super store`_
> _And paginates `InputTable` more_
> _By using `store data` and `preventAssignment` for goodness sake_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 338a745</samp>

* Fix a bug where the store data was not synced correctly with the super store ([link](https://github.com/baidu/amis/pull/8328/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL249-R249))
* Add pagination support and information to the InputTable component ([link](https://github.com/baidu/amis/pull/8328/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1530-R1537), [link](https://github.com/baidu/amis/pull/8328/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1614-R1618))
* Add the preventAssignment option to the replace plugin in `vite.config.ts` to avoid warnings ([link](https://github.com/baidu/amis/pull/8328/files?diff=unified&w=0#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL65-R66))
