### PR TITLE
feat: classname 配置中类名支持表达式 Close: #8388

### DIFF
--- a/docs/zh-CN/types/classname.md
+++ b/docs/zh-CN/types/classname.md
@@ -12,7 +12,9 @@ amis 中大部分的组件都支持配置 className 和 xxxClassName，他可以
 配置方式有两种：
 
 1. 直接配置字符串如：`className: "text-danger"` 文字标红。
-2. 采用对象配置，这个用法主要是方便写表达式如：`className: {"text-danger": "this.status == 1"}` 表示当数据 status 状态是 1 时，文字飘红。
+2. 采用对象配置，这个用法主要是方便写表达式如：`className: {"text-danger": "${status == 1}"}` 表示当数据 status 状态是 1 时，文字飘红。
+
+> 注意 3.5 版本开始类名中支持表达式如: `text-${status == 1 ? 'danger' : 'success'}`
 
 ```schema
 {
@@ -46,8 +48,9 @@ amis 中大部分的组件都支持配置 className 和 xxxClassName，他可以
                         "2": "在线"
                     },
                     "className": {
-                        "text-muted": "this.status == '1'",
-                        "text-success": "this.status == '2'"
+                        "text-muted": "${status == 1}",
+                        "text-success": "${status ==  2}",
+                        "text-${status}": true
                     }
                 }
             ]

--- a/packages/amis-core/src/utils/helper.ts
+++ b/packages/amis-core/src/utils/helper.ts
@@ -1566,8 +1566,9 @@ export function chainEvents(props: any, schema: any) {
 
 export function mapObject(
   value: any,
-  fn: Function,
-  skipFn?: (value: any) => boolean
+  valueMapper: (value: any) => any,
+  skipFn?: (value: any) => boolean,
+  keyMapper?: (key: string) => string
 ): any {
   // 如果value值满足skipFn条件则不做map操作
   skipFn =
@@ -1582,26 +1583,29 @@ export function mapObject(
           return false;
         };
 
-  if (!!skipFn(value)) {
+  if (skipFn(value)) {
     return value;
   }
 
   if (Array.isArray(value)) {
-    return value.map(item => mapObject(item, fn, skipFn));
+    return value.map(item => mapObject(item, valueMapper, skipFn, keyMapper));
   }
 
   if (isObject(value)) {
-    let tmpValue = {...value};
-    Object.keys(tmpValue).forEach(key => {
-      (tmpValue as PlainObject)[key] = mapObject(
-        (tmpValue as PlainObject)[key],
-        fn,
-        skipFn
+    let tmpValue = {};
+    Object.keys(value).forEach(key => {
+      const newKey = keyMapper ? keyMapper(key) : key;
+
+      (tmpValue as PlainObject)[newKey] = mapObject(
+        (value as PlainObject)[key],
+        valueMapper,
+        skipFn,
+        keyMapper
       );
     });
     return tmpValue;
   }
-  return fn(value);
+  return valueMapper(value);
 }
 
 export function loadScript(src: string) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cb04aa0</samp>

This pull request adds the feature of using expressions in the class name and the keys of the object value for AMIS components. It updates the Chinese documentation and example code of the `className` property, and enhances the `getExprProperties` and `mapObject` functions in the `filter-schema.ts` and `helper.ts` files respectively.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cb04aa0</samp>

> _Oh we're the coders of the sea, and we work with `className`_
> _We use expressions to map the keys, and we do it with a breeze_
> _Heave away, me lads and lasses, heave away with all your might_
> _We'll make the `filter-schema` function better, before the end of night_

### Why

Close: #8388

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cb04aa0</samp>

*  Add support for expressions in the class name property of the schema, such as `text-${status == 1 ? 'danger' : 'success'}` ([link](https://github.com/baidu/amis/pull/8392/files?diff=unified&w=0#diff-0ca5cf3224693a57654399067ee7479b4b273bb39c54864ff473daa0da92f55bL15-R18), [link](https://github.com/baidu/amis/pull/8392/files?diff=unified&w=0#diff-0ca5cf3224693a57654399067ee7479b4b273bb39c54864ff473daa0da92f55bL49-R53), [link](https://github.com/baidu/amis/pull/8392/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3R6), [link](https://github.com/baidu/amis/pull/8392/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3L64-R80))
*  Import and use the `tokenize` function from the `./tokenize` module to parse and replace expressions in the class name ([link](https://github.com/baidu/amis/pull/8392/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3R6), [link](https://github.com/baidu/amis/pull/8392/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3L64-R80))
*  Add a new parameter `keyMapper` to the `mapObject` function in the `helper.ts` file to map the keys of the object value to new keys, such as parsing expressions in the keys ([link](https://github.com/baidu/amis/pull/8392/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1569-R1571), [link](https://github.com/baidu/amis/pull/8392/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1585-R1608))
*  Use the `keyMapper` function in the `getExprProperties` function in the `filter-schema.ts` file to parse expressions in the keys of the object value ([link](https://github.com/baidu/amis/pull/8392/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3L64-R80))
*  Declare and use a new variable `type` in the `getExprProperties` function in the `filter-schema.ts` file to store the third part of the property name that indicates the type of the property ([link](https://github.com/baidu/amis/pull/8392/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3R33), [link](https://github.com/baidu/amis/pull/8392/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3L38-R44), [link](https://github.com/baidu/amis/pull/8392/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3L54-R56))
*  Update the documentation of the `className` property in the Chinese version to reflect the new feature and the version availability ([link](https://github.com/baidu/amis/pull/8392/files?diff=unified&w=0#diff-0ca5cf3224693a57654399067ee7479b4b273bb39c54864ff473daa0da92f55bL15-R18), [link](https://github.com/baidu/amis/pull/8392/files?diff=unified&w=0#diff-0ca5cf3224693a57654399067ee7479b4b273bb39c54864ff473daa0da92f55bL49-R53))
