### PR TITLE
chore: 添加补丁修复存量配置中存在无用主题属性问题

### DIFF
--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -66,6 +66,8 @@ export function cleanUndefined(obj: any) {
   return obj;
 }
 
+let themeUselessPropKeys: Array<string> = [];
+
 /**
  * 把 schema 处理一下传给 Preview 去渲染
  * 给每个节点加个 $$id 这样方便编辑
@@ -86,6 +88,26 @@ export function JSONPipeIn(obj: any, generateId = false): any {
   if (!obj.$$id) {
     flag = true;
     toUpdate.$$id = guid();
+  }
+
+  // 因为旧版本的 bug，导致有些存量页面，出现大量无用配置
+  // 所以这里做个兼容，把这些无用的配置清理掉
+  // 找特征，只有同时存在前三个属性，说明这是以前的脏数据
+  if (
+    themeUselessPropKeys.length > 2 &&
+    obj[themeUselessPropKeys[0]] &&
+    obj[themeUselessPropKeys[1]] &&
+    obj[themeUselessPropKeys[2]]
+  ) {
+    flag = true;
+    themeUselessPropKeys.forEach(key => {
+      toUpdate[key] = undefined;
+    });
+  }
+
+  if (obj.themeConfig) {
+    flag = true;
+    toUpdate['themeConfig'] = undefined;
   }
 
   // ['visible', 'visibleOn', 'hidden', 'hiddenOn', 'toggled'].forEach(key => {
@@ -1089,10 +1111,12 @@ export function needFillPlaceholder(curProps: any) {
     curProps.regionConfig?.needFillPlaceholder
   );
 }
+
 // 设置主题数据
 export function setThemeConfig(config: any) {
   themeConfig = config;
   themeOptionsData = getGlobalData(themeConfig);
+  themeUselessPropKeys = Object.keys(themeOptionsData);
 }
 
 // 获取主题数据和样式选择器数据


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 17dbe14</samp>

This pull request optimizes the configuration object size by removing some obsolete theme properties from `util.ts`. This improves the performance and usability of the editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 17dbe14</samp>

> _Oh we're the coders of the sea, and we work with JSON_
> _We trim the useless props, to make the config lean_
> _We use the `JSONPipeIn` to filter out the trash_
> _And we render the editor, with a mighty splash_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 17dbe14</samp>

*  Remove useless theme-related properties from configuration ([link](https://github.com/baidu/amis/pull/8340/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aR69-R84), [link](https://github.com/baidu/amis/pull/8340/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aR107-R120))
  - Define an array of `uselessThemeProps` in `util.ts` ([link](https://github.com/baidu/amis/pull/8340/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aR69-R84))
  - Check and clean up dirty data from old versions in `JSONPipeIn` function in `util.ts` ([link](https://github.com/baidu/amis/pull/8340/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aR107-R120))
    - Set `isDirty` flag to true if the first three properties are in `uselessThemeProps` ([link](https://github.com/baidu/amis/pull/8340/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aR107-R120))
    - Assign undefined to all the properties in `uselessThemeProps` in `toUpdate` object ([link](https://github.com/baidu/amis/pull/8340/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aR107-R120))
