### PR TITLE
feat: tinymce 编辑器当配置文件接收器为空时图片上传改成 base64 模式 Close: #6220

### DIFF
--- a/docs/zh-CN/components/form/input-rich-text.md
+++ b/docs/zh-CN/components/form/input-rich-text.md
@@ -142,6 +142,25 @@ table tr {
 }
 ```
 
+## 图片保存为 base64
+
+当使用 tinymce 编辑器的时候，如果配置文件接收器为空，当选择图片的时候，会自动转成 base64 格式存储
+
+```schema: scope="body"
+{
+    "type": "form",
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+        {
+            "type": "input-rich-text",
+            "name": "rich",
+            "label": "Rich Text",
+            "receiver": ""
+        }
+    ]
+}
+```
+
 ## 扩充 tinymce 插件
 
 需要在调用 amis 的时候，通过 `env.loadTinymcePlugin` 来加载自定义插件，可以查考： [examples/components/SchemaRender.jsx](https://github.com/baidu/amis/blob/master/examples/components/SchemaRender.jsx) 文件中的示例。

--- a/packages/amis/src/renderers/Form/InputRichText.tsx
+++ b/packages/amis/src/renderers/Form/InputRichText.tsx
@@ -117,7 +117,7 @@ export default class RichTextControl extends React.Component<
     this.handleChange = this.handleChange.bind(this);
     const imageReceiver = normalizeApi(
       props.receiver,
-      props.receiver.method || 'post'
+      props.receiver?.method || 'post'
     );
     imageReceiver.data = imageReceiver.data || {};
     const imageApi = buildApi(imageReceiver, props.data, {
@@ -205,6 +205,15 @@ export default class RichTextControl extends React.Component<
             );
 
             try {
+              if (!imageApi.url) {
+                var reader = new FileReader();
+                reader.readAsDataURL(blobInfo.blob());
+                reader.onloadend = function () {
+                  var base64data = reader.result;
+                  resolve(base64data);
+                };
+                return;
+              }
               const receiver = {
                 adaptor: (payload: object) => {
                   return {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 73ccc5f</samp>

This pull request enhances the `input-rich-text` component and its documentation. It fixes a bug with the `receiver` prop and adds a feature to save images as base64 data URLs.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 73ccc5f</samp>

> _If you want to insert an image_
> _In the `input-rich-text` widget_
> _You can use base64_
> _With a schema for sure_
> _And leave the `receiver` prop empty_

### Why

Close: #6220

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 73ccc5f</samp>

* Add a new feature to the input-rich-text component to save images as base64 data URLs when no imageApi url is provided ([link](https://github.com/baidu/amis/pull/8472/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15R208-R216))
* Fix a potential bug in the input-rich-text component to handle undefined receiver prop safely ([link](https://github.com/baidu/amis/pull/8472/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15L120-R120))
* Update the documentation of the input-rich-text component in `docs/zh-CN/components/form/input-rich-text.md` to explain the new feature and provide a schema example ([link](https://github.com/baidu/amis/pull/8472/files?diff=unified&w=0#diff-5763a9c8be2add40d5fb4ab942d81bd41c7206e75257284d7fbac17f9248cec8R145-R163))
