### PR TITLE
fix: 修复 dialog title 为空时 showButtonClose 开启不显示关闭按钮的问题 Close: #8108

### DIFF
--- a/packages/amis-ui/scss/components/_modal.scss
+++ b/packages/amis-ui/scss/components/_modal.scss
@@ -93,10 +93,6 @@
     border-bottom: var(--Modal-body-borderTop);
     border-top-left-radius: var(--Modal-content-borderRadius);
     border-top-right-radius: var(--Modal-content-borderRadius);
-
-    .Dialog-close {
-      content: var(--dialog-icon-icon);
-    }
   }
 
   &-title {
@@ -113,6 +109,10 @@
     text-decoration: none;
     vertical-align: middle;
     z-index: calc(#{$zindex-spinner-overlay} + 1);
+
+    .Dialog-close {
+      content: var(--dialog-icon-icon);
+    }
 
     svg {
       width: var(--dialog-icon-size);

--- a/packages/amis-ui/src/components/icons.tsx
+++ b/packages/amis-ui/src/components/icons.tsx
@@ -287,25 +287,26 @@ export function Icon({
     });
   }
 
-  // 从css变量中获取icon
-  function refFn(dom: any) {
-    if (dom) {
-      const domStyle = getComputedStyle(dom);
-      const svgStr = domStyle.getPropertyValue('content');
-      const svg = /(<svg.*<\/svg>)/.exec(svgStr);
+  if (iconContent) {
+    // 从css变量中获取icon
+    const refFn = function (dom: any) {
+      if (dom) {
+        const domStyle = getComputedStyle(dom);
+        const svgStr = domStyle.getPropertyValue('content');
+        const svg = /(<svg.*<\/svg>)/.exec(svgStr);
 
-      if (svg) {
-        const svgHTML = svg[0].replace(/\\"/g, '"');
-        if (dom.svgHTMLClone !== svgHTML) {
-          dom.innerHTML = svgHTML;
-          // 存储svg，不直接用innerHTML是防止<circle />渲染后变成<circle></circle>的情况
-          dom.svgHTMLClone = svgHTML;
-          dom.style.display = '';
+        if (svg) {
+          const svgHTML = svg[0].replace(/\\"/g, '"');
+          if (dom.svgHTMLClone !== svgHTML) {
+            dom.innerHTML = svgHTML;
+            // 存储svg，不直接用innerHTML是防止<circle />渲染后变成<circle></circle>的情况
+            dom.svgHTMLClone = svgHTML;
+            dom.style.display = '';
+          }
         }
       }
-    }
-  }
-  if (iconContent) {
+    };
+
     return (
       <div
         onClick={onClick}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 422b9fd</samp>

This pull request improves the style and performance of the modal and icon components in the `amis-ui` package. It updates the close icon of the modal component to match the dialog component, and it optimizes the icon component to avoid defining and using a function when the icon content is not available.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 422b9fd</samp>

> _Sing, O Muse, of the skillful coder who refined the Icon component_
> _And moved the `refFn` function inside the conditional block_
> _So that it would not waste resources or clutter the code_
> _But only run when the icon content shone like a star._

### Why

Close: #8108

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 422b9fd</samp>

* Remove redundant dialog close icon style from `_modal.scss` ([link](https://github.com/baidu/amis/pull/8378/files?diff=unified&w=0#diff-c76c418ad30430f01cd68aa78422398e032dc3750b37b2869b9d448a4e0b5c51L96-L99))
* Add lower specificity dialog close icon style to `_modal.scss` to allow custom overrides ([link](https://github.com/baidu/amis/pull/8378/files?diff=unified&w=0#diff-c76c418ad30430f01cd68aa78422398e032dc3750b37b2869b9d448a4e0b5c51R113-R116))
* Move `refFn` function inside icon content check in `Icon` component to improve performance and readability ([link](https://github.com/baidu/amis/pull/8378/files?diff=unified&w=0#diff-1db9a23d0ea625849dbe5c523e7ccab192bfa73c87891759c8a7de36e2d874efL290-R309))
