### PR TITLE
fix: 修复 combo 的 unique 模式 选项是个树形结构时的异常 Close: #8085

### DIFF
--- a/packages/amis-core/src/store/combo.ts
+++ b/packages/amis-core/src/store/combo.ts
@@ -2,6 +2,7 @@ import {types, SnapshotIn, Instance} from 'mobx-state-tree';
 import {iRendererStore} from './iRenderer';
 import type {IFormStore, IFormItemStore} from './form';
 import {getStoreById} from './manager';
+import {countTree} from '../utils/helper';
 
 export const UniqueGroup = types
   .model('UniqueGroup', {
@@ -58,7 +59,10 @@ export const ComboStore = iRendererStore
               return;
             }
 
-            let total = item.items[0].options.length;
+            let total = countTree(
+              item.items[0].options,
+              item => typeof item.value !== 'undefined'
+            );
             let current = item.items.reduce((total, item) => {
               return total + item.selectedOptions.length;
             }, 0);

--- a/packages/amis-core/src/store/formItem.ts
+++ b/packages/amis-core/src/store/formItem.ts
@@ -23,7 +23,8 @@ import {
   findTreeIndex,
   spliceTree,
   filterTree,
-  eachTree
+  eachTree,
+  mapTree
 } from '../utils/helper';
 import {flattenTree} from '../utils/helper';
 import find from 'lodash/find';
@@ -1253,9 +1254,10 @@ export const FormItemStore = StoreNode.named('FormItemStore')
           });
 
         if (filteredOptions.length) {
-          filteredOptions = filteredOptions.filter(
-            option => !~options.indexOf(option.value)
-          );
+          filteredOptions = mapTree(filteredOptions, item => ({
+            ...item,
+            disabled: ~options.indexOf(item.value)
+          }));
         }
       }
 

--- a/packages/amis-core/src/utils/helper.ts
+++ b/packages/amis-core/src/utils/helper.ts
@@ -1358,6 +1358,19 @@ export function getTreeParent<T extends TreeItem>(tree: Array<T>, value: T) {
   return ancestors?.length ? ancestors[ancestors.length - 1] : null;
 }
 
+export function countTree<T extends TreeItem>(
+  tree: Array<T>,
+  iterator?: (item: T, key: number, level: number, paths?: Array<T>) => any
+): number {
+  let count = 0;
+  eachTree(tree, (item, key, level, paths) => {
+    if (!iterator || iterator(item, key, level, paths)) {
+      count++;
+    }
+  });
+  return count;
+}
+
 export function ucFirst(str?: string) {
   return typeof str === 'string'
     ? str.substring(0, 1).toUpperCase() + str.substring(1)


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a567ae</samp>

This pull request enhances the functionality of the `ComboStore` and `FormItemStore` classes for handling tree-shaped data and options. It also adds a new `countTree` function to the `../utils/helper` module for counting tree items.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8a567ae</samp>

> _`countTree` counts nodes_
> _`ComboStore` fixes bug with it_
> _Autumn leaves disabled_

### Why

 Close: #8085

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a567ae</samp>

* Import and use `countTree` function to calculate the total number of options in a nested tree structure for `ComboStore` class ([link](https://github.com/baidu/amis/pull/8438/files?diff=unified&w=0#diff-b3e0f20412e925b4924b11ad118984d46d639321feb22920e29075b417f15d2eR5),[link](https://github.com/baidu/amis/pull/8438/files?diff=unified&w=0#diff-b3e0f20412e925b4924b11ad118984d46d639321feb22920e29075b417f15d2eL61-R65))
* Import and use `mapTree` function to mark options as disabled instead of filtering them out if they are already selected in another field for `FormItemStore` class ([link](https://github.com/baidu/amis/pull/8438/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L26-R27),[link](https://github.com/baidu/amis/pull/8438/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L1256-R1260))
* Add `countTree` and `mapTree` functions to `../utils/helper` module to provide utilities for working with nested tree structures ([link](https://github.com/baidu/amis/pull/8438/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aR1361-R1373))
