### PR TITLE
styles: 修复textarea组件在设置size时底线消失问题

### DIFF
--- a/packages/amis-ui/scss/components/form/_textarea.scss
+++ b/packages/amis-ui/scss/components/form/_textarea.scss
@@ -7,6 +7,8 @@
   > textarea.#{$ns}TextareaControl-input--counter {
     // 23 px 是计数器 counter 的高度
     padding-bottom: 23px;
+    // 设置size时会把textarea设置成inline-block，导致高度异常，所以这里需要设置成block
+    display: block !important;
   }
 
   > textarea {
@@ -15,10 +17,8 @@
     border: 1px solid var(--Form-input-borderColor);
     border-radius: var(--Form-input-borderRadius);
     background: var(--Form-input-bg);
-    padding: var(--input-textarea-paddingTop)
-      var(--input-textarea-paddingRight)
-      var(--input-textarea-paddingBottom)
-      var(--input-textarea-paddingLeft);
+    padding: var(--input-textarea-paddingTop) var(--input-textarea-paddingRight)
+      var(--input-textarea-paddingBottom) var(--input-textarea-paddingLeft);
     font-size: var(--Form-input-fontSize);
     display: block;
     width: 100%;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 128d7d6</samp>

Refactor SCSS code for textarea component. The pull request enhances the style and clarity of the `./packages/amis-ui/scss/components/form/_textarea.scss` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 128d7d6</samp>

> _A file with some styles for textareas_
> _Was updated with some minor repairs_
> _A comment was added_
> _A padding was padded_
> _And a blank line was gone, no one cares_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 128d7d6</samp>

*  Add a comment to explain why `display: block !important` is needed for the textarea element ([link](https://github.com/baidu/amis/pull/8347/files?diff=unified&w=0#diff-b7020c82803bdf4520f4b02de4d52defde92ce287a7ddbd2abeec8999f41d8d5R10-R11))
*  Reformat the padding property of the textarea element to make it more readable ([link](https://github.com/baidu/amis/pull/8347/files?diff=unified&w=0#diff-b7020c82803bdf4520f4b02de4d52defde92ce287a7ddbd2abeec8999f41d8d5L18-R21))
*  Remove an extra blank line at the end of the file `_textarea.scss` ([link](https://github.com/baidu/amis/pull/8347/files?diff=unified&w=0#diff-b7020c82803bdf4520f4b02de4d52defde92ce287a7ddbd2abeec8999f41d8d5L74-R74))
