### PR TITLE
fix(amis-editor): FormulaControl中过滤掉embed，避免默认值设置交互受影响

### DIFF
--- a/packages/amis-editor/src/renderer/FormulaControl.tsx
+++ b/packages/amis-editor/src/renderer/FormulaControl.tsx
@@ -484,7 +484,8 @@ export default class FormulaControl extends React.Component<
         'css',
         'validateApi',
         'themeCss',
-        'onEvent'
+        'onEvent',
+        'embed'
       ];
 
       // 当前组件要剔除的字段


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1043d34</samp>

Added `embed` prop to `FormulaControl` to enable modal formula editor. This allows users to edit formulas in a pop-up dialog instead of the sidebar.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1043d34</samp>

> _`embed` prop added_
> _formula editor in modal_
> _cutting through the screen_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1043d34</samp>

*  Add `embed` prop to `Formula` component to enable embedding in modal dialog ([link](https://github.com/baidu/amis/pull/8409/files?diff=unified&w=0#diff-ce07d539e9ec5eccae74ef6ee3032524b9a77ca3519a9f600cf3065ceaced70bL487-R488))
