### PR TITLE
feat: InputExcel组件支持autoFill Close: #8432

### DIFF
--- a/docs/zh-CN/components/form/input-excel.md
+++ b/docs/zh-CN/components/form/input-excel.md
@@ -242,6 +242,40 @@ order: 14
   }
   ```
 
+## 解析文件名称
+
+> `3.5.0`及以上版本
+
+文件解析成功后，可以使用`autoFill`属性，在当前组件所在的数据域中填充值，`input-excel`组件特有的保留字段请查看下方定义，`InputExcelData`中的字段可以用变量获取。通常可以利用这个属性为`input-excel`所在的表单追加文件名称。
+
+```typescript
+interface InputExcelData {
+  /* 文件名称 */
+  filename: string;
+}
+```
+
+```schema: scope="body"
+{
+    "type": "form",
+    "api": "/api/mock2/form/saveForm",
+    "debug": true,
+    "body": [
+        {
+            "type": "input-excel",
+            "name": "excel",
+            "label": "上传 Excel",
+            "autoFill": {
+              "operator": "amis",
+              "time": "${DATETOSTR(NOW(), 'YYYY-MM-DD HH:mm:ss')}",
+              "fileName": "${filename}"
+            }
+        }
+    ]
+}
+```
+
+
 ## 属性表
 
 | 属性名       | 类型                    | 默认值                          | 说明               | 版本    |
@@ -251,6 +285,7 @@ order: 14
 | includeEmpty | `boolean`               | true                            | 是否包含空值       |
 | plainText    | `boolean`               | true                            | 是否解析为纯文本   |
 | placeholder  | `string`                | `"拖拽 Excel 到这，或点击上传"` | 占位文本提示       | `2.8.1` |
+| autoFill  | `Record<string, string>`    |  | 自动填充       | `3.5.0` |
 
 ## 事件表
 

--- a/docs/zh-CN/components/form/options.md
+++ b/docs/zh-CN/components/form/options.md
@@ -1450,6 +1450,8 @@ order: 2
 
 ## 自动填充 autoFill
 
+> 支持该配置项的有：ButtonGroup、List、NestedSelect、Picker、Radios、Select、InputFile、InputImage、InputExcel
+
 一些选择器组件，支持配置`autoFill`，将当前已选中的选项的某个字段的值，自动填充到表单中某个表单项中，支持[数据映射](../../../docs/concepts/data-mapping)
 
 ```schema: scope="body"
@@ -1555,8 +1557,6 @@ order: 2
     ]
 }
 ```
-
-支持该配置项的有：ButtonGroup、List、NestedSelect、Picker、Radios、Select。
 
 ## 控制选项高度
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ab14f9</samp>

This pull request adds a new feature to the `input-excel` component that enables auto-filling other form fields based on the excel file name or a remote request. It also updates the documentation of the `input-excel` and `options` components to reflect this new feature and remove outdated information.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4ab14f9</samp>

> _`InputExcel` grows_
> _Auto-filling other fields_
> _Winter of typing_

### Why

Close: #8432

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4ab14f9</samp>

*  Add `autoFill` feature to `input-excel` component, which allows filling in other fields in the form based on the parsed file name or a remote request ([link](https://github.com/baidu/amis/pull/8445/files?diff=unified&w=0#diff-00c90e9ef78976a7a5e149e452bb31a9c2ba2d9ed42e895cedbc4b2a5673603dL3-R15), [link](https://github.com/baidu/amis/pull/8445/files?diff=unified&w=0#diff-00c90e9ef78976a7a5e149e452bb31a9c2ba2d9ed42e895cedbc4b2a5673603dR60-R66), [link](https://github.com/baidu/amis/pull/8445/files?diff=unified&w=0#diff-00c90e9ef78976a7a5e149e452bb31a9c2ba2d9ed42e895cedbc4b2a5673603dR108-R129), [link](https://github.com/baidu/amis/pull/8445/files?diff=unified&w=0#diff-00c90e9ef78976a7a5e149e452bb31a9c2ba2d9ed42e895cedbc4b2a5673603dL119-R158), [link](https://github.com/baidu/amis/pull/8445/files?diff=unified&w=0#diff-00c90e9ef78976a7a5e149e452bb31a9c2ba2d9ed42e895cedbc4b2a5673603dL164-R209))
* Update documentation of `input-excel` component to explain the usage and attributes of the `autoFill` feature, and provide an example schema and interface definition ([link](https://github.com/baidu/amis/pull/8445/files?diff=unified&w=0#diff-22ff384fd8098b2a0c42b340e9f3f53979d37ee43d06f60879b4dba9b45849c6R245-R278), [link](https://github.com/baidu/amis/pull/8445/files?diff=unified&w=0#diff-22ff384fd8098b2a0c42b340e9f3f53979d37ee43d06f60879b4dba9b45849c6R288))
* Update documentation of `options` type to include `input-excel` component in the list of components that support the `autoFill` feature, and remove the outdated list ([link](https://github.com/baidu/amis/pull/8445/files?diff=unified&w=0#diff-11e6861a71ce97317a5892bcf4d3b17ae460212a68bd45e9f51639272db8252eR1453-R1454), [link](https://github.com/baidu/amis/pull/8445/files?diff=unified&w=0#diff-11e6861a71ce97317a5892bcf4d3b17ae460212a68bd45e9f51639272db8252eL1559-L1560))
