### PR TITLE
fix: 修复sdk报错问题 Close: #8464

### DIFF
--- a/packages/amis-core/src/components/CustomStyle.tsx
+++ b/packages/amis-core/src/components/CustomStyle.tsx
@@ -48,13 +48,13 @@ export default function (props: CustomStyleProps) {
         id,
         defaultData,
         env?.customStyleClassPrefix,
-        env.getModalContainer?.().ownerDocument
+        env.getModalContainer?.()?.ownerDocument
       );
     }
 
     return () => {
       if (id && !styleIdCount.get(id)) {
-        removeCustomStyle('', id, env.getModalContainer?.().ownerDocument);
+        removeCustomStyle('', id, env.getModalContainer?.()?.ownerDocument);
       }
     };
   }, [themeCss, id]);
@@ -64,7 +64,7 @@ export default function (props: CustomStyleProps) {
       insertEditCustomStyle(
         wrapperCustomStyle,
         id,
-        env.getModalContainer?.().ownerDocument
+        env.getModalContainer?.()?.ownerDocument
       );
     }
 
@@ -73,7 +73,7 @@ export default function (props: CustomStyleProps) {
         removeCustomStyle(
           'wrapperCustomStyle',
           id,
-          env.getModalContainer?.().ownerDocument
+          env.getModalContainer?.()?.ownerDocument
         );
       }
     };


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7120e1a</samp>

Fix custom style bug for modal and wrapper elements. Use `env.getModalContainer()` to get the correct element reference in `CustomStyle.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7120e1a</samp>

> _`getModalContainer`_
> _parentheses fix the bug_
> _autumn leaves fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7120e1a</samp>

*  Fix a bug where custom style was not applied or removed correctly from modal container or wrapper element by adding parentheses to invoke `env.getModalContainer` function ([link](https://github.com/baidu/amis/pull/8466/files?diff=unified&w=0#diff-64f487ea8bb551e6157d95133fcf65572d6990b062dd31bf6502543a77ad9fb5L51-R51), [link](https://github.com/baidu/amis/pull/8466/files?diff=unified&w=0#diff-64f487ea8bb551e6157d95133fcf65572d6990b062dd31bf6502543a77ad9fb5L57-R57), [link](https://github.com/baidu/amis/pull/8466/files?diff=unified&w=0#diff-64f487ea8bb551e6157d95133fcf65572d6990b062dd31bf6502543a77ad9fb5L67-R67), [link](https://github.com/baidu/amis/pull/8466/files?diff=unified&w=0#diff-64f487ea8bb551e6157d95133fcf65572d6990b062dd31bf6502543a77ad9fb5L76-R76)) in `CustomStyle.tsx`
