### PR TITLE
feat: input-table增加是否展示列开关配置项

### DIFF
--- a/packages/amis-editor/src/plugin/Form/InputTable.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTable.tsx
@@ -1004,7 +1004,34 @@ export class TableControlPlugin extends BasePlugin {
               },
               getSchemaTpl('description'),
               getSchemaTpl('placeholder'),
-              getSchemaTpl('labelRemark')
+              getSchemaTpl('labelRemark'),
+              {
+                name: 'columnsTogglable',
+                label: tipedLabel(
+                  '列显示开关',
+                  '是否展示表格列的显隐开关控件，自动即列数量大于5时自动开启'
+                ),
+                type: 'button-group-select',
+                pipeIn: defaultValue('auto'),
+                size: 'sm',
+                labelAlign: 'left',
+                options: [
+                  {
+                    label: '自动',
+                    value: 'auto'
+                  },
+
+                  {
+                    label: '开启',
+                    value: true
+                  },
+
+                  {
+                    label: '关闭',
+                    value: false
+                  }
+                ]
+              }
             ]
           },
           {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43025f3</samp>

Add `columnsTogglable` property to `TableControlPlugin` to enable toggle control for table columns. This property lets users customize the table component in `amis-editor`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 43025f3</samp>

> _`columnsTogglable`_
> _A button group for table_
> _Autumn leaves or not_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 43025f3</samp>

* Add a new schema property `columnsTogglable` to the `TableControlPlugin` class to enable toggle control for table columns visibility ([link](https://github.com/baidu/amis/pull/8393/files?diff=unified&w=0#diff-01999eae047ec7fdb8502c22801699d39f7a54c994a9414462c0fbe21634ecd8L1007-R1034))
