### PR TITLE
fix(amis-editor): 优化删除快捷键执行逻辑

### DIFF
--- a/packages/amis-editor-core/src/component/Editor.tsx
+++ b/packages/amis-editor-core/src/component/Editor.tsx
@@ -373,11 +373,16 @@ export default class Editor extends Component<EditorProps> {
       // 删除快捷键
       if (this.store.activeId) {
         const node = store.getNodeById(this.store.activeId);
-        if (node && store.activeRegion) {
+        if (
+          node &&
+          store.activeRegion &&
+          node.info?.regions &&
+          node.info.regions.length > 1
+        ) {
           toast.warning('区域节点不可以直接删除。');
         } else if (store.isRootSchema(this.store.activeId)) {
           toast.warning('根节点不允许删除。');
-        } else if (node && node.moveable) {
+        } else if (node && (node.removable || node.removable === undefined)) {
           this.manager.del(this.store.activeId);
         } else {
           toast.warning('当前元素不允许删除。');

--- a/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
+++ b/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
@@ -107,7 +107,7 @@ export class FlexPluginBase extends LayoutBasePlugin {
                   getSchemaTpl('layout:flex-setting', {
                     label: '弹性布局设置',
                     direction: curRendererSchema.direction,
-                    justify: curRendererSchema.justify,
+                    justify: curRendererSchema.justify || 'center',
                     alignItems: curRendererSchema.alignItems
                   }),
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a60fd1</samp>

This pull request improves the user interface and experience of the amis-editor by fixing a warning message for region nodes in `Editor.tsx` and adding a default value for the justify property of the flex layout settings in `FlexPluginBase.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3a60fd1</samp>

> _`region` node warns_
> _only when many regions_
> _fall leaves are dropping_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3a60fd1</samp>

* Add a condition to show a warning message only when the region node has more than one region and is not removable ([link](https://github.com/baidu/amis/pull/8584/files?diff=unified&w=0#diff-18115adfb822b0c3059aa7b00cc9dcab379f5c15781d48b9acca0d863d27a0edL376-R385))
* Set a default value of 'center' for the justify property of the flex layout settings in `FlexPluginBase.tsx` ([link](https://github.com/baidu/amis/pull/8584/files?diff=unified&w=0#diff-0c77368e9183efe6a72ad9cdc7339d1c15ab5f70f8518721c1bda55460262a07L110-R110))
