### PR TITLE
fix: formulaControl去除rendererSchema对popOverContainer的配置

### DIFF
--- a/packages/amis-editor/src/renderer/FormulaControl.tsx
+++ b/packages/amis-editor/src/renderer/FormulaControl.tsx
@@ -515,21 +515,13 @@ export default class FormulaControl extends React.Component<
       } else {
         curRendererSchema.placeholder = '请输入静态值';
       }
-      // 设置popOverContainer
-      if (!curRendererSchema.popOverContainer) {
-        curRendererSchema.popOverContainer = window.document.body;
-      }
     }
 
     JSONPipeOut(curRendererSchema);
 
     // 对 schema 进行国际化翻译
     if (this.appLocale && this.appCorpusData) {
-      return translateSchema(
-        curRendererSchema,
-        this.appCorpusData,
-        (item: any) => item.__reactFiber || item.__reactProp // 在nextjs 13中，window.document.body对象，有__reactFiber，__reactProp 两个子对象，递归遍历会导致死循环，因此过滤掉
-      );
+      return translateSchema(curRendererSchema, this.appCorpusData);
     }
 
     return curRendererSchema;


### PR DESCRIPTION
### What

修复： #8355

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3283e51</samp>

> _Oh, we are the coders of the `FormulaControl`_
> _We fix the bugs and make the code more whole_
> _We heave and ho and pull the popovers in line_
> _And simplify the schema on the count of three_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3283e51</samp>

* Remove popOverContainer setting from curRendererSchema to fix popover bug in modal dialog ([link](https://github.com/baidu/amis/pull/8367/files?diff=unified&w=0#diff-ce07d539e9ec5eccae74ef6ee3032524b9a77ca3519a9f600cf3065ceaced70bL518-L521))
* Simplify translateSchema call by removing unnecessary filter function ([link](https://github.com/baidu/amis/pull/8367/files?diff=unified&w=0#diff-ce07d539e9ec5eccae74ef6ee3032524b9a77ca3519a9f600cf3065ceaced70bL528-R524))
