### PR TITLE
chore: 图片放大器点击阴影可关闭 Close: #8420

### DIFF
--- a/packages/amis-ui/src/components/ImageGallery.tsx
+++ b/packages/amis-ui/src/components/ImageGallery.tsx
@@ -295,6 +295,7 @@ export class ImageGallery extends React.Component<
 
         <Modal
           closeOnEsc
+          closeOnOutside
           size="full"
           onHide={this.close}
           show={this.state.isOpened}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 954c472</samp>

Added a `closeOnOutside` prop to the `Modal` component in `ImageGallery.tsx` to allow closing the image gallery by clicking outside. This improves the user experience and consistency of the image gallery feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 954c472</samp>

> _`Modal` component_
> _adds `closeOnOutside` prop_
> _autumn leaves falling_

### Why

Close: #8420

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 954c472</samp>

* Add a `closeOnOutside` prop to the `Modal` component that renders the image gallery, allowing the user to close the modal by clicking outside of it ([link](https://github.com/baidu/amis/pull/8442/files?diff=unified&w=0#diff-bed7585d0647a7896dee30a46f94d5624fba9662c725a5946ee61927fcc2d5b8R298))
