### PR TITLE
fix: 修复 tabs 下表单项禁用状态判断可能不正确的问题

### DIFF
--- a/packages/amis/__tests__/event-action/disabled.test.tsx
+++ b/packages/amis/__tests__/event-action/disabled.test.tsx
@@ -1,7 +1,7 @@
 import {fireEvent, render} from '@testing-library/react';
 import '../../src';
 import {render as amisRender} from '../../src';
-import {makeEnv} from '../helper';
+import {makeEnv, wait} from '../helper';
 
 test('EventAction:disabled', async () => {
   const {getByText, container}: any = render(
@@ -98,4 +98,50 @@ test('EventAction:disabled', async () => {
   fireEvent.click(getByText(/按钮6/));
 
   expect(container).toMatchSnapshot();
+});
+
+test('EventAction:disabledFormItem', async () => {
+  const {getByText, container}: any = render(
+    amisRender(
+      {
+        type: 'page',
+        body: [
+          {
+            type: 'form',
+            body: [
+              {
+                type: 'textarea',
+                id: 'textarea',
+                name: 'textarea',
+                disabled: true
+              }
+            ]
+          },
+          {
+            type: 'action',
+            label: '启用textarea',
+            onEvent: {
+              click: {
+                actions: [
+                  {
+                    actionType: 'enabled',
+                    componentId: 'textarea'
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {},
+      makeEnv({})
+    )
+  );
+
+  expect(container.querySelector('textarea[name="textarea"]')).toBeDisabled();
+  fireEvent.click(getByText(/启用textarea/));
+  await wait(200);
+  expect(
+    container.querySelector('textarea[name="textarea"]')
+  ).not.toBeDisabled();
 });

--- a/packages/amis/__tests__/renderers/Form/formitem.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/formitem.test.tsx
@@ -326,3 +326,53 @@ test('Renderer:FormItem:label with variable', async () => {
     '<span><span class="cxd-TplField"><span>Label ${b}</span></span></span>'
   );
 });
+
+test('Renderer:FormItem:disabledInTabs', async () => {
+  const onSubmit = jest.fn();
+
+  const {container, getByText} = render(
+    amisRender(
+      {
+        type: 'form',
+        id: 'theform',
+        submitText: 'Submit',
+        body: [
+          {
+            type: 'tabs',
+            disabled: false,
+            tabs: [
+              {
+                title: 'Tab1',
+                body: [
+                  {
+                    type: 'input-text',
+                    name: 'a',
+                    disabled: true
+                  }
+                ]
+              },
+
+              {
+                title: 'Tabb',
+                disabled: true,
+                body: [
+                  {
+                    type: 'input-text',
+                    name: 'b'
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {},
+      makeEnv({})
+    )
+  );
+
+  await wait(200);
+
+  expect(container.querySelector('input[name=a]')).toBeDisabled();
+  expect(container.querySelector('input[name=b]')).toBeDisabled();
+});

--- a/packages/amis/src/renderers/Tabs.tsx
+++ b/packages/amis/src/renderers/Tabs.tsx
@@ -808,7 +808,7 @@ export default class Tabs extends React.Component<TabsProps, TabsState> {
               `item/${index}`,
               (tab as any)?.type ? (tab as any) : tab.tab || tab.body,
               {
-                disabled: disabled,
+                disabled: disabled || isDisabled(tab, ctx) || undefined, // 下发个 undefined，让子表单项自己判断
                 data: ctx,
                 formMode: tab.mode || subFormMode || formMode,
                 formHorizontal:
@@ -853,7 +853,7 @@ export default class Tabs extends React.Component<TabsProps, TabsState> {
                   `tab/${index}`,
                   (tab as any)?.type ? (tab as any) : tab.tab || tab.body,
                   {
-                    disabled: disabled,
+                    disabled: disabled || isDisabled(tab, data) || undefined, // 下发个 undefined，让子表单项自己判断,
                     formMode: tab.mode || subFormMode || formMode,
                     formHorizontal:
                       tab.horizontal || subFormHorizontal || formHorizontal


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e7ec975</samp>

Added support for dynamic disabling of tabs and tab contents based on data expressions. Added test cases for the `enabled` action and the disabled form items inside tabs. Modified the `Tabs` and `Tab` renderers and the `disabled.test.tsx` and `formitem.test.tsx` test files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e7ec975</samp>

> _In the shadows of the form, the tabs conceal their doom_
> _`isDisabled` is the spell that seals their fate_
> _But the test case sees it all, it waits for them to render_
> _`enabled` is the action that breaks the gate_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e7ec975</samp>

*  Add `isDisabled` function to `Tabs` and `Tab` renderers to dynamically disable tabs and tab contents based on data context ([link](https://github.com/baidu/amis/pull/8555/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL811-R811), [link](https://github.com/baidu/amis/pull/8555/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL856-R856))
*  Modify `disabled` prop of tab components to use `isDisabled` function or original `disabled` prop or `undefined` as fallback ([link](https://github.com/baidu/amis/pull/8555/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL811-R811), [link](https://github.com/baidu/amis/pull/8555/files?diff=unified&w=0#diff-63184bed2da6b33acc3e0a8a3b99a6cefa77d06ea29e3794c5ad6f9a0106483aL856-R856))
*  Add test case for disabling form items inside tabs in `formitem.test.tsx` ([link](https://github.com/baidu/amis/pull/8555/files?diff=unified&w=0#diff-e9c9523d3c855bb36a86ae09f9f4b60f744b533b4c33ed740704852da53cc2bfR329-R378))
*  Add test case for enabling a disabled form item with `enabled` action in `disabled.test.tsx` ([link](https://github.com/baidu/amis/pull/8555/files?diff=unified&w=0#diff-e7ac4f16b4301c0a9f8054edfa1e4ba83a69196107253564b36de887c9d72072R102-R147))
*  Import `wait` function from `../helper` module in `disabled.test.tsx` ([link](https://github.com/baidu/amis/pull/8555/files?diff=unified&w=0#diff-e7ac4f16b4301c0a9f8054edfa1e4ba83a69196107253564b36de887c9d72072L4-R4))
