### PR TITLE
chore(editor): style中的backgroun-color转为themeCss中的background

### DIFF
--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -1122,6 +1122,10 @@ export function getThemeConfig() {
   return {themeConfig, ...themeOptionsData};
 }
 
+const backgroundMap: PlainObject = {
+  'background-color': 'background'
+};
+
 /**
  * 将style转换为组件ThemeCSS格式
  *
@@ -1142,8 +1146,11 @@ export function style2ThemeCss(data: any) {
   const paddingAndMargin: PlainObject = {};
   const font: PlainObject = {};
   Object.keys(style).forEach(key => {
-    if (['background', 'radius', 'boxShadow'].includes(key)) {
-      baseControlClassName[key + ':default'] = style[key];
+    if (
+      ['background', 'background-color', 'radius', 'boxShadow'].includes(key)
+    ) {
+      baseControlClassName[(backgroundMap[key] || key) + ':default'] =
+        style[key];
       delete style[key];
     } else if (
       ['color', 'fontSize', 'fontWeight', 'font-family', 'lineHeight'].includes(


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa228d2</samp>

Improve theme system and add utility function for background colors. Allow `background` or `background-color` properties for components and map them to theme variables in `util.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fa228d2</samp>

> _Oh, we're the coders of the sea, and we love a good theme_
> _We can change the background color with `background` or `background-color`_
> _We've got a function to map them to the variables we need_
> _So heave away, me hearties, heave away on the count of three_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fa228d2</samp>

*  Add a mapping object for background color properties ([link](https://github.com/baidu/amis/pull/8380/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aR1125-R1128))
*  Update the style to theme conversion function to handle both `background` and `background-color` properties ([link](https://github.com/baidu/amis/pull/8380/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL1145-R1153))
