### PR TITLE
fix: 遍历key && 无数据时展示0

### DIFF
--- a/packages/amis-editor/src/renderer/KeyValueMapControl.tsx
+++ b/packages/amis-editor/src/renderer/KeyValueMapControl.tsx
@@ -235,7 +235,7 @@ export class KeyValueMapControl extends React.Component<
     ];
 
     return (
-      <div className="ae-KeyValMapControlItem">
+      <div className="ae-KeyValMapControlItem" key={index}>
         <div className="ae-KeyValMapControlItem-Main">
           {render('dropdown', {
             type: 'flex',
@@ -340,11 +340,11 @@ export class KeyValueMapControl extends React.Component<
     const {render} = this.props;
     return (
       <div className="ae-KeyValMapControl-wrapper">
-        {unitOptions.length && (
+        {unitOptions.length ? (
           <div>
             {unitOptions.map((item, index) => this.renderOption(item, index))}
           </div>
-        )}
+        ) : null}
         <div className="ae-KeyValMapControl-footer">
           <Button level="enhance" onClick={this.handleAdd}>
             添加选项


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aa31e1e</samp>

Fix React warning and simplify rendering logic in `KeyValueMapControl` component. This component is used to edit key-value pairs in the amis-editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at aa31e1e</samp>

> _React warning, no more_
> _`KeyValueMapControl` is pure_
> _Ternary operator, logic is clear_
> _`key` prop, option list is here_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aa31e1e</samp>

* Add a `key` prop to each option `div` in the `KeyValueMapControl` component to avoid rendering issues and fix a warning message ([link](https://github.com/baidu/amis/pull/8481/files?diff=unified&w=0#diff-7665354a69a62eaa6b001e05ae57ca91601682103b036324dd26265160646723L238-R238))
* Use a ternary operator instead of `&&` to conditionally render the options `div` in the `KeyValueMapControl` component for more clarity and consistency ([link](https://github.com/baidu/amis/pull/8481/files?diff=unified&w=0#diff-7665354a69a62eaa6b001e05ae57ca91601682103b036324dd26265160646723L343-R347))
