### PR TITLE
fix: 修复引入 moment-timezone 后文档页面报错 Close:#8560

### DIFF
--- a/fis-conf.js
+++ b/fis-conf.js
@@ -241,7 +241,7 @@ fis.match('/examples/mod.js', {
   isMod: false
 });
 
-fis.match('markdown-it/**', {
+fis.match('{markdown-it,moment-timezone}/**', {
   preprocessor: fis.plugin('js-require-file')
 });
 
@@ -688,6 +688,7 @@ if (fis.project.currentMedia() === 'publish-sdk') {
     postprocessor: convertSCSSIE11
   });
   const ghPages = fis.media('gh-pages');
+  ghPages.set('project.files', ['examples/index.html']);
 
   ghPages.match('*.scss', {
     parser: fis.plugin('sass', {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6e332a</samp>

This file adds a dependency for `moment-timezone` and changes the GitHub Pages deployment settings to enable timezone-aware markdown rendering in `examples/index.html`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b6e332a</samp>

> _We're sailing on the web with `moment-timezone`_
> _We render markdown right no matter where we roam_
> _We heave and haul the `fis.match` pattern on the count of three_
> _And deploy our `examples` to the `ghPages` with glee_

### Why

Close: #8560

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b6e332a</samp>

* Expand fis.match pattern to include moment-timezone dependency for markdown-it plugin ([link](https://github.com/baidu/amis/pull/8561/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedL244-R244))
* Update ghPages configuration to only deploy examples/index.html file to GitHub Pages ([link](https://github.com/baidu/amis/pull/8561/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedR691))
