### PR TITLE
fix: 页面设计器组件搜索改用matchSorter

### DIFF
--- a/packages/amis-editor-core/src/store/editor.ts
+++ b/packages/amis-editor-core/src/store/editor.ts
@@ -53,6 +53,7 @@ import isPlainObject from 'lodash/isPlainObject';
 import {EditorManagerConfig} from '../manager';
 import {EditorNode, EditorNodeType} from './node';
 import findIndex from 'lodash/findIndex';
+import {matchSorter} from 'match-sorter';
 
 export interface SchemaHistory {
   versionId: number;
@@ -684,39 +685,26 @@ export const MainStore = types
       /** 根据关键字过滤组件 */
       groupedRenderersByKeyword(
         _subRenderers: Array<SubRendererInfo>,
-        keywords?: string
+        keywords: string = ''
       ) {
         const subRenderers = _subRenderers;
         const grouped: {
           [propName: string]: Array<SubRendererInfo>;
         } = {};
 
-        const regular = keywords
-          ? new RegExp(stringRegExp(keywords), 'i')
-          : null;
+        matchSorter(subRenderers, keywords, {
+          keys: ['name', 'description', 'scaffold.type', 'searchKeywords']
+        }).forEach(item => {
+          const tags = Array.isArray(item.tags)
+            ? item.tags.concat()
+            : item.tags
+            ? [item.tags]
+            : ['其他'];
 
-        subRenderers.forEach(item => {
-          if (
-            !keywords ||
-            ['name', 'description', 'scaffold.type', 'searchKeywords'].some(
-              key =>
-                resolveVariable(key, item) &&
-                regular &&
-                (regular.test(resolveVariable(key, item)) ||
-                  regular.test(resolveVariable(key, item)?.replaceAll('-', '')))
-            )
-          ) {
-            const tags = Array.isArray(item.tags)
-              ? item.tags.concat()
-              : item.tags
-              ? [item.tags]
-              : ['其他'];
-
-            tags.forEach(tag => {
-              grouped[tag] = grouped[tag] || [];
-              grouped[tag].push(item);
-            });
-          }
+          tags.forEach(tag => {
+            grouped[tag] = grouped[tag] || [];
+            grouped[tag].push(item);
+          });
         });
 
         return grouped;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 33bc90e</samp>

The pull request enhances the search functionality of the amis-editor-core package by using the `matchSorter` library. It applies the library to the search panel results in `SearchPanel.tsx` and the renderers by keywords in `editor.ts`. It also fixes a minor bug and improves the code formatting.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 33bc90e</samp>

> _Sing, O Muse, of the skillful coder who refined the search panel_
> _With the matchSorter function, a gift from the wise library_
> _He sorted and filtered the `renderers` by their `keywords`_
> _Like Zeus who orders the stars in the sky with his thunder_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 33bc90e</samp>

* Import `matchSorter` function from `match-sorter` library to improve filtering and sorting of items based on keywords ([link](https://github.com/baidu/amis/pull/8353/files?diff=unified&w=0#diff-365208d299ca70361fad5cb92a9e35bd9f1cdeec4664471fcd68447536fab80eR7), [link](https://github.com/baidu/amis/pull/8353/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8R56))
* Use `matchSorter` function to filter and sort `allResult` array in `SearchPanel.tsx` and `subRenderers` array in `editor.ts` based on `keywords` and a list of keys to match ([link](https://github.com/baidu/amis/pull/8353/files?diff=unified&w=0#diff-365208d299ca70361fad5cb92a9e35bd9f1cdeec4664471fcd68447536fab80eL197-R206), [link](https://github.com/baidu/amis/pull/8353/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8L694-R707))
* Assign default value of empty string to `keywords` parameter in `groupedResultByKeyword` and `groupedRenderersByKeyword` functions to avoid passing undefined values to `matchSorter` function and simplify logic ([link](https://github.com/baidu/amis/pull/8353/files?diff=unified&w=0#diff-365208d299ca70361fad5cb92a9e35bd9f1cdeec4664471fcd68447536fab80eL185-R186), [link](https://github.com/baidu/amis/pull/8353/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8L687-R688))
* Fix indentation of closing bracket of `else` block in `SearchPanel.tsx` for readability ([link](https://github.com/baidu/amis/pull/8353/files?diff=unified&w=0#diff-365208d299ca70361fad5cb92a9e35bd9f1cdeec4664471fcd68447536fab80eL225-R221))
