### PR TITLE
fix: 搜索框组件通过事件动作给页面变量赋值导致自身值受影响

### DIFF
--- a/packages/amis/src/renderers/SearchBox.tsx
+++ b/packages/amis/src/renderers/SearchBox.tsx
@@ -178,9 +178,10 @@ export class SearchBoxRenderer extends React.Component<
       this.setState({value: ''});
     }
   }
-
   setData(value: any) {
-    this.setState({value});
+    if (typeof value === 'string') {
+      this.setState({value});
+    }
   }
 
   render() {


### PR DESCRIPTION
### What
同步PageMaker分支
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e3d0a2</samp>

Fixed a bug in the `SearchBox` component that caused it to crash when used with a select field. Added a type check in the `setData` method to avoid setting the state with an invalid value.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0e3d0a2</samp>

> _`SearchBox` checks type_
> _Avoids invalid state crash_
> _A bug fix for fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0e3d0a2</samp>

*  Prevent setting invalid value to search box state ([link](https://github.com/baidu/amis/pull/8572/files?diff=unified&w=0#diff-31f99d01c6fce6b476f0823ef31ddbb20eebd2f4d78e5680f4fa9b2449a87afaL181-R184))
