### PR TITLE
feat: loadDataOnceFetchOnFilter 可以控制列的 searchable 或者 filterable 或者 se…

### DIFF
--- a/docs/zh-CN/components/crud.md
+++ b/docs/zh-CN/components/crud.md
@@ -2795,7 +2795,6 @@ CRUD 中不限制有多少个单条操作、添加一个操作对应的添加一
 > 本文中的例子为了不相互影响都关闭了这个功能。
 > 另外如果需要使用接口联动，需要设置`syncLocation: false`
 
-
 `syncLocation`开启后，数据域经过地址栏同步后，原始值被转化为字符串同步回数据域，但布尔值（boolean）同步后不符合预期数据结构，导致组件渲染出错。比如查询条件表单中包含[Checkbox](./form/checkbox)组件，此时可以设置`{"trueValue": "1", "falseValue": "0"}`，将真值和假值设置为字符串格式规避。
 
 ## 前端一次性加载
@@ -2846,8 +2845,6 @@ CRUD 中不限制有多少个单条操作、添加一个操作对应的添加一
     "syncLocation": false,
     "api": "/api/mock2/sample",
     "loadDataOnce": true,
-    "autoGenerateFilter": true,
-    "filterSettingSource": ["browser", "version"],
     "columns": [
         {
             "name": "id",
@@ -2894,6 +2891,131 @@ CRUD 中不限制有多少个单条操作、添加一个操作对应的添加一
 ```
 
 > **注意：**如果你的数据量较大，请务必使用服务端分页的方案，过多的前端数据展示，会显著影响前端页面的性能
+
+另外前端一次性加载当有查寻条件的时候，默认还是会重新请求一次，如果配置 `loadDataOnceFetchOnFilter` 为 `false` 则为前端过滤。
+
+```schema: scope="body"
+{
+  "type": "crud",
+  "syncLocation": false,
+  "api": "/api/mock2/sample",
+  "loadDataOnce": true,
+  "loadDataOnceFetchOnFilter": false,
+  "autoGenerateFilter": true,
+  "columns": [
+    {
+      "name": "id",
+      "label": "ID"
+    },
+    {
+      "name": "engine",
+      "label": "Rendering engine"
+    },
+    {
+      "name": "browser",
+      "label": "Browser"
+    },
+    {
+      "name": "platform",
+      "label": "Platform(s)"
+    },
+    {
+      "name": "version",
+      "label": "Engine version",
+      "searchable": {
+        "type": "select",
+        "name": "version",
+        "label": "Engine version",
+        "clearable": true,
+        "multiple": true,
+        "searchable": true,
+        "checkAll": true,
+        "options": [
+          "1.7",
+          "3.3",
+          "5.6"
+        ],
+        "maxTagCount": 10,
+        "extractValue": true,
+        "joinValues": false,
+        "delimiter": ",",
+        "defaultCheckAll": false,
+        "checkAllLabel": "全选"
+      }
+    },
+    {
+      "name": "grade",
+      "label": "CSS grade"
+    }
+  ]
+}
+```
+
+`loadDataOnceFetchOnFilter` 配置成 `true` 则会强制重新请求接口比如以下用法
+
+> 此时如果不配置或者配置为 `false` 是前端直接过滤，不过记得配置 name 为行数据中的属性，如果行数据中没有对应属性则不会起作用
+
+```schema: scope="body"
+{
+  "type": "crud",
+  "syncLocation": false,
+  "api": "/api/mock2/sample",
+  "loadDataOnce": true,
+  "loadDataOnceFetchOnFilter": true,
+  "headerToolbar": [
+    {
+      "type": "search-box",
+      "name": "keywords"
+    }
+  ],
+  "columns": [
+    {
+      "name": "id",
+      "label": "ID"
+    },
+    {
+      "name": "engine",
+      "label": "Rendering engine"
+    },
+    {
+      "name": "browser",
+      "label": "Browser"
+    },
+    {
+      "name": "platform",
+      "label": "Platform(s)"
+    },
+    {
+      "name": "version",
+      "label": "Engine version",
+      "searchable": {
+        "type": "select",
+        "name": "version",
+        "label": "Engine version",
+        "clearable": true,
+        "multiple": true,
+        "searchable": true,
+        "checkAll": true,
+        "options": [
+          "1.7",
+          "3.3",
+          "5.6"
+        ],
+        "maxTagCount": 10,
+        "extractValue": true,
+        "joinValues": false,
+        "delimiter": ",",
+        "defaultCheckAll": false,
+        "checkAllLabel": "全选"
+      }
+    },
+    {
+      "name": "grade",
+      "label": "CSS grade"
+    }
+  ]
+}
+```
 
 ## 动态列
 

--- a/packages/amis-core/src/store/crud.ts
+++ b/packages/amis-core/src/store/crud.ts
@@ -145,8 +145,7 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
       data?: object,
       options?: fetchOptions & {
         forceReload?: boolean;
-        loadDataOnce?: boolean; // 配置数据是否一次性加载，如果是这样，由前端来完成分页，排序等功能。
-        loadDataOnceFetchOnFilter?: boolean; // 在开启loadDataOnce时，filter时是否去重新请求api
+        loadDataOnce?: boolean; // 配置数据是否一次性加载，如果是这样，由前端来完成分页，排序等
         source?: string; // 支持自定义属于映射，默认不配置，读取 rows 或者 items
         loadDataMode?: boolean;
         syncResponse2Query?: boolean;
@@ -159,7 +158,6 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
       options: fetchOptions & {
         forceReload?: boolean;
         loadDataOnce?: boolean; // 配置数据是否一次性加载，如果是这样，由前端来完成分页，排序等功能。
-        loadDataOnceFetchOnFilter?: boolean; // 在开启loadDataOnce时，filter时是否去重新请求api
         source?: string; // 支持自定义属于映射，默认不配置，读取 rows 或者 items
         loadDataMode?: boolean;
         syncResponse2Query?: boolean;
@@ -181,36 +179,36 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
 
           if (Array.isArray(options.columns)) {
             options.columns.forEach((column: any) => {
-              let value: any;
+              let value: any =
+                typeof column.name === 'string'
+                  ? getVariable(self.query, column.name)
+                  : undefined;
               const key = column.name;
 
-              if ((column.searchable || column.filterable) && key) {
+              if (value != null && key) {
                 // value可能为null、undefined、''、0
-                value = getVariable(self.query, key);
-                if (value != null) {
-                  if (Array.isArray(value)) {
-                    if (value.length > 0) {
-                      const arr = [...items];
-                      let arrItems: Array<any> = [];
-                      value.forEach(item => {
-                        arrItems = [
-                          ...arrItems,
-                          ...matchSorter(arr, item, {
-                            keys: [key],
-                            threshold: matchSorter.rankings.CONTAINS
-                          })
-                        ];
-                      });
-                      items = items.filter((item: any) =>
-                        arrItems.find(a => a === item)
-                      );
-                    }
-                  } else {
-                    items = matchSorter(items, value, {
-                      keys: [key],
-                      threshold: matchSorter.rankings.CONTAINS
+                if (Array.isArray(value)) {
+                  if (value.length > 0) {
+                    const arr = [...items];
+                    let arrItems: Array<any> = [];
+                    value.forEach(item => {
+                      arrItems = [
+                        ...arrItems,
+                        ...matchSorter(arr, item, {
+                          keys: [key],
+                          threshold: matchSorter.rankings.CONTAINS
+                        })
+                      ];
                     });
+                    items = items.filter((item: any) =>
+                      arrItems.find(a => a === item)
+                    );
                   }
+                } else {
+                  items = matchSorter(items, value, {
+                    keys: [key],
+                    threshold: matchSorter.rankings.CONTAINS
+                  });
                 }
               }
             });

--- a/packages/amis/__tests__/renderers/CRUD.test.tsx
+++ b/packages/amis/__tests__/renderers/CRUD.test.tsx
@@ -166,7 +166,6 @@ test('3. Renderer:crud loadDataOnce', async () => {
             columnsNum: 4,
             showBtnToolbar: false
           },
-          filterSettingSource: ['version'],
           columns: [
             {
               name: 'id',

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -315,7 +315,11 @@ export interface CRUDCommonSchema extends BaseSchema, SpinnerExtraProps {
   loadDataOnce?: boolean;
 
   /**
-   * 在开启loadDataOnce时，filter时是否去重新请求api
+   * 在开启loadDataOnce时，当修改过滤条件时是否重新请求api
+   *
+   * 如果没有配置，当查询条件表单触发的会重新请求 api，当是列过滤或者是 search-box 触发的则不重新请求 api
+   * 如果配置为 true，则不管是什么触发都会重新请求 api
+   * 如果配置为 false 则不管是什么触发都不会重新请求 api
    */
   loadDataOnceFetchOnFilter?: boolean;
 
@@ -474,7 +478,6 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     filterTogglable: false,
     filterDefaultVisible: true,
     loadDataOnce: false,
-    loadDataOnceFetchOnFilter: true,
     autoFillHeight: false
   };
 
@@ -997,7 +1000,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
         undefined,
         undefined,
         undefined,
-        loadDataOnceFetchOnFilter,
+        loadDataOnceFetchOnFilter !== false,
         isInit
       );
   }
@@ -1190,7 +1193,6 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       pickerMode,
       env,
       loadDataOnce,
-      loadDataOnceFetchOnFilter,
       source,
       columns,
       dispatchEvent
@@ -1228,7 +1230,6 @@ export default class CRUD extends React.Component<CRUDProps, any> {
             autoAppend: true,
             forceReload,
             loadDataOnce,
-            loadDataOnceFetchOnFilter,
             source,
             silent,
             pageField,
@@ -1670,11 +1671,18 @@ export default class CRUD extends React.Component<CRUDProps, any> {
 
   handleQuery(
     values: object,
-    forceReload: boolean = false,
+    forceReload?: boolean,
     replace?: boolean,
     resetPage?: boolean
   ) {
-    const {store, syncLocation, env, pageField, perPageField} = this.props;
+    const {
+      store,
+      syncLocation,
+      env,
+      pageField,
+      perPageField,
+      loadDataOnceFetchOnFilter
+    } = this.props;
     store.updateQuery(
       resetPage
         ? {
@@ -1690,7 +1698,12 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       perPageField,
       replace
     );
-    this.search(undefined, undefined, replace, forceReload);
+    this.search(
+      undefined,
+      undefined,
+      replace,
+      forceReload ?? loadDataOnceFetchOnFilter === true
+    );
   }
 
   reload(

--- a/packages/amis/src/renderers/CRUD2.tsx
+++ b/packages/amis/src/renderers/CRUD2.tsx
@@ -537,7 +537,6 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
       env,
       loadType,
       loadDataOnce,
-      loadDataOnceFetchOnFilter,
       source,
       columns,
       perPage
@@ -574,7 +573,6 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
             autoAppend: true,
             forceReload,
             loadDataOnce,
-            loadDataOnceFetchOnFilter,
             source,
             silent,
             pageField,


### PR DESCRIPTION
…arch-box 触发过滤时是否重新请求 api

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 41103d8</samp>

This pull request adds a new feature to the `CRUD` component that allows users to choose between fetching data from the API or filtering data locally when the filter values change. The feature is controlled by a new property called `loadDataOnceFetchOnFilter` in the component schema. The pull request also updates the documentation, refactors some of the component logic, and removes some unnecessary or redundant properties from the `CRUD2` component and the test file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 41103d8</samp>

> _The `CRUD` component got a new feature_
> _To fetch data once or on filter, as you prefer_
> _The `loadDataOnceFetchOnFilter` prop_
> _Was added and documented on top_
> _But the `CRUD2` component dropped it later_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 41103d8</samp>

*  Implement a new feature for the CRUD and CRUD2 components to allow users to configure whether to fetch data from the API or filter data locally when the filter conditions change (`loadDataOnceFetchOnFilter` property) ([link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653R2895-R3019), [link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL148-R148), [link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL162), [link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-0d07c5f793889442c3a5bbba3eef9b9194da770b0844eff3c7910f39d9895838L169), [link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L318-R322), [link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L477), [link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1000-R1003), [link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1673-R1685), [link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1693-R1706))
*  Fix a bug in the `CRUDStore` class that caused the `filter` method to fail when the `column.name` was not a string ([link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL184-R211))
*  Refactor the `CRUD` and `CRUD2` components to simplify the logic of handling the `loadDataOnceFetchOnFilter` feature and avoid passing unnecessary arguments to the `renderQuery` and `renderHeader` methods ([link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1193), [link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1231), [link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL540), [link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL577))
*  Remove redundant or empty code blocks from the documentation and the test file of the CRUD component ([link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653L2798), [link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653L2849-L2850), [link](https://github.com/baidu/amis/pull/8351/files?diff=unified&w=0#diff-0d07c5f793889442c3a5bbba3eef9b9194da770b0844eff3c7910f39d9895838L169))
