### PR TITLE
chore:调整formula-editor中数组变量成员快捷列表文字为左对齐

### DIFF
--- a/packages/amis-ui/scss/components/_formula.scss
+++ b/packages/amis-ui/scss/components/_formula.scss
@@ -279,7 +279,7 @@
         min-width: 100px;
         padding: 0 5px;
         margin: 5px;
-        text-align: center;
+        text-align: left;
         li {
           line-height: 24px;
           &:hover {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0515d18</samp>

Changed the text alignment of formula editor buttons in `amis-ui` to match the design mockup. This affects the `_formula.scss` file in the `components` folder.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0515d18</samp>

> _`formula-editor`_
> _Aligns buttons to the left_
> _Autumn of mockups_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0515d18</samp>

*  Align formula editor buttons to the left ([link](https://github.com/baidu/amis/pull/8333/files?diff=unified&w=0#diff-f47fc8341294613d4ce27fd9352821306195cd2d1b8be120b13dde559c5f169dL282-R282)) to match the design mockup and improve the readability of the labels. This change affects the `.formula-editor .btn-group` selector in the `_formula.scss` file.
