### PR TITLE
fix: nextjs13环境下formulaControl组件popOverContainer 写死，导致编辑器出现死循环bug Close:#8355

### DIFF
--- a/packages/amis-core/src/utils/helper.ts
+++ b/packages/amis-core/src/utils/helper.ts
@@ -1587,7 +1587,7 @@ export function mapObject(
   }
 
   if (Array.isArray(value)) {
-    return value.map(item => mapObject(item, fn));
+    return value.map(item => mapObject(item, fn, skipFn));
   }
 
   if (isObject(value)) {
@@ -1595,7 +1595,8 @@ export function mapObject(
     Object.keys(tmpValue).forEach(key => {
       (tmpValue as PlainObject)[key] = mapObject(
         (tmpValue as PlainObject)[key],
-        fn
+        fn,
+        skipFn
       );
     });
     return tmpValue;

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -1063,14 +1063,12 @@ export function getI18nEnabled() {
 }
 
 /** schema 翻译方法 */
-export function translateSchema(schema: any, replaceData?: any) {
+export function translateSchema(schema: any, replaceData?: any, skipFn?: any) {
   replaceData = replaceData || (window as any)?.editorStore?.appCorpusData;
   if (!isPlainObject(replaceData)) {
     return schema;
   }
-  return mapObject(schema, (item: any) => {
-    return replaceData[item] || item;
-  });
+  return mapObject(schema, (item: any) => replaceData[item] || item, skipFn);
 }
 
 /** 应用级别的翻译方法 */

--- a/packages/amis-editor/src/renderer/FormulaControl.tsx
+++ b/packages/amis-editor/src/renderer/FormulaControl.tsx
@@ -516,15 +516,23 @@ export default class FormulaControl extends React.Component<
         curRendererSchema.placeholder = '请输入静态值';
       }
       // 设置popOverContainer
-      curRendererSchema.popOverContainer = window.document.body;
+      if (!curRendererSchema.popOverContainer) {
+        curRendererSchema.popOverContainer = window.document.body;
+      }
     }
+
+    JSONPipeOut(curRendererSchema);
 
     // 对 schema 进行国际化翻译
     if (this.appLocale && this.appCorpusData) {
-      return translateSchema(curRendererSchema, this.appCorpusData);
+      translateSchema(
+        curRendererSchema,
+        this.appCorpusData,
+        (item: any) => item.__reactFiber || item.__reactProp // 在nextjs 13中，window.document.body对象，有__reactFiber，__reactProp 两个子对象，递归遍历会导致死循环，因此过滤掉
+      );
     }
 
-    return JSONPipeOut(curRendererSchema);
+    return curRendererSchema;
   }
 
   @autobind


### PR DESCRIPTION
### What
修复issue问题: #8355
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcd86b2</samp>

Enhance the `mapObject` function to support skipping values, and refactor the `translateSchema` function to use it. Improve the formula editor rendering by using the `translateSchema` function.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bcd86b2</samp>

> _Sing, O Muse, of the skillful code review_
> _That moved and modified the functions wise_
> _To render formulas and schemas new_
> _With mapObject and skipFn as allies_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bcd86b2</samp>

*  Move and generalize `translateSchema` function to `packages/amis-core/src/utils/helper.ts` ([link](https://github.com/baidu/amis/pull/8359/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL1066-R1077), [link](https://github.com/baidu/amis/pull/8359/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1590-R1590), [link](https://github.com/baidu/amis/pull/8359/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1598-R1599))
*  Add `skipFn` parameter to `mapObject` function to allow skipping some values during mapping ([link](https://github.com/baidu/amis/pull/8359/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1590-R1590), [link](https://github.com/baidu/amis/pull/8359/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1598-R1599))
*  Use `translateSchema` function with `skipFn` parameter in `FormulaControl` component to avoid infinite recursion and preserve formula expressions ([link](https://github.com/baidu/amis/pull/8359/files?diff=unified&w=0#diff-ce07d539e9ec5eccae74ef6ee3032524b9a77ca3519a9f600cf3065ceaced70bL519-R535))
