### PR TITLE
chore: 调整 crud source 模式与 loadDataOnce 行为一致 Close: #6040

### DIFF
--- a/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
@@ -2599,7 +2599,7 @@ exports[`6. Renderer:crud source & alwaysShowPagination 1`] = `
                     <div
                       class="cxd-Crud-statistics"
                     >
-                      1/1 共：0 项
+                      1/1 共：10 项
                     </div>
                   </div>
                   <div

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -666,7 +666,9 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       const next = resolveVariableAndFilter(props.source, props.data, '| raw');
 
       if (!this.lastData || this.lastData !== next) {
-        store.initFromScope(props.data, props.source);
+        store.initFromScope(props.data, props.source, {
+          columns: store.columns ?? props.columns
+        });
         this.lastData = next;
       }
     }
@@ -1308,7 +1310,10 @@ export default class CRUD extends React.Component<CRUDProps, any> {
               ));
             return value;
           })
-      : source && store.initFromScope(data, source);
+      : source &&
+        store.initFromScope(data, source, {
+          columns: store.columns ?? columns
+        });
   }
 
   silentSearch(values?: object, clearSelection?: boolean, forceReload = false) {

--- a/packages/amis/src/renderers/CRUD2.tsx
+++ b/packages/amis/src/renderers/CRUD2.tsx
@@ -395,7 +395,9 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
       const next = resolveVariableAndFilter(props.source, props.data, '| raw');
 
       if (!this.lastData || this.lastData !== next) {
-        store.initFromScope(props.data, props.source);
+        store.initFromScope(props.data, props.source, {
+          columns: store.columns ?? props.columns
+        });
         this.lastData = next;
       }
     }
@@ -604,7 +606,10 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
               ));
             return value;
           })
-      : source && store.initFromScope(data, source);
+      : source &&
+        store.initFromScope(data, source, {
+          columns: store.columns ?? columns
+        });
   }
 
   @autobind


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c0876f2</samp>

This pull request enhances the `CRUD` component and its store to support column filtering and sorting from the scope data. It passes the `columns` prop or the `store.columns` value to the `initFromScope` function of the `store`, which uses the `matchSorter` and `sortArray` utilities to filter and sort the items. It also updates the `total` and `count` properties of the store accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c0876f2</samp>

> _`CRUDStore` filters_
> _`columns` by name and value_
> _autumn leaves sorted_

### Why

Close: #6040

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c0876f2</samp>

*  Add column filtering and sorting support to CRUD component and store
  * Modify `initFromScope` function in `CRUDStore` class to accept `options` parameter with `columns` array and use `matchSorter` and `sortArray` utilities to filter and sort items from source ([link](https://github.com/baidu/amis/pull/8470/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL587-R655))
  * Update `total` and `count` properties of store based on filtered and sorted items ([link](https://github.com/baidu/amis/pull/8470/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL587-R655))
  * Pass `columns` prop or `store.columns` value to `initFromScope` function of store in `componentDidUpdate` and `syncItems` methods of `CRUD` component ([link](https://github.com/baidu/amis/pull/8470/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L669-R671), [link](https://github.com/baidu/amis/pull/8470/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1311-R1316))
