### PR TITLE
fix: 修复 input-table 中存在公式表达式值没有及时更新的问题 Close: #8263

### DIFF
--- a/examples/components/CRUD/List.jsx
+++ b/examples/components/CRUD/List.jsx
@@ -3,32 +3,18 @@ export default {
   remark: 'bla bla bla',
   body: {
     type: 'crud',
-    api: '/api/sample',
+    name: 'thelist',
+    api: {
+      method: 'get',
+      url: '/api/sample',
+      sendOn: '${mode}'
+    },
     mode: 'list',
     draggable: true,
     saveOrderApi: {
       url: '/api/sample/saveOrder'
     },
     orderField: 'weight',
-    filter: {
-      title: '条件搜索',
-      submitText: '',
-      body: [
-        {
-          type: 'input-text',
-          name: 'keywords',
-          placeholder: '通过关键字搜索',
-          addOn: {
-            label: '搜索',
-            type: 'submit'
-          }
-        },
-        {
-          type: 'plain',
-          text: '这只是个示例, 目前搜索对查询结果无效.'
-        }
-      ]
-    },
     affixHeader: true,
     bulkActions: [
       {
@@ -63,6 +49,44 @@ export default {
     ],
     quickSaveApi: '/api/sample/bulkUpdate',
     quickSaveItemApi: '/api/sample/$id',
+    headerToolbar: [
+      {
+        type: 'form',
+        mode: 'inline',
+        wrapWithPanel: false,
+        submitOnChange: true,
+        submitOnInit: true,
+        target: 'thelist',
+        body: [
+          {
+            type: 'select',
+            name: 'mode',
+            className: 'mb-0',
+            selectFirst: true,
+            options: [
+              {
+                label: '模式 1',
+                value: 'mode1'
+              },
+              {
+                label: '模式 2',
+                value: 'mode2'
+              }
+            ]
+          },
+          {
+            type: 'input-text',
+            name: 'keywords',
+            placeholder: '通过关键字搜索',
+            className: 'mb-0',
+            addOn: {
+              label: '搜索',
+              type: 'submit'
+            }
+          }
+        ]
+      }
+    ],
     listItem: {
       actions: [
         {

--- a/packages/amis-core/src/WithStore.tsx
+++ b/packages/amis-core/src/WithStore.tsx
@@ -252,7 +252,7 @@ export function HocStoreFactory(renderer: {
                   props.store?.storeType === 'ComboStore'
                   ? undefined
                   : syncDataFromSuper(
-                      store.data,
+                      props.data,
                       (props.data as any).__super,
                       (prevProps.data as any).__super,
                       store,

--- a/packages/amis-core/src/store/crud.ts
+++ b/packages/amis-core/src/store/crud.ts
@@ -61,12 +61,11 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
       // 因为会把数据呈现在地址栏上。
       return createObject(
         createObject(self.data, {
-          ...self.query,
           items: self.items.concat(),
           selectedItems: self.selectedItems.concat(),
           unSelectedItems: self.unSelectedItems.concat()
         }),
-        {}
+        {...self.query}
       );
     },
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8c10536</samp>

This pull request adds a new feature to the `crud` component in `List.jsx` to allow different data fetching and filtering modes, and improves the performance and correctness of the `CRUDStore` and the `WithStore` components in `crud.ts` and `WithStore.tsx`. It changes the `filter`, `body`, and `api` properties of the `crud` component, the `snapshot` getter of the `CRUDStore`, and the `syncDataFromSuper` function of the `WithStore` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8c10536</samp>

> _`crud` component_
> _changes data and filter modes_
> _autumn leaves falling_

### Why

 Close: #8263

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8c10536</samp>

* Optimize the performance of the `snapshot` getter of the `CRUDStore` by swapping the order of the arguments in the `createObject` function ([link](https://github.com/baidu/amis/pull/8364/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL64-R68))
* Fix a bug in the `syncDataFromSuper` function of the `WithStore` component by using `props.data` instead of `store.data` as the current data ([link](https://github.com/baidu/amis/pull/8364/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL255-R255))
* Enhance the `crud` component in `examples/components/CRUD/List.jsx` by adding a `name` attribute, a dynamic `api` attribute, and a `headerToolbar` property ([link](https://github.com/baidu/amis/pull/8364/files?diff=unified&w=0#diff-96a3b2a184bccf325ac1e6519544f48d6f9d1bdd6892165f8b28a282429fd039L6-R11), [link](https://github.com/baidu/amis/pull/8364/files?diff=unified&w=0#diff-96a3b2a184bccf325ac1e6519544f48d6f9d1bdd6892165f8b28a282429fd039L13-L31), [link](https://github.com/baidu/amis/pull/8364/files?diff=unified&w=0#diff-96a3b2a184bccf325ac1e6519544f48d6f9d1bdd6892165f8b28a282429fd039R52-R89))
