### PR TITLE
fix: combo、toolbar等问题修复

### DIFF
--- a/examples/components/CRUD/List.jsx
+++ b/examples/components/CRUD/List.jsx
@@ -3,32 +3,18 @@ export default {
   remark: 'bla bla bla',
   body: {
     type: 'crud',
-    api: '/api/sample',
+    name: 'thelist',
+    api: {
+      method: 'get',
+      url: '/api/sample',
+      sendOn: '${mode}'
+    },
     mode: 'list',
     draggable: true,
     saveOrderApi: {
       url: '/api/sample/saveOrder'
     },
     orderField: 'weight',
-    filter: {
-      title: '条件搜索',
-      submitText: '',
-      body: [
-        {
-          type: 'input-text',
-          name: 'keywords',
-          placeholder: '通过关键字搜索',
-          addOn: {
-            label: '搜索',
-            type: 'submit'
-          }
-        },
-        {
-          type: 'plain',
-          text: '这只是个示例, 目前搜索对查询结果无效.'
-        }
-      ]
-    },
     affixHeader: true,
     bulkActions: [
       {
@@ -63,6 +49,44 @@ export default {
     ],
     quickSaveApi: '/api/sample/bulkUpdate',
     quickSaveItemApi: '/api/sample/$id',
+    headerToolbar: [
+      {
+        type: 'form',
+        mode: 'inline',
+        wrapWithPanel: false,
+        submitOnChange: true,
+        submitOnInit: true,
+        target: 'thelist',
+        body: [
+          {
+            type: 'select',
+            name: 'mode',
+            className: 'mb-0',
+            selectFirst: true,
+            options: [
+              {
+                label: '模式 1',
+                value: 'mode1'
+              },
+              {
+                label: '模式 2',
+                value: 'mode2'
+              }
+            ]
+          },
+          {
+            type: 'input-text',
+            name: 'keywords',
+            placeholder: '通过关键字搜索',
+            className: 'mb-0',
+            addOn: {
+              label: '搜索',
+              type: 'submit'
+            }
+          }
+        ]
+      }
+    ],
     listItem: {
       actions: [
         {

--- a/packages/amis-core/src/SchemaRenderer.tsx
+++ b/packages/amis-core/src/SchemaRenderer.tsx
@@ -64,7 +64,8 @@ export const RENDERER_TRANSMISSION_OMIT_PROPS = [
   'label',
   'renderLabel',
   'trackExpression',
-  'editorSetting'
+  'editorSetting',
+  'updatePristineAfterStoreDataReInit'
 ];
 
 const componentCache: SimpleMap = new SimpleMap();

--- a/packages/amis-core/src/WithStore.tsx
+++ b/packages/amis-core/src/WithStore.tsx
@@ -247,6 +247,10 @@ export function HocStoreFactory(renderer: {
                       ...store.data,
                       ...props.data
                     }
+                  : // combo 不需要同步，如果要同步，在 Combo.tsx 里面已经实现了相关逻辑
+                  // 目前主要的问题是，如果 combo 中表单项名字和 combo 本身的名字一样，会导致里面的值会被覆盖成数组
+                  props.store?.storeType === 'ComboStore'
+                  ? undefined
                   : syncDataFromSuper(
                       props.data,
                       (props.data as any).__super,

--- a/packages/amis-core/src/WithStore.tsx
+++ b/packages/amis-core/src/WithStore.tsx
@@ -252,7 +252,7 @@ export function HocStoreFactory(renderer: {
                   props.store?.storeType === 'ComboStore'
                   ? undefined
                   : syncDataFromSuper(
-                      props.data,
+                      store.data,
                       (props.data as any).__super,
                       (prevProps.data as any).__super,
                       store,

--- a/packages/amis-core/src/WithStore.tsx
+++ b/packages/amis-core/src/WithStore.tsx
@@ -207,7 +207,8 @@ export function HocStoreFactory(renderer: {
                 ...(store.hasRemoteData ? store.data : null), // todo 只保留 remote 数据
                 ...this.formatData(props.defaultData),
                 ...this.formatData(props.data)
-              })
+              }),
+              props.updatePristineAfterStoreDataReInit === false
             );
           }
         } else if (
@@ -234,7 +235,8 @@ export function HocStoreFactory(renderer: {
                       store,
                       props.syncSuperStore === true
                     )
-              )
+              ),
+              props.updatePristineAfterStoreDataReInit === false
             );
           } else if (props.data && (props.data as any).__super) {
             store.initData(
@@ -252,10 +254,14 @@ export function HocStoreFactory(renderer: {
                       store,
                       false
                     )
-              )
+              ),
+              props.updatePristineAfterStoreDataReInit === false
             );
           } else {
-            store.initData(createObject(props.scope, props.data));
+            store.initData(
+              createObject(props.scope, props.data),
+              props.updatePristineAfterStoreDataReInit === false
+            );
           }
         } else if (
           !props.trackExpression &&
@@ -278,8 +284,9 @@ export function HocStoreFactory(renderer: {
                 ...store.data
               }),
 
-              store.storeType === 'FormStore' &&
-                prevProps.store?.storeType === 'CRUDStore'
+              props.updatePristineAfterStoreDataReInit === false ||
+                (store.storeType === 'FormStore' &&
+                  prevProps.store?.storeType === 'CRUDStore')
             );
           }
           // nextProps.data.__super !== props.data.__super) &&
@@ -295,7 +302,8 @@ export function HocStoreFactory(renderer: {
             createObject(props.scope, {
               // ...nextProps.data,
               ...store.data
-            })
+            }),
+            props.updatePristineAfterStoreDataReInit === false
           );
         }
       }

--- a/packages/amis-core/src/WithStore.tsx
+++ b/packages/amis-core/src/WithStore.tsx
@@ -252,7 +252,7 @@ export function HocStoreFactory(renderer: {
                   props.store?.storeType === 'ComboStore'
                   ? undefined
                   : syncDataFromSuper(
-                      store.data,
+                      props.data,
                       (props.data as any).__super,
                       (prevProps.data as any).__super,
                       store,

--- a/packages/amis-core/src/store/crud.ts
+++ b/packages/amis-core/src/store/crud.ts
@@ -61,12 +61,11 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
       // 因为会把数据呈现在地址栏上。
       return createObject(
         createObject(self.data, {
-          ...self.query,
           items: self.items.concat(),
           selectedItems: self.selectedItems.concat(),
           unSelectedItems: self.unSelectedItems.concat()
         }),
-        {}
+        {...self.query}
       );
     },
 

--- a/packages/amis/__tests__/renderers/Form/combo.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/combo.test.tsx
@@ -969,3 +969,35 @@ test('Renderer:select autofill in combo', async () => {
     combo: [{type: '1', a: 'a'}]
   });
 });
+
+// 10. combo 内部表单项与 combo 同名时，原来会出现内部表单项的值变成数组的情况
+test('Renderer:combo 内部表单项与 combo 同名', async () => {
+  const {container, submitBtn, findByText, onSubmit, baseElement} = await setup(
+    [
+      {
+        type: 'combo',
+        name: 'a',
+        label: 'combo',
+        className: 'removableFalse',
+        removable: false,
+        multiple: true,
+        items: [
+          {
+            name: 'a',
+            type: 'input-text',
+            label: 'A'
+          }
+        ],
+        value: [{}]
+      }
+    ]
+  );
+
+  const input = container.querySelector('input[name="a"]') as HTMLInputElement;
+  fireEvent.change(input, {target: {value: '1'}});
+  await wait(400);
+
+  fireEvent.change(input, {target: {value: '123'}});
+  await wait(400);
+  expect(input.value).toBe('123');
+});

--- a/packages/amis/src/renderers/Form/Combo.tsx
+++ b/packages/amis/src/renderers/Form/Combo.tsx
@@ -1719,7 +1719,8 @@ export default class ComboControl extends React.Component<ComboProps> {
           ref: this.makeFormRef(0),
           onInit: this.handleSingleFormInit,
           canAccessSuperData,
-          formStore: undefined
+          formStore: undefined,
+          updatePristineAfterStoreDataReInit: false
         }
       );
     } else if (multiple && index !== undefined && index >= 0) {
@@ -1750,7 +1751,8 @@ export default class ComboControl extends React.Component<ComboProps> {
           value: undefined,
           formItemValue: undefined,
           formStore: undefined,
-          ...(tabsMode ? {} : {lazyLoad})
+          ...(tabsMode ? {} : {lazyLoad}),
+          updatePristineAfterStoreDataReInit: false
         }
       );
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,7 +62,8 @@ export default defineConfig({
     }),
     monacoEditorPlugin({}),
     replace({
-      __editor_i18n: !!I18N
+      __editor_i18n: !!I18N,
+      preventAssignment: true
     })
   ].filter(n => n),
   optimizeDeps: {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fd2c56d</samp>

This pull request adds a new feature to the CRUD component to support different data fetching modes, and fixes some bugs related to the store and the combo component. It also updates the `vite.config.ts` file to avoid a warning from the `replace` plugin. The main files affected are `List.jsx`, `WithStore.tsx`, `Combo.tsx`, `SchemaRenderer.tsx`, and `crud.ts`. A new test case is added to `combo.test.tsx` to verify the bug fix.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fd2c56d</samp>

> _Sing, O Muse, of the valiant code warriors who strove_
> _To enhance and repair the CRUD component, the pride of the web app,_
> _How they added new props and tests, and fixed bugs with skill and resolve,_
> _And how they silenced the warnings of the `replace` plugin, the crafty shapeshifter._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fd2c56d</samp>

*  Add a form component to the CRUD example to control the data fetching mode and keywords ([link](https://github.com/baidu/amis/pull/8421/files?diff=unified&w=0#diff-96a3b2a184bccf325ac1e6519544f48d6f9d1bdd6892165f8b28a282429fd039L6-R11), [link](https://github.com/baidu/amis/pull/8421/files?diff=unified&w=0#diff-96a3b2a184bccf325ac1e6519544f48d6f9d1bdd6892165f8b28a282429fd039R52-R89))
*  Remove the filter component from the CRUD example to simplify the UI ([link](https://github.com/baidu/amis/pull/8421/files?diff=unified&w=0#diff-96a3b2a184bccf325ac1e6519544f48d6f9d1bdd6892165f8b28a282429fd039L13-L31))
*  Add a new property `updatePristineAfterStoreDataReInit` to the schema renderer and the store factory to control the pristine state of the store after data reinitialization ([link](https://github.com/baidu/amis/pull/8421/files?diff=unified&w=0#diff-337f9a56707dbfa5917084f1e2048555a5ade95f13df3f685076114867426347L67-R68), [link](https://github.com/baidu/amis/pull/8421/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL210-R211), [link](https://github.com/baidu/amis/pull/8421/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL237-R239), [link](https://github.com/baidu/amis/pull/8421/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL255-R268), [link](https://github.com/baidu/amis/pull/8421/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL281-R293), [link](https://github.com/baidu/amis/pull/8421/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL298-R310), [link](https://github.com/baidu/amis/pull/8421/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1722-R1723), [link](https://github.com/baidu/amis/pull/8421/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L1753-R1755))
*  Fix a bug that caused the query parameters to be overwritten by the data properties when the store was serialized ([link](https://github.com/baidu/amis/pull/8421/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL64-R68))
*  Avoid syncing the super store data to the combo store when the combo name and the inner form item name are the same ([link](https://github.com/baidu/amis/pull/8421/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acR250-R253), [link](https://github.com/baidu/amis/pull/8421/files?diff=unified&w=0#diff-1689fddd6fe92bb44bae574b18fd1bf4ed54d85a41bc725b29e9c8498291ffafR972-R1003))
*  Avoid a warning from the replace plugin by setting the `preventAssignment` property to true in `vite.config.ts` ([link](https://github.com/baidu/amis/pull/8421/files?diff=unified&w=0#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL65-R66))
