### PR TITLE
fix: Form组件配置页面跳转事件可能会导致持久化数据无法清除问题

### DIFF
--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -1154,6 +1154,8 @@ export default class Form extends React.Component<FormProps, object> {
 
         if (target) {
           this.submitToTarget(filterTarget(target, values), values);
+          /** 可能配置页面跳转事件，页面路由变化导致persistKey不一致，无法清除持久化数据，所以提交成功事件之前先清理一下 */
+          clearPersistDataAfterSubmit && store.clearLocalPersistData();
           dispatchEvent('submitSucc', createObject(this.props.data, values));
         } else if (action.actionType === 'reload') {
           action.target &&
@@ -1185,6 +1187,7 @@ export default class Form extends React.Component<FormProps, object> {
                   ? filter(saveFailed, store.data)
                   : undefined,
               onSuccess: async (result: Payload) => {
+                clearPersistDataAfterSubmit && store.clearLocalPersistData();
                 // result为提交接口返回的内容
                 const dispatcher = await dispatchEvent(
                   'submitSucc',
@@ -1245,6 +1248,7 @@ export default class Form extends React.Component<FormProps, object> {
               });
             });
         } else {
+          clearPersistDataAfterSubmit && store.clearLocalPersistData();
           // type为submit，但是没有配api以及target时，只派发事件
           dispatchEvent('submitSucc', createObject(this.props.data, values));
         }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6556104</samp>

This pull request introduces a new feature for the form renderer to clear the local persist data of the form store. This can help avoid data inconsistency issues when the form data is submitted to the server or the page route changes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6556104</samp>

> _To clear the persist data of the form_
> _We added a prop to the renderer norm_
> _`clearPersistDataAfterSubmit`_
> _Will do the trick, bit by bit_
> _And keep the form store and route in good form_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6556104</samp>

*  Add a feature to clear the local persist data of the form store before or after submitting the form data, depending on the user's preference and the outcome of the submission. ([link](https://github.com/baidu/amis/pull/8354/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3R1157-R1158), [link](https://github.com/baidu/amis/pull/8354/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3R1190), [link](https://github.com/baidu/amis/pull/8354/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3R1251))
  * In `packages/amis-core/src/renderers/Form.tsx`, check the `clearPersistDataAfterSubmit` prop of the form before calling the `submitToTarget` method. If it is true, clear the persist data using the `store.clearPersistData` method. ([link](https://github.com/baidu/amis/pull/8354/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3R1157-R1158))
