### PR TITLE
fix: className为对象且下发给子组件时表达式计算错误问题

### DIFF
--- a/packages/amis/src/renderers/Card.tsx
+++ b/packages/amis/src/renderers/Card.tsx
@@ -6,7 +6,11 @@ import {SchemaNode, Schema, ActionObject, PlainObject} from 'amis-core';
 import {filter, evalExpression} from 'amis-core';
 import {Checkbox} from 'amis-ui';
 import {padArr, isVisible, isDisabled, noop, hashCode} from 'amis-core';
-import {resolveVariable, resolveVariableAndFilter} from 'amis-core';
+import {
+  resolveVariable,
+  resolveVariableAndFilter,
+  filterClassNameObject
+} from 'amis-core';
 import QuickEdit, {SchemaQuickEdit} from './QuickEdit';
 import PopOver, {SchemaPopOver} from './PopOver';
 import {TableCell} from './Table';
@@ -460,7 +464,10 @@ export class CardRenderer extends React.Component<CardProps> {
                 disabled: dragging || isDisabled(action, data),
                 className: cx(
                   'Card-action',
-                  action.className || `${size ? `Card-action--${size}` : ''}`
+                  filterClassNameObject(
+                    action.className || `${size ? `Card-action--${size}` : ''}`,
+                    data
+                  )
                 ),
                 componentClass: 'a',
                 onAction: this.handleAction
@@ -529,7 +536,10 @@ export class CardRenderer extends React.Component<CardProps> {
             },
             {
               useCardLabel,
-              className: cx('Card-fieldValue', field.className),
+              className: cx(
+                'Card-fieldValue',
+                filterClassNameObject(field.className, data)
+              ),
               rowIndex: itemIndex,
               colIndex: key,
               value: field.name ? resolveVariable(field.name, data) : undefined,
@@ -721,16 +731,27 @@ export class CardRenderer extends React.Component<CardProps> {
       media,
       ...rest
     } = this.props;
-
-    const headerCn = header?.className || headerClassName;
-    const titleCn = header?.titleClassName || titleClassName;
-    const subTitleCn = header?.subTitleClassName || subTitleClassName;
-    const descCn = header?.descClassName || descClassName;
+    const ctx = this.props.data;
+    const headerCn =
+      filterClassNameObject(header?.className, ctx) || headerClassName;
+    const titleCn =
+      filterClassNameObject(header?.titleClassName, ctx) || titleClassName;
+    const subTitleCn =
+      filterClassNameObject(header?.subTitleClassName, ctx) ||
+      subTitleClassName;
+    const descCn =
+      filterClassNameObject(header?.descClassName, ctx) || descClassName;
     const descriptionCn =
-      header?.descriptionClassName || descriptionClassName || descCn;
-    const avatarTextCn = header?.avatarTextClassName || avatarTextClassName;
-    const avatarCn = header?.avatarClassName || avatarClassName;
-    const imageCn = header?.imageClassName || imageClassName;
+      filterClassNameObject(header?.descriptionClassName, ctx) ||
+      descriptionClassName ||
+      descCn;
+    const avatarTextCn =
+      filterClassNameObject(header?.avatarTextClassName, ctx) ||
+      avatarTextClassName;
+    const avatarCn =
+      filterClassNameObject(header?.avatarClassName, ctx) || avatarClassName;
+    const imageCn =
+      filterClassNameObject(header?.imageClassName, ctx) || imageClassName;
     const mediaPosition = media?.position;
 
     return (

--- a/packages/amis/src/renderers/Cards.tsx
+++ b/packages/amis/src/renderers/Cards.tsx
@@ -13,7 +13,11 @@ import {
   autobind,
   createObject
 } from 'amis-core';
-import {isPureVariable, resolveVariableAndFilter} from 'amis-core';
+import {
+  isPureVariable,
+  resolveVariableAndFilter,
+  filterClassNameObject
+} from 'amis-core';
 import Sortable from 'sortablejs';
 import {filter} from 'amis-core';
 import {Icon} from 'amis-ui';
@@ -849,12 +853,15 @@ export default class Cards extends React.Component<GridProps, object> {
     } = this.props;
 
     let cardProps: Partial<CardProps | Card2Props> = {
-      className: cx((card && card.className) || '', {
-        'is-checked': item.checked,
-        'is-modified': item.modified,
-        'is-moved': item.moved,
-        'is-dragging': store.dragging
-      }),
+      className: cx(
+        filterClassNameObject((card && card.className) || '', item.locals),
+        {
+          'is-checked': item.checked,
+          'is-modified': item.modified,
+          'is-moved': item.moved,
+          'is-dragging': store.dragging
+        }
+      ),
       item,
       key: index,
       itemIndex: item.index,

--- a/packages/amis/src/renderers/DropDownButton.tsx
+++ b/packages/amis/src/renderers/DropDownButton.tsx
@@ -3,7 +3,7 @@ import {createObject, Renderer, RendererProps} from 'amis-core';
 import {Overlay} from 'amis-core';
 import {PopOver} from 'amis-core';
 import {TooltipWrapper} from 'amis-ui';
-import {isDisabled, isVisible, noop} from 'amis-core';
+import {isDisabled, isVisible, noop, filterClassNameObject} from 'amis-core';
 import {filter} from 'amis-core';
 import {Icon, hasIcon} from 'amis-ui';
 import {
@@ -289,7 +289,7 @@ export default class DropDownButton extends React.Component<
               : button.level
               ? `Button--${button.level}`
               : '',
-            button.className
+            filterClassNameObject(button.className, data)
           )}
         >
           {render(

--- a/packages/amis/src/renderers/List.tsx
+++ b/packages/amis/src/renderers/List.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {findDOMNode} from 'react-dom';
 import Sortable from 'sortablejs';
 import omit from 'lodash/omit';
+import {filterClassNameObject} from 'amis-core';
 import {Button, Spinner, Checkbox, Icon, SpinnerExtraProps} from 'amis-ui';
 import {
   ListStore,
@@ -1270,7 +1271,10 @@ export class ListItem extends React.Component<ListItemProps> {
             {
               rowIndex: itemIndex,
               colIndex: key,
-              className: cx('ListItem-fieldValue', field.className),
+              className: cx(
+                'ListItem-fieldValue',
+                filterClassNameObject(field.className, data)
+              ),
               value: field.name ? resolveVariable(field.name, data) : undefined,
               onAction: this.handleAction,
               onQuickChange: this.handleQuickChange


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dd41610</samp>

This pull request adds support for dynamic className expressions based on data context for various renderers in `amis`. It introduces a new utility function `filterClassNameObject` in `amis-core` to evaluate and filter the object type className property. It updates and adds tests for the affected renderers.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at dd41610</samp>

> _Sing, O Muse, of the skillful work of the code smiths_
> _Who crafted many a renderer with dynamic class names_
> _Using the `filterClassNameObject` function, a gift from the gods_
> _To adorn their cards, lists, buttons, and fields with beauty and grace_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dd41610</samp>

*  Add the function `filterClassNameObject` to evaluate expressions in the object type `className` property and return a plain object for the `cx` function ([link](https://github.com/baidu/amis/pull/8424/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3L5-R6),[link](https://github.com/baidu/amis/pull/8424/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3R87-R111))
*  Use the `filterClassNameObject` function in the card, cards, drop down button, and list renderers to handle the `className` property of various components ([link](https://github.com/baidu/amis/pull/8424/files?diff=unified&w=0#diff-4150c48e95a705cc618511fd041790dbdad4cd6a7b0673b1758fe73be7a33a2fL9-R13),[link](https://github.com/baidu/amis/pull/8424/files?diff=unified&w=0#diff-4150c48e95a705cc618511fd041790dbdad4cd6a7b0673b1758fe73be7a33a2fL463-R470),[link](https://github.com/baidu/amis/pull/8424/files?diff=unified&w=0#diff-4150c48e95a705cc618511fd041790dbdad4cd6a7b0673b1758fe73be7a33a2fL532-R542),[link](https://github.com/baidu/amis/pull/8424/files?diff=unified&w=0#diff-4150c48e95a705cc618511fd041790dbdad4cd6a7b0673b1758fe73be7a33a2fL724-R754),[link](https://github.com/baidu/amis/pull/8424/files?diff=unified&w=0#diff-83895e4b0993db67cbfb774b8539e7625318f250de1b4a848611cabedf9e828bL16-R20),[link](https://github.com/baidu/amis/pull/8424/files?diff=unified&w=0#diff-83895e4b0993db67cbfb774b8539e7625318f250de1b4a848611cabedf9e828bL852-R864),[link](https://github.com/baidu/amis/pull/8424/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L6-R6),[link](https://github.com/baidu/amis/pull/8424/files?diff=unified&w=0#diff-b418acd90c1d48c3c0ba60d0d887e3da862151da8d4cb09c8f6b6cbfe0e61005L292-R292),[link](https://github.com/baidu/amis/pull/8424/files?diff=unified&w=0#diff-6551e087ba390220793c5f644f0d1a67ba14aa330dcd0afab19c252f6f38d37dR5),[link](https://github.com/baidu/amis/pull/8424/files?diff=unified&w=0#diff-6551e087ba390220793c5f644f0d1a67ba14aa330dcd0afab19c252f6f38d37dL1273-R1277))
*  Add test cases for the card and cards renderers to verify the functionality of the `filterClassNameObject` function with different expressions ([link](https://github.com/baidu/amis/pull/8424/files?diff=unified&w=0#diff-e60358684484344c661b58e6343042c4a8b46d5166f337cafe5850842d2ade37L6-R6),[link](https://github.com/baidu/amis/pull/8424/files?diff=unified&w=0#diff-e60358684484344c661b58e6343042c4a8b46d5166f337cafe5850842d2ade37R374-R469))
