### PR TITLE
feat: inputNumber配置单位支持label/value这种配置,显示和给后端的单位区分开

### DIFF
--- a/packages/amis-editor/src/plugin/Form/InputNumber.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputNumber.tsx
@@ -227,22 +227,48 @@ export class NumberControlPlugin extends BasePlugin {
                   label: '单位选项',
                   mode: 'normal',
                   name: 'unitOptions',
-                  flat: true,
+                  // flat: true,
                   items: [
                     {
-                      placeholder: '单位选项',
-                      type: i18nEnabled ? 'input-text-i18n' : 'input-text',
-                      name: 'text'
+                      type: 'flex',
+                      items: [
+                        {
+                          placeholder: '文本',
+                          type: i18nEnabled ? 'input-text-i18n' : 'input-text',
+                          name: 'label',
+                          label: '文本：',
+                          labelWidth: '50px'
+                        },
+                        {
+                          placeholder: '值',
+                          type: i18nEnabled ? 'input-text-i18n' : 'input-text',
+                          name: 'value',
+                          label: '值：',
+                          labelWidth: '50px'
+                        }
+                      ],
+                      style: {
+                        position: 'static',
+                        flexWrap: 'nowrap',
+                        flexDirection: 'column'
+                      }
                     }
                   ],
                   draggable: false,
                   multiple: true,
                   pipeIn: (value: any) => {
-                    if (!isObject(value)) {
-                      return Array.isArray(value) ? value : [];
+                    if (Array.isArray(value)) {
+                      return value.map(item =>
+                        typeof item === 'string'
+                          ? {
+                              label: item,
+                              value: item
+                            }
+                          : item
+                      );
+                    } else {
+                      return [];
                     }
-                    const res = value.map((item: any) => item.value);
-                    return res;
                   },
                   pipeOut: (value: any[]) => {
                     if (!value.length) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1344b12</samp>

This pull request improves the customization and functionality of the `number` control in the AMIS editor. It enables custom unit options and fixes value conversion for the `unitOptions` property in `Form/InputNumber.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1344b12</samp>

> _`unitOptions` grows_
> _custom labels and values_
> _autumn of numbers_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1344b12</samp>

* Change the schema of the `unitOptions` property of the `number` control to use a nested array of flex items with label and value fields ([link](https://github.com/baidu/amis/pull/8418/files?diff=unified&w=0#diff-c459de2eb5b316e5e49ab103c7fa1a03c20cf7693bd79b8e039e782b48c5731aL230-R254))
* Fix the logic of the `pipeIn` and `pipeOut` functions of the `unitOptions` property to handle the new schema and ensure consistency ([link](https://github.com/baidu/amis/pull/8418/files?diff=unified&w=0#diff-c459de2eb5b316e5e49ab103c7fa1a03c20cf7693bd79b8e039e782b48c5731aL241-R271))
