### PR TITLE
fix: 修复 formItem label 做两次变量替换的问题同时优化 label 描述中取当前数据的及时性问题

### DIFF
--- a/packages/amis-core/src/renderers/Item.tsx
+++ b/packages/amis-core/src/renderers/Item.tsx
@@ -28,13 +28,12 @@ import {
   ClassName,
   Schema
 } from '../types';
-import {filter} from '../utils/tpl';
 import {HocStoreFactory} from '../WithStore';
 import {wrapControl} from './wrapControl';
 import debounce from 'lodash/debounce';
 import {isApiOutdated, isEffectiveApi} from '../utils/api';
 import {findDOMNode} from 'react-dom';
-import {dataMapping, setThemeClassName} from '../utils';
+import {dataMapping, setThemeClassName, traceProps} from '../utils';
 import Overlay from '../components/Overlay';
 import PopOver from '../components/PopOver';
 import CustomStyle from '../components/CustomStyle';
@@ -1022,12 +1021,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
               style={labelWidth != null ? {width: labelWidth} : undefined}
             >
               <span>
-                {label
-                  ? render(
-                      'label',
-                      typeof label === 'string' ? filter(label, data) : label
-                    )
-                  : null}
+                {label ? render('label', label) : null}
                 {required && (label || labelRemark) ? (
                   <span className={cx(`Form-star`)}>*</span>
                 ) : null}
@@ -1163,12 +1157,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
           {label && renderLabel !== false ? (
             <label className={cx(`Form-label`, getItemLabelClassName(props))}>
               <span>
-                {label
-                  ? render(
-                      'label',
-                      typeof label === 'string' ? filter(label, data) : label
-                    )
-                  : null}
+                {label ? render('label', label) : null}
                 {required && (label || labelRemark) ? (
                   <span className={cx(`Form-star`)}>*</span>
                 ) : null}
@@ -1355,12 +1344,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
               style={labelWidth != null ? {width: labelWidth} : undefined}
             >
               <span>
-                {label
-                  ? render(
-                      'label',
-                      typeof label === 'string' ? filter(label, data) : label
-                    )
-                  : label}
+                {label ? render('label', label) : label}
                 {required && (label || labelRemark) ? (
                   <span className={cx(`Form-star`)}>*</span>
                 ) : null}
@@ -1494,10 +1478,7 @@ export class FormItemWrap extends React.Component<FormItemProps> {
                 style={labelWidth != null ? {width: labelWidth} : undefined}
               >
                 <span>
-                  {render(
-                    'label',
-                    typeof label === 'string' ? filter(label, data) : label
-                  )}
+                  {render('label', label)}
                   {required && (label || labelRemark) ? (
                     <span className={cx(`Form-star`)}>*</span>
                   ) : null}

--- a/packages/amis-core/src/store/formItem.ts
+++ b/packages/amis-core/src/store/formItem.ts
@@ -24,7 +24,9 @@ import {
   spliceTree,
   filterTree,
   eachTree,
-  mapTree
+  mapTree,
+  setVariable,
+  cloneObject
 } from '../utils/helper';
 import {flattenTree} from '../utils/helper';
 import find from 'lodash/find';
@@ -265,6 +267,14 @@ export const FormItemStore = StoreNode.named('FormItemStore')
           ? value.split(delimiter || ',').map((v: string) => v.trim())
           : [];
         return values;
+      },
+
+      getMergedData(data: any) {
+        const result = cloneObject(data);
+        setVariable(result, self.name, self.tmpValue);
+        setVariable(result, '__value', self.tmpValue);
+        setVariable(result, '__name', self.name);
+        return result;
       }
     };
   })

--- a/packages/amis/__tests__/renderers/Form/formitem.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/formitem.test.tsx
@@ -290,3 +290,39 @@ test('Renderer:FormItem:dynamicName', async () => {
     abc: '123'
   });
 });
+
+test('Renderer:FormItem:label with variable', async () => {
+  const onSubmit = jest.fn();
+
+  const {container, getByText} = render(
+    amisRender(
+      {
+        type: 'form',
+        id: 'theform',
+        submitText: 'Submit',
+        body: [
+          {
+            type: 'input-text',
+            name: 'b',
+            label: 'Label ${a}'
+          }
+        ],
+        title: 'The form'
+      },
+      {
+        onSubmit,
+        data: {
+          a: '${b}',
+          b: '123'
+        }
+      },
+      makeEnv({})
+    )
+  );
+
+  await wait(200);
+  const label = container.querySelector('label');
+  expect(label?.innerHTML).toBe(
+    '<span><span class="cxd-TplField"><span>Label ${b}</span></span></span>'
+  );
+});

--- a/packages/amis/__tests__/renderers/Form/inputDate.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/inputDate.test.tsx
@@ -504,10 +504,14 @@ test('Renderer:inputDate disabledDate', async () => {
   const monday = moment().day(1);
   const tuesday = moment().day(2);
   const mondayCell = container.querySelector(
-    '.cxd-DatePicker-popover tr td[data-value="' + monday.date() + '"]'
+    '.cxd-DatePicker-popover tr td[data-value="' +
+      monday.date() +
+      '"]:not(.rdtOld)'
   ) as HTMLElement;
   const tuesdayCell = container.querySelector(
-    '.cxd-DatePicker-popover tr td[data-value="' + tuesday.date() + '"]'
+    '.cxd-DatePicker-popover tr td[data-value="' +
+      tuesday.date() +
+      '"]:not(.rdtOld)'
   ) as HTMLElement;
 
   expect(mondayCell).toHaveClass('rdtDisabled');


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e3a6ca1</samp>

This pull request enhances the form item component and its store to support variables in the name and value properties. It also improves the performance of rendering the form item label. The main changes are in `Item.tsx`, `wrapControl.tsx`, and `formItem.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e3a6ca1</samp>

> _Form item merges_
> _`data` with parent's data_
> _Autumn of variables_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e3a6ca1</samp>

*  Simplify the label prop of the form item to avoid filtering the data in the render function ([link](https://github.com/baidu/amis/pull/8553/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1025-R1025), [link](https://github.com/baidu/amis/pull/8553/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1166-R1161), [link](https://github.com/baidu/amis/pull/8553/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1358-R1348), [link](https://github.com/baidu/amis/pull/8553/files?diff=unified&w=0#diff-3c32a1d8dd75c9d73a75e6ce444aed076fa83613f47ce248cf604dbb9bf1c4a8L1497-R1482)) in `Item.tsx`
