### PR TITLE
fix: 修复app 模式渲染菜单报 key 重复的 warning

### DIFF
--- a/packages/amis/src/renderers/App.tsx
+++ b/packages/amis/src/renderers/App.tsx
@@ -392,7 +392,12 @@ export default class App extends React.Component<AppProps, object> {
 
             if (!subHeader && link.icon) {
               children.push(
-                <Icon cx={cx} icon={link.icon} className="AsideNav-itemIcon" />
+                <Icon
+                  key="icon"
+                  cx={cx}
+                  icon={link.icon}
+                  className="AsideNav-itemIcon"
+                />
               );
             } else if (store.folded && depth === 1 && !subHeader) {
               children.push(
@@ -416,11 +421,12 @@ export default class App extends React.Component<AppProps, object> {
 
             return link.path ? (
               /^https?\:/.test(link.path) ? (
-                <a target="_blank" href={link.path} rel="noopener">
+                <a target="_blank" key="link" href={link.path} rel="noopener">
                   {children}
                 </a>
               ) : (
                 <a
+                  key="link"
                   onClick={this.handleNavClick}
                   href={link.path || (link.children && link.children[0].path)}
                 >
@@ -428,7 +434,10 @@ export default class App extends React.Component<AppProps, object> {
                 </a>
               )
             ) : (
-              <a onClick={link.children ? () => toggleExpand(link) : undefined}>
+              <a
+                key="link"
+                onClick={link.children ? () => toggleExpand(link) : undefined}
+              >
                 {children}
               </a>
             );


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 970a604</samp>

Add `key` props to list components in `App.tsx`. This improves rendering performance and avoids React warnings.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 970a604</samp>

> _React warns of doom without the keys_
> _We heed the call and fix the lists_
> _No more unstable renders in the app_
> _We optimize the performance with a snap_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 970a604</samp>

*  Add `key` props to list elements to avoid React warnings (`[link](https://github.com/baidu/amis/pull/8447/files?diff=unified&w=0#diff-b3a4d413575f4fe07501c750c75d47f53100ca6a9536c98886c7b67d63542d39L395-R400)`, `[link](https://github.com/baidu/amis/pull/8447/files?diff=unified&w=0#diff-b3a4d413575f4fe07501c750c75d47f53100ca6a9536c98886c7b67d63542d39L419-R429)`, `[link](https://github.com/baidu/amis/pull/8447/files?diff=unified&w=0#diff-b3a4d413575f4fe07501c750c75d47f53100ca6a9536c98886c7b67d63542d39L431-R440)`)
