### PR TITLE
feat(amis-editor): 动作弹窗中记录常用动作

### DIFF
--- a/packages/amis-editor-core/scss/control/_event-action.scss
+++ b/packages/amis-editor-core/scss/control/_event-action.scss
@@ -253,6 +253,21 @@
 }
 
 .action-config-dialog {
+  *:not(svg) {
+    font-size: 12px;
+  }
+
+  .common-actions {
+    position: absolute;
+    top: #{px2rem(-41px)};
+    left: #{px2rem(80px)};
+
+    .common-actions-label {
+      line-height: #{px2rem(24px)};
+      margin-right: 4px;
+    }
+  }
+
   .action-config-panel {
     background: #ffffff;
     border: 1px solid #e8e9eb;

--- a/packages/amis-editor/src/renderer/event-control/action-config-dialog.tsx
+++ b/packages/amis-editor/src/renderer/event-control/action-config-dialog.tsx
@@ -7,14 +7,15 @@ import {
   RendererPluginAction,
   tipedLabel,
   getSchemaTpl,
-  defaultValue
+  defaultValue,
+  persistGet
 } from 'amis-editor-core';
 import React from 'react';
 import {ActionConfig, ComponentInfo} from './types';
 import ActionConfigPanel from './action-config-panel';
 import {BASE_ACTION_PROPS} from './comp-action-select';
 import {findActionNode} from './helper';
-import {PlainObject, SchemaNode} from 'amis-core';
+import {PlainObject, SchemaNode, Option} from 'amis-core';
 
 interface ActionDialogProp {
   show: boolean;
@@ -164,6 +165,41 @@ export default class ActionDialog extends React.Component<ActionDialogProp> {
     }
   }
 
+  // 获取常用动作列表schema
+  getCommonUseActionSchema() {
+    const commonUseActions = persistGet('common-use-actions', []).slice(0, 5);
+    return commonUseActions.map((action: Option) => {
+      return {
+        type: 'tag',
+        label: action.label,
+        displayMode: 'rounded',
+        color: 'active',
+        style: {
+          borderColor: '#2468f2',
+          cursor: 'pointer'
+        },
+        onEvent: {
+          click: {
+            actions: [
+              {
+                actionType: 'setValue',
+                componentName: 'actionType',
+                args: {
+                  value: action.value
+                }
+              },
+              {
+                actionType: 'custom',
+                script:
+                  "document.querySelector('.action-tree li .is-checked')?.scrollIntoView()"
+              }
+            ]
+          }
+        }
+      };
+    });
+  }
+
   render() {
     const {
       data,
@@ -176,6 +212,7 @@ export default class ActionDialog extends React.Component<ActionDialogProp> {
       onClose,
       render
     } = this.props;
+    const commonUseActionSchema = this.getCommonUseActionSchema();
 
     return render(
       'inner',
@@ -206,6 +243,20 @@ export default class ActionDialog extends React.Component<ActionDialogProp> {
             // debug: true,
             onSubmit: this.props.onSubmit?.bind(this, type),
             body: [
+              {
+                type: 'flex',
+                className: 'common-actions',
+                justify: 'flex-start',
+                visibleOn: `${commonUseActionSchema.length}`,
+                items: [
+                  {
+                    type: 'tpl',
+                    tpl: '常用动作：',
+                    className: 'common-actions-label'
+                  },
+                  ...commonUseActionSchema
+                ]
+              },
               {
                 type: 'grid',
                 className: 'h-full',

--- a/packages/amis-editor/src/renderer/event-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/event-control/helper.tsx
@@ -10,6 +10,8 @@ import {
   getSchemaTpl,
   JsonGenerateID,
   JSONGetById,
+  persistGet,
+  persistSet,
   PluginActions,
   RendererPluginAction,
   RendererPluginEvent,
@@ -24,7 +26,8 @@ import {
   mapTree,
   normalizeApi,
   PlainObject,
-  Schema
+  Schema,
+  Option
 } from 'amis-core';
 import {Button} from 'amis';
 import {i18n as _i18n} from 'i18n-runtime';
@@ -3496,4 +3499,23 @@ export const getEventControlConfig = (
       return action;
     }
   };
+};
+
+/**
+ * 更新localStorage存储的常用动作
+ */
+export const updateCommonUseActions = (action: Option) => {
+  const commonUseActions = persistGet('common-use-actions', []);
+  const index = commonUseActions.findIndex(
+    (item: Option) => item.value === action.value
+  );
+  if (index >= 0) {
+    commonUseActions[index].use += 1;
+  } else {
+    commonUseActions.unshift(action);
+  }
+  commonUseActions.sort(
+    (before: Option, next: Option) => next.use - before.use
+  );
+  persistSet('common-use-actions', commonUseActions);
 };

--- a/packages/amis-editor/src/renderer/event-control/index.tsx
+++ b/packages/amis-editor/src/renderer/event-control/index.tsx
@@ -21,7 +21,8 @@ import {
   getEventStrongDesc,
   getEventLabel,
   getPropOfAcion,
-  SELECT_PROPS_CONTAINER
+  SELECT_PROPS_CONTAINER,
+  updateCommonUseActions
 } from './helper';
 import {
   ActionConfig,
@@ -994,6 +995,12 @@ export class EventControl extends React.Component<
         this.updateAction?.(config.eventKey, config.actionIndex, action);
       }
     }
+
+    updateCommonUseActions({
+      label: action.__title,
+      value: config.actionType,
+      use: 1
+    });
 
     this.removeDataSchema();
     this.setState({showAcionDialog: false});


### PR DESCRIPTION
### 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化语料改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 其他改动（是关于什么的改动？）


### 需求背景和解决方案

背景：事件动作中的组件特性动作很常见但是在很底下。
方案：新增常用动作，记录用户最近使用的5个动作

### 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 英文 |          |
| 中文 | 新增常用动作 |

### 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
