### PR TITLE
feat: inputTag 支持边输入边搜索 Close: #1124

### DIFF
--- a/packages/amis/src/renderers/Form/InputTag.tsx
+++ b/packages/amis/src/renderers/Form/InputTag.tsx
@@ -21,6 +21,7 @@ import {isMobile} from 'amis-core';
 import {FormOptionsSchema} from '../../Schema';
 import {supportStatic} from './StaticHoc';
 import {TooltipWrapperSchema} from '../TooltipWrapper';
+import {matchSorter} from 'match-sorter';
 
 /**
  * Tag 输入框
@@ -516,7 +517,7 @@ export default class TagControl extends React.PureComponent<
       this.addItem2(option);
       return;
     }
-    if (this.isReachMax() || this.state.inputValue || !option) {
+    if (this.isReachMax() || !option) {
       return;
     }
 
@@ -573,16 +574,22 @@ export default class TagControl extends React.PureComponent<
       loadingConfig,
       valueField,
       env,
-      mobileUI
+      mobileUI,
+      labelField
     } = this.props;
 
+    const term = this.state.inputValue;
     const finnalOptions = Array.isArray(options)
       ? filterTree(
           options,
-          item =>
-            (Array.isArray(item.children) && !!item.children.length) ||
-            (item[valueField || 'value'] !== undefined &&
-              (mobileUI || !~selectedOptions.indexOf(item))),
+          (item: Option, key: number, level: number, paths: Array<Option>) =>
+            item[valueField || 'value'] !== undefined &&
+            (mobileUI || !~selectedOptions.indexOf(item)) &&
+            (matchSorter([item].concat(paths), term, {
+              keys: [labelField || 'label', valueField || 'value'],
+              threshold: matchSorter.rankings.CONTAINS
+            }).length ||
+              (Array.isArray(item.children) && !!item.children.length)),
           0,
           true
         )


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bfeecb4</samp>

Improve fuzzy matching and ranking of options for `InputTag` component. Use `matchSorter` to filter and sort options based on input and option attributes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bfeecb4</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The `InputTag` component, that versatile tool_
> _That lets the user choose from a branching tree of options_
> _With fuzzy matching and ranking by the `matchSorter` rule_

### Why

Close: #1124 

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bfeecb4</samp>

* Import `matchSorter` function to perform fuzzy matching and ranking of options ([link](https://github.com/baidu/amis/pull/8533/files?diff=unified&w=0#diff-4103a995836e1ba992d9983ff105ac554d14cd82653af751b39057246d3f5fb7R24))
* Remove condition that prevented options from being rendered on input ([link](https://github.com/baidu/amis/pull/8533/files?diff=unified&w=0#diff-4103a995836e1ba992d9983ff105ac554d14cd82653af751b39057246d3f5fb7L519-R520))
* Modify `filterTree` function to use `matchSorter` on options and paths ([link](https://github.com/baidu/amis/pull/8533/files?diff=unified&w=0#diff-4103a995836e1ba992d9983ff105ac554d14cd82653af751b39057246d3f5fb7L576-R592))
