### PR TITLE
fix(amis-editor): 表格2.0脚手架loading状态错误

### DIFF
--- a/packages/amis-editor/src/renderer/FieldSetting.tsx
+++ b/packages/amis-editor/src/renderer/FieldSetting.tsx
@@ -144,10 +144,7 @@ export class FieldSetting extends React.Component<
       (prevValue?.length !== value?.length || !isEqual(prevValue, value)) &&
       !isEqual(value, prevState?.fields)
     ) {
-      this.setState({
-        loading: true,
-        fields: Array.isArray(value) ? value : []
-      });
+      this.setState({fields: Array.isArray(value) ? value : []});
     }
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b0f2d2</samp>

Removed unnecessary `loading` state from `FieldSetting` component in `amis-editor`. This fixed a bug that caused the field setting panel to hang when switching fields.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4b0f2d2</samp>

> _No more `loading` state_
> _Field setting panel is fast_
> _Autumn leaves change type_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4b0f2d2</samp>

*  Removed `loading` state from `setState` call in `FieldSetting` component to fix loading spinner bug ([link](https://github.com/baidu/amis/pull/8575/files?diff=unified&w=0#diff-826b212ace06045d989fcddc09c0da1071c579d4e57a23592138ff471bd6b7e0L147-R147))
