### PR TITLE
fix：快速编辑弹窗默认没有组件选择入口；快速弹窗打开组件不显示

### DIFF
--- a/packages/amis-editor-core/src/component/SubEditor.tsx
+++ b/packages/amis-editor-core/src/component/SubEditor.tsx
@@ -75,8 +75,8 @@ export class SubEditor extends React.Component<SubEditorProps> {
     if (!!context.info.memberImmutable) {
       const panels = context.data.concat();
       context.data.splice(0, context.data.length);
-      // const renderersPanel = panels.filter(r => r.key !== 'renderers');
-      panels && context.data.push(...panels);
+      const renderersPanel = panels.filter(r => r.key !== 'renderers');
+      renderersPanel && context.data.push(...renderersPanel);
       // 默认选中大纲
       context.changeLeftPanelKey = 'outline';
     }

--- a/packages/amis-editor-core/src/component/SubEditor.tsx
+++ b/packages/amis-editor-core/src/component/SubEditor.tsx
@@ -75,8 +75,8 @@ export class SubEditor extends React.Component<SubEditorProps> {
     if (!!context.info.memberImmutable) {
       const panels = context.data.concat();
       context.data.splice(0, context.data.length);
-      const renderersPanel = panels.filter(r => r.key !== 'renderers');
-      renderersPanel && context.data.push(...renderersPanel);
+      // const renderersPanel = panels.filter(r => r.key !== 'renderers');
+      panels && context.data.push(...panels);
       // 默认选中大纲
       context.changeLeftPanelKey = 'outline';
     }

--- a/packages/amis-editor/src/plugin/Form/Static.tsx
+++ b/packages/amis-editor/src/plugin/Form/Static.tsx
@@ -70,50 +70,36 @@ setSchemaTpl('quickEdit', (patch: any, manager: any) => ({
         asFormItem: true,
         visibleOn: 'data.quickEdit',
         mode: 'row',
-        children: ({value, onBulkChange, name, data}: any) => {
-          if (value === true) {
-            value = {};
+        children: ({value, onChange, data}: any) => {
+          // 打开快速编辑面板默认显示
+          if (!value.type) {
+            value = {
+              type: 'input-text',
+              name: data.key
+            };
           } else {
-            value = getVariable(data.__super, 'quickEdit');
+            // 获取quickEdit属性值
+            value = getVariable(data, 'quickEdit');
           }
-
-          const originMode = value.mode;
-
+          const originMode = value?.mode || 'popOver';
           value = {
             ...value,
-            type: 'form',
-            mode: 'normal',
-            wrapWithPanel: false,
-            body: value?.body?.length
-              ? value.body
-              : [
-                  {
-                    type: 'input-text',
-                    name: data.key
-                  }
-                ]
+            mode: 'normal'
           };
-
-          if (value.mode) {
-            delete value.mode;
-          }
 
           // todo 多个快速编辑表单模式看来只能代码模式编辑了。
           return (
             <Button
+              level="info"
+              className="m-b"
+              size="sm"
               block
-              level="primary"
               onClick={() => {
                 manager.openSubEditor({
                   title: '配置快速编辑类型',
                   value: value,
                   onChange: (value: any) =>
-                    onBulkChange({
-                      [name]: {
-                        ...value,
-                        mode: originMode
-                      }
-                    })
+                    onChange({...value, mode: originMode}, 'quickEdit')
                 });
               }}
             >

--- a/packages/amis-editor/src/plugin/Form/Static.tsx
+++ b/packages/amis-editor/src/plugin/Form/Static.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Button} from 'amis';
-import get from 'lodash/get';
+import {get, clone} from 'lodash';
 import {
   defaultValue,
   getSchemaTpl,
@@ -72,22 +72,25 @@ setSchemaTpl('quickEdit', (patch: any, manager: any) => ({
         mode: 'row',
         children: ({value, onChange, data}: any) => {
           // 打开快速编辑面板默认显示
-          if (!value.type) {
+          if (value === true || !value?.type) {
             value = {
               type: 'container',
               body: [
                 {
                   type: 'input-text',
-                  mode: 'normal',
                   name: data.key
                 }
               ]
             };
           } else {
             // 获取quickEdit属性值
-            value = getVariable(data, 'quickEdit');
+            value = clone(getVariable(data, 'quickEdit'));
           }
           const originMode = value?.mode || 'popOver';
+
+          if (value?.mode) {
+            delete value.mode;
+          }
 
           if (!value.body) {
             value = {
@@ -117,121 +120,6 @@ setSchemaTpl('quickEdit', (patch: any, manager: any) => ({
               }}
             >
               配置快速编辑
-            </Button>
-          );
-        }
-      }
-    ]
-  }
-}));
-
-// 查看更多
-setSchemaTpl('morePopOver', (patch: any, manager: any) => ({
-  type: 'ae-switch-more',
-  mode: 'normal',
-  name: 'popOver',
-  label: '查看更多展示',
-  value: false,
-  hiddenOnDefault: true,
-  formType: 'extend',
-  pipeIn: (value: any) => !!value,
-  form: {
-    body: [
-      {
-        label: '弹出模式',
-        name: 'popOver.mode',
-        type: 'button-group-select',
-        visibleOn: 'data.popOver',
-        pipeIn: defaultValue('popOver'),
-        options: [
-          {
-            label: '浮层',
-            value: 'popOver'
-          },
-
-          {
-            label: '弹框',
-            value: 'dialog'
-          },
-
-          {
-            label: '抽屉',
-            value: 'drawer'
-          }
-        ]
-      },
-      {
-        name: 'popOver.position',
-        label: '浮层位置',
-        type: 'select',
-        visibleOn:
-          'data.popOver && (data.popOver.mode === "popOver" || !data.popOver.mode)',
-        pipeIn: defaultValue('center'),
-        options: [
-          {
-            label: '目标左上角',
-            value: 'left-top'
-          },
-          {
-            label: '目标右上角',
-            value: 'right-top'
-          },
-          {
-            label: '目标中部',
-            value: 'center'
-          },
-          {
-            label: '目标左下角',
-            value: 'left-bottom'
-          },
-          {
-            label: '目标右下角',
-            value: 'right-bottom'
-          },
-          {
-            label: '页面左上角',
-            value: 'fixed-left-top'
-          },
-          {
-            label: '页面右上角',
-            value: 'fixed-right-top'
-          },
-          {
-            label: '页面左下角',
-            value: 'fixed-left-bottom'
-          },
-          {
-            label: '页面右下角',
-            value: 'fixed-right-bottom'
-          }
-        ]
-      },
-      {
-        visibleOn: 'data.popOver',
-        name: 'popOver',
-        mode: 'row',
-        asFormItem: true,
-        children: ({value, onChange}: any) => {
-          value = {
-            type: 'panel',
-            title: '查看详情',
-            body: '内容详情',
-            ...value
-          };
-
-          return (
-            <Button
-              block
-              level="primary"
-              onClick={() => {
-                manager.openSubEditor({
-                  title: '配置查看更多展示内容',
-                  value: value,
-                  onChange: (value: any) => onChange(value, 'quickEdit')
-                });
-              }}
-            >
-              查看更多内容配置
             </Button>
           );
         }

--- a/packages/amis-editor/src/plugin/Form/Static.tsx
+++ b/packages/amis-editor/src/plugin/Form/Static.tsx
@@ -74,19 +74,32 @@ setSchemaTpl('quickEdit', (patch: any, manager: any) => ({
           // 打开快速编辑面板默认显示
           if (!value.type) {
             value = {
-              type: 'input-text',
-              name: data.key
+              type: 'container',
+              body: [
+                {
+                  type: 'input-text',
+                  mode: 'normal',
+                  name: data.key
+                }
+              ]
             };
           } else {
             // 获取quickEdit属性值
             value = getVariable(data, 'quickEdit');
           }
           const originMode = value?.mode || 'popOver';
-          value = {
-            ...value,
-            mode: 'normal'
-          };
 
+          if (!value.body) {
+            value = {
+              type: 'container',
+              body: [
+                {
+                  ...value,
+                  mode: 'normal'
+                }
+              ]
+            };
+          }
           // todo 多个快速编辑表单模式看来只能代码模式编辑了。
           return (
             <Button

--- a/packages/amis-editor/src/plugin/Others/TableCell.tsx
+++ b/packages/amis-editor/src/plugin/Others/TableCell.tsx
@@ -1,5 +1,6 @@
 import {Button} from 'amis';
 import React from 'react';
+import {clone} from 'lodash';
 import {getI18nEnabled, registerEditorPlugin} from 'amis-editor-core';
 import {
   BasePlugin,
@@ -117,33 +118,24 @@ export class TableCellPlugin extends BasePlugin {
               asFormItem: true,
               children: ({value, onChange, data}: any) => {
                 // 打开快速编辑面板默认显示
-                if (!value.type) {
+                if (value === true || !value?.type) {
                   value = {
                     type: 'container',
                     body: [
                       {
                         type: 'input-text',
-                        mode: 'normal',
                         name: data.key
                       }
                     ]
                   };
                 } else {
                   // 获取quickEdit属性值
-                  value = getVariable(data, 'quickEdit');
+                  value = clone(getVariable(data, 'quickEdit'));
                 }
                 const originMode = value?.mode || 'popOver';
 
-                if (!value.body) {
-                  value = {
-                    type: 'container',
-                    body: [
-                      {
-                        ...value,
-                        mode: 'normal'
-                      }
-                    ]
-                  };
+                if (value?.mode) {
+                  delete value.mode;
                 }
                 // todo 多个快速编辑表单模式看来只能代码模式编辑了。
                 return (

--- a/packages/amis-editor/src/plugin/Others/TableCell.tsx
+++ b/packages/amis-editor/src/plugin/Others/TableCell.tsx
@@ -11,6 +11,7 @@ import {
 } from 'amis-editor-core';
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {getVariable} from 'amis-core';
+import {normalize} from 'path';
 
 export class TableCellPlugin extends BasePlugin {
   static id = 'TableCellPlugin';
@@ -114,33 +115,22 @@ export class TableCellPlugin extends BasePlugin {
               visibleOn: 'data.quickEdit',
               name: 'quickEdit',
               asFormItem: true,
-              children: ({value, onBulkChange, name, data}: any) => {
-                if (value === true) {
-                  value = {};
-                } else if (typeof value === 'undefined') {
+              children: ({value, onChange, data}: any) => {
+                // 打开快速编辑面板默认显示
+                if (!value.type) {
+                  value = {
+                    type: 'input-text',
+                    name: data.key
+                  };
+                } else {
+                  // 获取quickEdit属性值
                   value = getVariable(data, 'quickEdit');
                 }
-
-                const originMode = value.mode;
-
+                const originMode = value?.mode || 'popOver';
                 value = {
                   ...value,
-                  type: 'form',
-                  mode: 'normal',
-                  wrapWithPanel: false,
-                  body: value?.body?.length
-                    ? value.body
-                    : [
-                        {
-                          type: 'input-text',
-                          name: data.key
-                        }
-                      ]
+                  mode: 'normal'
                 };
-
-                if (value.mode) {
-                  delete value.mode;
-                }
 
                 // todo 多个快速编辑表单模式看来只能代码模式编辑了。
                 return (
@@ -153,14 +143,8 @@ export class TableCellPlugin extends BasePlugin {
                       this.manager.openSubEditor({
                         title: '配置快速编辑类型',
                         value: value,
-                        onChange: value => {
-                          onBulkChange({
-                            [name]: {
-                              ...value,
-                              mode: originMode
-                            }
-                          });
-                        }
+                        onChange: value =>
+                          onChange({...value, mode: originMode}, 'quickEdit')
                       });
                     }}
                   >

--- a/packages/amis-editor/src/plugin/Others/TableCell.tsx
+++ b/packages/amis-editor/src/plugin/Others/TableCell.tsx
@@ -11,6 +11,7 @@ import {
 } from 'amis-editor-core';
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {getVariable} from 'amis-core';
+import {schemaToArray} from '../../util';
 
 export class TableCellPlugin extends BasePlugin {
   static id = 'TableCellPlugin';
@@ -124,7 +125,7 @@ export class TableCellPlugin extends BasePlugin {
                 const originMode = value.mode;
 
                 value = {
-                  type: 'input-text',
+                  type: 'wrapper',
                   name: data.name,
                   ...value
                 };
@@ -148,14 +149,15 @@ export class TableCellPlugin extends BasePlugin {
                           body: ['$$'],
                           wrapWithPanel: false
                         },
-                        onChange: value =>
+                        onChange: value => {
                           onChange(
                             {
                               ...value,
                               mode: originMode
                             },
                             'quickEdit'
-                          )
+                          );
+                        }
                       });
                     }}
                   >

--- a/packages/amis-editor/src/plugin/Others/TableCell.tsx
+++ b/packages/amis-editor/src/plugin/Others/TableCell.tsx
@@ -119,19 +119,32 @@ export class TableCellPlugin extends BasePlugin {
                 // 打开快速编辑面板默认显示
                 if (!value.type) {
                   value = {
-                    type: 'input-text',
-                    name: data.key
+                    type: 'container',
+                    body: [
+                      {
+                        type: 'input-text',
+                        mode: 'normal',
+                        name: data.key
+                      }
+                    ]
                   };
                 } else {
                   // 获取quickEdit属性值
                   value = getVariable(data, 'quickEdit');
                 }
                 const originMode = value?.mode || 'popOver';
-                value = {
-                  ...value,
-                  mode: 'normal'
-                };
 
+                if (!value.body) {
+                  value = {
+                    type: 'container',
+                    body: [
+                      {
+                        ...value,
+                        mode: 'normal'
+                      }
+                    ]
+                  };
+                }
                 // todo 多个快速编辑表单模式看来只能代码模式编辑了。
                 return (
                   <Button

--- a/packages/amis-editor/src/plugin/Others/TableCell.tsx
+++ b/packages/amis-editor/src/plugin/Others/TableCell.tsx
@@ -114,7 +114,7 @@ export class TableCellPlugin extends BasePlugin {
               visibleOn: 'data.quickEdit',
               name: 'quickEdit',
               asFormItem: true,
-              children: ({value, onChange, data}: any) => {
+              children: ({value, onBulkChange, name, data}: any) => {
                 if (value === true) {
                   value = {};
                 } else if (typeof value === 'undefined') {
@@ -124,14 +124,25 @@ export class TableCellPlugin extends BasePlugin {
                 const originMode = value.mode;
 
                 value = {
-                  type: 'wrapper',
-                  name: data.name,
-                  ...value
+                  ...value,
+                  type: 'form',
+                  mode: 'normal',
+                  wrapWithPanel: false,
+                  body: value?.body?.length
+                    ? value.body
+                    : [
+                        {
+                          type: 'input-text',
+                          name: data.key
+                        }
+                      ]
                 };
-                delete value.mode;
+
+                if (value.mode) {
+                  delete value.mode;
+                }
 
                 // todo 多个快速编辑表单模式看来只能代码模式编辑了。
-
                 return (
                   <Button
                     level="info"
@@ -142,20 +153,13 @@ export class TableCellPlugin extends BasePlugin {
                       this.manager.openSubEditor({
                         title: '配置快速编辑类型',
                         value: value,
-                        slot: {
-                          type: 'form',
-                          mode: 'normal',
-                          body: ['$$'],
-                          wrapWithPanel: false
-                        },
                         onChange: value => {
-                          onChange(
-                            {
+                          onBulkChange({
+                            [name]: {
                               ...value,
                               mode: originMode
-                            },
-                            'quickEdit'
-                          );
+                            }
+                          });
                         }
                       });
                     }}

--- a/packages/amis-editor/src/plugin/Others/TableCell.tsx
+++ b/packages/amis-editor/src/plugin/Others/TableCell.tsx
@@ -11,7 +11,6 @@ import {
 } from 'amis-editor-core';
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {getVariable} from 'amis-core';
-import {schemaToArray} from '../../util';
 
 export class TableCellPlugin extends BasePlugin {
   static id = 'TableCellPlugin';

--- a/packages/amis-editor/src/plugin/TableCell2.tsx
+++ b/packages/amis-editor/src/plugin/TableCell2.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import get from 'lodash/get';
+import {get, clone} from 'lodash';
 import flattenDeep from 'lodash/flattenDeep';
 import {Button, Icon} from 'amis';
 import {getVariable, isObject} from 'amis-core';
@@ -480,22 +480,25 @@ export class TableCell2Plugin extends BasePlugin {
               label: false,
               children: ({value, onBulkChange, name, data}: any) => {
                 // 打开快速编辑面板默认显示
-                if (!value.type) {
+                if (value === true || !value?.type) {
                   value = {
                     type: 'container',
                     body: [
                       {
                         type: 'input-text',
-                        mode: 'normal',
                         name: data.key
                       }
                     ]
                   };
                 } else {
                   // 获取quickEdit属性值
-                  value = getVariable(data, 'quickEdit');
+                  value = clone(getVariable(data, 'quickEdit'));
                 }
                 const originMode = value?.mode || 'popOver';
+
+                if (value?.mode) {
+                  delete value.mode;
+                }
 
                 if (!value.body) {
                   value = {

--- a/packages/amis-editor/src/plugin/TableCell2.tsx
+++ b/packages/amis-editor/src/plugin/TableCell2.tsx
@@ -482,21 +482,31 @@ export class TableCell2Plugin extends BasePlugin {
                 // 打开快速编辑面板默认显示
                 if (!value.type) {
                   value = {
-                    type: 'input-text',
-                    name: data.key
+                    type: 'container',
+                    body: [
+                      {
+                        type: 'input-text',
+                        mode: 'normal',
+                        name: data.key
+                      }
+                    ]
                   };
                 } else {
                   // 获取quickEdit属性值
                   value = getVariable(data, 'quickEdit');
                 }
                 const originMode = value?.mode || 'popOver';
-                value = {
-                  ...value,
-                  mode: 'normal'
-                };
 
-                if (value.mode) {
-                  delete value.mode;
+                if (!value.body) {
+                  value = {
+                    type: 'container',
+                    body: [
+                      {
+                        ...value,
+                        mode: 'normal'
+                      }
+                    ]
+                  };
                 }
                 // todo 多个快速编辑表单模式看来只能代码模式编辑了。
                 return (

--- a/packages/amis-editor/src/plugin/TableCell2.tsx
+++ b/packages/amis-editor/src/plugin/TableCell2.tsx
@@ -431,11 +431,6 @@ export class TableCell2Plugin extends BasePlugin {
         mode: 'normal',
         formType: 'extend',
         bulk: true,
-        defaultData: {
-          quickEdit: {
-            mode: 'popOver'
-          }
-        },
         trueValue: {
           mode: 'popOver'
         },
@@ -484,27 +479,20 @@ export class TableCell2Plugin extends BasePlugin {
               asFormItem: true,
               label: false,
               children: ({value, onBulkChange, name, data}: any) => {
-                if (value === true) {
-                  value = {};
+                // 打开快速编辑面板默认显示
+                if (!value.type) {
+                  value = {
+                    type: 'input-text',
+                    name: data.key
+                  };
                 } else {
-                  value = getVariable(data.__super, 'quickEdit');
+                  // 获取quickEdit属性值
+                  value = getVariable(data, 'quickEdit');
                 }
-
                 const originMode = value?.mode || 'popOver';
-
                 value = {
                   ...value,
-                  type: 'form',
-                  mode: 'normal',
-                  wrapWithPanel: false,
-                  body: value?.body?.length
-                    ? value.body
-                    : [
-                        {
-                          type: 'input-text',
-                          name: data.key
-                        }
-                      ]
+                  mode: 'normal'
                 };
 
                 if (value.mode) {

--- a/packages/amis-editor/src/plugin/TableCell2.tsx
+++ b/packages/amis-editor/src/plugin/TableCell2.tsx
@@ -441,7 +441,7 @@ export class TableCell2Plugin extends BasePlugin {
         },
         isChecked: (e: any) => {
           const {data, name} = e;
-          return get(data, name);
+          return !!get(data, name);
         },
         form: {
           body: [
@@ -486,8 +486,8 @@ export class TableCell2Plugin extends BasePlugin {
               children: ({value, onBulkChange, name, data}: any) => {
                 if (value === true) {
                   value = {};
-                } else if (typeof value === 'undefined') {
-                  value = getVariable(data, 'quickEdit');
+                } else {
+                  value = getVariable(data.__super, 'quickEdit');
                 }
 
                 const originMode = value?.mode || 'popOver';


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3dba446</samp>

This pull request improves the amis-editor by enhancing the table cell plugin and fixing a bug in the sub editor. It enables the table cell plugin to handle more schema types and ensures the renderers panel is always visible.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3dba446</samp>

> _We are the renderers of doom_
> _We defy the context data's gloom_
> _We unleash the power of the table cell_
> _We edit the schemas with our plugin spell_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3dba446</samp>

*  Remove filtering of renderers panel from context data to fix bug of disappearing panel when switching schemas ([link](https://github.com/baidu/amis/pull/8441/files?diff=unified&w=0#diff-6d734e24dd983184fd036bb62cec9ac5cf70a17ffd14cd375cb0d98c494b7008L78-R79))
*  Import schemaToArray utility function from amis-editor-core to convert schema object to array of schema nodes for table cell plugin ([link](https://github.com/baidu/amis/pull/8441/files?diff=unified&w=0#diff-6255acc5c33482efec7af39b45b627e4c5a26a025506fe9a302aabd18c2102bdR14))
*  Change type of value prop from input-text to wrapper to support more complex schema types in table cell plugin ([link](https://github.com/baidu/amis/pull/8441/files?diff=unified&w=0#diff-6255acc5c33482efec7af39b45b627e4c5a26a025506fe9a302aabd18c2102bdL127-R128))
*  Fix syntax errors in onChange handler of value prop in `TableCell.tsx` by adding missing curly brace and semicolon ([link](https://github.com/baidu/amis/pull/8441/files?diff=unified&w=0#diff-6255acc5c33482efec7af39b45b627e4c5a26a025506fe9a302aabd18c2102bdL151-R152), [link](https://github.com/baidu/amis/pull/8441/files?diff=unified&w=0#diff-6255acc5c33482efec7af39b45b627e4c5a26a025506fe9a302aabd18c2102bdL158-R160))
