### PR TITLE
feat: jump 补充第三个参数信息 Close: #2936

### DIFF
--- a/packages/amis-core/src/RootRenderer.tsx
+++ b/packages/amis-core/src/RootRenderer.tsx
@@ -211,7 +211,7 @@ export class RootRenderer extends React.Component<RootRendererProps> {
 
           const redirect =
             action.redirect && filter(action.redirect, store.data);
-          redirect && env.jumpTo(redirect, action);
+          redirect && env.jumpTo(redirect, action, store.data);
           action.reload &&
             this.reloadTarget(
               delegate || (this.context as IScopedContext),

--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -1274,7 +1274,7 @@ export default class Form extends React.Component<FormProps, object> {
               action.redirect || redirect,
               store.data
             );
-            finalRedirect && env.jumpTo(finalRedirect, action);
+            finalRedirect && env.jumpTo(finalRedirect, action, store.data);
           } else if (action.reload || reload) {
             this.reloadTarget(
               filterTarget(action.reload || reload!, store.data),
@@ -1352,7 +1352,7 @@ export default class Form extends React.Component<FormProps, object> {
 
           const redirect =
             action.redirect && filter(action.redirect, store.data);
-          redirect && env.jumpTo(redirect, action);
+          redirect && env.jumpTo(redirect, action, store.data);
 
           action.reload &&
             this.reloadTarget(

--- a/packages/amis-core/src/store/app.ts
+++ b/packages/amis-core/src/store/app.ts
@@ -189,7 +189,7 @@ export const AppStore = ServiceStore.named('AppStore')
         self.schema = null;
         self.fetchSchema(page.schemaApi, self.activePage, {method: 'get'});
       } else if (page.redirect) {
-        env.jumpTo(page.redirect);
+        env.jumpTo(page.redirect, undefined, self.data);
         return;
       } else if (page.rewrite) {
         this.rewrite(page.rewrite, env);

--- a/packages/amis/src/renderers/App.tsx
+++ b/packages/amis/src/renderers/App.tsx
@@ -282,7 +282,7 @@ export default class App extends React.Component<AppProps, object> {
 
     const env = this.props.env;
     const link = e.currentTarget.getAttribute('href')!;
-    env.jumpTo(link);
+    env.jumpTo(link, undefined, this.props.data);
   }
 
   renderHeader() {

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -739,7 +739,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
 
       // 由于 ajax 一段时间后再弹出，肯定被浏览器给阻止掉的，所以提前弹。
       const redirect = action.redirect && filter(action.redirect, data);
-      redirect && action.blank && env.jumpTo(redirect, action);
+      redirect && action.blank && env.jumpTo(redirect, action, data);
 
       return store
         .saveRemote(action.api!, data, {
@@ -759,7 +759,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
           }
 
           const redirect = action.redirect && filter(action.redirect, data);
-          redirect && !action.blank && env.jumpTo(redirect, action);
+          redirect && !action.blank && env.jumpTo(redirect, action, data);
           action.reload
             ? this.reloadTarget(filterTarget(action.reload, data), data)
             : redirect
@@ -870,7 +870,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
               action.close && this.closeTarget(action.close);
 
               const redirect = action.redirect && filter(action.redirect, data);
-              redirect && env.jumpTo(redirect, action);
+              redirect && env.jumpTo(redirect, action, data);
             })
             .catch(() => null);
       } else if (onAction) {
@@ -1135,7 +1135,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
 
     let redirect = action.redirect ?? dialogAction.redirect;
     redirect = redirect && filter(redirect, ctx);
-    redirect && env.jumpTo(redirect, dialogAction);
+    redirect && env.jumpTo(redirect, dialogAction, ctx);
   }
 
   handleDialogClose(confirmed = false) {

--- a/packages/amis/src/renderers/Card.tsx
+++ b/packages/amis/src/renderers/Card.tsx
@@ -307,11 +307,15 @@ export class CardRenderer extends React.Component<CardProps> {
     } = this.props;
 
     if (href) {
-      env.jumpTo(filter(href, data), {
-        type: 'button',
-        actionType: 'url',
-        blank
-      });
+      env.jumpTo(
+        filter(href, data),
+        {
+          type: 'button',
+          actionType: 'url',
+          blank
+        },
+        data
+      );
       return;
     }
 

--- a/packages/amis/src/renderers/Dialog.tsx
+++ b/packages/amis/src/renderers/Dialog.tsx
@@ -1018,7 +1018,7 @@ export class DialogRenderer extends Dialog {
 
           const reidrect =
             action.redirect && filter(action.redirect, store.data);
-          reidrect && env.jumpTo(reidrect, action);
+          reidrect && env.jumpTo(reidrect, action, store.data);
           action.reload &&
             this.reloadTarget(
               filterTarget(action.reload, store.data),

--- a/packages/amis/src/renderers/Drawer.tsx
+++ b/packages/amis/src/renderers/Drawer.tsx
@@ -940,7 +940,7 @@ export class DrawerRenderer extends Drawer {
 
           const redirect =
             action.redirect && filter(action.redirect, store.data);
-          redirect && env.jumpTo(redirect, action);
+          redirect && env.jumpTo(redirect, action, store.data);
           action.reload &&
             this.reloadTarget(
               filterTarget(action.reload, store.data),

--- a/packages/amis/src/renderers/Nav.tsx
+++ b/packages/amis/src/renderers/Nav.tsx
@@ -868,7 +868,11 @@ const ConditionBuilderWithRemoteOptions = withRemoteConfig({
     if (response.value && !someTree(config, item => item.active)) {
       const {env} = props;
 
-      env.jumpTo(filter(response.value as string, props.data));
+      env.jumpTo(
+        filter(response.value as string, props.data),
+        undefined,
+        props.data
+      );
     }
   },
   normalizeConfig(
@@ -1262,7 +1266,7 @@ const ConditionBuilderWithRemoteOptions = withRemoteConfig({
       if (!link.to) {
         return;
       }
-      env?.jumpTo(filter(link.to as string, data), link as any);
+      env?.jumpTo(filter(link.to as string, data), link as any, data);
     }
 
     render() {
@@ -1378,7 +1382,9 @@ export class NavigationRenderer extends React.Component<RendererProps> {
         );
 
         env?.jumpTo(
-          filter(child ? child.to : (children[0].to as string), data)
+          filter(child ? child.to : (children[0].to as string), data),
+          undefined,
+          data
         );
       }
     } else if (actionType === 'collapse') {

--- a/packages/amis/src/renderers/Page.tsx
+++ b/packages/amis/src/renderers/Page.tsx
@@ -522,7 +522,7 @@ export default class Page extends React.Component<PageProps> {
 
           const redirect =
             action.redirect && filter(action.redirect, store.data);
-          redirect && env.jumpTo(redirect, action);
+          redirect && env.jumpTo(redirect, action, store.data);
           action.reload &&
             this.reloadTarget(
               filterTarget(action.reload, store.data),
@@ -631,7 +631,7 @@ export default class Page extends React.Component<PageProps> {
         : target.closest('a[data-link]')?.getAttribute('data-link');
 
     if (env && link) {
-      env.jumpTo(link);
+      env.jumpTo(link, undefined, this.props.data);
       e.preventDefault();
     }
   }

--- a/packages/amis/src/renderers/Service.tsx
+++ b/packages/amis/src/renderers/Service.tsx
@@ -739,7 +739,7 @@ export default class Service extends React.Component<ServiceProps> {
 
           const redirect =
             action.redirect && filter(action.redirect, store.data);
-          redirect && env.jumpTo(redirect, action);
+          redirect && env.jumpTo(redirect, action, store.data);
           action.reload &&
             this.reloadTarget(
               filterTarget(action.reload, store.data),

--- a/packages/amis/src/renderers/Wizard.tsx
+++ b/packages/amis/src/renderers/Wizard.tsx
@@ -683,7 +683,7 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
 
           const reidrect =
             action.redirect && filter(action.redirect, store.data);
-          reidrect && env.jumpTo(reidrect, action);
+          reidrect && env.jumpTo(reidrect, action, store.data);
 
           action.reload &&
             this.reloadTarget(
@@ -908,7 +908,7 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
             filter(action.redirect || step.redirect || redirect, store.data);
 
           if (finalRedirect) {
-            env.jumpTo(finalRedirect, action);
+            env.jumpTo(finalRedirect, action, store.data);
           } else if (action.reload || step.reload || reload) {
             this.reloadTarget(
               filterTarget(action.reload || step.reload || reload!, store.data),
@@ -931,7 +931,7 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
         filter(action.redirect || step.redirect || redirect, store.data);
 
       if (finalRedirect) {
-        env.jumpTo(finalRedirect, action);
+        env.jumpTo(finalRedirect, action, store.data);
       } else if (action.reload || step.reload || reload) {
         this.reloadTarget(
           filterTarget(action.reload || step.reload || reload!, store.data),


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b3dbaa</samp>

This pull request updates the `env.jumpTo` method calls in various renderer components and classes to pass the relevant data as a third argument. This allows the method to resolve variables in the redirect URL or action based on the data context. The changes affect the `Form`, `CRUD`, `Nav`, `Page`, `Wizard`, `RootRenderer`, `AppStore`, `App`, `Card`, `Dialog`, `Drawer`, and `Service` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8b3dbaa</samp>

> _`env.jumpTo` grows_
> _Adding data to the jump_
> _Autumn of changes_

### Why

Close: #2936

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8b3dbaa</samp>

*  Add `store.data` argument to `env.jumpTo` method calls in various renderer components to pass the current data context for resolving variables in redirect URL or action ([link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1277-R1277), [link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3L1355-R1355), [link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL1021-R1021), [link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L943-R943), [link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L525-R525), [link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852L742-R742), [link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-8c1e1e55c146ca688906b7443643b4a9c53472e61bd55b64d534e92d1b247e3bL686-R686), [link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-8c1e1e55c146ca688906b7443643b4a9c53472e61bd55b64d534e92d1b247e3bL911-R911), [link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-8c1e1e55c146ca688906b7443643b4a9c53472e61bd55b64d534e92d1b247e3bL934-R934))
*  Add `data` argument to `env.jumpTo` method calls in various renderer components to pass the data of the item, link, or card that triggered the action ([link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L742-R742), [link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L762-R762), [link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L873-R873), [link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-4150c48e95a705cc618511fd041790dbdad4cd6a7b0673b1758fe73be7a33a2fL310-R318), [link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL1265-R1269), [link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL1381-R1387), [link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L634-R634))
*  Add `ctx` argument to `env.jumpTo` method call in `CRUD` renderer component to pass the data context of the dialog action ([link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1138-R1138))
*  Add `this.props.data` argument to `env.jumpTo` method call in `App` renderer component to pass the data from the parent or source ([link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-b3a4d413575f4fe07501c750c75d47f53100ca6a9536c98886c7b67d63542d39L285-R285))
*  Add `props.data` argument to `env.jumpTo` method call in `ConditionBuilderWithRemoteOptions` component to pass the data from the parent or source ([link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-d28c7ab328bb8a97e9bb5b69bf2344a707101eac02c186b7adc3a2fc061f582bL871-R875))
*  Add `self.data` argument to `env.jumpTo` method call in `AppStore` class to pass the global data of the application ([link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-448bfcf052982e75f5ea29205c8acd04d9673ce63a9cbc241e77e984555e7252L192-R192))
*  Add `store.data` argument to `env.jumpTo` method call in `RootRenderer` class to pass the current data context, following the update of the `jumpTo` method in the `ScopedContext` class ([link](https://github.com/baidu/amis/pull/8446/files?diff=unified&w=0#diff-4cba0119d1b827598fb03c9a62c9380b173776edc7267f0eb7577a50b3d7bb22L214-R214))
