### PR TITLE
fix: 处理input-number单位选项交互;input-table展示列配置项位置处理 & progress组件配置面板去除模版配置项 feat：组件状态支持"可见"配置项

### DIFF
--- a/packages/amis-editor/src/component/BaseControl.ts
+++ b/packages/amis-editor/src/component/BaseControl.ts
@@ -253,6 +253,7 @@ export const formItemControl: (
           key: 'status',
           body: normalizeBodySchema(
             [
+              getSchemaTpl('visible'),
               getSchemaTpl('hidden'),
               supportStatic ? getSchemaTpl('static') : null,
               // TODO: 下面的部分表单项才有，是不是判断一下是否是表单项

--- a/packages/amis-editor/src/plugin/Form/InputNumber.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputNumber.tsx
@@ -223,7 +223,45 @@ export class NumberControlPlugin extends BasePlugin {
                 },
                 getSchemaTpl('prefix'),
                 getSchemaTpl('suffix'),
-                getSchemaTpl('keyValueMapControl'),
+                getSchemaTpl('combo-container', {
+                  type: 'combo',
+                  label: '单位选项',
+                  mode: 'normal',
+                  name: 'unitOptions',
+                  items: [
+                    {
+                      placeholder: '文本',
+                      type: i18nEnabled ? 'input-text-i18n' : 'input-text',
+                      name: 'label'
+                    },
+                    {
+                      placeholder: '值',
+                      type: 'input-text',
+                      name: 'value'
+                    }
+                  ],
+                  draggable: false,
+                  multiple: true,
+                  pipeIn: (value: any) => {
+                    if (Array.isArray(value)) {
+                      return value.map(item =>
+                        typeof item === 'string'
+                          ? {
+                              label: item,
+                              value: item
+                            }
+                          : item
+                      );
+                    }
+                    return [];
+                  },
+                  pipeOut: (value: any[]) => {
+                    if (!value.length) {
+                      return undefined;
+                    }
+                    return value;
+                  }
+                }),
                 getSchemaTpl('labelRemark'),
                 getSchemaTpl('remark'),
                 getSchemaTpl('placeholder'),

--- a/packages/amis-editor/src/plugin/Form/InputNumber.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputNumber.tsx
@@ -259,7 +259,9 @@ export class NumberControlPlugin extends BasePlugin {
                     if (!value.length) {
                       return undefined;
                     }
-                    return value;
+                    return value.map(item =>
+                      item.value ? item : {label: item.label, value: item.label}
+                    );
                   }
                 }),
                 getSchemaTpl('labelRemark'),

--- a/packages/amis-editor/src/plugin/Form/InputTable.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTable.tsx
@@ -1004,34 +1004,7 @@ export class TableControlPlugin extends BasePlugin {
               },
               getSchemaTpl('description'),
               getSchemaTpl('placeholder'),
-              getSchemaTpl('labelRemark'),
-              {
-                name: 'columnsTogglable',
-                label: tipedLabel(
-                  '列显示开关',
-                  '是否展示表格列的显隐控件，“自动”即列数量大于5时自动开启'
-                ),
-                type: 'button-group-select',
-                pipeIn: defaultValue('auto'),
-                size: 'sm',
-                labelAlign: 'left',
-                options: [
-                  {
-                    label: '自动',
-                    value: 'auto'
-                  },
-
-                  {
-                    label: '开启',
-                    value: true
-                  },
-
-                  {
-                    label: '关闭',
-                    value: false
-                  }
-                ]
-              }
+              getSchemaTpl('labelRemark')
             ]
           },
           {
@@ -1064,6 +1037,43 @@ export class TableControlPlugin extends BasePlugin {
       {
         title: '外观',
         body: getSchemaTpl('collapseGroup', [
+          {
+            title: '基本',
+            body: [
+              {
+                name: 'columnsTogglable',
+                label: tipedLabel(
+                  '列显示开关',
+                  '是否展示表格列的显隐控件，“自动”即列数量大于5时自动开启'
+                ),
+                type: 'button-group-select',
+                pipeIn: defaultValue('auto'),
+                size: 'sm',
+                labelAlign: 'left',
+                options: [
+                  {
+                    label: '自动',
+                    value: 'auto'
+                  },
+
+                  {
+                    label: '开启',
+                    value: true
+                  },
+
+                  {
+                    label: '关闭',
+                    value: false
+                  }
+                ]
+              },
+              getSchemaTpl('switch', {
+                name: 'affixHeader',
+                label: '是否固定表头',
+                pipeIn: defaultValue(false)
+              })
+            ]
+          },
           getSchemaTpl('style:formItem', {renderer: context.info.renderer}),
           getSchemaTpl('style:classNames', {
             schema: [

--- a/packages/amis-editor/src/plugin/Nav.tsx
+++ b/packages/amis-editor/src/plugin/Nav.tsx
@@ -378,7 +378,7 @@ export class NavPlugin extends BasePlugin {
           // },
           {
             title: '状态',
-            body: [getSchemaTpl('hidden')]
+            body: [getSchemaTpl('visible'), getSchemaTpl('hidden')]
           }
         ])
       },

--- a/packages/amis-editor/src/plugin/Progress.tsx
+++ b/packages/amis-editor/src/plugin/Progress.tsx
@@ -92,26 +92,6 @@ export class ProgressPlugin extends BasePlugin {
                 needDeleteProps: ['placeholder'],
                 valueType: 'number' // 期望数值类型，不过 amis中会尝试字符串 trans 数值类型
               }),
-              getSchemaTpl('menuTpl', {
-                label: tipedLabel(
-                  '数值模板',
-                  '值渲染模板，支持JSX、数据域变量使用, 默认 ${value}%'
-                ),
-                name: 'valueTpl',
-                variables: [
-                  {
-                    label: '值字段',
-                    children: [
-                      {
-                        label: '进度值',
-                        value: 'value',
-                        tag: 'number'
-                      }
-                    ]
-                  }
-                ],
-                requiredDataPropsVariables: true
-              }),
 
               getSchemaTpl('switch', {
                 name: 'showLabel',

--- a/packages/amis-editor/src/plugin/Service.tsx
+++ b/packages/amis-editor/src/plugin/Service.tsx
@@ -273,7 +273,7 @@ export class ServicePlugin extends BasePlugin {
             },
             {
               title: '状态',
-              body: [getSchemaTpl('hidden')]
+              body: [getSchemaTpl('visible'), getSchemaTpl('hidden')]
             },
             {
               title: '高级',

--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -792,7 +792,7 @@ setSchemaTpl(
     return {
       title: '状态',
       body: [
-        getSchemaTpl('newVisible'),
+        getSchemaTpl('visible'),
         getSchemaTpl('hidden'),
         !config?.unsupportStatic && config?.isFormItem
           ? getSchemaTpl('static')
@@ -876,17 +876,6 @@ setSchemaTpl('static', {
   mode: 'normal',
   name: 'static',
   expressionName: 'staticOn'
-});
-
-// 新版配置面板兼容 [可见] 状态
-setSchemaTpl('newVisible', {
-  type: 'ae-StatusControl',
-  label: '可见',
-  mode: 'normal',
-  name: 'visible',
-  expressionName: 'visibleOn',
-  visibleOn:
-    'data.visible || data.visible === false || data.visibleOn !== undefined'
 });
 
 setSchemaTpl('hidden', {

--- a/packages/amis-editor/src/tpl/options.tsx
+++ b/packages/amis-editor/src/tpl/options.tsx
@@ -739,13 +739,3 @@ setSchemaTpl('optionDeleteControl', (params: OptionControlParams) => {
     }
   });
 });
-
-/**
- * key value映射类组件
- */
-setSchemaTpl('keyValueMapControl', {
-  type: 'ae-keyValueMapControl',
-  label: '单位选项',
-  name: 'unitOptions',
-  mode: 'normal'
-});


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3514f38</samp>

This pull request updates and improves the schema templates for editing various `amis` components in the `amis-editor`. It adds the `visible` property to some components, reorganizes the `table` component options, adds the unit options for the `input-number` component, and removes some unsupported or redundant properties. It also fixes some compatibility and internationalization issues.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3514f38</samp>

> _Some schema templates were added or removed_
> _To make `amis` components improved_
> _The `visible` property was made consistent_
> _The `valueTpl` option became nonexistent_
> _And some options were repositioned or moved_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3514f38</samp>

*  Add a schema template for the `visible` property to various components, using the `common` file ([link](https://github.com/baidu/amis/pull/8515/files?diff=unified&w=0#diff-851dba93506fd34484adaa1d720285d572d18ca4392a0c4893fca27c4159fa92R256), [link](https://github.com/baidu/amis/pull/8515/files?diff=unified&w=0#diff-09783eec140bf3c70e8dd5932d5b8108bd6777cd334ea0a27322d0f09586de29L381-R381), [link](https://github.com/baidu/amis/pull/8515/files?diff=unified&w=0#diff-6a2f7c2cc26a108293bdd2d7ca6ca8d6b06acbf8e2d17424a50526d6affa6f67L276-R276), [link](https://github.com/baidu/amis/pull/8515/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05L795-R795), [link](https://github.com/baidu/amis/pull/8515/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05L881-L891))
*  Modify the schema template for the `NumberControlPlugin` in `InputNumber.tsx`, adding a new option for unit options and using the `i18nEnabled` variable ([link](https://github.com/baidu/amis/pull/8515/files?diff=unified&w=0#diff-c459de2eb5b316e5e49ab103c7fa1a03c20cf7693bd79b8e039e782b48c5731aL226-R264))
*  Reorganize the schema template for the `TableControlPlugin` in `InputTable.tsx`, moving the `columnsTogglable` property and adding the `affixHeader` property ([link](https://github.com/baidu/amis/pull/8515/files?diff=unified&w=0#diff-01999eae047ec7fdb8502c22801699d39f7a54c994a9414462c0fbe21634ecd8L1007-R1007), [link](https://github.com/baidu/amis/pull/8515/files?diff=unified&w=0#diff-01999eae047ec7fdb8502c22801699d39f7a54c994a9414462c0fbe21634ecd8R1040-R1076))
*  Remove the schema template for the `valueTpl` property from the `ProgressPlugin` in `Progress.tsx`, as it is not supported by the `progress` component ([link](https://github.com/baidu/amis/pull/8515/files?diff=unified&w=0#diff-6ddce7589047fa0b03657030e041891a72416ebd3a417d35e6006b8428cae731L95-L114))
*  Remove the schema template for the `keyValueMapControl` property from the `options` file, as it is replaced by the `combo-container` type ([link](https://github.com/baidu/amis/pull/8515/files?diff=unified&w=0#diff-4ff8190ccb19edb2d788deb7ebf73420c1799a07d6061d2aeb89ab77e9e66b95L742-L751))
