### PR TITLE
fix: 修复位运算与过滤器冲突问题 Close: #8391

### DIFF
--- a/packages/amis-formula/__tests__/evalute.test.ts
+++ b/packages/amis-formula/__tests__/evalute.test.ts
@@ -580,3 +580,9 @@ test('evalute:namespace', () => {
   expect(evaluate('${ls: &["c"]["c"]}', {})).toMatchObject({d: 4});
   expect(evaluate('${ls: &["c"][key]}', {})).toMatchObject({d: 4});
 });
+
+test('evalute:speical characters', () => {
+  // 优先识别成位运算，而不是过滤器
+  expect(evaluate('${1 | 2}', {})).toBe(3);
+  expect(evaluate('${1 | abc}', {abc: 2})).toBe(3);
+});

--- a/packages/amis-formula/__tests__/lexer.test.ts
+++ b/packages/amis-formula/__tests__/lexer.test.ts
@@ -31,13 +31,19 @@ test('lexer:simple', () => {
 test('lexer:filter', () => {
   expect(
     getTokens('\\$abc is ${abc | date: YYYY-MM-DD HH\\:mm\\:ss}', {
-      evalMode: false
+      evalMode: false,
+      filters: {
+        date() {}
+      }
     })
   ).toMatchSnapshot();
 
   expect(
     getTokens('\\$abc is ${abc | isTrue : trueValue : falseValue}', {
-      evalMode: false
+      evalMode: false,
+      filters: {
+        isTrue() {}
+      }
     })
   ).toMatchSnapshot();
 });
@@ -55,7 +61,10 @@ test('lexer:exception', () => {
 
   expect(() =>
     getTokens('${a | filter: \\x2}', {
-      evalMode: false
+      evalMode: false,
+      filters: {
+        filter() {}
+      }
     })
   ).toThrow('Unexpected token x in 1:17');
 });

--- a/packages/amis-formula/__tests__/parser.test.ts
+++ b/packages/amis-formula/__tests__/parser.test.ts
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import {parse} from '../src/index';
 
 test('parser:simple', () => {
@@ -120,8 +121,12 @@ test('parser:filter', () => {
 test('parser:filter-escape', () => {
   expect(
     parse('\\$abc is ${abc | date: YYYY-MM-DD HH\\:mm\\:ss}', {
-      evalMode: false
-    })
+      evalMode: false,
+      filters: {
+        date: (input: any, format = 'LLL', inputFormat = 'X') =>
+          moment(input, inputFormat).format(format)
+      }
+    } as any)
   ).toMatchSnapshot();
 });
 

--- a/packages/amis-formula/src/types.ts
+++ b/packages/amis-formula/src/types.ts
@@ -61,6 +61,8 @@ export interface LexerOptions {
    * ${abc | html}
    */
   allowFilter?: boolean;
+
+  isFilter?: (name: string) => boolean;
 }
 
 export type TokenTypeName =


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 949c6b9</samp>

This pull request improves the expression parser and evaluator for `amis-formula` by resolving a syntax ambiguity with the pipe symbol. It also adds a new test case to verify the correct handling of special characters in expressions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 949c6b9</samp>

> _Sing, O Muse, of the cunning code reviewer_
> _Who found the flaw in the expression parser_
> _That caused confusion when the pipe symbol_
> _Was used without a filter name to follow_

### Why

 Close: #8391

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 949c6b9</samp>

* Fix the issue of ambiguous syntax between bitwise operators and filters in expressions ([link](https://github.com/baidu/amis/pull/8505/files?diff=unified&w=0#diff-df5c016047fe12131380e19914112903120d0ba7ae0a6baabe19927a039328b4R1), [link](https://github.com/baidu/amis/pull/8505/files?diff=unified&w=0#diff-df5c016047fe12131380e19914112903120d0ba7ae0a6baabe19927a039328b4R374-R380))
* Add a new test case to check the evaluation of expressions with special characters, such as the pipe symbol ([link](https://github.com/baidu/amis/pull/8505/files?diff=unified&w=0#diff-12afc0d8fc19329d900d849d7b791da51b3e399126e9e38059c4a30ba33e9c9dR583-R587))
