### PR TITLE
feat: input-text 支持配置 nativeAutoComplete 比如可用来配置支持浏览器生成默认密码 Close: #4471

### DIFF
--- a/docs/zh-CN/components/form/input-text.md
+++ b/docs/zh-CN/components/form/input-text.md
@@ -439,6 +439,7 @@ order: 56
 | borderMode            | `"full"\| "half" \| "none"`               | `"full"`  | 输入框边框模式，全边框，还是半边框，或者没边框。                                            |
 | inputControlClassName | `string`                                  |           | control 节点的 CSS 类名                                                                     |
 | nativeInputClassName  | `string`                                  |           | 原生 input 标签的 CSS 类名                                                                  |
+| nativeAutoComplete    | `string`                                  | `off`     | 原生 input 标签的 `autoComplete` 属性，比如配置集成 `new-password`                          |
 
 ## 事件表
 

--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -65,6 +65,12 @@ export interface TextControlSchema extends FormOptionsSchema {
   autoComplete?: SchemaApi;
 
   /**
+   * 配置原生 input 的 autoComplete 属性
+   * @default off
+   */
+  nativeAutoComplete?: string;
+
+  /**
    * 边框模式，全边框，还是半边框，或者没边框。
    */
   borderMode?: 'full' | 'half' | 'none';
@@ -199,7 +205,8 @@ export default class TextControl extends React.PureComponent<
     valueField: 'value',
     placeholder: '',
     allowInputText: true,
-    trimContents: true
+    trimContents: true,
+    nativeAutoComplete: 'off'
   };
 
   componentDidMount() {
@@ -699,7 +706,8 @@ export default class TextControl extends React.PureComponent<
       popOverContainer,
       themeCss,
       css,
-      id
+      id,
+      nativeAutoComplete
     } = this.props;
     let type = this.props.type?.replace(/^(?:native|input)\-/, '');
 
@@ -816,7 +824,7 @@ export default class TextControl extends React.PureComponent<
                     maxLength,
                     minLength
                   })}
-                  autoComplete="off"
+                  autoComplete={nativeAutoComplete}
                   size={10}
                   className={cx(nativeInputClassName)}
                 />
@@ -943,7 +951,8 @@ export default class TextControl extends React.PureComponent<
       minLength,
       themeCss,
       css,
-      id
+      id,
+      nativeAutoComplete
     } = this.props;
 
     const type = this.props.type?.replace(/^(?:native|input)\-/, '');
@@ -984,7 +993,7 @@ export default class TextControl extends React.PureComponent<
           min={min}
           maxLength={maxLength}
           minLength={minLength}
-          autoComplete="off"
+          autoComplete={nativeAutoComplete}
           size={10}
           step={step}
           onChange={this.handleNormalInputChange}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f54f1dc</samp>

This pull request adds a new property `nativeAutoComplete` to the `input-text` component, which enables users to customize the native autocomplete behavior of the input tag. The property is also documented in the `input-text.md` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f54f1dc</samp>

> _To make input tags more complete_
> _A new prop was added so neat_
> _`nativeAutoComplete`_
> _Lets you set or delete_
> _The attribute for password or street_

### Why

Close: #4471

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f54f1dc</samp>

*  Add a new property `nativeAutoComplete` to the `input-text` component to allow users to configure the native `autoComplete` attribute of the input tag ([link](https://github.com/baidu/amis/pull/8465/files?diff=unified&w=0#diff-6168ac65de5239321577435909f0cdf4416fab03222927b17af4ccacaee7f12aR442), [link](https://github.com/baidu/amis/pull/8465/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11R68-R73), [link](https://github.com/baidu/amis/pull/8465/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L202-R209))
*  Pass the `nativeAutoComplete` property to the input tag rendered by the `InputText` and `InputTextControl` classes, replacing the hardcoded value of `autoComplete` attribute ([link](https://github.com/baidu/amis/pull/8465/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L702-R710), [link](https://github.com/baidu/amis/pull/8465/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L819-R827), [link](https://github.com/baidu/amis/pull/8465/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L946-R955), [link](https://github.com/baidu/amis/pull/8465/files?diff=unified&w=0#diff-d33de2d53bb8958696721b7bb3cf1f4bbf31aa1cd69d7f05d458fed38ea19a11L987-R996))
