### PR TITLE
fix: 修复 crud 中使用 pagination 配置 showPerPage 无效问题 Close: #8373

### DIFF
--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -1927,20 +1927,16 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       | 'popOverContainerSelector'
       | 'total'
       | 'perPageAvailable'
+      | 'showPerPage'
     > = {};
 
     /** 优先级：showPageInput显性配置 > (lastPage > 9) */
     if (typeof toolbar !== 'string') {
+      Object.assign(extraProps, toolbar);
       const showPageInput = (toolbar as Schema).showPageInput;
 
       extraProps.showPageInput =
         showPageInput === true || (lastPage > 9 && showPageInput == null);
-      extraProps.maxButtons = (toolbar as Schema).maxButtons;
-      extraProps.layout = (toolbar as Schema).layout;
-      extraProps.popOverContainerSelector = (
-        toolbar as Schema
-      ).popOverContainerSelector;
-      extraProps.perPageAvailable = (toolbar as Schema).perPageAvailable;
       extraProps.total = resolveVariableAndFilter(
         (toolbar as Schema).total,
         store.data


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 440040b</samp>

Simplify and optimize the CRUD toolbar props copying in `CRUD.tsx`. Remove unused props from `extraProps` and use `Object.assign` instead of manual assignments.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 440040b</samp>

> _`Object.assign`_
> _Copies `toolbar` props fast_
> _Simpler code in spring_

### Why

Close: #8373

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 440040b</samp>

*  Simplify the code for copying toolbar properties to extraProps using Object.assign ([link](https://github.com/baidu/amis/pull/8377/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1930-R1939))
*  Remove unused properties from extraProps ([link](https://github.com/baidu/amis/pull/8377/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1930-R1939))
