### PR TITLE
fix: 修复两层弹窗里面都放 crud , 里面的弹窗确认同时关闭外层弹窗的问题 Close: #1405

### DIFF
--- a/packages/amis/src/renderers/Dialog.tsx
+++ b/packages/amis/src/renderers/Dialog.tsx
@@ -911,9 +911,8 @@ export class DialogRenderer extends Dialog {
     const {onAction, store, onConfirm, env, dispatchEvent, onClose} =
       this.props;
     if (action.from === this.$$id) {
-      return onAction
-        ? onAction(e, action, data, throwErrors, delegate || this.context)
-        : false;
+      // 可能是孩子又派送回来到自己了，这时候就不要处理了。
+      return;
     }
 
     const scoped = this.context as IScopedContext;

--- a/packages/amis/src/renderers/Drawer.tsx
+++ b/packages/amis/src/renderers/Drawer.tsx
@@ -871,9 +871,8 @@ export class DrawerRenderer extends Drawer {
     const {onClose, onAction, store, env, dispatchEvent} = this.props;
 
     if (action.from === this.$$id) {
-      return onAction
-        ? onAction(e, action, data, throwErrors, delegate || this.context)
-        : false;
+      // 可能是孩子又派送回来到自己了，这时候就不要处理了。
+      return;
     }
 
     const scoped = this.context as IScopedContext;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00e8c0c</samp>

Prevent modal components from handling actions dispatched by their children. Add comments and return statements to `DialogRenderer` and `DrawerRenderer` classes in `packages/amis/src/renderers/Dialog.tsx` and `packages/amis/src/renderers/Drawer.tsx` respectively.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 00e8c0c</samp>

> _`Dialog` and `Drawer`_
> _Modal components with kids_
> _Avoid repeat actions_

### Why

Close: #1405 

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 00e8c0c</samp>

*  Prevent modal components from handling actions dispatched by their children ([link](https://github.com/baidu/amis/pull/8537/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL914-R915), [link](https://github.com/baidu/amis/pull/8537/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L874-R875))
