### PR TITLE
fix: className使用表达式时未计算问题

### DIFF
--- a/packages/amis-core/src/utils/filter-schema.ts
+++ b/packages/amis-core/src/utils/filter-schema.ts
@@ -63,9 +63,13 @@ export function getExprProperties(
       exprProps[key] = value;
     } else if (
       (type === 'className' || type === 'ClassName') &&
-      !props?.[key] && // 如果 props 里面有则是 props 优先
       value &&
-      (typeof value === 'string' || isPlainObject(value))
+      (typeof value === 'string' || isPlainObject(value)) &&
+      // 如果 props 里面有则是 props 优先（props中存在且schema中未设置则认为是props下发的，否则当做表达式计算）
+      (!props?.[key] ||
+        (isPlainObject(value)
+          ? value.hasOwnProperty(props?.[key])
+          : value === props?.[key]))
     ) {
       exprProps[`${key}Raw`] = value;
       exprProps[key] =


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 96fd330</samp>

Fixed a bug in `filter-schema.ts` that caused the className prop to be ignored for some components. Changed the logic for assigning raw props values to handle object values.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 96fd330</samp>

> _`className` prop fixed_
> _Object values not parsed_
> _Winter bug resolved_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 96fd330</samp>

* Fix className prop not working for some components by checking if the value is an object and using the props key as the className instead of evaluating the value as an expression ([link](https://github.com/baidu/amis/pull/8417/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3L66-R72))
