### PR TITLE
fix: editor manager getContentSchemas 中 type 获取问题

### DIFF
--- a/packages/amis-editor-core/src/manager.ts
+++ b/packages/amis-editor-core/src/manager.ts
@@ -1983,7 +1983,8 @@ export class EditorManager {
 
     // 更新组件树中的所有上下文数据声明为最新数据
     while (scope) {
-      const [nodeId, type] = scope.id.split('-');
+      const [nodeId] = scope.id.split('-');
+      const type = scope.id.replace(`${nodeId}-`, '');
       const scopeNode = this.store.getNodeById(nodeId, type);
 
       // 拿非重复组件id的父组件作为主数据域展示，如CRUD，不展示表格，只展示增删改查信息，避免变量面板出现两份数据


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e41752e</samp>

Fixed a bug in `manager.ts` that caused incorrect component type detection for scope ids with multiple dashes. This allows the editor to handle nested components correctly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e41752e</samp>

> _`scope id` has dash_
> _split by first, use the rest_
> _bug fixed in autumn_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e41752e</samp>

* Fix a bug that caused incorrect component type when scope id contains more than one dash ([link](https://github.com/baidu/amis/pull/8443/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fL1986-R1987))
