### PR TITLE
feat: CRUD组件支持开启syncLocation后解析Query中的原始类型数据

### DIFF
--- a/docs/zh-CN/components/crud.md
+++ b/docs/zh-CN/components/crud.md
@@ -200,6 +200,20 @@ CRUD 组件对数据源接口的数据结构要求如下：
 | orderDir | 'asc'/'desc' | 排序方式                       |
 | keywords | string       | 搜索关键字                     |
 
+### 解析Query原始类型
+
+> `3.5.0`及以上版本
+
+`syncLocation`开启后，CRUD在初始化数据域时，将会对url中的Query进行转换，将原始类型的字符串格式的转化为同位类型，目前仅支持**布尔类型**
+
+```
+"true"  ==> true
+"false" ==> false
+```
+
+如果只想保持字符串格式，可以设置`"parsePrimitiveQuery": false`关闭该特性，具体效果参考[示例](../../../examples/crud/parse-primitive-query)。
+
+
 ## 功能
 
 既然这个渲染器叫增删改查，那接下来分开介绍这几个功能吧。
@@ -2795,7 +2809,7 @@ CRUD 中不限制有多少个单条操作、添加一个操作对应的添加一
 > 本文中的例子为了不相互影响都关闭了这个功能。
 > 另外如果需要使用接口联动，需要设置`syncLocation: false`
 
-`syncLocation`开启后，数据域经过地址栏同步后，原始值被转化为字符串同步回数据域，但布尔值（boolean）同步后不符合预期数据结构，导致组件渲染出错。比如查询条件表单中包含[Checkbox](./form/checkbox)组件，此时可以设置`{"trueValue": "1", "falseValue": "0"}`，将真值和假值设置为字符串格式规避。
+`syncLocation`开启后，数据域经过地址栏同步后，原始值被转化为字符串同步回数据域，但布尔值（boolean）同步后不符合预期数据结构，导致组件渲染出错。比如查询条件表单中包含[Checkbox](./form/checkbox)组件，此时可以设置`{"trueValue": "1", "falseValue": "0"}`，将真值和假值设置为字符串格式规避。从`3.5.0`版本开始，已经支持[`parsePrimitiveQuery`](#解析query原始类型)，该配置默认开启。
 
 ## 前端一次性加载
 

--- a/examples/components/CRUD/ParsePrimitiveQuery.jsx
+++ b/examples/components/CRUD/ParsePrimitiveQuery.jsx
@@ -1,0 +1,73 @@
+export default {
+  "title": "解析Query参数",
+  "body": [
+    {
+      "type": "alert",
+      "body": {
+        "type": "html",
+        "html": "<code>parsePrimitiveQuery</code>默认开启，开启后会对url中的Query进行转换，将原始类型的字符串格式的转化为同位类型，目前仅支持<strong>布尔类型</strong>"
+      },
+      "level": "info",
+      "showCloseButton": true,
+      "showIcon": true,
+      "className": "mb-2"
+    },
+    {
+      "type": "crud",
+      "name": "crud",
+      "syncLocation": true,
+      "api": "/api/mock2/crud/table5",
+      "filter": {
+        "debug": true,
+        "title": "条件搜索",
+        "body": [
+          {
+            "type": "group",
+            "body": [
+              {
+                "type": "switch",
+                "name": "status",
+                "label": "已核验",
+                "size": "sm",
+                "value": false
+              }
+            ]
+          }
+        ],
+        "actions": [
+          {
+            "type": "reset",
+            "label": "重置"
+          },
+          {
+            "type": "submit",
+            "level": "primary",
+            "label": "查询"
+          }
+        ]
+      },
+      "columns": [
+        {
+          "name": "id",
+          "label": "ID"
+        },
+        {
+          "name": "browser",
+          "label": "Browser"
+        },
+        {
+          "name": "status",
+          "label": "已核验",
+          "type": "tpl",
+          "tpl": "${status === true ? '是' : '否'}",
+          "filterable": {
+            "options": [
+              {"label": "是", "value": true},
+              {"label": "否", "value": false}
+            ]
+          }
+        },
+      ]
+    }
+  ]
+}

--- a/examples/components/Example.jsx
+++ b/examples/components/Example.jsx
@@ -57,6 +57,7 @@ import LoadOnceTableCrudSchema from './CRUD/LoadOnce';
 import ExportCSVExcelSchema from './CRUD/ExportCSVExcel';
 import CRUDDynamicSchema from './CRUD/Dynamic';
 import CRUDSimplePagerSchema from './CRUD/SimplePager';
+import CRUDParsePrimitiveQuerySchema from './CRUD/ParsePrimitiveQuery';
 import ItemActionchema from './CRUD/ItemAction';
 import SdkTest from './Sdk/Test';
 import JSONSchemaForm from './Form/Schem';
@@ -460,6 +461,11 @@ export const examples = [
             label: '简单分页',
             path: '/examples/crud/simple-pager',
             component: makeSchemaRenderer(CRUDSimplePagerSchema)
+          },
+          {
+            label: '解析Query参数',
+            path: '/examples/crud/parse-primitive-query',
+            component: makeSchemaRenderer(CRUDParsePrimitiveQuerySchema)
           }
           // {
           //     label: '测试',

--- a/mock/cfc/mock/crud/table5.js
+++ b/mock/cfc/mock/crud/table5.js
@@ -1,0 +1,487 @@
+/** 列字段为布尔值，开启查询 */
+module.exports = function (req, res) {
+  const perPage = 10;
+  const page = req.query.page || 1;
+  let items = data.concat();
+
+  const validQueryKey = Object.keys(req.query).filter(
+    item => item !== 'keywords' && req.query[item] != null
+  );
+
+  if (validQueryKey.length > 0) {
+    items = items.filter(item =>
+      validQueryKey.every(key => {
+        if (key === 'status') {
+          return item[key] === (req.query[key] === 'true' ? true : false);
+        }
+
+        return !!~req.query[key].indexOf(item[key] || '');
+      })
+    );
+  }
+
+  const ret = {
+    status: 0,
+    msg: 'ok',
+    data: {
+      count: items.length,
+      rows: items.concat().splice((page - 1) * perPage, perPage)
+    }
+  };
+
+  res.json(ret);
+};
+
+const data = [
+  {
+      "browser": "Internet Explorer 4.0",
+      "platform": "Win 95+",
+      "version": "4",
+      "grade": "X",
+      "status": true
+  },
+  {
+      "browser": "Internet Explorer 5.0",
+      "platform": "Win 95+",
+      "version": "5",
+      "grade": "C",
+      "status": false
+  },
+  {
+      "browser": "Internet Explorer 5.5",
+      "platform": "Win 95+",
+      "version": "5.5",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Trident",
+      "browser": "Internet Explorer 6",
+      "version": "6",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Trident",
+      "browser": "Internet Explorer 7",
+      "version": "7",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Trident",
+      "browser": "AOL browser (AOL desktop)",
+      "platform": "Win XP",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Firefox 1.0",
+      "platform": "Win 98+ / OSX.2+",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Firefox 1.5",
+      "platform": "Win 98+ / OSX.2+",
+      "version": "1.8",
+      "status": false
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Firefox 2.0",
+      "platform": "Win 98+ / OSX.2+",
+      "version": "1.8",
+      "status": true
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Firefox 3.0",
+      "platform": "Win 2k+ / OSX.3+",
+      "version": "1.9",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Camino 1.0",
+      "platform": "OSX.2+",
+      "version": "1.8",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Camino 1.5",
+      "platform": "OSX.3+",
+      "version": "1.8",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Netscape 7.2",
+      "platform": "Win 95+ / Mac OS 8.6-9.2",
+      "version": "1.7",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Netscape Browser 8",
+      "platform": "Win 98SE+",
+      "version": "1.7",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Netscape Navigator 9",
+      "platform": "Win 98+ / OSX.2+",
+      "version": "1.8",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Mozilla 1.0",
+      "platform": "Win 95+ / OSX.1+",
+      "version": "1",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Mozilla 1.1",
+      "platform": "Win 95+ / OSX.1+",
+      "version": "1.1",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Mozilla 1.2",
+      "platform": "Win 95+ / OSX.1+",
+      "version": "1.2",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Mozilla 1.3",
+      "platform": "Win 95+ / OSX.1+",
+      "version": "1.3",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Mozilla 1.4",
+      "platform": "Win 95+ / OSX.1+",
+      "version": "1.4",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Mozilla 1.5",
+      "platform": "Win 95+ / OSX.1+",
+      "version": "1.5",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Mozilla 1.6",
+      "platform": "Win 95+ / OSX.1+",
+      "version": "1.6",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Mozilla 1.7",
+      "platform": "Win 98+ / OSX.1+",
+      "version": "1.7",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Mozilla 1.8",
+      "platform": "Win 98+ / OSX.1+",
+      "version": "1.8",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Seamonkey 1.1",
+      "platform": "Win 98+ / OSX.2+",
+      "version": "1.8",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Gecko",
+      "browser": "Epiphany 2.20",
+      "platform": "Gnome",
+      "version": "1.8",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Webkit",
+      "browser": "Safari 1.2",
+      "platform": "OSX.3",
+      "version": "125.5",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Webkit",
+      "browser": "Safari 1.3",
+      "platform": "OSX.3",
+      "version": "312.8",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Webkit",
+      "browser": "Safari 2.0",
+      "platform": "OSX.4+",
+      "version": "419.3",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Webkit",
+      "browser": "Safari 3.0",
+      "platform": "OSX.4+",
+      "version": "522.1",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Webkit",
+      "browser": "OmniWeb 5.5",
+      "platform": "OSX.4+",
+      "version": "420",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Webkit",
+      "browser": "iPod Touch / iPhone",
+      "platform": "iPod",
+      "version": "420.1",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Webkit",
+      "browser": "S60",
+      "platform": "S60",
+      "version": "413",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Presto",
+      "browser": "Opera 7.0",
+      "platform": "Win 95+ / OSX.1+",
+      "version": "-",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Presto",
+      "browser": "Opera 7.5",
+      "platform": "Win 95+ / OSX.2+",
+      "version": "-",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Presto",
+      "browser": "Opera 8.0",
+      "platform": "Win 95+ / OSX.2+",
+      "version": "-",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Presto",
+      "browser": "Opera 8.5",
+      "platform": "Win 95+ / OSX.2+",
+      "version": "-",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Presto",
+      "browser": "Opera 9.0",
+      "platform": "Win 95+ / OSX.3+",
+      "version": "-",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Presto",
+      "browser": "Opera 9.2",
+      "platform": "Win 88+ / OSX.3+",
+      "version": "-",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Presto",
+      "browser": "Opera 9.5",
+      "platform": "Win 88+ / OSX.3+",
+      "version": "-",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Presto",
+      "browser": "Opera for Wii",
+      "platform": "Wii",
+      "version": "-",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Presto",
+      "browser": "Nokia N800",
+      "platform": "N800",
+      "version": "-",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Presto",
+      "browser": "Nintendo DS browser",
+      "platform": "Nintendo DS",
+      "version": "8.5",
+      "grade": "C",
+      "status": true
+  },
+  {
+      "engine": "KHTML",
+      "browser": "Konqureror 3.1",
+      "platform": "KDE 3.1",
+      "version": "3.1",
+      "grade": "C",
+      "status": false
+  },
+  {
+      "engine": "KHTML",
+      "browser": "Konqureror 3.3",
+      "platform": "KDE 3.3",
+      "version": "3.3",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "KHTML",
+      "browser": "Konqureror 3.5",
+      "platform": "KDE 3.5",
+      "version": "3.5",
+      "grade": "A",
+      "status": false
+  },
+  {
+      "engine": "Tasman",
+      "browser": "Internet Explorer 4.5",
+      "platform": "Mac OS 8-9",
+      "version": "-",
+      "grade": "X",
+      "status": true
+  },
+  {
+      "engine": "Tasman",
+      "browser": "Internet Explorer 5.1",
+      "platform": "Mac OS 7.6-9",
+      "version": "1",
+      "grade": "C",
+      "status": false
+  },
+  {
+      "engine": "Tasman",
+      "browser": "Internet Explorer 5.2",
+      "platform": "Mac OS 8-X",
+      "version": "1",
+      "grade": "C",
+      "status": true
+  },
+  {
+      "engine": "Misc",
+      "browser": "NetFront 3.1",
+      "platform": "Embedded devices",
+      "version": "-",
+      "grade": "C",
+      "status": false
+  },
+  {
+      "engine": "Misc",
+      "browser": "NetFront 3.4",
+      "platform": "Embedded devices",
+      "version": "-",
+      "grade": "A",
+      "status": true
+  },
+  {
+      "engine": "Misc",
+      "browser": "Dillo 0.8",
+      "platform": "Embedded devices",
+      "version": "-",
+      "grade": "X",
+      "status": false
+  },
+  {
+      "engine": "Misc",
+      "browser": "Links",
+      "platform": "Text only",
+      "version": "-",
+      "grade": "X",
+      "status": true
+  },
+  {
+      "engine": "Misc",
+      "browser": "Lynx",
+      "platform": "Text only",
+      "version": "-",
+      "grade": "X",
+      "status": false
+  },
+  {
+      "engine": "Misc",
+      "browser": "IE Mobile",
+      "platform": "Windows Mobile 6",
+      "version": "-",
+      "grade": "C",
+      "status": true
+  },
+  {
+      "engine": "Misc",
+      "browser": "PSP browser",
+      "platform": "PSP",
+      "version": "-",
+      "grade": "C",
+      "status": false
+  },
+  {
+      "engine": "Other browsers",
+      "browser": "All others",
+      "platform": "-",
+      "version": "-",
+      "grade": "U",
+      "status": true
+  }
+].map(function (item, index) {
+  return Object.assign({}, item, {
+    id: index + 1
+  });
+});

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -57,6 +57,7 @@ import {
   isPureVariable,
   resolveVariableAndFilter,
   parseQuery,
+  parsePrimitiveQueryString,
   isMobile
 } from 'amis-core';
 
@@ -362,6 +363,11 @@ export interface CRUDCommonSchema extends BaseSchema, SpinnerExtraProps {
    * 内容区域占满屏幕剩余空间
    */
   autoFillHeight?: TableSchema['autoFillHeight'];
+
+  /**
+   * 是否开启Query信息转换，开启后将会对url中的Query进行转换，将字符串格式的布尔值转化为同位类型
+   */
+  parsePrimitiveQuery?: boolean;
 }
 
 export type CRUDCardsSchema = CRUDCommonSchema & {
@@ -461,7 +467,8 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     'formStore',
     'autoFillHeight',
     'maxTagCount',
-    'overflowTagPopover'
+    'overflowTagPopover',
+    'parsePrimitiveQuery'
   ];
   static defaultProps = {
     toolbarInline: true,
@@ -478,7 +485,8 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     filterTogglable: false,
     filterDefaultVisible: true,
     loadDataOnce: false,
-    autoFillHeight: false
+    autoFillHeight: false,
+    parsePrimitiveQuery: true
   };
 
   control: any;
@@ -525,21 +533,22 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       pageField,
       perPageField,
       syncLocation,
-      loadDataOnce
+      loadDataOnce,
+      parsePrimitiveQuery
     } = props;
 
     this.mounted = true;
 
     if (syncLocation && location && (location.query || location.search)) {
       store.updateQuery(
-        parseQuery(location),
+        parseQuery(location, {parsePrimitive: parsePrimitiveQuery}),
         undefined,
         pageField,
         perPageField
       );
     } else if (syncLocation && !location && window.location.search) {
       store.updateQuery(
-        parseQuery(window.location),
+        parseQuery(window.location, {parsePrimitive: parsePrimitiveQuery}),
         undefined,
         pageField,
         perPageField
@@ -633,7 +642,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     ) {
       // 同步地址栏，那么直接检测 query 是否变了，变了就重新拉数据
       store.updateQuery(
-        parseQuery(props.location),
+        parseQuery(props.location, {parsePrimitive: props.parsePrimitiveQuery}),
         undefined,
         props.pageField,
         props.perPageField
@@ -972,7 +981,8 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       env,
       pageField,
       perPageField,
-      loadDataOnceFetchOnFilter
+      loadDataOnceFetchOnFilter,
+      parsePrimitiveQuery
     } = this.props;
 
     /** 找出clearValueOnHidden的字段, 保证updateQuery时不会使用上次的保留值 */
@@ -983,6 +993,11 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     values = syncLocation
       ? qsparse(qsstringify(values, undefined, true))
       : values;
+
+    /** 把布尔值反解出来 */
+    if (parsePrimitiveQuery) {
+      values = parsePrimitiveQueryString(values);
+    }
 
     store.updateQuery(
       {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9dc4f41</samp>

This pull request adds a new feature to the amis framework that enables parsing query parameters as primitive types, such as boolean values. It updates the helper module, the CRUD component, the documentation, and the examples to support this feature. It also adds a new example schema to the Example component to showcase some advanced amis features.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9dc4f41</samp>

> _If you want to parse booleans in CRUD_
> _You can use the new prop `parsePrimitiveQuery`_
> _It will use a helper function_
> _To handle the conversion_
> _And make your queries more accurate and snappy_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9dc4f41</samp>

*  Add a new feature to the CRUD component that allows parsing query parameters as primitive types, such as boolean values ([link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R60), [link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R366-R370), [link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L464-R471), [link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L481-R489), [link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L528-R537), [link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L535-R544), [link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L542-R551), [link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L636-R645), [link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L975-R985), [link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R997-R1001), [link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL2045-R2087))
*  Update the `parseQuery` utility function in `helper.ts` to accept an option object that controls whether to use the new feature or not ([link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL2045-R2087))
*  Remove a redundant line of code in `helper.ts` that assigns the query object to a variable ([link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL2063))
*  Add a new section to the documentation of the CRUD component in `crud.md` that explains the new feature and provides an example link ([link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653R203-R216))
*  Add a new example schema file in `ParsePrimitiveQuery.jsx` that demonstrates the new feature and the use of the `switch` filter to handle boolean values ([link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-8b7ddba661c5078c57bc1077528d745a2f0382307af0d0f0a463a92c40e30e6dR1-R73))
*  Import the new example schema file to the Example component in `Example.jsx` and add a new route path and label for it in the sidebar menu ([link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-47cbaf4b0d33a2b529a902b365e6fe5b0a514ea4e5c0150395b32a04327a296bR60), [link](https://github.com/baidu/amis/pull/8500/files?diff=unified&w=0#diff-47cbaf4b0d33a2b529a902b365e6fe5b0a514ea4e5c0150395b32a04327a296bR464-R468))
