### PR TITLE
feat: env.replaceTextIgnoreKeys 支持函数 Close: #7035

### DIFF
--- a/docs/zh-CN/start/getting-started.md
+++ b/docs/zh-CN/start/getting-started.md
@@ -754,8 +754,7 @@ let amisScoped = amis.embed(
   {
     replaceText: {
       service: 'http://localhost'
-    },
-    replaceTextKeys: ['api']
+    }
   }
 );
 ```
@@ -773,6 +772,29 @@ type, name, mode, target, reload
 ```
 
 如果发现有字段被意外替换了，可以通过设置这个属性来避免
+
+通过字符串数组或者函数来过滤字段，比如：
+
+```javascript
+let amisScoped = amis.embed(
+  '#root',
+  {
+    type: 'page',
+    body: {
+      type: 'service',
+      api: 'service/api'
+    }
+  },
+  {},
+  {
+    replaceText: {
+      service: 'http://localhost'
+    },
+    // replaceTextIgnoreKeys: ['api']，
+    replaceTextIgnoreKeys: key => key === 'api'
+  }
+);
+```
 
 #### toastPosition
 

--- a/packages/amis-core/src/env.tsx
+++ b/packages/amis-core/src/env.tsx
@@ -120,7 +120,9 @@ export interface RendererEnv {
   /**
    * 文本替换的黑名单，因为属性太多了所以改成黑名单的 flags
    */
-  replaceTextIgnoreKeys?: String[];
+  replaceTextIgnoreKeys?:
+    | String[]
+    | ((key: string, value: any, object: any) => boolean);
 
   /**
    * 解析url参数

--- a/packages/amis-core/src/utils/replaceText.ts
+++ b/packages/amis-core/src/utils/replaceText.ts
@@ -7,20 +7,31 @@ import {isObject, JSONTraverse} from './helper';
 export function replaceText(
   schema: any,
   replaceText?: {[propName: string]: string},
-  replaceTextIgnoreKeys?: String[]
+  replaceTextIgnoreKeys?:
+    | String[]
+    | ((key: string, value: any, object: any) => boolean)
 ) {
   // 进行文本替换
   if (replaceText && isObject(replaceText)) {
     let replicaSchema = cloneDeep(schema);
     const replaceKeys = Object.keys(replaceText);
     replaceKeys.sort((a, b) => b.length - a.length); // 避免用户将短的放前面
-    const IgnoreKeys = new Set(replaceTextIgnoreKeys || []);
+    const IgnoreKeys = new Set(
+      Array.isArray(replaceTextIgnoreKeys) ? replaceTextIgnoreKeys : []
+    );
+    const ignore =
+      typeof replaceTextIgnoreKeys === 'function'
+        ? replaceTextIgnoreKeys
+        : (key: string) => {
+            return IgnoreKeys.has(key);
+          };
+
     JSONTraverse(replicaSchema, (value: any, key: string, object: any) => {
       const descriptor = Object.getOwnPropertyDescriptor(object, key);
       if (
         typeof value === 'string' &&
-        !IgnoreKeys.has(key) &&
-        descriptor?.writable
+        descriptor?.writable &&
+        !ignore(key, value, object)
       ) {
         for (const replaceKey of replaceKeys) {
           if (~value.indexOf(replaceKey)) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 55473df</samp>

This pull request improves the `replaceText` feature and its documentation. It allows users to filter keys and values with a custom function, and updates the docs and types accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 55473df</samp>

> _If you want to replace text with ease_
> _You can use the `replaceText` feature, please_
> _But if some keys you want to skip_
> _You can pass a function, not just a list_
> _To the option `replaceTextIgnoreKeys`_

### Why

Close: #7035

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 55473df</samp>

* Remove `replaceTextKeys` option from `replaceText` documentation ([link](https://github.com/baidu/amis/pull/8510/files?diff=unified&w=0#diff-cecdf20aaa84e6464093def72aee232955ad9649b13e7187284dfb7176b3cdacL757-R757))
* Add example of using a function to filter keys for `replaceText` feature ([link](https://github.com/baidu/amis/pull/8510/files?diff=unified&w=0#diff-cecdf20aaa84e6464093def72aee232955ad9649b13e7187284dfb7176b3cdacR776-R798))
* Update `RendererEnv` interface to accept a function for `replaceTextIgnoreKeys` option ([link](https://github.com/baidu/amis/pull/8510/files?diff=unified&w=0#diff-62f2e14b837dfa7b7f5f94ee2a856825f211639ddf0f85d783c666dbcd7f8d0dL123-R123))
* Refactor `replaceText` function to use `ignore` function instead of a set of strings ([link](https://github.com/baidu/amis/pull/8510/files?diff=unified&w=0#diff-53fb1a4945d62b6335fc247673d64a59fee08926d3470647d0695b8e66c0cef2L10-R10), [link](https://github.com/baidu/amis/pull/8510/files?diff=unified&w=0#diff-53fb1a4945d62b6335fc247673d64a59fee08926d3470647d0695b8e66c0cef2L17-R32))
