### PR TITLE
fix: 解决表单项 pipeIn 和 pipeOut 的 this 丢失

### DIFF
--- a/packages/amis-core/src/renderers/wrapControl.tsx
+++ b/packages/amis-core/src/renderers/wrapControl.tsx
@@ -643,7 +643,8 @@ export function wrapControl<
 
             if (pipeOut) {
               const oldValue = this.model.value;
-              value = callStrFunction(
+              value = callStrFunction.call(
+                this,
                 pipeOut,
                 ['value', 'oldValue', 'data'],
                 value,
@@ -768,7 +769,8 @@ export function wrapControl<
             } = this.props;
 
             if (pipeOut) {
-              value = callStrFunction(
+              value = callStrFunction.call(
+                this,
                 pipeOut,
                 ['value', 'oldValue', 'data'],
                 value,
@@ -791,7 +793,8 @@ export function wrapControl<
             let value: any = this.model ? this.model.tmpValue : control.value;
 
             if (control.pipeIn) {
-              value = callStrFunction(
+              value = callStrFunction.call(
+                this,
                 control.pipeIn,
                 ['value', 'data'],
                 value,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b70e633</samp>

Fix `pipeIn` and `pipeOut` functions of controls and wrappers to use the correct context. This affects the file `wrapControl.tsx` in the `amis-core` package.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b70e633</samp>

> _Sing, O Muse, of the cunning coder who fixed the bug_
> _That plagued the controls and wrappers of the web app divine,_
> _And how he used the call method of the function, like a lug_
> _Of iron, to bind the context of the wrapper to the line._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b70e633</samp>

* Fix bug where `pipeOut` and `pipeIn` functions of controls and wrapper component would not have access to the `this` context of the wrapper component in `wrapControl.tsx` ([link](https://github.com/baidu/amis/pull/8487/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL646-R647), [link](https://github.com/baidu/amis/pull/8487/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL771-R773), [link](https://github.com/baidu/amis/pull/8487/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL794-R797))
