### PR TITLE
docs: API文档错别字修复

### DIFF
--- a/docs/zh-CN/types/api.md
+++ b/docs/zh-CN/types/api.md
@@ -690,7 +690,7 @@ const schema = {
 
 #### 拦截请求
 
-如果 api 发送适配器中，修改 api 对象，在 api 对象里面放入 `mockReponse` 属性，则会拦截请求发送，amis 内部会直接使用 `mockReponse` 的结果返回。
+如果 api 发送适配器中，修改 api 对象，在 api 对象里面放入 `mockResponse` 属性，则会拦截请求发送，amis 内部会直接使用 `mockResponse` 的结果返回。
 
 ```js
 const schema = {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eb9d72e</samp>

Fix a typo in the `mockResponse` documentation. Update the code example in `docs/zh-CN/types/api.md` to use the correct spelling.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at eb9d72e</samp>

> _`mockResponse` typo_
> _Fixed in documentation_
> _Clearer for spring code_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eb9d72e</samp>

* Fix typo in `mockResponse` feature documentation ([link](https://github.com/baidu/amis/pull/8336/files?diff=unified&w=0#diff-00d0e84a1779e47502d96b34c102949f10dacf775ca91423e751dffbc7ce7683L693-R693))
