### PR TITLE
fix: 修复 searchable 在 sdk 中弹窗层被挡住问题 & 配置为 input-group 换行问题 

### DIFF
--- a/packages/amis/src/renderers/Table/HeadCellSearchDropdown.tsx
+++ b/packages/amis/src/renderers/Table/HeadCellSearchDropdown.tsx
@@ -53,7 +53,10 @@ export function HeadCellSearchDropDown({
         ]
       };
     } else if (searchable) {
-      if (searchable.body || searchable.tabs || searchable.fieldSet) {
+      if (
+        !searchable.type &&
+        (searchable.body || searchable.tabs || searchable.fieldSet)
+      ) {
         // todo 删除此处代码，这些都是不推荐的用法
         schema = {
           title: '',
@@ -196,6 +199,7 @@ export function HeadCellSearchDropDown({
           >
             {
               render('quick-search-form', formSchema, {
+                popOverContainer,
                 data: {
                   ...data
                 },


### PR DESCRIPTION

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bffb0b5</samp>

This pull request enhances the table head cell search feature by allowing custom search form types and fixing the form layout. It modifies the `searchable` and `type` props and the `HeadCellSearchDropdown.tsx` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bffb0b5</samp>

> _Sing, O Muse, of the skillful coder who enhanced_
> _The `searchable` prop of table head cells, and gave_
> _The user the power to define the `type` of schema_
> _That shapes the search form in its proper place and space._

### Why

Close: #8031
Close: #8415

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bffb0b5</samp>

*  Add a condition to avoid conflicts between deprecated and new ways of defining search form schema ([link](https://github.com/baidu/amis/pull/8439/files?diff=unified&w=0#diff-f7780da9091a356f2349f5d0b7e7c95fbc83b5ea89ebed9e46482c91572183a5L56-R59))
*  Pass `popOverContainer` prop to `Form` component to fix search form overflow bug ([link](https://github.com/baidu/amis/pull/8439/files?diff=unified&w=0#diff-f7780da9091a356f2349f5d0b7e7c95fbc83b5ea89ebed9e46482c91572183a5R202))
