### PR TITLE
chore: 规范自定义样式生成id

### DIFF
--- a/packages/amis-core/src/utils/style-helper.ts
+++ b/packages/amis-core/src/utils/style-helper.ts
@@ -56,7 +56,7 @@ export function findOrCreateStyle(id: string, doc?: Document) {
 }
 
 export function insertStyle(style: string, id: string, doc?: Document) {
-  const varStyleTag = findOrCreateStyle(id, doc);
+  const varStyleTag = findOrCreateStyle('amis-' + id, doc);
 
   // bca-disable-line
   varStyleTag.innerHTML = style;
@@ -348,7 +348,7 @@ export interface InsertCustomStyle {
  */
 export function removeCustomStyle(type: string, id: string, doc?: Document) {
   const style = (doc || document).getElementById(
-    (type ? type + '-' : '') + id.replace('u:', '')
+    'amis-' + (type ? type + '-' : '') + id.replace('u:', '')
   );
   if (style) {
     style.remove();


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8021589</samp>

Add `amis-` prefix to style tag ids in `style-helper.ts`. This avoids id conflicts and improves naming consistency for custom styles.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8021589</samp>

> _`findOrCreateStyle` in the dark of the night_
> _`removeCustomStyle` with a flash of the light_
> _No more id conflicts, only `amis-` prevail_
> _We are the masters of the style tag trail_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8021589</samp>

*  Add 'amis-' prefix to style tag ids to avoid conflicts and maintain consistency ([link](https://github.com/baidu/amis/pull/8514/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL59-R59), [link](https://github.com/baidu/amis/pull/8514/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL351-R351))
*  Update `findOrCreateStyle` function to create or find style tag with prefixed id ([link](https://github.com/baidu/amis/pull/8514/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL59-R59))
*  Update `removeCustomStyle` function to remove style tag with prefixed id ([link](https://github.com/baidu/amis/pull/8514/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL351-R351))
