### PR TITLE
chore: Wizard组件在第一步时可以隐藏默认prev按钮，按钮数据域支持currentStep

### DIFF
--- a/docs/zh-CN/components/wizard.md
+++ b/docs/zh-CN/components/wizard.md
@@ -57,7 +57,14 @@ order: 73
 
 ## 自定义按钮
 
-可以在每个 `step` 中配置 `actions` 来自定义按钮。
+可以在每个 `step` 中配置 `actions` 来自定义按钮。按钮所在数据域查看`WizardActionData`定义（`3.5.0`及以上版本支持）
+
+```typescript
+interface WizardActionData {
+  /* 当前步骤数值，从1开始 */
+  currentStep: number;
+}
+```
 
 ```schema: scope="body"
 {
@@ -78,6 +85,12 @@ order: 73
                 }
             ],
             actions: [
+                {
+                    "label": "Prev",
+                    "type": "button",
+                    "actionType": "prev",
+                    "disabledOn": "${currentStep === 1}"
+                },
                 {
                     label: "Next",
                     type: 'button',
@@ -100,7 +113,6 @@ order: 73
                     type: 'button',
                     actionType: 'prev'
                 },
-
                 {
                     label: "Submit",
                     type: 'button',

--- a/packages/amis/__tests__/renderers/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Wizard.test.tsx.snap
@@ -385,14 +385,6 @@ exports[`Renderer:Wizard actionPrevLabel actionNextLabel actionFinishLabel class
         class="cxd-Wizard-footer cxd-Panel-footer"
         role="wizard-footer"
       >
-        <div
-          class="cxd-Button cxd-Button--default cxd-Button--size-default is-disabled btn-lg btn-primary"
-          disabled=""
-        >
-          <span>
-            PrevStep
-          </span>
-        </div>
         <button
           class="cxd-Button cxd-Button--primary cxd-Button--size-default btn-lg btn-primary"
           type="button"
@@ -815,14 +807,6 @@ exports[`Renderer:Wizard dialog 1`] = `
                 class="cxd-Wizard-footer cxd-Panel-footer"
                 role="wizard-footer"
               >
-                <div
-                  class="cxd-Button cxd-Button--default cxd-Button--size-default is-disabled"
-                  disabled=""
-                >
-                  <span>
-                    上一步
-                  </span>
-                </div>
                 <button
                   class="cxd-Button cxd-Button--primary cxd-Button--size-default"
                   type="button"
@@ -1202,14 +1186,6 @@ exports[`Renderer:Wizard dialog 2`] = `
                 class="cxd-Wizard-footer cxd-Panel-footer"
                 role="wizard-footer"
               >
-                <div
-                  class="cxd-Button cxd-Button--default cxd-Button--size-default is-disabled"
-                  disabled=""
-                >
-                  <span>
-                    上一步
-                  </span>
-                </div>
                 <button
                   class="cxd-Button cxd-Button--primary cxd-Button--size-default"
                   type="button"
@@ -1512,14 +1488,6 @@ exports[`Renderer:Wizard initApi default 1`] = `
         class="cxd-Wizard-footer cxd-Panel-footer"
         role="wizard-footer"
       >
-        <div
-          class="cxd-Button cxd-Button--default cxd-Button--size-default is-disabled"
-          disabled=""
-        >
-          <span>
-            上一步
-          </span>
-        </div>
         <button
           class="cxd-Button cxd-Button--primary cxd-Button--size-default"
           type="button"
@@ -1789,14 +1757,6 @@ exports[`Renderer:Wizard initApi reload 1`] = `
                 class="cxd-Wizard-footer cxd-Panel-footer"
                 role="wizard-footer"
               >
-                <div
-                  class="cxd-Button cxd-Button--default cxd-Button--size-default is-disabled"
-                  disabled=""
-                >
-                  <span>
-                    上一步
-                  </span>
-                </div>
                 <button
                   class="cxd-Button cxd-Button--primary cxd-Button--size-default"
                   type="button"
@@ -2593,14 +2553,6 @@ exports[`Renderer:Wizard initApi show loading 2`] = `
         class="cxd-Wizard-footer cxd-Panel-footer"
         role="wizard-footer"
       >
-        <div
-          class="cxd-Button cxd-Button--default cxd-Button--size-default is-disabled"
-          disabled=""
-        >
-          <span>
-            上一步
-          </span>
-        </div>
         <button
           class="cxd-Button cxd-Button--primary cxd-Button--size-default"
           type="button"
@@ -3912,14 +3864,6 @@ exports[`Renderer:Wizard validate 1`] = `
         class="cxd-Wizard-footer cxd-Panel-footer"
         role="wizard-footer"
       >
-        <div
-          class="cxd-Button cxd-Button--default cxd-Button--size-default is-disabled"
-          disabled=""
-        >
-          <span>
-            上一步
-          </span>
-        </div>
         <button
           class="cxd-Button cxd-Button--primary cxd-Button--size-default"
           type="button"

--- a/packages/amis/src/renderers/Wizard.tsx
+++ b/packages/amis/src/renderers/Wizard.tsx
@@ -1117,6 +1117,9 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
           {step.actions.map((action, index) =>
             render(`action/${index}`, action, {
               key: index,
+              data: createObject(this.props.data, {
+                currentStep: currentStepIndex
+              }),
               onAction: this.handleAction,
               disabled:
                 action.disabled ||
@@ -1140,11 +1143,13 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
             type: 'button',
             label: __(actionPrevLabel),
             actionType: 'prev',
-            className: actionClassName
+            className: actionClassName,
+            hiddenOn: '${currentStep === 1}'
           },
           {
             disabled: waiting || !prevCanJump || disabled,
-            onAction: this.handleAction
+            onAction: this.handleAction,
+            data: createObject(this.props.data, {currentStep: currentStepIndex})
           }
         )}
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2513894</samp>

This pull request adds a feature to customize wizard buttons based on the current step, and an option to hide the `Prev` button on the first step. It updates the `Wizard` renderer and the `docs/zh-CN/components/wizard.md` file accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2513894</samp>

> _`Wizard` component_
> _Enhanced with button logic_
> _Fixes format too_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2513894</samp>

*  Add `WizardActionData` type to customize buttons based on current step ([link](https://github.com/baidu/amis/pull/8474/files?diff=unified&w=0#diff-5c1f4a519a77c178ba3e1c178bdcb522dfb39e412cc3a935107d2ddd1abb4cd4L60-R68), [link](https://github.com/baidu/amis/pull/8474/files?diff=unified&w=0#diff-8c1e1e55c146ca688906b7443643b4a9c53472e61bd55b64d534e92d1b247e3bR1120-R1122), [link](https://github.com/baidu/amis/pull/8474/files?diff=unified&w=0#diff-8c1e1e55c146ca688906b7443643b4a9c53472e61bd55b64d534e92d1b247e3bL1143-R1152))
*  Remove empty line in `docs/zh-CN/components/wizard.md` for formatting ([link](https://github.com/baidu/amis/pull/8474/files?diff=unified&w=0#diff-5c1f4a519a77c178ba3e1c178bdcb522dfb39e412cc3a935107d2ddd1abb4cd4L103))
