### PR TITLE
feat: api 文件下载文件名识别忽略大小写同时支持前端指定 Close: #6177

### DIFF
--- a/docs/zh-CN/components/action.md
+++ b/docs/zh-CN/components/action.md
@@ -333,6 +333,8 @@ icon 也可以是 url 地址，比如
 
 通过配置 `"actionType":"download"` 和 `api`，可以实现下载请求，它其实是 `ajax` 的一种特例，自动给 api 加上了 `"responseType": "blob"`。
 
+> 3.5.0 版本开始可以配置 `downloadFileName` 来覆盖下载文件名。注意：即便配置了 `downloadFileName`，api 依然需要返回 `Content-Disposition` 头。
+
 ```schema: scope="body"
 {
     "label": "下载",

--- a/examples/components/Play.jsx
+++ b/examples/components/Play.jsx
@@ -199,7 +199,7 @@ export default class PlayGround extends React.Component {
         };
 
         let response = await axios(config);
-        response = await attachmentAdpator(response, __);
+        response = await attachmentAdpator(response, __, api);
 
         if (response.status >= 400) {
           if (response.data) {

--- a/examples/embed.tsx
+++ b/examples/embed.tsx
@@ -213,7 +213,7 @@ export function embed(
       let response = config.mockResponse
         ? config.mockResponse
         : await axios(config);
-      response = await attachmentAdpator(response, __);
+      response = await attachmentAdpator(response, __, api);
       response = responseAdaptor(api)(response);
 
       if (response.status >= 400) {

--- a/packages/amis-core/src/types.ts
+++ b/packages/amis-core/src/types.ts
@@ -230,6 +230,7 @@ export interface ApiObject extends BaseApiObject {
   ) => ApiObject | Promise<ApiObject>;
   /** 是否过滤为空字符串的 query 参数 */
   filterEmptyQuery?: boolean;
+  downloadFileName?: string;
 }
 export type ApiString = string;
 export type Api = ApiString | ApiObject;

--- a/packages/amis-core/src/utils/handleAction.ts
+++ b/packages/amis-core/src/utils/handleAction.ts
@@ -33,6 +33,7 @@ export function handleAction(
     action.actionType = 'ajax';
     const api = normalizeApi((action as any).api);
     api.responseType = 'blob';
+    api.downloadFileName = action.downloadFileName;
     (action as any).api = api;
   }
 

--- a/packages/amis-editor-core/src/env.ts
+++ b/packages/amis-editor-core/src/env.ts
@@ -10,7 +10,8 @@ export const env: RenderOptions = {
   jumpTo: () => {
     toast.info('温馨提示：预览模式下禁止跳转');
   },
-  fetcher: async ({url, method, data, config, headers}: any) => {
+  fetcher: async (api: any) => {
+    let {url, method, data, config, headers} = api;
     config = config || {};
     config.url = url;
     config.withCredentials = true;
@@ -40,7 +41,7 @@ export const env: RenderOptions = {
     }
 
     let response = await axios(config);
-    response = await attachmentAdpator(response, (msg: string) => '');
+    response = await attachmentAdpator(response, (msg: string) => msg, api);
     return response;
   },
   isCancel: (value: any) => (axios as any).isCancel(value),

--- a/packages/amis/src/Schema.ts
+++ b/packages/amis/src/Schema.ts
@@ -617,6 +617,11 @@ export interface SchemaApiObject {
    * autoFill 是否显示自动填充错误提示
    */
   silent?: boolean;
+
+  /**
+   * 文件下载时，指定文件名
+   */
+  downloadFileName?: string;
 }
 
 export type SchemaApi = string | SchemaApiObject;

--- a/packages/amis/src/renderers/Action.tsx
+++ b/packages/amis/src/renderers/Action.tsx
@@ -198,6 +198,7 @@ export interface DownloadActionSchema
    * 指定为下载行为
    */
   actionType: 'download';
+  downloadFileName?: string;
 }
 
 export interface SaveAsActionSchema
@@ -362,6 +363,7 @@ export interface OtherActionSchema extends ButtonSchema {
 
 export interface VanillaAction extends ButtonSchema {
   actionType?: string;
+  downloadFileName?: string;
 }
 
 /**
@@ -426,7 +428,8 @@ const ActionProps = [
   'requireSelected',
   'countDown',
   'fileName',
-  'isolateScope'
+  'isolateScope',
+  'downloadFileName'
 ];
 import {filterContents} from './Remark';
 import {ClassNamesFn, themeable, ThemeProps} from 'amis-core';
@@ -624,6 +627,7 @@ export class Action extends React.Component<ActionProps, ActionState> {
       action.actionType = 'ajax';
       const api = normalizeApi((action as AjaxActionSchema).api);
       api.responseType = 'blob';
+      api.downloadFileName = action.downloadFileName;
       (action as AjaxActionSchema).api = api;
     }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d781247</samp>

This pull request adds a feature to allow customizing the file name for downloaded attachments in `download` and `vanilla` actions. It updates the `attachmentAdpator`, `fetcher`, and `handleAction` functions, as well as the `ApiObject` and `ActionSchema` interfaces, to support the new `downloadFileName` property. It also modifies the documentation and the example code to reflect this feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d781247</samp>

> _If you want to download a file_
> _With a name that is not so vile_
> _You can use `downloadFileName`_
> _In the action config or the `api` param_
> _And the `attachmentAdpator` will handle the style_

### Why

Close: #6177

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d781247</samp>

*  Add `downloadFileName` property to action configuration to override file name returned by API ([link](https://github.com/baidu/amis/pull/8471/files?diff=unified&w=0#diff-14efa61b55a270c37a101b885c2bcc5bc2525fe5dcefe9c65ff9f36cc0b4b4edR336-R337), [link](https://github.com/baidu/amis/pull/8471/files?diff=unified&w=0#diff-4d89203911a9d3ef38c82118f074ad24c49244699f1f2cbb6072134908f60098R201), [link](https://github.com/baidu/amis/pull/8471/files?diff=unified&w=0#diff-4d89203911a9d3ef38c82118f074ad24c49244699f1f2cbb6072134908f60098R366), [link](https://github.com/baidu/amis/pull/8471/files?diff=unified&w=0#diff-1d70ef86e04744f8ab32d8c9957e4784c6b948efa3fcf7b2557766e973378f23R620-R624))
*  Pass `downloadFileName` property from action configuration to `attachmentAdpator` function, which handles file download logic ([link](https://github.com/baidu/amis/pull/8471/files?diff=unified&w=0#diff-5137ffd3ac5c47279bb5615cf832b9123f909d763e58ba367327e65d738eeab8L202-R202), [link](https://github.com/baidu/amis/pull/8471/files?diff=unified&w=0#diff-87941d3a37b91c5deb23aa31d74dd4260118b71257f89262cce39dcac1d5dd2aL216-R216), [link](https://github.com/baidu/amis/pull/8471/files?diff=unified&w=0#diff-e2108b57c9e333efc257616f4e5cce01dfe8019eb0873e05a6d2e6cb2d01a633R36), [link](https://github.com/baidu/amis/pull/8471/files?diff=unified&w=0#diff-4d89203911a9d3ef38c82118f074ad24c49244699f1f2cbb6072134908f60098L429-R432), [link](https://github.com/baidu/amis/pull/8471/files?diff=unified&w=0#diff-4d89203911a9d3ef38c82118f074ad24c49244699f1f2cbb6072134908f60098R630), [link](https://github.com/baidu/amis/pull/8471/files?diff=unified&w=0#diff-d925f9b5a4ca7881b911fc829bdb900bc2321ac9ac0c91e10882c36113f02920L43-R44))
*  Modify `attachmentAdpator` function to use `downloadFileName` property if present, instead of parsing file name from `Content-Disposition` header ([link](https://github.com/baidu/amis/pull/8471/files?diff=unified&w=0#diff-551407b8dbee6e727f84705450fb1b605a721f6bd10ad70c537a0caabfdd60adL8-R14), [link](https://github.com/baidu/amis/pull/8471/files?diff=unified&w=0#diff-551407b8dbee6e727f84705450fb1b605a721f6bd10ad70c537a0caabfdd60adL14-R36))
*  Add `api` parameter of type `ApiObject` to `attachmentAdpator` function and `fetcher` function, to pass the `downloadFileName` property and other API configuration ([link](https://github.com/baidu/amis/pull/8471/files?diff=unified&w=0#diff-9795a06699f88c4c144fccb14b9ddca83b8d9639d2062c27b01495b6b80e7d7dR233), [link](https://github.com/baidu/amis/pull/8471/files?diff=unified&w=0#diff-551407b8dbee6e727f84705450fb1b605a721f6bd10ad70c537a0caabfdd60adL8-R14), [link](https://github.com/baidu/amis/pull/8471/files?diff=unified&w=0#diff-e2108b57c9e333efc257616f4e5cce01dfe8019eb0873e05a6d2e6cb2d01a633R36), [link](https://github.com/baidu/amis/pull/8471/files?diff=unified&w=0#diff-d925f9b5a4ca7881b911fc829bdb900bc2321ac9ac0c91e10882c36113f02920L13-R14))
