### PR TITLE
fix: 修复 crud 点选出现无限循环的问题 Close: #8523

### DIFF
--- a/packages/amis-core/src/store/formItem.ts
+++ b/packages/amis-core/src/store/formItem.ts
@@ -1254,10 +1254,15 @@ export const FormItemStore = StoreNode.named('FormItemStore')
           });
 
         if (filteredOptions.length) {
-          filteredOptions = mapTree(filteredOptions, item => ({
-            ...item,
-            disabled: ~options.indexOf(item.value)
-          }));
+          filteredOptions = mapTree(filteredOptions, item => {
+            if (~options.indexOf(item.value)) {
+              return {
+                ...item,
+                disabled: true
+              };
+            }
+            return item;
+          });
         }
       }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 61c9f42</samp>

Fix a bug in `FormItemStore` that disabled all options for multiple tree form items. Modify the `syncOptions` function in `packages/amis-core/src/store/formItem.ts` to preserve the original `disabled` property of each option.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 61c9f42</samp>

> _`syncOptions` fixed_
> _no more disabled options_
> _when `tree` and `multiple`_

### Why

Close: #8523

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 61c9f42</samp>

* Fix a bug that disabled all options in a form item with `multiple` and `tree` props ([link](https://github.com/baidu/amis/pull/8524/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L1257-R1265))
