### PR TITLE
fix: 表单配置面板-可见 配置项默认开启

### DIFF
--- a/packages/amis-editor/src/renderer/StatusControl.tsx
+++ b/packages/amis-editor/src/renderer/StatusControl.tsx
@@ -24,6 +24,7 @@ export interface StatusControlProps extends FormControlProps {
   // 应用于不需要 bulkChange 的场景，如
   noBulkChange?: boolean;
   noBulkChangeData?: any;
+  defaultTrue?: boolean; // 默认是否开启，用于“可见”等默认开启的配置项
   onDataChange?: (value: any) => void;
 }
 
@@ -58,7 +59,8 @@ export class StatusControl extends React.Component<
       noBulkChangeData,
       expressionName,
       name,
-      trueValue
+      trueValue,
+      defaultTrue
     } = this.props;
 
     const formData: StatusFormData = {
@@ -78,7 +80,11 @@ export class StatusControl extends React.Component<
     }
     return {
       checked:
-        ctx[name] == trueValue || typeof ctx[expressionName] === 'string',
+        ctx[name] == trueValue ||
+        typeof ctx[expressionName] === 'string' ||
+        (!!defaultTrue &&
+          ctx[name] == undefined &&
+          ctx[expressionName] == undefined),
       formData
     };
   }

--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -863,6 +863,7 @@ setSchemaTpl('readonly', {
 
 setSchemaTpl('visible', {
   type: 'ae-StatusControl',
+  defaultTrue: true,
   label: '可见',
   mode: 'normal',
   name: 'visible',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 68827a3</samp>

Added a `defaultTrue` property to the status control component to allow more control over the default states of options. Enabled the `visible` option by default for all components in the editor using the common template.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 68827a3</samp>

> _`visible` option_
> _now default true for all_
> _a spring of status_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 68827a3</samp>

*  Add a `defaultTrue` property to the `StatusControlProps` interface and the `StatusControl` class to enable some options like visibility by default ([link](https://github.com/baidu/amis/pull/8331/files?diff=unified&w=0#diff-04709e53c43bdedbb92ed32bd99c2d62584ca89aec4243a5fef10598148bae02R27), [link](https://github.com/baidu/amis/pull/8331/files?diff=unified&w=0#diff-04709e53c43bdedbb92ed32bd99c2d62584ca89aec4243a5fef10598148bae02L61-R63), [link](https://github.com/baidu/amis/pull/8331/files?diff=unified&w=0#diff-04709e53c43bdedbb92ed32bd99c2d62584ca89aec4243a5fef10598148bae02L81-R87))
*  Set the `defaultTrue` property to true for the `visible` option in the common template for the editor in `common.tsx` ([link](https://github.com/baidu/amis/pull/8331/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05R866))
