### PR TITLE
fix: return trabslateScahema函数

### DIFF
--- a/packages/amis-editor/src/renderer/FormulaControl.tsx
+++ b/packages/amis-editor/src/renderer/FormulaControl.tsx
@@ -525,7 +525,7 @@ export default class FormulaControl extends React.Component<
 
     // 对 schema 进行国际化翻译
     if (this.appLocale && this.appCorpusData) {
-      translateSchema(
+      return translateSchema(
         curRendererSchema,
         this.appCorpusData,
         (item: any) => item.__reactFiber || item.__reactProp // 在nextjs 13中，window.document.body对象，有__reactFiber，__reactProp 两个子对象，递归遍历会导致死循环，因此过滤掉


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f13432d</samp>

Fixed a schema translation bug in `FormulaControl.tsx` and improved internationalization support for amis-editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f13432d</samp>

> _`translateSchema` returns_
> _no more mutation of schema_
> _autumn bug is fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f13432d</samp>

* Fixed a bug where the schema was not updated correctly when switching languages by returning the translated schema instead of mutating the original one in `translateSchema` ([link](https://github.com/baidu/amis/pull/8361/files?diff=unified&w=0#diff-ce07d539e9ec5eccae74ef6ee3032524b9a77ca3519a9f600cf3065ceaced70bL528-R528))
