### PR TITLE
fix: 修复复用的 contextmenu 实例可能已销毁的问题

### DIFF
--- a/packages/amis-ui/src/components/Alert.tsx
+++ b/packages/amis-ui/src/components/Alert.tsx
@@ -54,7 +54,7 @@ export interface AlertState {
 export class Alert extends React.Component<AlertProps, AlertState> {
   static instance: any = null;
   static async getInstance() {
-    if (!Alert.instance) {
+    if (!Alert.instance || Alert.instance.unmount) {
       console.warn('Alert 组件应该没有被渲染，所以隐性的渲染到 body 了');
       const container = document.body;
       const div = document.createElement('div');
@@ -89,6 +89,7 @@ export class Alert extends React.Component<AlertProps, AlertState> {
     cancelText: '取消'
   };
   originInstance: Alert | null;
+  unmount = false;
   constructor(props: AlertProps) {
     super(props);
 
@@ -125,6 +126,7 @@ export class Alert extends React.Component<AlertProps, AlertState> {
   }
 
   componentWillUnmount() {
+    this.unmount = true;
     if (Alert.instance === this) {
       Alert.instance = this.originInstance || null;
       this.originInstance = null;

--- a/packages/amis-ui/src/components/ContextMenu.tsx
+++ b/packages/amis-ui/src/components/ContextMenu.tsx
@@ -51,7 +51,7 @@ export class ContextMenu extends React.Component<
 > {
   static instance: any = null;
   static async getInstance() {
-    if (!ContextMenu.instance) {
+    if (!ContextMenu.instance || ContextMenu.instance.unmount) {
       const container = document.body;
       const div = document.createElement('div');
       container.appendChild(div);
@@ -84,6 +84,7 @@ export class ContextMenu extends React.Component<
     y: number;
   } | null;
 
+  unmount = false;
   constructor(props: ContextMenuProps) {
     super(props);
 
@@ -97,6 +98,7 @@ export class ContextMenu extends React.Component<
   }
 
   componentWillUnmount() {
+    this.unmount = true;
     ContextMenu.instance = this.originInstance;
     document.body.removeEventListener('click', this.handleOutClick, true);
     document.removeEventListener('keydown', this.handleKeyDown);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 42f4cde</samp>

This pull request enhances the memory management and error handling of the `Alert` and `ContextMenu` components by adding and checking unmount flags. It prevents rendering these components to the body when they are unmounted, avoiding potential memory leaks and errors.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 42f4cde</samp>

> _Unleash the fury of the `Alert`_
> _No memory leaks, no errors to avert_
> _Destroy the evil of the `ContextMenu`_
> _Check the flag before you render to the doom_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 42f4cde</samp>

*  Prevent memory leaks and errors for `Alert` and `ContextMenu` components by checking their unmount status before rendering ([link](https://github.com/baidu/amis/pull/8399/files?diff=unified&w=0#diff-2acdd4d7456e360c65cda3ac871a7516411e2d90f43aab161418272388cc45fdL57-R57), [link](https://github.com/baidu/amis/pull/8399/files?diff=unified&w=0#diff-aac8cfd184853a8924093dd047a9f55d4030711c6bb72cb5572071db78697e41L54-R54))
*  Add `unmount` property to `Alert` and `ContextMenu` instances to indicate whether they have been unmounted from the body ([link](https://github.com/baidu/amis/pull/8399/files?diff=unified&w=0#diff-2acdd4d7456e360c65cda3ac871a7516411e2d90f43aab161418272388cc45fdR92), [link](https://github.com/baidu/amis/pull/8399/files?diff=unified&w=0#diff-aac8cfd184853a8924093dd047a9f55d4030711c6bb72cb5572071db78697e41R87))
*  Set `unmount` property to true when `Alert` and `ContextMenu` instances are unmounted from the body in `Alert.tsx` and `ContextMenu.tsx` ([link](https://github.com/baidu/amis/pull/8399/files?diff=unified&w=0#diff-2acdd4d7456e360c65cda3ac871a7516411e2d90f43aab161418272388cc45fdR129), [link](https://github.com/baidu/amis/pull/8399/files?diff=unified&w=0#diff-aac8cfd184853a8924093dd047a9f55d4030711c6bb72cb5572071db78697e41R101))
