### PR TITLE
fix: Cards & Operation组件配置面板去除“新增按钮”配置项

### DIFF
--- a/packages/amis-editor/src/plugin/Card.tsx
+++ b/packages/amis-editor/src/plugin/Card.tsx
@@ -82,25 +82,6 @@ export class CardPlugin extends BasePlugin {
             getSchemaTpl('layout:originPosition', {value: 'left-top'}),
             {
               children: (
-                <Button
-                  size="sm"
-                  className="m-b-sm"
-                  level="info"
-                  block
-                  onClick={() =>
-                    // this.manager.showInsertPanel('actions', context.id)
-                    this.manager.showRendererPanel(
-                      '按钮',
-                      '请从左侧组件面板中点击添加按钮元素'
-                    )
-                  }
-                >
-                  新增按钮
-                </Button>
-              )
-            },
-            {
-              children: (
                 <div>
                   <Button
                     block

--- a/packages/amis-editor/src/plugin/Operation.tsx
+++ b/packages/amis-editor/src/plugin/Operation.tsx
@@ -50,29 +50,16 @@ export class OperationPlugin extends BasePlugin {
 
   panelTitle = '操作栏';
   panelBodyCreator = (context: BaseEventContext) => {
-    return [
-      getSchemaTpl('className', {
-        name: 'innerClassName'
-      }),
-
+    return getSchemaTpl('tabs', [
       {
-        children: (
-          <Button
-            block
-            className="m-b-sm ae-Button--enhance"
-            onClick={() => {
-              // this.manager.showInsertPanel('buttons', context.id, '按钮');
-              this.manager.showRendererPanel(
-                '按钮',
-                '请从左侧组件面板中点击添加新的按钮'
-              );
-            }}
-          >
-            添加按钮
-          </Button>
-        )
+        title: '外观',
+        body: [
+          getSchemaTpl('className', {
+            name: 'innerClassName'
+          })
+        ]
       }
-    ];
+    ]);
   };
 
   buildSubRenderers(


### PR DESCRIPTION
### What

组件配置面板分类已经调整，没有“按钮”tag类型了，去除“新增按钮”配置项

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f6f8fea</samp>

*  Simplify the card plugin by removing the button for adding a new button ([link](https://github.com/baidu/amis/pull/8527/files?diff=unified&w=0#diff-2598ee4f39e11dd487affc85bc26fa0b6a2ddf0a19bc3ffa37b50e48a278d50aL85-L103))
*  Refactor the operation plugin to use tabs for appearance and behavior settings and remove the redundant button for adding a new button ([link](https://github.com/baidu/amis/pull/8527/files?diff=unified&w=0#diff-af7f2960905447bb89941a83aa87d377d72c10d609e651b733bf49a600f40f25L53-R62))
