### PR TITLE
fix(editor): 修复antd主题下button主题选择无样式问题 Close#8413

### DIFF
--- a/packages/amis-editor-core/scss/components/_button.scss
+++ b/packages/amis-editor-core/scss/components/_button.scss
@@ -1,5 +1,10 @@
 .ae-ButtonLevel-MenuTpl {
-  height: 40px;
+  height: 32px;
   display: flex;
   align-items: center;
+  button {
+    width: 100%;
+    height: 26px;
+    padding: 0;
+  }
 }

--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -1085,8 +1085,17 @@ setSchemaTpl('buttonLevel', {
   label: '按钮样式',
   type: 'select',
   name: 'level',
-  menuTpl:
-    '<div class="ae-ButtonLevel-MenuTpl"><button type="button" class="cxd-Button cxd-Button--${value} cxd-Button--size-sm cxd-Button--block">${label}</button></div>',
+  menuTpl: {
+    type: 'container',
+    bodyClassName: 'ae-ButtonLevel-MenuTpl',
+    body: {
+      type: 'button',
+      label: '${label}',
+
+      size: 'sm',
+      level: '${value}'
+    }
+  },
   options: [
     {
       label: '默认',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 50274bc</samp>

Reduced the height of the level buttons in the editor and changed the menu template to use the `button` component from amis. This improves the UI consistency and the code readability.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 50274bc</samp>

> _`menuTpl` object_
> _uses `button` component_
> _simpler and cleaner_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 50274bc</samp>

* Reduce the height of the menu template buttons and style them with CSS ([link](https://github.com/baidu/amis/pull/8434/files?diff=unified&w=0#diff-ea1fdf3bcbfb73b4907f0eaa3ae6f8d84debb904fb032f217689a47914831149L2-R9))
* Replace the string template for the menuTpl property with an object template that uses the amis button component ([link](https://github.com/baidu/amis/pull/8434/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05L1088-R1098))
* Pass the level, type, label, and size props to the button component to control its appearance and behavior ([link](https://github.com/baidu/amis/pull/8434/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05L1088-R1098))
* Wrap the button component with a container component that applies the `.ae-ButtonLevel-MenuTpl` class to the body ([link](https://github.com/baidu/amis/pull/8434/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05L1088-R1098))
* Update the file `packages/amis-editor/src/tpl/common.tsx` to use the new object template for the menuTpl property ([link](https://github.com/baidu/amis/pull/8434/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05L1088-R1098))
