### PR TITLE
fix: 修复 react-json-view import 异常 Close: #8145

### DIFF
--- a/packages/amis-core/src/utils/debug.tsx
+++ b/packages/amis-core/src/utils/debug.tsx
@@ -8,10 +8,12 @@ import {findDOMNode, render, unmountComponentAtNode} from 'react-dom';
 // import {createRoot} from 'react-dom/client';
 import {autorun, observable} from 'mobx';
 import {observer} from 'mobx-react';
-import {uuidv4} from './helper';
+import {uuidv4, importLazyComponent} from './helper';
 import position from './position';
 
-export const JsonView = React.lazy(() => import('react-json-view'));
+export const JsonView = React.lazy(() =>
+  import('react-json-view').then(importLazyComponent)
+);
 
 class Log {
   @observable cat = '';

--- a/packages/amis-core/src/utils/helper.ts
+++ b/packages/amis-core/src/utils/helper.ts
@@ -2175,3 +2175,8 @@ export function evalTrackExpression(
     })
     .join('');
 }
+
+// 很奇怪的问题，react-json-view import 有些情况下 mod.default 才是 esModule
+export function importLazyComponent(mod: any) {
+  return mod.default.__esModule ? mod.default : mod;
+}

--- a/packages/amis-editor-core/src/plugin/DataDebug.tsx
+++ b/packages/amis-editor-core/src/plugin/DataDebug.tsx
@@ -1,7 +1,10 @@
 import {registerEditorPlugin} from '../manager';
 import {BaseEventContext, BasePlugin, BasicToolbarItem} from '../plugin';
 import React from 'react';
-export const JsonView = React.lazy(() => import('react-json-view'));
+import {importLazyComponent} from 'amis-core';
+export const JsonView = React.lazy(() =>
+  import('react-json-view').then(importLazyComponent)
+);
 
 /**
  * 添加调试功能

--- a/packages/amis/src/renderers/Json.tsx
+++ b/packages/amis/src/renderers/Json.tsx
@@ -4,9 +4,15 @@ import {Renderer, RendererProps} from 'amis-core';
 import type {InteractionProps} from 'react-json-view';
 import {autobind, getPropValue, noop} from 'amis-core';
 import {BaseSchema} from '../Schema';
-import {resolveVariableAndFilter, isPureVariable} from 'amis-core';
+import {
+  resolveVariableAndFilter,
+  isPureVariable,
+  importLazyComponent
+} from 'amis-core';
 
-export const JsonView = React.lazy(() => import('react-json-view'));
+export const JsonView = React.lazy(() =>
+  import('react-json-view').then(importLazyComponent)
+);
 /**
  * JSON 数据展示控件。
  * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/json


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 823d03c</samp>

Use `importLazyComponent` to fix dynamic import of `react-json-view` in various modules. This function resolves a compatibility issue between esModule and commonjs formats.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 823d03c</samp>

> _`importLazyComponent`_
> _fixes dynamic imports of `react-json-view`_
> _a winter workaround_

### Why

Close: #8145

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 823d03c</samp>

*  Define a helper function `importLazyComponent` to handle dynamic imports of `react-json-view` module ([link](https://github.com/baidu/amis/pull/8369/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aR2178-R2182))
*  Use `importLazyComponent` to wrap the dynamic imports of `react-json-view` in `./utils/debug.tsx`, `./plugin/DataDebug.tsx`, and `./renderers/Json.tsx` ([link](https://github.com/baidu/amis/pull/8369/files?diff=unified&w=0#diff-267ff9b13396c5c999812bf56a8daa603837b2764942c35a0c077b53692bf177L11-R16), [link](https://github.com/baidu/amis/pull/8369/files?diff=unified&w=0#diff-5a7853178be0e5a8cd7d50d902b972c676cd0d01a063fb1a46c6e99382e9642dL4-R7), [link](https://github.com/baidu/amis/pull/8369/files?diff=unified&w=0#diff-54776b8fe2416351bc0b5253353b9160553cda5d4048f6f58435b904361c28faL7-R15))
*  Fix a potential issue where the imported module may have a default property that is the actual esModule ([link](https://github.com/baidu/amis/pull/8369/files?diff=unified&w=0#diff-267ff9b13396c5c999812bf56a8daa603837b2764942c35a0c077b53692bf177L11-R16), [link](https://github.com/baidu/amis/pull/8369/files?diff=unified&w=0#diff-5a7853178be0e5a8cd7d50d902b972c676cd0d01a063fb1a46c6e99382e9642dL4-R7), [link](https://github.com/baidu/amis/pull/8369/files?diff=unified&w=0#diff-54776b8fe2416351bc0b5253353b9160553cda5d4048f6f58435b904361c28faL7-R15))
