### PR TITLE
feat: 表单项支持动态 name 可搭配 each 一起使用 Close: #4212

### DIFF
--- a/docs/zh-CN/components/each.md
+++ b/docs/zh-CN/components/each.md
@@ -10,6 +10,8 @@ order: 45
 
 ## 基本用法
 
+通过 name 属性指定要循环的数组，items 属性指定循环的内容。
+
 ```schema: scope="page"
 {
   "type": "page",
@@ -29,7 +31,9 @@ order: 45
 
 ### 如果是对象数组
 
-如果数组中的数据是对象，可以直接使用 data.xxx 来获取，另外能用 data.index 来获取数组索引，但如果对象本身也有名字为 index 的字段就会覆盖到，获取不到索引了。
+如果数组中的数据是对象，可以直接使用内部变量 xxx 来获取，或者通过 `item.xxxx`。另外能用 index 来获取数组索引。
+
+> 如果成员对象本身也有名字为 index 的字段就会覆盖到，获取不到索引了，请查看「循环嵌套」的章节解决
 
 ```schema:height="160" scope="page"
 {
@@ -42,8 +46,45 @@ order: 45
         "name": "arr",
         "items": {
             "type": "tpl",
-            "tpl": "<span class='label label-default m-l-sm'><%= data.name %>:<%= data.index %></span> "
+            "tpl": "<span class='label label-default m-l-sm'>${name}:${index}</span> "
         }
+    }
+}
+```
+
+### 循环嵌套
+
+如果存在嵌套使用，通过默认的 `item` 或者 `index` 始终是拿的最里面那层的信息，想要获取上层 each 的信息，则需要自定义 `itemKeyName` 和 `indexKeyName` 来指定字段名。
+
+```schema:height="160" scope="page"
+{
+  "type": "page",
+  "data": {
+    "arr": [{"name": "a", "subList": ["a1", "a2"]}, {"name": "b", "subList": ["b1", "b2"]}, {"name": "c", "subList": ["c1", "c2"]}]
+  },
+  "body": {
+        "type": "each",
+        "name": "arr",
+        "itemKeyName": "itemOutter",
+        "indexKeyName": "indexOutter",
+        "items": [
+            {
+                "type": "tpl",
+                "inline": false,
+                "tpl": "<span class='label label-default m-l-sm'>${name}:${index}</span> "
+            },
+
+            {
+                "type": "each",
+                "name": "subList",
+                "items": [
+                    {
+                        "type": "tpl",
+                        "tpl": "<span class='label label-default m-l-sm'>${itemOutter.name}-${item}:${indexOutter}-${index}</span> "
+                    }
+                ]
+            }
+        ]
     }
 }
 ```
@@ -138,13 +179,47 @@ List 的内容、Card 卡片的内容配置同上
 
 `name` 的优先级会比 `source` 更高
 
+## 动态表单项
+
+> 3.5.0 版本开始支持
+
+表单项支持通过表达式配置动态表单项，可结合 `each` 组件一起使用。
+
+```schema: scope="page"
+{
+  "type": "page",
+  "data": {
+    "arr": ["A", "B", "C"]
+  },
+  "body": [
+    {
+        type: "form",
+        debug: true,
+        body: [
+            {
+                "type": "each",
+                "source": "${arr}",
+                "items": {
+                    "type": "input-text",
+                    "label": "Input${item}",
+                    "name": "text${index}"
+                }
+            }
+        ]
+    }
+  ]
+}
+```
+
 ## 属性表
 
-| 属性名      | 类型     | 默认值   | 说明                                                                 |
-| ----------- | -------- | -------- | -------------------------------------------------------------------- |
-| type        | `string` | `"each"` | 指定为 Each 组件                                                     |
-| value       | `array`  | `[]`     | 用于循环的值                                                         |
-| name        | `string` |          | 获取数据域中变量                                                     |
-| source      | `string` |          | 获取数据域中变量， 支持 [数据映射](../../docs/concepts/data-mapping) |
-| items       | `object` |          | 使用`value`中的数据，循环输出渲染器。                                |
-| placeholder | `string` |          | 当 `value` 值不存在或为空数组时的占位文本                            |
+| 属性名       | 类型     | 默认值   | 说明                                                                 |
+| ------------ | -------- | -------- | -------------------------------------------------------------------- |
+| type         | `string` | `"each"` | 指定为 Each 组件                                                     |
+| value        | `array`  | `[]`     | 用于循环的值                                                         |
+| name         | `string` |          | 获取数据域中变量                                                     |
+| source       | `string` |          | 获取数据域中变量， 支持 [数据映射](../../docs/concepts/data-mapping) |
+| items        | `object` |          | 使用`value`中的数据，循环输出渲染器。                                |
+| placeholder  | `string` |          | 当 `value` 值不存在或为空数组时的占位文本                            |
+| itemKeyName  | `string` | `item`   | 获取循环当前数组成员                                                 |
+| indexKeyName | `string` | `index`  | 获取循环当前索引                                                     |

--- a/packages/amis/__tests__/renderers/Form/formitem.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/formitem.test.tsx
@@ -244,3 +244,49 @@ test('Renderer:FormItem:extraName', async () => {
     end: `${moment().format('YYYY-MM')}-16`
   });
 });
+
+test('Renderer:FormItem:dynamicName', async () => {
+  const onSubmit = jest.fn();
+
+  const {container, getByText} = render(
+    amisRender(
+      {
+        type: 'form',
+        id: 'theform',
+        submitText: 'Submit',
+        body: [
+          {
+            type: 'input-text',
+            name: '${a}',
+            label: 'Label'
+          }
+        ],
+        title: 'The form'
+      },
+      {
+        onSubmit,
+        data: {
+          a: 'abc'
+        }
+      },
+      makeEnv({})
+    )
+  );
+
+  const input = container.querySelector('input[name=abc]');
+  expect(input).toBeTruthy();
+  fireEvent.change(input!, {
+    target: {
+      value: '123'
+    }
+  });
+  await wait(500); // 有 250 秒左右的节流
+  fireEvent.click(getByText('Submit'));
+  await wait(300);
+
+  expect(onSubmit).toHaveBeenCalled();
+
+  expect(onSubmit.mock.calls[0][0]).toMatchObject({
+    abc: '123'
+  });
+});

--- a/packages/amis/src/renderers/Each.tsx
+++ b/packages/amis/src/renderers/Each.tsx
@@ -5,6 +5,34 @@ import {resolveVariable, resolveVariableAndFilter} from 'amis-core';
 import {createObject, getPropValue, isObject} from 'amis-core';
 import {BaseSchema, SchemaCollection} from '../Schema';
 
+export interface EachExtraProps extends RendererProps {
+  items: any;
+  item: any;
+  index: number;
+  itemKeyName: string;
+  indexKeyName: string;
+  name: string;
+}
+
+function EachItem(props: EachExtraProps) {
+  const {render, data, items, item, name, index, itemKeyName, indexKeyName} =
+    props;
+  const ctx = React.useMemo(
+    () =>
+      createObject(data, {
+        ...(isObject(item) ? item : {}),
+        [name]: item,
+        [itemKeyName || 'item']: item,
+        [indexKeyName || 'index']: index
+      }),
+    [item, data, name, index, itemKeyName, indexKeyName]
+  );
+
+  return render(`item/${index}`, items, {
+    data: ctx
+  });
+}
+
 /**
  * Each 循环功能渲染器。
  * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/each
@@ -24,6 +52,20 @@ export interface EachSchema extends BaseSchema {
    * 关联字段名 支持数据映射
    */
   source?: string;
+
+  /**
+   * 用来控制通过什么字段读取成员数据，考虑到可能多层嵌套
+   * 如果名字一样会读取不到上层变量，所以这里可以指定一下
+   * @default item
+   */
+  itemKeyName?: string;
+
+  /**
+   * 用来控制通过什么字段读取序号，考虑到可能多层嵌套
+   * 如果名字一样会读取不到上层变量，所以这里可以指定一下
+   * @default index
+   */
+  indexKeyName?: string;
 
   items?: SchemaCollection;
 
@@ -50,6 +92,8 @@ export default class Each extends React.Component<EachProps> {
       style,
       render,
       items,
+      itemKeyName,
+      indexKeyName,
       placeholder,
       classnames: cx,
       translate: __
@@ -82,17 +126,19 @@ export default class Each extends React.Component<EachProps> {
     return (
       <div className={cx('Each', className)} style={buildStyle(style, data)}>
         {Array.isArray(arr) && arr.length && items ? (
-          arr.map((item: any, index: number) =>
-            render(`item/${index}`, items, {
-              data: createObject(
-                data,
-                isObject(item)
-                  ? {index, ...item}
-                  : {[name]: item, item: item, index}
-              ),
-              key: index
-            })
-          )
+          arr.map((item: any, index: number) => (
+            <EachItem
+              {...this.props}
+              items={items}
+              key={index}
+              index={index}
+              data={data}
+              item={item}
+              name={name}
+              itemKeyName={itemKeyName}
+              indexKeyName={indexKeyName}
+            />
+          ))
         ) : (
           <div className={cx('Each-placeholder')}>
             {render('placeholder', __(placeholder))}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f2ce1d</samp>

This pull request adds support for expressions in control names and custom variable names for each items. It modifies the `wrapControl` function and the `Each` renderer, and introduces a new `EachItem` component. These changes allow more flexibility and control over the data binding and rendering of controls and arrays.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3f2ce1d</samp>

> _`wrapControl` parses_
> _expressions for `name` property_
> _autumn leaves change too_

### Why

Close: #4212 

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3f2ce1d</samp>

*  Import `tokenize` function to parse expressions in control names ([link](https://github.com/baidu/amis/pull/8452/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL34-R34))
*  Remove `name` property from `wrapControl` function and compute it dynamically from `$schema` or expression ([link](https://github.com/baidu/amis/pull/8452/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL132), [link](https://github.com/baidu/amis/pull/8452/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL166-R172))
*  Replace `name!` argument with `model.name` in `onChange` calls to avoid null or undefined errors ([link](https://github.com/baidu/amis/pull/8452/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL740-R749))
*  Add `EachItem` component to render each item in `Each` renderer with a custom data context ([link](https://github.com/baidu/amis/pull/8452/files?diff=unified&w=0#diff-004324fd9c356174caedccb3450d00ee36b0de65d751179c5ee3a97dc396c7d8R8-R35), [link](https://github.com/baidu/amis/pull/8452/files?diff=unified&w=0#diff-004324fd9c356174caedccb3450d00ee36b0de65d751179c5ee3a97dc396c7d8L85-R141))
*  Add `itemKeyName` and `indexKeyName` properties to `EachSchema` interface and pass them to `EachItem` component to customize item and index variables ([link](https://github.com/baidu/amis/pull/8452/files?diff=unified&w=0#diff-004324fd9c356174caedccb3450d00ee36b0de65d751179c5ee3a97dc396c7d8R56-R69), [link](https://github.com/baidu/amis/pull/8452/files?diff=unified&w=0#diff-004324fd9c356174caedccb3450d00ee36b0de65d751179c5ee3a97dc396c7d8R95-R96))
