### PR TITLE
fix: 修复icon组件设置外观不生效问题

### DIFF
--- a/packages/amis-editor/src/plugin/Icon.tsx
+++ b/packages/amis-editor/src/plugin/Icon.tsx
@@ -130,7 +130,7 @@ export class IconPlugin extends BasePlugin {
               body: [
                 getSchemaTpl('theme:select', {
                   label: '尺寸',
-                  name: 'themeCss.className.font.fontSize'
+                  name: 'themeCss.className.iconSize'
                 }),
                 getSchemaTpl('theme:colorPicker', {
                   label: '颜色',

--- a/packages/amis-ui/scss/components/form/_icon-select.scss
+++ b/packages/amis-ui/scss/components/form/_icon-select.scss
@@ -221,7 +221,6 @@
 
         &-name {
           margin: 0;
-          margin-bottom: var(--IconSelect-xs-margin);
           font-size: var(--IconSelect-type-font-size);
           color: var(--IconSelect-icon-name-color);
         }

--- a/packages/amis/src/renderers/Icon.tsx
+++ b/packages/amis/src/renderers/Icon.tsx
@@ -90,7 +90,7 @@ export class Icon extends React.Component<IconProps, object> {
           onMouseLeave={this.handleMouseLeave}
           className={cx(
             className,
-            setThemeClassName('baseControlClassName', id, themeCss),
+            setThemeClassName('className', id, themeCss),
             setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
           )}
         />


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 35f477d</samp>

This pull request fixes a bug in the `IconPlugin` class and improves the consistency of the `Icon` class. It updates the schema template and the themeCss property name for the icon size and class name in `Icon.tsx` and `IconPlugin.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 35f477d</samp>

> _`IconPlugin` fixed_
> _Size and class name aligned_
> _A crisp autumn code_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 35f477d</samp>

* Fix a bug in IconPlugin that caused icon size to be controlled by font size ([link](https://github.com/baidu/amis/pull/8330/files?diff=unified&w=0#diff-fd3fe72052baded5f048dce2f55f2ac314c0b35abe23647f6b64e2d5dca73d5bL133-R133))
* Use consistent themeCss property name for icon class name in Icon ([link](https://github.com/baidu/amis/pull/8330/files?diff=unified&w=0#diff-26fc101db139c006d317ebf50b343f3be07294c93815ad2275dd21e76babec4aL93-R93))
