### PR TITLE
chore: 调整选项搜索策略改成 contains 更加精准

### DIFF
--- a/packages/amis-core/src/store/crud.ts
+++ b/packages/amis-core/src/store/crud.ts
@@ -196,7 +196,8 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
                         arrItems = [
                           ...arrItems,
                           ...matchSorter(arr, item, {
-                            keys: [key]
+                            keys: [key],
+                            threshold: matchSorter.rankings.CONTAINS
                           })
                         ];
                       });
@@ -206,7 +207,8 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
                     }
                   } else {
                     items = matchSorter(items, value, {
-                      keys: [key]
+                      keys: [key],
+                      threshold: matchSorter.rankings.CONTAINS
                     });
                   }
                 }
@@ -366,7 +368,8 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
                         arrItems = [
                           ...arrItems,
                           ...matchSorter(arr, item, {
-                            keys: [key]
+                            keys: [key],
+                            threshold: matchSorter.rankings.CONTAINS
                           })
                         ];
                       });
@@ -376,7 +379,8 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
                     }
                   } else {
                     filteredItems = matchSorter(filteredItems, value, {
-                      keys: [key]
+                      keys: [key],
+                      threshold: matchSorter.rankings.CONTAINS
                     });
                   }
                 }

--- a/packages/amis-editor/src/renderer/DataBindingControl.tsx
+++ b/packages/amis-editor/src/renderer/DataBindingControl.tsx
@@ -194,7 +194,8 @@ export class SimpleDataBindingControl extends React.Component<
   async handleSearch(keywords: string) {
     this.setState({
       filteredFields: matchSorter(this.props.fields, keywords, {
-        keys: ['label', 'value', 'children']
+        keys: ['label', 'value', 'children'],
+        threshold: matchSorter.rankings.CONTAINS
       })
     });
   }

--- a/packages/amis-ui/src/components/DropDownSelection.tsx
+++ b/packages/amis-ui/src/components/DropDownSelection.tsx
@@ -68,7 +68,8 @@ class DropDownSelection extends BaseSelection<
         return !!(
           (Array.isArray(option.children) && option.children.length) ||
           !!matchSorter([option].concat(paths), text, {
-            keys: [labelField || 'label', valueField || 'value']
+            keys: [labelField || 'label', valueField || 'value'],
+            threshold: matchSorter.rankings.CONTAINS
           }).length
         );
       },

--- a/packages/amis-ui/src/components/InputBoxWithSuggestion.tsx
+++ b/packages/amis-ui/src/components/InputBoxWithSuggestion.tsx
@@ -43,7 +43,8 @@ export class InputBoxWithSuggestion extends React.Component<InputBoxWithSuggesti
   filterOptions(options: any[]) {
     return this.props.value
       ? matchSorter(options, this.props.value, {
-          keys: ['label', 'value']
+          keys: ['label', 'value'],
+          threshold: matchSorter.rankings.CONTAINS
         })
       : options;
   }

--- a/packages/amis-ui/src/components/SelectMobile.tsx
+++ b/packages/amis-ui/src/components/SelectMobile.tsx
@@ -111,7 +111,8 @@ export default class SelectMobile extends React.Component<Props, SelectState> {
     let filtedOptions: Array<Option> =
       inputValue && checkAllBySearch !== false
         ? matchSorter(options, inputValue, {
-            keys: [labelField || 'label', valueField || 'value']
+            keys: [labelField || 'label', valueField || 'value'],
+            threshold: matchSorter.rankings.CONTAINS
           })
         : options.concat();
     const optionsValues = filtedOptions.map(option => option.value);
@@ -231,7 +232,8 @@ export default class SelectMobile extends React.Component<Props, SelectState> {
       let filtedOptions: Array<Option> = (
         inputValue && !loadOptions
           ? matchSorter(options, inputValue, {
-              keys: [labelField || 'label', valueField || 'value']
+              keys: [labelField || 'label', valueField || 'value'],
+              threshold: matchSorter.rankings.CONTAINS
             })
           : options.concat()
       ).filter((option: Option) => !option.hidden && option.visible !== false);
@@ -282,7 +284,8 @@ export default class SelectMobile extends React.Component<Props, SelectState> {
     let filtedOptions: Array<Option> = (
       inputValue && isOpen && !loadOptions
         ? matchSorter(options, inputValue, {
-            keys: [labelField || 'label', valueField || 'value']
+            keys: [labelField || 'label', valueField || 'value'],
+            threshold: matchSorter.rankings.CONTAINS
           })
         : options.concat()
     ).filter(

--- a/packages/amis-ui/src/components/formula/VariableList.tsx
+++ b/packages/amis-ui/src/components/formula/VariableList.tsx
@@ -221,7 +221,8 @@ function VariableList(props: VariableListProps) {
         return !!(
           (Array.isArray(i.children) && i.children.length) ||
           !!matchSorter([i].concat(paths), term, {
-            keys: ['label', 'value']
+            keys: ['label', 'value'],
+            threshold: matchSorter.rankings.CONTAINS
           }).length
         );
       },

--- a/packages/amis/src/renderers/Form/IconPicker.tsx
+++ b/packages/amis/src/renderers/Form/IconPicker.tsx
@@ -257,7 +257,10 @@ export default class IconPickerControl extends React.PureComponent<
         {({getInputProps, getItemProps, isOpen, inputValue}) => {
           let filteredOptions =
             inputValue && isOpen
-              ? matchSorter(options, inputValue, {keys: ['label', 'value']})
+              ? matchSorter(options, inputValue, {
+                  keys: ['label', 'value'],
+                  threshold: matchSorter.rankings.CONTAINS
+                })
               : options;
 
           return (

--- a/packages/amis/src/renderers/Form/IconSelect.tsx
+++ b/packages/amis/src/renderers/Form/IconSelect.tsx
@@ -326,7 +326,10 @@ export default class IconSelectControl extends React.PureComponent<
     const inputValue = this.state.searchValue;
 
     const filteredIcons = inputValue
-      ? matchSorter(icons, inputValue, {keys: ['name']})
+      ? matchSorter(icons, inputValue, {
+          keys: ['name'],
+          threshold: matchSorter.rankings.CONTAINS
+        })
       : icons;
     return (
       <>

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -722,7 +722,8 @@ export default class TextControl extends React.PureComponent<
           let filtedOptions =
             inputValue && isOpen && !autoComplete
               ? matchSorter(options, inputValue, {
-                  keys: [labelField || 'label', valueField || 'value']
+                  keys: [labelField || 'label', valueField || 'value'],
+                  threshold: matchSorter.rankings.CONTAINS
                 })
               : options;
           const indices = isOpen

--- a/packages/amis/src/renderers/Form/InputTree.tsx
+++ b/packages/amis/src/renderers/Form/InputTree.tsx
@@ -250,7 +250,8 @@ export default class TreeControl extends React.Component<TreeProps, TreeState> {
         ...option
       };
       option.visible = !!matchSorter([option], keywords, {
-        keys: [labelField || 'label', valueField || 'value']
+        keys: [labelField || 'label', valueField || 'value'],
+        threshold: matchSorter.rankings.CONTAINS
       }).length;
 
       if (!option.visible && option.children) {

--- a/packages/amis/src/renderers/Form/NestedSelect.tsx
+++ b/packages/amis/src/renderers/Form/NestedSelect.tsx
@@ -559,7 +559,8 @@ export default class NestedSelectControl extends React.Component<
               paths: Array<Option>
             ) =>
               !!matchSorter([option].concat(paths), inputValue, {
-                keys: [labelField || 'label', valueField || 'value']
+                keys: [labelField || 'label', valueField || 'value'],
+                threshold: matchSorter.rankings.CONTAINS
               }).length || !!(option.children && option.children.length),
             1,
             true

--- a/packages/amis/src/renderers/Form/TabsTransfer.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransfer.tsx
@@ -126,7 +126,8 @@ export class BaseTabsTransferRenderer<
           return !!(
             (Array.isArray(option.children) && option.children.length) ||
             !!matchSorter([option].concat(paths), term, {
-              keys: [labelField || 'label', valueField || 'value']
+              keys: [labelField || 'label', valueField || 'value'],
+              threshold: matchSorter.rankings.CONTAINS
             }).length
           );
         },

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -405,7 +405,8 @@ export class BaseTransferRenderer<
           return !!(
             (Array.isArray(option.children) && option.children.length) ||
             !!matchSorter([option].concat(paths), term, {
-              keys: [labelField || 'label', valueField || 'value']
+              keys: [labelField || 'label', valueField || 'value'],
+              threshold: matchSorter.rankings.CONTAINS
             }).length
           );
         },

--- a/packages/amis/src/renderers/Form/TreeSelect.tsx
+++ b/packages/amis/src/renderers/Form/TreeSelect.tsx
@@ -377,7 +377,8 @@ export default class TreeSelectControl extends React.Component<
         ...option
       };
       option.visible = !!matchSorter([option], keywords, {
-        keys: [labelField || 'label', valueField || 'value']
+        keys: [labelField || 'label', valueField || 'value'],
+        threshold: matchSorter.rankings.CONTAINS
       }).length;
 
       if (!option.visible && option.children) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ab2491</samp>

This pull request adds a `threshold` option to the `matchSorter` function call in various components and classes in the amis UI and core packages. The `threshold` option allows the components and classes to perform a fuzzy search that matches items that contain the search term, not just start with it. This improves the user-friendliness and usability of the components and classes that use the `matchSorter` function. The affected files include `SelectMobile.tsx`, `DataBindingControl.tsx`, `DropDownSelection.tsx`, `VariableList.tsx`, `InputBoxWithSuggestion.tsx`, `IconPicker.tsx`, `IconSelect.tsx`, `InputText.tsx`, `InputTree.tsx`, `NestedSelect.tsx`, `TabsTransfer.tsx`, `Transfer.tsx`, `TreeSelect.tsx`, and `crud.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4ab2491</samp>

> _Oh we are the `matchSorter` crew_
> _We make the search more friendly and true_
> _We add a threshold option to every call_
> _And we match the terms that contain, not just start with, them all_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4ab2491</samp>

*  Add a threshold option to the matchSorter function calls in various components to make the fuzzy search more tolerant and match items that contain the search term, not just start with it ([link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL199-R200), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL209-R211), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL369-R372), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL379-R383), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-356912b33e7beb16160bcb11dd6545ab163826d831934adee56510cbd4ea490bL197-R198), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-abb27a21bd425df5d4d689bdc6858e46ec83dd19885db52601f2658df3814201L71-R72), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-ea04d5790edbde6f5b8024537e7e639026aaab523c76d6df7253b19c6a84faf0L46-R47), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-3656ac98b3eebd1f8c5c22657cb0eadc6c41637705d2b5597066b387f9011fb5L114-R115), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-3656ac98b3eebd1f8c5c22657cb0eadc6c41637705d2b5597066b387f9011fb5L234-R236), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-3656ac98b3eebd1f8c5c22657cb0eadc6c41637705d2b5597066b387f9011fb5L285-R288), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-20ccd77f29dae5effdf503856c6589eb936a52ec3ac2f9a852f7c0d4b6b5a562L224-R225), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-88d6eb6b9b17a53b8204798065d5cdf0563e211ff2f7a776597fa7c7400fb855L260-R263), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-49d6f3f00021b4f9590babc577f72384ca28f30e459dd1aec1e677b790500c06L329-R332), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L725-R726), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-527e78ca6789f4f47200b93123fe7f7884acc6890540c2616a3bc4cf4f41cd2bL253-R254), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565L562-R563), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-36d4a19803ba21094b5aee307abb8b8c5cad04fcb3c373082cddf1566b591f21L129-R130), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-07debd2e776c043c2635a6714d9622ad216538a5d1a7d75a982e41f30e711e71L408-R409), [link](https://github.com/baidu/amis/pull/8329/files?diff=unified&w=0#diff-9e1b32863ebd5d805fac50e10de5eb0f6e2cd1c3385b3674813bf1994426ae95L380-R381))
