### PR TITLE
fix: 组合穿梭器  预览拖拽排序已选项 页面有弹框提醒

### DIFF
--- a/packages/amis-editor-core/src/component/Preview.tsx
+++ b/packages/amis-editor-core/src/component/Preview.tsx
@@ -413,24 +413,37 @@ export default class Preview extends Component<PreviewProps> {
 
   @autobind
   handleDragEnter(e: React.DragEvent) {
+    if (!this.props.editable) {
+      // 非编辑态下不监听拖拽事件
+      return;
+    }
     const manager = this.props.manager;
     manager.dnd.dragEnter(e.nativeEvent);
   }
 
   @autobind
   handleDragLeave(e: React.DragEvent) {
+    if (!this.props.editable) {
+      return;
+    }
     const manager = this.props.manager;
     manager.dnd.dragLeave(e.nativeEvent);
   }
 
   @autobind
   handleDragOver(e: React.DragEvent) {
+    if (!this.props.editable) {
+      return;
+    }
     const manager = this.props.manager;
     manager.dnd.dragOver(e.nativeEvent);
   }
 
   @autobind
   handleDrop(e: React.DragEvent) {
+    if (!this.props.editable) {
+      return;
+    }
     const manager = this.props.manager;
     manager.dnd.drop(e.nativeEvent);
   }


### PR DESCRIPTION
### What
对于combo、CRUD、组合穿梭器等组件，如果配置可拖拽，在页面设计器预览态下拖拽会提示”请先选择一个元素作为插入的位置。“

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 551215f</samp>

This pull request improves the read-only mode of the preview component in `amis-editor-core` by disabling the drag and drop functionality. This prevents accidental modifications to the `schema` or the `state` props.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 551215f</samp>

> _To preview a component with ease_
> _We added some checks for `editable`_
> _No drag and drop allowed_
> _When the prop is set to false_
> _To prevent unwanted changes to state or schema_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 551215f</samp>

*  Prevent drag and drop events and interactions for the preview component when it is in read-only mode ([link](https://github.com/baidu/amis/pull/8341/files?diff=unified&w=0#diff-d9b508133ad06e8946597f0255a1b4529b6fb9f0c2bf3c170e0fcef582fff0e9R416-R419), [link](https://github.com/baidu/amis/pull/8341/files?diff=unified&w=0#diff-d9b508133ad06e8946597f0255a1b4529b6fb9f0c2bf3c170e0fcef582fff0e9R426-R428), [link](https://github.com/baidu/amis/pull/8341/files?diff=unified&w=0#diff-d9b508133ad06e8946597f0255a1b4529b6fb9f0c2bf3c170e0fcef582fff0e9R435-R437), [link](https://github.com/baidu/amis/pull/8341/files?diff=unified&w=0#diff-d9b508133ad06e8946597f0255a1b4529b6fb9f0c2bf3c170e0fcef582fff0e9R444-R446)) in `Preview.tsx`
