### PR TITLE
chore: 修复 downshift 使用 es6 语法导致

### DIFF
--- a/fis-conf.js
+++ b/fis-conf.js
@@ -253,7 +253,7 @@ fis.match('*.html:jsx', {
 
 // 这些用了 esm
 fis.match(
-  '{echarts/**.js,zrender/**.js,echarts-wordcloud/**.js,markdown-it-html5-media/**.js,react-hook-form/**.js,qrcode.react/**.js,axios/**.js}',
+  '{echarts/**.js,zrender/**.js,echarts-wordcloud/**.js,markdown-it-html5-media/**.js,react-hook-form/**.js,qrcode.react/**.js,axios/**.js,downshift/**.js,react-intersection-observer/**.js}',
   {
     parser: fis.plugin('typescript', {
       sourceMap: false,


### PR DESCRIPTION
低版本浏览器报错问题 Closes #5011

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7a68031</samp>

Updated fis configuration to support new modules for amis features. Added `downshift` and `react-intersection-observer` to the fis match pattern in `fis-conf.js`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7a68031</samp>

> _`fis` matches more_
> _`downshift` and `intersection`_
> _autumn leaves lazy_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7a68031</samp>

* Enable esm parsing for downshift and react-intersection-observer modules ([link](https://github.com/baidu/amis/pull/8371/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedL256-R256))
