### PR TITLE
fix: 修复 REPLACE 公式第二个参数是空字符串时导致的死循环问题 Close: #8200

### DIFF
--- a/packages/amis-formula/src/evalutor.ts
+++ b/packages/amis-formula/src/evalutor.ts
@@ -1215,6 +1215,7 @@ export class Evaluator {
    */
   fnBEFORELAST(text: string, delimiter: string = '.') {
     text = this.normalizeText(text);
+    delimiter = this.normalizeText(delimiter);
     return text.split(delimiter).slice(0, -1).join(delimiter) || text + '';
   }
 
@@ -1298,6 +1299,7 @@ export class Evaluator {
    * @returns {string} 判断结果
    */
   fnSTARTSWITH(text: string, search: string) {
+    search = this.normalizeText(search);
     if (!search) {
       return false;
     }
@@ -1317,6 +1319,7 @@ export class Evaluator {
    * @returns {string} 判断结果
    */
   fnENDSWITH(text: string, search: string) {
+    search = this.normalizeText(search);
     if (!search) {
       return false;
     }
@@ -1336,6 +1339,7 @@ export class Evaluator {
    * @returns {string} 判断结果
    */
   fnCONTAINS(text: string, search: string) {
+    search = this.normalizeText(search);
     if (!search) {
       return false;
     }
@@ -1357,7 +1361,13 @@ export class Evaluator {
    */
   fnREPLACE(text: string, search: string, replace: string) {
     text = this.normalizeText(text);
+    search = this.normalizeText(search);
+    replace = this.normalizeText(replace);
     let result = text;
+
+    if (typeof replace === 'undefined' || !search) {
+      return result;
+    }
 
     while (true) {
       const idx = result.indexOf(search);
@@ -1387,11 +1397,12 @@ export class Evaluator {
    * @returns {number} 命中的位置
    */
   fnSEARCH(text: string, search: string, start: number = 0) {
+    search = this.normalizeText(search);
     text = this.normalizeText(text);
     start = this.formatNumber(start);
 
     const idx = text.indexOf(search, start);
-    if (~idx) {
+    if (~idx && search) {
       return idx;
     }
 
@@ -1411,6 +1422,8 @@ export class Evaluator {
    */
   fnMID(text: string, from: number, len: number) {
     text = this.normalizeText(text);
+    from = this.formatNumber(from);
+    len = this.formatNumber(len);
     return text.substring(from, from + len);
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f5208ec</samp>

This pull request enhances the text manipulation capabilities of `evalutor.ts` by adding or improving functions that normalize, format, and compare text values. It also ensures that the arguments are properly validated and handled by using `normalizeText` and `formatNumber`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f5208ec</samp>

> _We are the evaluators of the text_
> _We normalize and format with no regrets_
> _We manipulate the strings with skill and power_
> _We defy the errors that would make us cower_

### Why

Close: #8200

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f5208ec</samp>

*  Normalize text, search, and replace arguments for string functions using `normalizeText` method ([link](https://github.com/baidu/amis/pull/8365/files?diff=unified&w=0#diff-6e98a1dfcecf7c45fc01fdf27b5c21e037dc90466a0761a63998e1736958b433R1218), [link](https://github.com/baidu/amis/pull/8365/files?diff=unified&w=0#diff-6e98a1dfcecf7c45fc01fdf27b5c21e037dc90466a0761a63998e1736958b433R1302), [link](https://github.com/baidu/amis/pull/8365/files?diff=unified&w=0#diff-6e98a1dfcecf7c45fc01fdf27b5c21e037dc90466a0761a63998e1736958b433R1322), [link](https://github.com/baidu/amis/pull/8365/files?diff=unified&w=0#diff-6e98a1dfcecf7c45fc01fdf27b5c21e037dc90466a0761a63998e1736958b433R1342), [link](https://github.com/baidu/amis/pull/8365/files?diff=unified&w=0#diff-6e98a1dfcecf7c45fc01fdf27b5c21e037dc90466a0761a63998e1736958b433L1360-R1371), [link](https://github.com/baidu/amis/pull/8365/files?diff=unified&w=0#diff-6e98a1dfcecf7c45fc01fdf27b5c21e037dc90466a0761a63998e1736958b433L1390-R1405)) in `packages/amis-formula/src/evalutor.ts`
