### PR TITLE
chore(amis-editor): Form配置面板删除多余的labelAlign控件

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Form.tsx
+++ b/packages/amis-editor/src/plugin/Form/Form.tsx
@@ -978,24 +978,6 @@ export class FormPlugin extends BasePlugin {
                 }),
                 getSchemaTpl('horizontal'),
                 {
-                  name: 'labelAlign',
-                  label: '标签对齐方式',
-                  type: 'button-group-select',
-                  size: 'sm',
-                  visibleOn: "${mode === 'horizontal'}",
-                  pipeIn: defaultValue('right', false),
-                  options: [
-                    {
-                      label: '左对齐',
-                      value: 'left'
-                    },
-                    {
-                      label: '右对齐',
-                      value: 'right'
-                    }
-                  ]
-                },
-                {
                   label: '列数',
                   name: 'columnCount',
                   type: 'input-number',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec1726a</samp>

Removed `labelAlign` property from `FormPlugin` class in `Form.tsx` to simplify form configuration and avoid confusion with `labelPosition`. Part of a pull request to refactor the form plugin.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ec1726a</samp>

> _`labelAlign` gone_
> _Form plugin refactored well_
> _Spring cleaning the code_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ec1726a</samp>

* Remove `labelAlign` property from `FormPlugin` class to simplify form configuration and avoid confusion with `labelPosition` property ([link](https://github.com/baidu/amis/pull/8478/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL981-L998))
