### PR TITLE
chore: 锁定codemirror声明版本5.60.10，避免不兼容升级

### DIFF
--- a/packages/amis-editor-core/package.json
+++ b/packages/amis-editor-core/package.json
@@ -67,7 +67,7 @@
     "@svgr/rollup": "^6.2.1",
     "@types/async": "^2.0.45",
     "@types/classnames": "^2.2.3",
-    "@types/codemirror": "^5.60.5",
+    "@types/codemirror": "5.60.10",
     "@types/deep-diff": "^1.0.0",
     "@types/history": "^4.6.0",
     "@types/hoist-non-react-statics": "^3.0.1",

--- a/packages/amis-editor/package.json
+++ b/packages/amis-editor/package.json
@@ -57,7 +57,7 @@
     "@svgr/rollup": "^6.2.1",
     "@types/async": "^2.0.45",
     "@types/classnames": "^2.2.3",
-    "@types/codemirror": "^5.60.5",
+    "@types/codemirror": "5.60.10",
     "@types/deep-diff": "^1.0.0",
     "@types/history": "^4.6.0",
     "@types/hoist-non-react-statics": "^3.0.1",

--- a/packages/amis/package.json
+++ b/packages/amis/package.json
@@ -87,7 +87,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@types/async": "^2.0.45",
-    "@types/codemirror": "^5.60.3",
+    "@types/codemirror": "5.60.10",
     "@types/echarts": "^4.9.2",
     "@types/file-saver": "^2.0.1",
     "@types/history": "^4.6.0",


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f073de</samp>

Fixed the `@types/codemirror` dependency version to 5.60.10 in three `package.json` files to avoid type conflicts with newer versions. This ensures the proper functioning of the code editor component in `amis`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3f073de</samp>

> _`codemirror` types_
> _fixed to older version_
> _autumn of breaking_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3f073de</samp>

* Fix dependency version of `@types/codemirror` to 5.60.10 in three packages to avoid type conflicts with newer versions ([link](https://github.com/baidu/amis/pull/8416/files?diff=unified&w=0#diff-a4748fb9fe2d46502c7750a6b7c1cf5b4421968cea8501b3a9aaccb825ca35ecL70-R70), [link](https://github.com/baidu/amis/pull/8416/files?diff=unified&w=0#diff-7ae8386aceb47f61a4a2b316c8113f28fa64c584162ac38e128559bda675b242L60-R60), [link](https://github.com/baidu/amis/pull/8416/files?diff=unified&w=0#diff-b49028542a3bb14de6e47e46a9f09f23ffeff3afea2a17d5ddace75726a33e12L90-R90))
