### PR TITLE
fix: input-date 静态展示问题 Close: #8458

### DIFF
--- a/packages/amis/src/renderers/Form/StaticHoc.tsx
+++ b/packages/amis/src/renderers/Form/StaticHoc.tsx
@@ -150,11 +150,12 @@ export function supportStatic<T extends FormControlProps>() {
 }
 
 function renderStaticDateTypes(props: any) {
-  const {render, type, inputFormat, timeFormat, format, value} = props;
+  const {render, type, inputFormat, valueFormat, timeFormat, format, value} =
+    props;
   return render('static-input-date', {
     type: 'date',
     value,
     format: type === 'time' && timeFormat ? timeFormat : inputFormat,
-    valueFormat: format
+    valueFormat: valueFormat || format
   });
 }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5aee16b</samp>

Added `valueFormat` prop to static date input renderer to support custom formats. Fixed a bug in `StaticHoc.tsx` where the static date input would not respect the `format` prop.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5aee16b</samp>

> _`valueFormat` prop_
> _customizes static date input_
> _a winter bug fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5aee16b</samp>

* Add `valueFormat` prop to `renderStaticDateTypes` function to customize static date value format ([link](https://github.com/baidu/amis/pull/8469/files?diff=unified&w=0#diff-6743296e062555d6d5ef1ffa806450e07b74989e2b2bcc829517a34a8560e918L153-R159))
