### PR TITLE
chore: 调整InputFile组件错误提示位置, 增加多文件上传示例

### DIFF
--- a/docs/zh-CN/components/form/input-file.md
+++ b/docs/zh-CN/components/form/input-file.md
@@ -302,6 +302,48 @@ order: 21
 }
 ```
 
+## 上传文件列表
+
+```schema: scope="body"
+{
+    "type": "form",
+    "api": "/api/mock2/form/saveForm",
+    "debug": true,
+    "data": {
+      "files": [
+        {
+          "id":"2ba48d02d349",
+          "value":"http://amis.bj.bcebos.com/amis/2017-11/1510713111265/fis3-react.md",
+          "url":"http://amis.bj.bcebos.com/amis/2017-11/1510713111265/fis3-react.md",
+          "filename":"file1.md",
+          "name":"file1.md",
+          "state":"uploaded"
+        },
+        {
+          "id":"14723e0bc640",
+          "value":"http://amis.bj.bcebos.com/amis/2017-11/1510713111265/fis3-react.md",
+          "url":"http://amis.bj.bcebos.com/amis/2017-11/1510713111265/fis3-react.md",
+          "filename":"file2.md",
+          "name":"file2.md",
+          "state":"uploaded"
+        }
+      ]
+    },
+    "body": [
+      {
+          "type": "input-file",
+          "name": "files",
+          "label": false,
+          "mode": "horizontal",
+          "accept": "*",
+          "receiver": "/api/mock2/upload/random",
+          "multiple": true,
+          "joinValues": false
+      }
+    ]
+}
+```
+
 ## 属性表
 
 除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置

--- a/mock/cfc/mock/upload/random.js
+++ b/mock/cfc/mock/upload/random.js
@@ -1,0 +1,31 @@
+/** 测试上传，随机成功 */
+module.exports = function(req, res) {
+  const pool = [1,2,3,4,5,6,7,8,9,10];
+  let result = pool.slice();
+
+  for( let i = 0; i < pool.length; i++) {
+    let k = Math.floor(Math.random() * (pool.length - i) + i);
+    [result[i], result[k]] = [result[k], result[i]];
+  }
+
+  const randomNum = result[0];
+
+  if (randomNum > 5) {
+    return res.json({
+      status: 0,
+      msg: '上传成功',
+      data: {
+        "value": `http://amis.bj.bcebos.com/amis/random/${randomNum}`,
+        "url": `http://amis.bj.bcebos.com/amis/random/${randomNum}`,
+        "filename": `random${randomNum}.js`
+      }
+    });
+  }
+  else {
+    return res.json({
+      status: 500,
+      msg: '上传失败',
+      data: null
+    });
+  }
+}

--- a/packages/amis-ui/scss/components/form/_file.scss
+++ b/packages/amis-ui/scss/components/form/_file.scss
@@ -300,6 +300,7 @@
 
     > a {
       cursor: pointer;
+      font-size: var(--fontSizeSm);
     }
   }
 }

--- a/packages/amis/src/renderers/Form/InputFile.tsx
+++ b/packages/amis/src/renderers/Form/InputFile.tsx
@@ -1497,7 +1497,7 @@ export default class FileControl extends React.Component<FileProps, FileState> {
               return (
                 <li key={file.id}>
                   <TooltipWrapper
-                    placement="bottom"
+                    placement="top"
                     container={container || env?.getModalContainer}
                     tooltipClassName={cx(
                       'FileControl-list-tooltip',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4cca5d</samp>

This pull request adds a drag and drop upload feature to the `input-file` component. It updates the documentation, the mock server, the style, and the tooltip of the component. It demonstrates how to use the `files` and `receiver` properties to handle the upload process and display the uploaded files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f4cca5d</samp>

> _`input-file` component_
> _drag and drop files to upload_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f4cca5d</samp>

* Add an example schema for the input-file component with drag and drop upload feature ([link](https://github.com/baidu/amis/pull/8566/files?diff=unified&w=0#diff-693893014a89e89d5d88406bee4953c9129cb8ea6dc9a3197baaecf597a0bddaR305-R346))
* Simulate a random upload success or failure response with a mock server script (`mock/cfc/mock/upload/random.js`) ([link](https://github.com/baidu/amis/pull/8566/files?diff=unified&w=0#diff-b875e36296884f73f6ea9fd3319e6cb6882bc5909a61e2c0bd43c6969c9093e3R1-R32))
* Adjust the font size of the file list items to a smaller value ([link](https://github.com/baidu/amis/pull/8566/files?diff=unified&w=0#diff-75b0706a3eaeb3d5632debc03411197abc6641be9e6ea620664ea57885697096R303))
* Change the tooltip placement from bottom to top to avoid overlapping with the file list ([link](https://github.com/baidu/amis/pull/8566/files?diff=unified&w=0#diff-5797b78d8d3f6d8899dfdb4fdebd4cf26bfb055b5b98c285726d6b8cad948b33L1500-R1500))
