### PR TITLE
fix: 修复 $ref  在表格的 table 中时 label 不展示的问题 Close: #1121

### DIFF
--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -979,7 +979,12 @@ export const TableStore = iRendererStore
       return tableRef;
     }
 
-    function update(config: Partial<STableStore>) {
+    function update(
+      config: Partial<STableStore>,
+      options?: {
+        resolveDefinitions?: (ref: string) => any;
+      }
+    ) {
       config.primaryField !== undefined &&
         (self.primaryField = config.primaryField);
       config.selectable !== undefined && (self.selectable = config.selectable);
@@ -1039,8 +1044,21 @@ export const TableStore = iRendererStore
 
       if (config.columns && Array.isArray(config.columns)) {
         let columns: Array<SColumn> = config.columns
-          .filter(column => column)
-          .concat();
+          .map(column => {
+            if (
+              options?.resolveDefinitions &&
+              typeof (column as any)?.$ref == 'string' &&
+              (column as any).$ref
+            ) {
+              return {
+                ...options.resolveDefinitions((column as any).$ref),
+                ...column
+              };
+            }
+
+            return column;
+          })
+          .filter(column => column);
 
         // 更新列顺序，afterCreate生命周期中更新columns不会触发组件的render
         const key = getPersistDataKey(columns);

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -603,7 +603,8 @@ export default class Table extends React.Component<TableProps, object> {
       loading,
       canAccessSuperData,
       lazyRenderAfter,
-      tableLayout
+      tableLayout,
+      resolveDefinitions
     } = props;
 
     let combineNum = props.combineNum;
@@ -614,29 +615,34 @@ export default class Table extends React.Component<TableProps, object> {
       );
     }
 
-    store.update({
-      selectable,
-      draggable,
-      columns,
-      columnsTogglable,
-      orderBy: onQuery ? orderBy : undefined,
-      orderDir,
-      multiple,
-      footable,
-      expandConfig,
-      primaryField,
-      itemCheckableOn,
-      itemDraggableOn,
-      hideCheckToggler,
-      combineNum,
-      combineFromIndex,
-      keepItemSelectionOnPageChange,
-      maxKeepItemSelectionLength,
-      loading,
-      canAccessSuperData,
-      lazyRenderAfter,
-      tableLayout
-    });
+    store.update(
+      {
+        selectable,
+        draggable,
+        columns,
+        columnsTogglable,
+        orderBy: onQuery ? orderBy : undefined,
+        orderDir,
+        multiple,
+        footable,
+        expandConfig,
+        primaryField,
+        itemCheckableOn,
+        itemDraggableOn,
+        hideCheckToggler,
+        combineNum,
+        combineFromIndex,
+        keepItemSelectionOnPageChange,
+        maxKeepItemSelectionLength,
+        loading,
+        canAccessSuperData,
+        lazyRenderAfter,
+        tableLayout
+      },
+      {
+        resolveDefinitions
+      }
+    );
 
     if (
       isPlainObject(autoGenerateFilter) &&
@@ -893,7 +899,9 @@ export default class Table extends React.Component<TableProps, object> {
         if (changes.orderBy && !props.onQuery) {
           delete changes.orderBy;
         }
-        store.update(changes as any);
+        store.update(changes as any, {
+          resolveDefinitions: props.resolveDefinitions
+        });
       }
     );
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 281cbb7</samp>

Enhanced the `Table` component and the `TableStore` class to support dynamic column definitions from external sources. This allows users to define columns in a separate file or URL and reference them in the table schema. This improves the modularity and reusability of table configurations.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 281cbb7</samp>

> _To make tables more dynamic and fun_
> _The `update` function was redone_
> _It can resolve definitions_
> _From external provisions_
> _By using a `resolveDefinitions` prop as a gun_

### Why

Close: #1121

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 281cbb7</samp>

*  Add a `resolveDefinitions` prop to the `Table` component, which is a function that can resolve references to column definitions from other sources ([link](https://github.com/baidu/amis/pull/8532/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL606-R607))
*  Pass the `resolveDefinitions` prop to the `TableStore` instance that the component creates, and to the `update` function of the store, when it initializes or updates the store with the props, or when it handles the `onColumnsChange` event from the `TableHead` component ([link](https://github.com/baidu/amis/pull/8532/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL617-R645), [link](https://github.com/baidu/amis/pull/8532/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL896-R904))
*  Modify the `update` function of the `TableStore` class in `packages/amis-core/src/store/table.ts` to accept an optional `options` parameter, which can contain the `resolveDefinitions` function ([link](https://github.com/baidu/amis/pull/8532/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL982-R987))
*  Use the `resolveDefinitions` function from the `options` parameter to map the `config.columns` array and merge the resolved column definitions with the original ones, if they have a `$ref` property that is a string, in the `update` function of the `TableStore` class ([link](https://github.com/baidu/amis/pull/8532/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1042-R1062))
