### PR TITLE
fix: 弹窗外观文字去掉vertical

### DIFF
--- a/packages/amis-editor/src/plugin/Dialog.tsx
+++ b/packages/amis-editor/src/plugin/Dialog.tsx
@@ -406,7 +406,8 @@ export class DialogPlugin extends BasePlugin {
             body: [
               getSchemaTpl('theme:font', {
                 label: '文字',
-                name: 'themeCss.dialogTitleClassName.font'
+                name: 'themeCss.dialogTitleClassName.font',
+                hasVertical: false
               }),
               getSchemaTpl('theme:paddingAndMargin', {
                 name: 'themeCss.dialogHeaderClassName.padding-and-margin',

--- a/packages/amis-editor/src/plugin/Tpl.tsx
+++ b/packages/amis-editor/src/plugin/Tpl.tsx
@@ -261,8 +261,7 @@ export class TplPlugin extends BasePlugin {
             baseExtra: [
               getSchemaTpl('theme:font', {
                 label: '文字',
-                name: 'themeCss.baseControlClassName.font',
-                hasVertical: false
+                name: 'themeCss.baseControlClassName.font'
               })
             ]
           })


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a9e095</samp>

This pull request modifies the `theme:font` schema template in `Dialog.tsx` and `Tpl.tsx` to control the visibility of the vertical alignment options in the editor UI. The change simplifies the font settings for the dialog title and restores the original font settings for the base control.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3a9e095</samp>

> _`hasVertical` hides_
> _dialog title alignment_
> _simpler in winter_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3a9e095</samp>

*  Add a new property `hasVertical` to the `theme:font` schema template to control the visibility of vertical alignment options in the editor UI ([link](https://github.com/baidu/amis/pull/8335/files?diff=unified&w=0#diff-d3bebdf8ee046a9260ff973d8fc59a35ef327db18d55902021b571b045359e1aL409-R410), [link](https://github.com/baidu/amis/pull/8335/files?diff=unified&w=0#diff-0ad9036f99ece8237d04604b822cc6dd71bdf2f44fb3cf34345368349c26b4b6L264-R264))
*  Hide the vertical alignment options for the dialog title font in `Dialog.tsx` to simplify the font settings and avoid unnecessary options ([link](https://github.com/baidu/amis/pull/8335/files?diff=unified&w=0#diff-d3bebdf8ee046a9260ff973d8fc59a35ef327db18d55902021b571b045359e1aL409-R410))
*  Show the vertical alignment options for the base control font in `Tpl.tsx` to restore the original behavior and make the schema template consistent with other places ([link](https://github.com/baidu/amis/pull/8335/files?diff=unified&w=0#diff-0ad9036f99ece8237d04604b822cc6dd71bdf2f44fb3cf34345368349c26b4b6L264-R264))
