### PR TITLE
style: select 的其他模式值显示超长时与默认模式保持统一  Close: #4514

### DIFF
--- a/packages/amis-ui/scss/components/_result-box.scss
+++ b/packages/amis-ui/scss/components/_result-box.scss
@@ -237,6 +237,14 @@
     }
   }
 
+  &-valueLabel {
+    max-width: var(--Form-valueLabel-maxWidth);
+    overflow: hidden;
+    vertical-align: top;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   &-placeholder {
     color: var(--Form-input-placeholderColor);
     flex-grow: 1;

--- a/packages/amis-ui/src/components/ResultBox.tsx
+++ b/packages/amis-ui/src/components/ResultBox.tsx
@@ -186,35 +186,49 @@ export class ResultBox extends React.Component<ResultBoxProps> {
             </div>
           </TooltipWrapper>
         ) : (
-          <div
-            className={cx('ResultBox-value', {
-              'is-invalid': isShowInvalid
-            })}
+          <TooltipWrapper
+            container={popOverContainer}
+            placement={'top'}
+            tooltip={item['label']}
+            trigger={'hover'}
             key={index}
           >
-            <span className={cx('ResultBox-valueLabel')}>
-              {itemRender(item)}
-            </span>
-            <a data-index={index} onClick={this.removeItem}>
-              <Icon icon="close" className="icon" />
-            </a>
-          </div>
+            <div
+              className={cx('ResultBox-value', {
+                'is-invalid': isShowInvalid
+              })}
+            >
+              <span className={cx('ResultBox-valueLabel')}>
+                {itemRender(item)}
+              </span>
+              <a data-index={index} onClick={this.removeItem}>
+                <Icon icon="close" className="icon" />
+              </a>
+            </div>
+          </TooltipWrapper>
         );
       });
     }
 
     return tags.map((item, index) => (
-      <div
-        className={cx('ResultBox-value', {
-          'is-invalid': showInvalidMatch && item?.__unmatched
-        })}
+      <TooltipWrapper
+        container={popOverContainer}
+        placement={'top'}
+        tooltip={item['label']}
+        trigger={'hover'}
         key={index}
       >
-        <span className={cx('ResultBox-valueLabel')}>{itemRender(item)}</span>
-        <a data-index={index} onClick={this.removeItem}>
-          <Icon icon="close" className="icon" />
-        </a>
-      </div>
+        <div
+          className={cx('ResultBox-value', {
+            'is-invalid': showInvalidMatch && item?.__unmatched
+          })}
+        >
+          <span className={cx('ResultBox-valueLabel')}>{itemRender(item)}</span>
+          <a data-index={index} onClick={this.removeItem}>
+            <Icon icon="close" className="icon" />
+          </a>
+        </div>
+      </TooltipWrapper>
     ));
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0700c52</samp>

The pull request improves the UI of the `ResultBox` component by adding tooltips and preventing label overflow. The tooltips show the full label of the selected item or tag on hover, and the label overflow is handled by a new CSS class.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0700c52</samp>

> _To improve the result box UI_
> _A new CSS class was applied_
> _And tooltips were added_
> _To show labels padded_
> _With the `item['label']` property_

### Why

Close: #4514 

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0700c52</samp>

*  Add tooltip wrapper to show full label of value and tags in result box component ([link](https://github.com/baidu/amis/pull/8468/files?diff=unified&w=0#diff-b2b02397aef9b4b756c750f0b676d6ee9c06c43000e874cd361f0b21d3b730dbL189-R208), [link](https://github.com/baidu/amis/pull/8468/files?diff=unified&w=0#diff-b2b02397aef9b4b756c750f0b676d6ee9c06c43000e874cd361f0b21d3b730dbL207-R231))
*  Add CSS class to prevent value label from overflowing or wrapping in result box component ([link](https://github.com/baidu/amis/pull/8468/files?diff=unified&w=0#diff-21f40f2463597a4f1f9a6a1513592095223ecfd51987e33cd984dd4ab7faa087R240-R247))
