### PR TITLE
feat: input-table增加是否展示列开关配置项, table更新配置项交互

### DIFF
--- a/packages/amis-editor/src/plugin/Form/InputTable.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTable.tsx
@@ -1009,7 +1009,7 @@ export class TableControlPlugin extends BasePlugin {
                 name: 'columnsTogglable',
                 label: tipedLabel(
                   '列显示开关',
-                  '是否展示表格列的显隐开关控件，自动即列数量大于5时自动开启'
+                  '是否展示表格列的显隐控件，“自动”即列数量大于5时自动开启'
                 ),
                 type: 'button-group-select',
                 pipeIn: defaultValue('auto'),

--- a/packages/amis-editor/src/plugin/Form/InputTable.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTable.tsx
@@ -1004,7 +1004,34 @@ export class TableControlPlugin extends BasePlugin {
               },
               getSchemaTpl('description'),
               getSchemaTpl('placeholder'),
-              getSchemaTpl('labelRemark')
+              getSchemaTpl('labelRemark'),
+              {
+                name: 'columnsTogglable',
+                label: tipedLabel(
+                  '列显示开关',
+                  '是否展示表格列的显隐开关控件，自动即列数量大于5时自动开启'
+                ),
+                type: 'button-group-select',
+                pipeIn: defaultValue('auto'),
+                size: 'sm',
+                labelAlign: 'left',
+                options: [
+                  {
+                    label: '自动',
+                    value: 'auto'
+                  },
+
+                  {
+                    label: '开启',
+                    value: true
+                  },
+
+                  {
+                    label: '关闭',
+                    value: false
+                  }
+                ]
+              }
             ]
           },
           {

--- a/packages/amis-editor/src/plugin/Table.tsx
+++ b/packages/amis-editor/src/plugin/Table.tsx
@@ -571,15 +571,14 @@ export class TablePlugin extends BasePlugin {
             body: [
               {
                 name: 'columnsTogglable',
-                label: '展示列显示开关',
+                label: tipedLabel(
+                  '列显示开关',
+                  '是否展示表格列的显隐控件，“自动”即列数量大于5时自动开启'
+                ),
                 type: 'button-group-select',
                 pipeIn: defaultValue('auto'),
                 size: 'sm',
                 labelAlign: 'left',
-                horizontal: {
-                  left: 5,
-                  right: 7
-                },
                 options: [
                   {
                     label: '自动',
@@ -595,8 +594,7 @@ export class TablePlugin extends BasePlugin {
                     label: '关闭',
                     value: false
                   }
-                ],
-                description: '自动即列数量大于5个时自动开启'
+                ]
               },
 
               getSchemaTpl('switch', {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9c2d7fb</samp>

This pull request improves the table component in the editor by adding a `columnsTogglable` property to the `TableControlPlugin` class and simplifying the same property in the `TablePlugin` class. This allows the user to control the visibility of the table columns and enhances the consistency and usability of the editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9c2d7fb</samp>

> _`columnsTogglable`_
> _simpler schema for table_
> _autumn leaves fall fast_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9c2d7fb</samp>

*  Add a new schema property `columnsTogglable` to the `TableControlPlugin` class, which allows the user to show or hide a toggle button for the table columns ([link](https://github.com/baidu/amis/pull/8394/files?diff=unified&w=0#diff-01999eae047ec7fdb8502c22801699d39f7a54c994a9414462c0fbe21634ecd8L1007-R1034))
*  Update the schema property `columnsTogglable` in the `TablePlugin` class, which renders a table component, to use the same helper functions and default value as the `TableControlPlugin` class ([link](https://github.com/baidu/amis/pull/8394/files?diff=unified&w=0#diff-d01a7abf584cd914dc4d94abbeb0f35326953f6b5b19bbd9efbbb846b29f0194L574-R581))
*  Remove the redundant `description` property from the `columnsTogglable` property in the `TablePlugin` class, as the tooltip is provided by the `tipedLabel` function ([link](https://github.com/baidu/amis/pull/8394/files?diff=unified&w=0#diff-d01a7abf584cd914dc4d94abbeb0f35326953f6b5b19bbd9efbbb846b29f0194L598-R597))
