### PR TITLE
fix: 修复 app 模式 bcn 中存在动态路径问题 Close: #8012

### DIFF
--- a/packages/amis-core/src/store/app.ts
+++ b/packages/amis-core/src/store/app.ts
@@ -4,6 +4,7 @@ import {NavigationObject} from '../types';
 import {
   createObject,
   filterTree,
+  replaceUrlParams,
   findTree,
   guid,
   mapTree
@@ -152,7 +153,12 @@ export const AppStore = ServiceStore.named('AppStore')
 
       findTree(self.pages, (item, index, level, paths) => {
         if (item.id === page.id) {
-          bcn = paths.filter(item => item.path && item.label);
+          bcn = paths
+            .filter(item => item.path && item.label)
+            .map(item => ({
+              ...item,
+              path: replaceUrlParams(item.path, params)
+            }));
           if (env.showFullBreadcrumbPath) {
             bcn = paths.filter(item => item.label);
           }

--- a/packages/amis-core/src/utils/helper.ts
+++ b/packages/amis-core/src/utils/helper.ts
@@ -10,6 +10,7 @@ import isNaN from 'lodash/isNaN';
 import isNumber from 'lodash/isNumber';
 import isString from 'lodash/isString';
 import qs from 'qs';
+import {compile} from 'path-to-regexp';
 
 import type {Schema, PlainObject, FunctionPropertyNames} from '../types';
 
@@ -2183,4 +2184,12 @@ export function evalTrackExpression(
 // 很奇怪的问题，react-json-view import 有些情况下 mod.default 才是 esModule
 export function importLazyComponent(mod: any) {
   return mod.default.__esModule ? mod.default : mod;
+}
+
+export function replaceUrlParams(path: string, params: Record<string, any>) {
+  if (typeof path === 'string' && /\:\w+/.test(path)) {
+    return compile(path)(params);
+  }
+
+  return path;
 }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 229ed8b</samp>

Added a new utility function `replaceUrlParams` to support dynamic breadcrumb navigation. This function allows creating paths with parameters from user input or data, and is used in the `app.ts` store module.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 229ed8b</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever function, `replaceUrlParams`, to craft_
> _The paths of breadcrumbs, guiding users with ease_
> _Through the winding web, like Theseus with his shaft_

### Why

Close: #8012

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 229ed8b</samp>

* Import and define `replaceUrlParams` function to dynamically generate path strings from parameters ([link](https://github.com/baidu/amis/pull/8444/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aR13), [link](https://github.com/baidu/amis/pull/8444/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aR2188-R2195), [link](https://github.com/baidu/amis/pull/8444/files?diff=unified&w=0#diff-448bfcf052982e75f5ea29205c8acd04d9673ce63a9cbc241e77e984555e7252R7))
* Apply `replaceUrlParams` function to breadcrumb navigation items in `app.ts` to reflect page path parameters ([link](https://github.com/baidu/amis/pull/8444/files?diff=unified&w=0#diff-448bfcf052982e75f5ea29205c8acd04d9673ce63a9cbc241e77e984555e7252L155-R161))
