### PR TITLE
feat: 扩展mountIconSpriteToDom方法

### DIFF
--- a/packages/amis/src/renderers/Form/IconSelectStore.tsx
+++ b/packages/amis/src/renderers/Form/IconSelectStore.tsx
@@ -15,14 +15,14 @@ export interface SvgIconGroup {
 
 export let svgIcons: SvgIconGroup[] = [];
 
-function getSvgMountNode() {
-  const node = document.getElementById('amis-icon-manage-mount-node');
+function getSvgMountNode(nodeId: string = 'amis-icon-manage-mount-node') {
+  const node = document.getElementById(nodeId);
 
   if (node) {
     return node;
   } else {
     const newNode = document.createElement('div');
-    newNode.setAttribute('id', 'amis-icon-manage-mount-node');
+    newNode.setAttribute('id', nodeId);
     newNode.setAttribute('style', 'width:0;height:0;visibility:hidden;');
 
     if (document.body.firstElementChild) {
@@ -35,9 +35,9 @@ function getSvgMountNode() {
   }
 }
 
-export function mountIconSpiriteToDom(spirite: string) {
-  const node = getSvgMountNode();
-  node && (node.innerHTML = spirite);
+export function mountIconSpriteToDom(sprite: string, nodeId?: string) {
+  const node = getSvgMountNode(nodeId);
+  node && (node.innerHTML = sprite);
 }
 
 type refreshIconListFunc = null | (() => any);
@@ -47,17 +47,17 @@ export let refreshIconList: refreshIconListFunc = null;
 export function setRefreshSvgListAction(
   func: ({
     setSvgIconList,
-    mountIconSpiriteToDom
+    mountIconSpriteToDom
   }: {
     setSvgIconList: (arr: SvgIconGroup[]) => void;
-    mountIconSpiriteToDom: (str: string) => void;
+    mountIconSpriteToDom: (str: string) => void;
   }) => any
 ) {
   if (func && typeof func === 'function') {
     refreshIconList = () =>
       func({
         setSvgIconList,
-        mountIconSpiriteToDom
+        mountIconSpriteToDom
       });
   } else {
     refreshIconList = null;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2c5b80e</samp>

This pull request enhances the IconSelectStore component by allowing custom SVG mount nodes and fixing a typo. It modifies the `getSvgMountNode` and `mountIconSpriteToDom` functions in `packages/amis/src/renderers/Form/IconSelectStore.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2c5b80e</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _the functions of the IconSelectStore, the source of splendid icons._
> _He added a new parameter, `nodeId`, to the functions_
> _that mount and refresh the SVG sprites, the shining images of gods and heroes._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2c5b80e</samp>

*  Rename and modify `mountIconSpiriteToDom` function to accept `nodeId` parameter and fix typo ([link](https://github.com/baidu/amis/pull/8476/files?diff=unified&w=0#diff-df85e0ce7304d029978646b7026e2457e18e153b1d76ee4610bd3a949eea27beL38-R40), [link](https://github.com/baidu/amis/pull/8476/files?diff=unified&w=0#diff-df85e0ce7304d029978646b7026e2457e18e153b1d76ee4610bd3a949eea27beL50-R53), [link](https://github.com/baidu/amis/pull/8476/files?diff=unified&w=0#diff-df85e0ce7304d029978646b7026e2457e18e153b1d76ee4610bd3a949eea27beL60-R60))
*  Modify `getSvgMountNode` function to use `nodeId` parameter instead of hard-coded string ([link](https://github.com/baidu/amis/pull/8476/files?diff=unified&w=0#diff-df85e0ce7304d029978646b7026e2457e18e153b1d76ee4610bd3a949eea27beL18-R19), [link](https://github.com/baidu/amis/pull/8476/files?diff=unified&w=0#diff-df85e0ce7304d029978646b7026e2457e18e153b1d76ee4610bd3a949eea27beL25-R25))
*  Update `setRefreshSvgListAction` function to use renamed and modified `mountIconSpiriteToDom` function and pass `nodeId` parameter ([link](https://github.com/baidu/amis/pull/8476/files?diff=unified&w=0#diff-df85e0ce7304d029978646b7026e2457e18e153b1d76ee4610bd3a949eea27beL50-R53), [link](https://github.com/baidu/amis/pull/8476/files?diff=unified&w=0#diff-df85e0ce7304d029978646b7026e2457e18e153b1d76ee4610bd3a949eea27beL60-R60))
