### PR TITLE
style: inputTree 节点操作按钮根据规范改成左对齐  Close: #6273

### DIFF
--- a/packages/amis-ui/scss/components/form/_tree.scss
+++ b/packages/amis-ui/scss/components/form/_tree.scss
@@ -199,6 +199,7 @@
     height: var(--Tree-itemHeight);
     line-height: var(--Tree-itemHeight);
     padding-right: var(--Tree-icon-gap);
+    flex-shrink: 0;
 
     > a {
       display: inline-block;
@@ -359,7 +360,6 @@
 
   &-itemText {
     cursor: pointer;
-    flex: 1 auto;
     display: inline-block;
     color: var(--inputTree-base-default-color);
     font-size: var(--select-tree-fontSize);

--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -37,6 +37,7 @@ import {LocaleProps, localeable} from 'amis-core';
 import Spinner, {SpinnerExtraProps} from './Spinner';
 import {ItemRenderStates} from './Selection';
 import VirtualList from './virtual-list';
+import TooltipWrapper from './TooltipWrapper';
 
 interface IDropIndicator {
   left: number;
@@ -1275,33 +1276,42 @@ export class TreeSelector extends React.Component<
             !(item.defer && !item.loaded) ? (
               <div className={cx('Tree-item-icons')}>
                 {creatable && hasAbility(item, 'creatable') ? (
-                  <a
-                    onClick={this.handleAdd.bind(this, item)}
-                    data-tooltip={__(createTip)}
-                    data-position="left"
+                  <TooltipWrapper
+                    placement={'bottom'}
+                    tooltip={__(createTip)}
+                    trigger={'hover'}
+                    tooltipTheme="dark"
                   >
-                    <Icon icon="plus" className="icon" />
-                  </a>
+                    <a onClick={this.handleAdd.bind(this, item)}>
+                      <Icon icon="plus" className="icon" />
+                    </a>
+                  </TooltipWrapper>
                 ) : null}
 
                 {removable && hasAbility(item, 'removable') ? (
-                  <a
-                    onClick={this.handleRemove.bind(this, item)}
-                    data-tooltip={__(removeTip)}
-                    data-position="left"
+                  <TooltipWrapper
+                    placement={'bottom'}
+                    tooltip={__(removeTip)}
+                    trigger={'hover'}
+                    tooltipTheme="dark"
                   >
-                    <Icon icon="minus" className="icon" />
-                  </a>
+                    <a onClick={this.handleRemove.bind(this, item)}>
+                      <Icon icon="minus" className="icon" />
+                    </a>
+                  </TooltipWrapper>
                 ) : null}
 
                 {editable && hasAbility(item, 'editable') ? (
-                  <a
-                    onClick={this.handleEdit.bind(this, item)}
-                    data-tooltip={__(editTip)}
-                    data-position="left"
+                  <TooltipWrapper
+                    placement={'bottom'}
+                    tooltip={__(editTip)}
+                    trigger={'hover'}
+                    tooltipTheme="dark"
                   >
-                    <Icon icon="new-edit" className="icon" />
-                  </a>
+                    <a onClick={this.handleEdit.bind(this, item)}>
+                      <Icon icon="new-edit" className="icon" />
+                    </a>
+                  </TooltipWrapper>
                 ) : null}
               </div>
             ) : null}

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/transfer.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/transfer.test.tsx.snap
@@ -2222,10 +2222,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                               <div
                                 class="cxd-Tree-item-icons"
                               >
-                                <a
-                                  data-position="left"
-                                  data-tooltip="移除该节点"
-                                >
+                                <a>
                                   <icon-mock
                                     classname="icon icon-minus"
                                     icon="minus"
@@ -2261,10 +2258,7 @@ exports[`Renderer:transfer follow left mode 1`] = `
                               <div
                                 class="cxd-Tree-item-icons"
                               >
-                                <a
-                                  data-position="left"
-                                  data-tooltip="移除该节点"
-                                >
+                                <a>
                                   <icon-mock
                                     classname="icon icon-minus"
                                     icon="minus"
@@ -2926,10 +2920,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                               <div
                                 class="cxd-Tree-item-icons"
                               >
-                                <a
-                                  data-position="left"
-                                  data-tooltip="移除该节点"
-                                >
+                                <a>
                                   <icon-mock
                                     classname="icon icon-minus"
                                     icon="minus"
@@ -2965,10 +2956,7 @@ exports[`Renderer:transfer follow left mode 2`] = `
                               <div
                                 class="cxd-Tree-item-icons"
                               >
-                                <a
-                                  data-position="left"
-                                  data-tooltip="移除该节点"
-                                >
+                                <a>
                                   <icon-mock
                                     classname="icon icon-minus"
                                     icon="minus"


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1cd98b6</samp>

This pull request improves the tree component in the form package by fixing some layout and readability issues in the `_tree.scss` file and enhancing the tooltips for the tree item icons in the `Tree.tsx` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1cd98b6</samp>

> _The tree component needed some fixes_
> _To improve its layout and its mixins_
> _So they tweaked the `flex`_
> _And the `TooltipWrapper` next_
> _And now the tree item icons have nixes_

### Why

 Close: #6273

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1cd98b6</samp>

*  Prevent tree item labels from shrinking and tree items from overflowing in nested or long trees by adjusting the flex properties in the `_tree.scss` file ([link](https://github.com/baidu/amis/pull/8497/files?diff=unified&w=0#diff-336249700e93e82be1613415e7b5266a2144796bd2df1ce3a74ec2079edaf1ebR202), [link](https://github.com/baidu/amis/pull/8497/files?diff=unified&w=0#diff-336249700e93e82be1613415e7b5266a2144796bd2df1ce3a74ec2079edaf1ebL362))
* Import and use the `TooltipWrapper` component to improve the appearance and consistency of the tooltips for the tree item icons in the `Tree.tsx` file ([link](https://github.com/baidu/amis/pull/8497/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7R40), [link](https://github.com/baidu/amis/pull/8497/files?diff=unified&w=0#diff-32eeb867c2efcdcbebc7d8f9cc1a1629a4fb268da261b5c032a720f5263657d7L1278-R1314))
