### PR TITLE
fix: table2单元格宽度自适应、嵌套数据展示等问题修复

### DIFF
--- a/docs/zh-CN/components/table2.md
+++ b/docs/zh-CN/components/table2.md
@@ -24,7 +24,8 @@ order: 67
             "columns": [
                 {
                     "title": "Engine",
-                    "name": "engine"
+                    "name": "engine",
+                    "width": 120
                 },
                 {
                     "title": "Version",
@@ -933,8 +934,36 @@ order: 67
                 {
                     "title": "Version",
                     "name": "version",
-                    "fixed": "left",
-                    "width": 100
+                    "type": "property",
+                    "width": 400,
+                    "items": [
+                        {
+                            "label": "cpu",
+                            "content": "1 core"
+                        },
+                        {
+                            "label": "memory",
+                            "content": "4G"
+                        },
+                        {
+                            "label": "disk",
+                            "content": "80G"
+                        },
+                        {
+                            "label": "network",
+                            "content": "4M",
+                            "span": 2
+                        },
+                        {
+                            "label": "IDC",
+                            "content": "beijing"
+                        },
+                        {
+                            "label": "Note",
+                            "content": "其它说明",
+                            "span": 3
+                        }
+                    ]
                 },
                 {
                     "title": "Browser",
@@ -1969,7 +1998,7 @@ order: 67
         "data":{
             "rows":[
                 {
-                    "engine":"Trident",
+                    "engine":"Trident1",
                     "browser":"Internet Explorer 4.0",
                     "platform":"Win 95+",
                     "version":"4",
@@ -1977,7 +2006,7 @@ order: 67
                     "id":1,
                     "children":[
                         {
-                            "engine":"Trident",
+                            "engine":"Trident1-1",
                             "browser":"Internet Explorer 4.0",
                             "platform":"Win 95+",
                             "version":"4",
@@ -1985,7 +2014,7 @@ order: 67
                             "id":1001,
                             "children":[
                                 {
-                                    "engine":"Trident",
+                                    "engine":"Trident1-1-1",
                                     "browser":"Internet Explorer 4.0",
                                     "platform":"Win 95+",
                                     "version":"4",
@@ -1993,7 +2022,7 @@ order: 67
                                     "id":10001
                                 },
                                 {
-                                    "engine":"Trident",
+                                    "engine":"Trident1-1-2",
                                     "browser":"Internet Explorer 5.0",
                                     "platform":"Win 95+",
                                     "version":"5",
@@ -2003,7 +2032,7 @@ order: 67
                             ]
                         },
                         {
-                            "engine":"Trident",
+                            "engine":"Trident1-2",
                             "browser":"Internet Explorer 5.0",
                             "platform":"Win 95+",
                             "version":"5",
@@ -2013,7 +2042,7 @@ order: 67
                     ]
                 },
                 {
-                    "engine":"Trident",
+                    "engine":"Trident2",
                     "browser":"Internet Explorer 5.0",
                     "platform":"Win 95+",
                     "version":"5",
@@ -2021,7 +2050,7 @@ order: 67
                     "id":2,
                     "children":[
                         {
-                            "engine":"Trident",
+                            "engine":"Trident2-1",
                             "browser":"Internet Explorer 4.0",
                             "platform":"Win 95+",
                             "version":"4",
@@ -2029,7 +2058,7 @@ order: 67
                             "id":2001
                         },
                         {
-                            "engine":"Trident",
+                            "engine":"Trident2-2",
                             "browser":"Internet Explorer 5.0",
                             "platform":"Win 95+",
                             "version":"5",
@@ -2123,6 +2152,10 @@ order: 67
                 "type":"table2",
                 "source":"$rows",
                 "columns":[
+                    {
+                        "name":"id",
+                        "title":"ID"
+                    },
                     {
                         "name":"engine",
                         "title":"Engine"
@@ -2321,6 +2354,10 @@ order: 67
                 "type":"table2",
                 "source":"$rows",
                 "columns":[
+                    {
+                        "name": "id",
+                        "title": "ID"
+                    },
                     {
                         "name":"engine",
                         "title":"Engine"

--- a/packages/amis-core/src/store/table2.ts
+++ b/packages/amis-core/src/store/table2.ts
@@ -280,12 +280,17 @@ export const TableStore2 = ServiceStore.named('TableStore2')
       });
     }
 
-    function getRowByIndex(rowIndex: number, levels?: Array<string>): IRow2 {
+    function getRowByIndex(
+      rowIndex: number,
+      levels?: Array<number>,
+      rows?: Array<IRow2>
+    ): IRow2 {
+      rows = rows || self.rows;
       if (levels && levels.length > 0) {
         const index = +(levels.shift() || 0);
-        return getRowByIndex(index, levels);
+        return getRowByIndex(rowIndex, levels, rows[index].children);
       }
-      return self.rows[rowIndex];
+      return rows[rowIndex];
     }
 
     function isSelected(row: IRow2): boolean {

--- a/packages/amis-ui/scss/components/_table2.scss
+++ b/packages/amis-ui/scss/components/_table2.scss
@@ -527,12 +527,9 @@
       color: var(--TableRow-onDisabled-color);
     }
 
-    > tbody
-      > tr:not(.#{$ns}Table-row-disabled)
-      > td.#{$ns}Table-cell-row-hover {
-      background: var(--Table-onHover-bg);
-      border-color: var(--Table-onHover-borderColor);
-      color: var(--Table-onHover-color);
+    > tbody > tr > td.#{$ns}Table-cell-fix-left,
+    > tbody > tr > td.#{$ns}Table-cell-fix-right {
+      background: inherit;
     }
 
     > thead > tr > th.#{$ns}Table-cell-fix-left-last,
@@ -553,7 +550,7 @@
 
     > thead > tr > th.#{$ns}Table-cell-fix-right-first,
     > tbody > tr > td.#{$ns}Table-cell-fix-right-first,
-    > tfoot > tr > td.#{$ns}Table-cell-fix-right-last {
+    > tfoot > tr > td.#{$ns}Table-cell-fix-right-first {
       &:after {
         position: absolute;
         top: 0;
@@ -610,10 +607,6 @@
         > td.#{$ns}Table-cell-fix-left {
           border-right: none;
         }
-
-        > td.#{$ns}Table-cell-fix-left:not(.#{$ns}Table-cell-row-hover) {
-          background: #fff;
-        }
       }
 
       > tfoot > tr > td:not(:last-child) {
@@ -643,10 +636,6 @@
       > tbody > tr:not(.#{$ns}Table-row-disabled) {
         > td.#{$ns}Table-cell-fix-right {
           border-right: none;
-        }
-
-        > td.#{$ns}Table-cell-fix-right:not(.#{$ns}Table-cell-row-hover) {
-          background: #fff;
         }
       }
     }

--- a/packages/amis-ui/src/components/table/Cell.tsx
+++ b/packages/amis-ui/src/components/table/Cell.tsx
@@ -54,7 +54,6 @@ export class BodyCell extends React.Component<Props> {
       style,
       groupId,
       depth,
-      index,
       col,
       wrapperComponent: Component,
       classnames: cx
@@ -73,7 +72,6 @@ export class BodyCell extends React.Component<Props> {
         data-group-id={groupId || null}
         data-depth={depth || null}
         data-col={col}
-        data-index={index === -1 ? null : index}
       >
         {children}
       </Component>

--- a/packages/amis-ui/src/components/table/ColGroup.tsx
+++ b/packages/amis-ui/src/components/table/ColGroup.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import {observer} from 'mobx-react';
+
+import {ColumnProps} from './index';
+
+export function ColGroup({
+  columns,
+  colWidths,
+  isFixed,
+  syncTableWidth,
+  initTableWidth,
+  showReal
+}: {
+  columns: Array<ColumnProps>;
+  colWidths: {
+    [key: string]: {
+      width: number;
+      realWidth: number;
+      minWidth: number;
+      originWidth: number;
+    };
+  };
+  isFixed: boolean;
+  syncTableWidth: Function;
+  initTableWidth: Function;
+  showReal?: boolean;
+}) {
+  const domRef = React.createRef<HTMLTableColElement>();
+
+  React.useEffect(() => {
+    if (domRef.current) {
+      initTableWidth();
+      syncTableWidth();
+    }
+  }, []);
+
+  React.useEffect(() => {
+    const table = domRef.current!.parentElement!;
+    const observer = new MutationObserver(() => {
+      syncTableWidth();
+    });
+    observer.observe(table, {
+      attributes: true,
+      childList: true,
+      subtree: true
+    });
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return (
+    <colgroup ref={domRef}>
+      {columns.map((col, index) => {
+        const style: any = {};
+
+        if (colWidths[col?.name]?.width) {
+          style.width = colWidths[col?.name].width;
+        } else if (col.width) {
+          style.width = col.width;
+        } else if (showReal) {
+          style.width = col.realWidth;
+        }
+
+        if (!isFixed && style.width) {
+          style.minWidth = style.width;
+        }
+
+        return <col style={style} key={index} />;
+      })}
+    </colgroup>
+  );
+}
+
+export default observer(ColGroup);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9cfcdf4</samp>

This pull request enhances the table2 component with new props, improved styles, and better performance. It also fixes some bugs and updates the documentation with more examples. The main changes are in the files `packages/amis-ui/src/components/table/index.tsx`, `packages/amis/src/renderers/Table2/index.tsx`, and `docs/zh-CN/components/table2.md`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9cfcdf4</samp>

> _Sing, O Muse, of the mighty Table2, the wondrous work of code_
> _That renders rows and columns with many a feature and mode_
> _How the skilled developers, like Hephaestus at his forge,_
> _Improved its logic, style, and performance with their clever code change_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9cfcdf4</samp>

*  Add a `ColGroup` component to render a `colgroup` element with the column widths and styles for the `table2` component ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-7e9c888101a3ea93b3a469745ef4efd1b26136e1e00e9fc632813c1372797d59R1-R75),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R37),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L772-R825))
*  Add a `width` prop to the `ColumnProps` interface and the `engine` column in the examples to allow setting the column width ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R155-R156),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-e8b85e81bbe5cff7411adaeb4a91921da046554867928fe7598fb18cd94c6b42L27-R28))
*  Add a `tableLayout` prop to the `TableProps` and `Table2Props` interfaces and the `Table` and `Table2` components to allow setting the table layout mode ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R159),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L335-R347),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1796-R1814),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1823-R1844),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R390-R391))
*  Modify the logic of calculating and updating the column widths based on the table body cells instead of the head cells, and use the column names as keys for the `colWidths` state object ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1955-R2065),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1997-R2116))
*  Add `useEffect` hooks to initialize and sync the table width when the component is mounted or the table attributes or children change, and use the `debounce` and `resizeSensor` functions to detect the table resize event ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R12),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R27),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R487),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R495-R500),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R408-R413),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R613-R617))
*  Modify the logic of the `getRowByIndex` function in the `TableStore2` value to use the `levels` parameter to recursively find the nested row by index ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292L283-R293))
*  Modify the style rules of the fixed left and right columns in the `table2` component to inherit the background color from the parent row and remove the white background when not hovered ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-454e6ead402be0ea4c02bde78c3cb25833f8c6ee15c4f067be5f388c1a5ab80bL530-R532),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-454e6ead402be0ea4c02bde78c3cb25833f8c6ee15c4f067be5f388c1a5ab80bL556-R553),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-454e6ead402be0ea4c02bde78c3cb25833f8c6ee15c4f067be5f388c1a5ab80bL613-L616),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-454e6ead402be0ea4c02bde78c3cb25833f8c6ee15c4f067be5f388c1a5ab80bL647-L650))
*  Modify the logic of the `onRowMouseEnter` and `onRowMouseLeave` methods of the `Table` class to remove the classnames prop and the hover class logic, and to use the `itemActions` prop to check if the row actions are enabled ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1120-R1161),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1129-R1170),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1156-R1194))
*  Modify the logic of the `handleResizeStart`, `handleResize`, and `handleResizeEnd` methods of the `Table` class to use the column name instead of the index to get and update the column width information, and to remove the left style and the fixed column classes of the resize target when the resizing is finished ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L792-R836),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R851),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L817-R865),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R704-R706),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R717-R720),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R726))
*  Modify the logic of the `handleDrop` and `handleAction` methods of the `Table2` component to use the `primaryField` prop as the first fallback for the expandable key variable, instead of the second fallback ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1383-R1390),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1444-R1451))
*  Modify the logic of the constructor and the `componentDidUpdate` method of the `Table2` component to use the `primaryField` prop as the first fallback for the `rowSelectionKeyField` property of the store, instead of the last or second fallback ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L495-R499),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L582-R586),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L654-R658))
*  Modify the logic of the `render` method of the `Table2` component to check if the `selectable` or `rowSelection` prop is enabled before creating the `rowSelectionConfig` object, and to use the store or the prop as the row selection configuration ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1538-R1554),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1551-R1573),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1615-L1620))
*  Modify the logic of the `renderCell` and `renderCellSchema` methods of the `Table` and `Table2` components to add the `levels` parameter to the render function of the column, to pass the nesting levels information to the column renderer ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1387-R1402),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L821-R834))
*  Modify the logic of the `render` and `renderScrollTable` methods of the `Table` class to remove the loading condition for rendering the table foot, to always show the foot summary regardless of the loading state ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1829-R1850),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1942-R1963),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1948-R1969))
*  Modify the `version` column in the fixed header and column example to render a property type column with multiple items and span settings ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-e8b85e81bbe5cff7411adaeb4a91921da046554867928fe7598fb18cd94c6b42L936-R966))
*  Modify the `engine` values of the rows in the default nesting example to differentiate them from each other ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-e8b85e81bbe5cff7411adaeb4a91921da046554867928fe7598fb18cd94c6b42L1972-R2001),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-e8b85e81bbe5cff7411adaeb4a91921da046554867928fe7598fb18cd94c6b42L1980-R2009),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-e8b85e81bbe5cff7411adaeb4a91921da046554867928fe7598fb18cd94c6b42L1988-R2017),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-e8b85e81bbe5cff7411adaeb4a91921da046554867928fe7598fb18cd94c6b42L1996-R2025),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-e8b85e81bbe5cff7411adaeb4a91921da046554867928fe7598fb18cd94c6b42L2006-R2035),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-e8b85e81bbe5cff7411adaeb4a91921da046554867928fe7598fb18cd94c6b42L2016-R2045),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-e8b85e81bbe5cff7411adaeb4a91921da046554867928fe7598fb18cd94c6b42L2024-R2053),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-e8b85e81bbe5cff7411adaeb4a91921da046554867928fe7598fb18cd94c6b42L2032-R2061))
*  Add an `id` column to the default nesting and the multiple selection nesting examples to demonstrate how to use the `id` property to identify the row data ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-e8b85e81bbe5cff7411adaeb4a91921da046554867928fe7598fb18cd94c6b42R2156-R2159),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-e8b85e81bbe5cff7411adaeb4a91921da046554867928fe7598fb18cd94c6b42R2358-R2361))
*  Remove the `index` prop and the `data-index` attribute from the `BodyCell` class in the `Cell.tsx` file, as they are not used in the component ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-539af974c4e9aa075965626eaefbccaa30877dfc60c3be8b9b2527a1e469acd7L57),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-539af974c4e9aa075965626eaefbccaa30877dfc60c3be8b9b2527a1e469acd7L76))
*  Remove the `syncTableWidth` call from the `Table` class in the `index.tsx` file, as it is already handled by the `useEffect` hooks ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L489))
*  Remove the `columnWidthReady` variable and the `span` element with the `updateTableInfoRef` ref from the `render` method of the `Table` class in the `index.tsx` file, as they are not needed for the new logic of updating the table width ([link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L2065-L2066),[link](https://github.com/baidu/amis/pull/8372/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L2094))
