### PR TITLE
fix: 修复工具栏导出 excel 识别成 button 事件面板没有事件的问题

### DIFF
--- a/packages/amis-editor/src/plugin/Button.tsx
+++ b/packages/amis-editor/src/plugin/Button.tsx
@@ -413,14 +413,16 @@ export class ButtonPlugin extends BasePlugin {
             ? [
                 getSchemaTpl('eventControl', {
                   name: 'onEvent',
-                  ...getEventControlConfig(this.manager, context)
+                  ...getEventControlConfig(this.manager, context),
+                  rawType: 'button'
                 }),
                 getOldActionSchema(this.manager, context)
               ]
             : [
                 getSchemaTpl('eventControl', {
                   name: 'onEvent',
-                  ...getEventControlConfig(this.manager, context)
+                  ...getEventControlConfig(this.manager, context),
+                  rawType: 'button'
                 })
               ]
       }

--- a/packages/amis-editor/src/renderer/event-control/index.tsx
+++ b/packages/amis-editor/src/renderer/event-control/index.tsx
@@ -131,14 +131,16 @@ export class EventControl extends React.Component<
 
   constructor(props: EventControlProps) {
     super(props);
-    const {events, value, data} = props;
+    const {events, value, data, rawType} = props;
 
     const eventPanelActive: {
       [prop: string]: boolean;
     } = {};
 
     const pluginEvents =
-      events[!data.type || data.type === 'text' ? 'plain' : data.type] || [];
+      events[
+        rawType || (!data.type || data.type === 'text' ? 'plain' : data.type)
+      ] || [];
 
     pluginEvents.forEach((event: RendererPluginEvent) => {
       eventPanelActive[event.eventName] = true;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 74fad47</samp>

This pull request adds support for custom button types and events in the `amis-editor` package. It modifies the `Button` plugin and the `EventControl` renderer to pass and handle the `rawType` property of the button component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 74fad47</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A wondrous way to vary the events of buttons_
> _By passing `rawType` from the component's source_
> _To the `EventControl` renderer, the shaper of actions._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 74fad47</samp>

*  Add `rawType` property to `eventControl` schema templates to pass the original button type to `EventControl` renderer ([link](https://github.com/baidu/amis/pull/8583/files?diff=unified&w=0#diff-da2ca6c6a8ac5b6fcef2f72eb2ab705288b464dc1ddda4122cffd5f2cecf022bL416-R417), [link](https://github.com/baidu/amis/pull/8583/files?diff=unified&w=0#diff-da2ca6c6a8ac5b6fcef2f72eb2ab705288b464dc1ddda4122cffd5f2cecf022bL423-R425))
*  Modify `EventControl` constructor to accept an optional `rawType` parameter and use it to select the plugin events based on the button type ([link](https://github.com/baidu/amis/pull/8583/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754L134-R134), [link](https://github.com/baidu/amis/pull/8583/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754L141-R143))
*  Update `EventControl` renderer in `packages/amis-editor/src/renderer/event-control/index.tsx` to support different types of events for different types of buttons, such as `button`, `submit`, `reset`, etc. ([link](https://github.com/baidu/amis/pull/8583/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754L141-R143))
