### PR TITLE
feat:input-file样式调整

### DIFF
--- a/packages/amis-ui/scss/components/form/_file.scss
+++ b/packages/amis-ui/scss/components/form/_file.scss
@@ -47,6 +47,8 @@
   // }
 
   &-description {
+    margin-top: var(--inputFile-base-des-margin);
+    line-height: 20px;
     color: var(--inputFile-base-des-color);
     font-size: var(--inputFile-base-des-fontSize);
     font-weight: var(--inputFile-base-des-fontWeight);

--- a/packages/amis/src/renderers/Form/InputFile.tsx
+++ b/packages/amis/src/renderers/Form/InputFile.tsx
@@ -1445,7 +1445,7 @@ export default class FileControl extends React.Component<FileProps, FileState> {
               ) : (
                 <>
                   <Button
-                    level="default"
+                    level="enhance"
                     disabled={disabled}
                     className={cx('FileControl-selectBtn', btnClassName, {
                       'is-disabled':
@@ -1469,17 +1469,15 @@ export default class FileControl extends React.Component<FileProps, FileState> {
                   </Button>
                 </>
               )}
-              {description
-                ? render('desc', description, {
-                    className: cx(
-                      'FileControl-description',
-                      descriptionClassName
-                    )
-                  })
-                : null}
             </div>
           )}
         </DropZone>
+
+        {description
+          ? render('desc', description, {
+              className: cx('FileControl-description', descriptionClassName)
+            })
+          : null}
 
         {maxSize && !drag ? (
           <div className={cx('FileControl-sizeTip')}>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 406b1a3</samp>

This pull request enhances the file input component in `amis` by changing its button style, layout, and description text. It modifies the `InputFile.tsx` and `_file.scss` files to implement these changes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 406b1a3</samp>

> _Oh we're the crew of the CSS ship, and we sail the web so fine_
> _We tweak the style of the `file input`, and we make it look divine_
> _We heave away on the margin and the line-height, on the count of three_
> _We move the `file input description` out of the drop zone, and we sing with glee_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 406b1a3</samp>

* Enhance the style and functionality of the file input component in `InputFile.tsx` and `_file.scss` ([link](https://github.com/baidu/amis/pull/8535/files?diff=unified&w=0#diff-5797b78d8d3f6d8899dfdb4fdebd4cf26bfb055b5b98c285726d6b8cad948b33L1448-R1448), [link](https://github.com/baidu/amis/pull/8535/files?diff=unified&w=0#diff-5797b78d8d3f6d8899dfdb4fdebd4cf26bfb055b5b98c285726d6b8cad948b33L1472-R1481), [link](https://github.com/baidu/amis/pull/8535/files?diff=unified&w=0#diff-75b0706a3eaeb3d5632debc03411197abc6641be9e6ea620664ea57885697096R50-R51))
  - Change the file select button level to enhance for more prominence ([link](https://github.com/baidu/amis/pull/8535/files?diff=unified&w=0#diff-5797b78d8d3f6d8899dfdb4fdebd4cf26bfb055b5b98c285726d6b8cad948b33L1448-R1448))
  - Move the file input description element outside the drop zone for more visibility ([link](https://github.com/baidu/amis/pull/8535/files?diff=unified&w=0#diff-5797b78d8d3f6d8899dfdb4fdebd4cf26bfb055b5b98c285726d6b8cad948b33L1472-R1481))
  - Add some margin and line-height to the file input description element for better alignment ([link](https://github.com/baidu/amis/pull/8535/files?diff=unified&w=0#diff-75b0706a3eaeb3d5632debc03411197abc6641be9e6ea620664ea57885697096R50-R51))
