### PR TITLE
fixed: 组件面板搜索功能优化

### DIFF
--- a/packages/amis-editor-core/scss/_renderers.scss
+++ b/packages/amis-editor-core/scss/_renderers.scss
@@ -244,7 +244,7 @@
 // 左侧组件面板/info提示弹窗
 .ae-RendererThumb {
   max-width: 328px;
-  min-height: 120px;
+  min-height: 70px;
   padding: 5px;
   font-size: 12px;
   color: #151b26;
@@ -271,7 +271,7 @@
   .ae-Renderer-preview {
     position: relative;
     max-height: 200px;
-    overflow: hidden;
+    // overflow: hidden;
   }
 }
 

--- a/packages/amis-editor/src/plugin/Audio.tsx
+++ b/packages/amis-editor/src/plugin/Audio.tsx
@@ -13,6 +13,7 @@ export class AudioPlugin extends BasePlugin {
   name = '音频';
   isBaseComponent = true;
   description = '音频控件，可以用来播放各种音频文件。';
+  docLink = '/amis/zh-CN/components/audio';
   tags = ['功能'];
   icon = 'fa fa-music';
   pluginIcon = 'audio-plugin';

--- a/packages/amis-editor/src/plugin/CollapseGroup.tsx
+++ b/packages/amis-editor/src/plugin/CollapseGroup.tsx
@@ -21,6 +21,7 @@ export class CollapseGroupPlugin extends BasePlugin {
   isBaseComponent = true;
   description =
     '折叠面板，当信息量较大且分类较多时，可使用折叠面板进行分类收纳。';
+  docLink = '/amis/zh-CN/components/collapse';
   tags = ['布局容器'];
   icon = 'fa fa-align-justify';
   pluginIcon = 'collapse-plugin';

--- a/packages/amis-editor/src/plugin/Container.tsx
+++ b/packages/amis-editor/src/plugin/Container.tsx
@@ -23,6 +23,7 @@ export class ContainerPlugin extends LayoutBasePlugin {
   name = '容器';
   isBaseComponent = true;
   description = '一个简单的容器，可以将多个渲染器放置在一起。';
+  docLink = '/amis/zh-CN/components/container';
   tags = ['布局容器'];
   order = -2;
   icon = 'fa fa-square-o';

--- a/packages/amis-editor/src/plugin/Date.tsx
+++ b/packages/amis-editor/src/plugin/Date.tsx
@@ -42,6 +42,7 @@ export class DatePlugin extends BasePlugin {
   isBaseComponent = true;
   description =
     '主要用来关联字段名做日期展示，支持各种格式如：X（时间戳），YYYY-MM-DD HH:mm:ss。';
+  docLink = '/amis/zh-CN/components/date';
   tags = ['展示'];
   icon = 'fa fa-calendar';
   pluginIcon = 'date-plugin';

--- a/packages/amis-editor/src/plugin/Datetime.tsx
+++ b/packages/amis-editor/src/plugin/Datetime.tsx
@@ -45,7 +45,7 @@ export class DatetimePlugin extends DatePlugin {
   name = '日期时间展示';
   isBaseComponent = true;
   pluginIcon = 'datetime-plugin';
-
+  docLink = '/amis/zh-CN/components/date';
   previewSchema = {
     ...this.scaffold,
     format: 'YYYY-MM-DD HH:mm:ss',

--- a/packages/amis-editor/src/plugin/Divider.tsx
+++ b/packages/amis-editor/src/plugin/Divider.tsx
@@ -22,6 +22,7 @@ export class DividerPlugin extends BasePlugin {
   icon = 'fa fa-minus';
   pluginIcon = 'divider-plugin';
   description = '用来展示一个分割线，可用来做视觉上的隔离。';
+  docLink = '/amis/zh-CN/components/divider';
   scaffold = {
     type: 'divider'
   };

--- a/packages/amis-editor/src/plugin/Each.tsx
+++ b/packages/amis-editor/src/plugin/Each.tsx
@@ -20,6 +20,7 @@ export class EachPlugin extends BasePlugin {
   memberImmutable = true;
   description = '功能渲染器，可以基于现有变量循环输出渲染器。';
   searchKeywords = '循环渲染器';
+  docLink = '/amis/zh-CN/components/each';
   tags = ['功能'];
   icon = 'fa fa-repeat';
   pluginIcon = 'each-plugin';

--- a/packages/amis-editor/src/plugin/Form/InputText.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputText.tsx
@@ -41,7 +41,7 @@ export class TextControlPlugin extends BasePlugin {
 
   description = '文本输入框，支持普通文本、密码、URL、邮箱等多种内容输入';
 
-  docLink = '/amis/zh-CN/components/form/text';
+  docLink = '/amis/zh-CN/components/form/input-text';
 
   tags = ['表单项'];
 

--- a/packages/amis-editor/src/plugin/IFrame.tsx
+++ b/packages/amis-editor/src/plugin/IFrame.tsx
@@ -18,6 +18,7 @@ export class IFramePlugin extends BasePlugin {
   name = 'iFrame';
   isBaseComponent = true;
   description = '可以用来嵌入现有页面。';
+  docLink = '/amis/zh-CN/components/iframe';
   tags = ['功能'];
   icon = 'fa fa-window-maximize';
   pluginIcon = 'iframe-plugin';

--- a/packages/amis-editor/src/plugin/Image.tsx
+++ b/packages/amis-editor/src/plugin/Image.tsx
@@ -21,6 +21,7 @@ export class ImagePlugin extends BasePlugin {
   isBaseComponent = true;
   description =
     '可以用来展示一张图片，支持静态设置图片地址，也可以配置 <code>name</code> 与变量关联。';
+  docLink = '/amis/zh-CN/components/image';
   tags = ['展示'];
   icon = 'fa fa-photo';
   pluginIcon = 'image-plugin';

--- a/packages/amis-editor/src/plugin/Images.tsx
+++ b/packages/amis-editor/src/plugin/Images.tsx
@@ -14,6 +14,7 @@ export class ImagesPlugin extends BasePlugin {
   name = '图片集';
   isBaseComponent = true;
   description = '展示多张图片';
+  docLink = '/amis/zh-CN/components/images';
   tags = ['展示'];
   icon = 'fa fa-clone';
   pluginIcon = 'images-plugin';

--- a/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
+++ b/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
@@ -30,19 +30,39 @@ export const defaultFlexColumnSchema = (title?: string) => {
     isFixedWidth: false
   };
 };
+
+const defaultFlexPreviewSchema = (title?: string) => {
+  return {
+    type: 'tpl',
+    tpl: title,
+    wrapperComponent: '',
+    className: 'bg-light center',
+    style: {
+      display: 'block',
+      flex: '1 1 auto',
+      flexBasis: 'auto',
+      textAlign: 'center',
+      marginRight: 10
+    },
+    inline: false
+  };
+};
+
 // 默认的布局容器Schema
-const defaultFlexContainerSchema = {
+const defaultFlexContainerSchema = (
+  flexItemSchema: (title?: string) => any = defaultFlexColumnSchema
+) => ({
   type: 'flex',
   className: 'p-1',
   items: [
-    defaultFlexColumnSchema('第一列'),
-    defaultFlexColumnSchema('第二列'),
-    defaultFlexColumnSchema('第三列')
+    flexItemSchema('第一列'),
+    flexItemSchema('第二列'),
+    flexItemSchema('第三列')
   ],
   style: {
     position: 'relative'
   }
-};
+});
 
 export class FlexPluginBase extends LayoutBasePlugin {
   static id = 'FlexPluginBase';
@@ -59,10 +79,8 @@ export class FlexPluginBase extends LayoutBasePlugin {
     '布局容器 是基于 CSS Flex 实现的布局效果，它比 Grid 和 HBox 对子节点位置的可控性更强，比用 CSS 类的方式更易用';
   docLink = '/amis/zh-CN/components/flex';
   tags = ['布局容器'];
-  scaffold: any = defaultFlexContainerSchema;
-  previewSchema = {
-    ...this.scaffold
-  };
+  scaffold: any = defaultFlexContainerSchema();
+  previewSchema = defaultFlexContainerSchema(defaultFlexPreviewSchema);
 
   panelTitle = '布局容器';
 
@@ -266,7 +284,7 @@ export class FlexPluginBase extends LayoutBasePlugin {
             className: 'ae-InsertBefore is-vertical',
             onClick: () =>
               this.manager.appendSiblingSchema(
-                defaultFlexContainerSchema,
+                defaultFlexContainerSchema(),
                 true,
                 true
               )
@@ -279,7 +297,7 @@ export class FlexPluginBase extends LayoutBasePlugin {
             className: 'ae-InsertAfter is-vertical',
             onClick: () =>
               this.manager.appendSiblingSchema(
-                defaultFlexContainerSchema,
+                defaultFlexContainerSchema(),
                 false,
                 true
               )

--- a/packages/amis-editor/src/plugin/Layout/Layout_fixed.tsx
+++ b/packages/amis-editor/src/plugin/Layout/Layout_fixed.tsx
@@ -8,7 +8,7 @@ export default class Layout_fixed extends FlexPluginBase {
   name = '悬浮容器';
   isBaseComponent = true;
   pluginIcon = 'layout-fixed-plugin';
-  description = '悬浮容器: 基于 CSS Flex 实现的特殊布局容器。';
+  description = '悬浮容器: 基于 CSS Fixed 实现的特殊布局容器。';
   order = 0;
   scaffold: any = {
     type: 'container',
@@ -24,6 +24,16 @@ export default class Layout_fixed extends FlexPluginBase {
     },
     wrapperBody: false,
     originPosition: 'right-bottom'
+  };
+  previewSchema: any = {
+    type: 'container',
+    body: [],
+    style: {
+      position: 'static',
+      display: 'block'
+    },
+    size: 'none',
+    wrapperBody: false
   };
   panelTitle = '悬浮容器';
 }

--- a/packages/amis-editor/src/plugin/Pagination.tsx
+++ b/packages/amis-editor/src/plugin/Pagination.tsx
@@ -21,6 +21,7 @@ export class PaginationPlugin extends BasePlugin {
   name = '分页组件';
   isBaseComponent = true;
   description = '分页组件，可以对列表进行分页展示，提高页面性能';
+  docLink = '/amis/zh-CN/components/pagination';
   tags = ['展示'];
   icon = 'fa fa-window-minimize';
   lastLayoutSetting = ['pager'];

--- a/packages/amis-editor/src/plugin/Time.tsx
+++ b/packages/amis-editor/src/plugin/Time.tsx
@@ -40,7 +40,7 @@ export class TimePlugin extends DatePlugin {
   isBaseComponent = true;
 
   pluginIcon = 'time-plugin';
-
+  docLink = '/amis/zh-CN/components/date';
   scaffold = {
     type: 'time',
     value: Math.round(Date.now() / 1000),


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e81e76b</samp>

This pull request adds or updates the `docLink` property for several editor plugins to link to the corresponding documentation pages for the AMIS components. It also improves the appearance and functionality of some editor plugins, such as the `Layout_fixed` and the `FlexPluginBase`. It removes some unnecessary CSS rules from `_renderers.scss`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e81e76b</samp>

> _Oh we're the crew of the AMIS ship, and we sail the web so free_
> _We add the `docLink` to every plugin, so the users can learn and see_
> _We fix the layout and the preview, and we polish the CSS_
> _We heave and ho on the count of three, and we make the editor the best_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e81e76b</samp>

*  Added `docLink` properties to various plugin classes to specify the documentation URLs for the corresponding components in the AMIS framework ([link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-ff8e197301de6b531c03595ddb05b8b55f26fc6cbd8e4944798a19a1e4995c34R16), [link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-33cf8f47f6167ca85dcfc70353f5c54cf9b8214d182806a5ae5315524864b4c6R24), [link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-a8bde19ea54cb5b89af40437705c677c4ed3ed7d653c8821c63841a1a96fd18cR26), [link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-188c9ca195f01b7becbfe70a8c7a8355d2fefe7868b8a96206525ccdef57db4dR45), [link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-e5677cc0de000158cc72358e52f4aaf1ed4133f2b7861803c4ee142e8dd13e29L48-R48), [link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-b06ad49b8b64d0e50fe3529a2d3d5b4efe25aca142e28e03c0d9411b397134c8R25), [link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-3a0279a7838f7675af297c48b02cc8e56f6db60530dc4293b6b0f1d09fb47185R23), [link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-26c59dc0ce3e3cddbba8f6dcf27f0691c29a9dc965bc16cd1728cf6bd51ca713R21), [link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-080f970ff41a9d0e1619e4d8d2190127b7b241f179ed33b91f4f0fe48475fd41R24), [link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-56455bda1d9d4fbd51a8c855a272024feb8277669aa011d205c953cde21e2278R17), [link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-a9ddd77e9761f09529c503212eaa0939fb5f04c01652d1b09117ebf7442e1766R24), [link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-d81ad22d457fdd80935898ee407669ff90994f495a20fc98a6a0fd1728a47e8cL43-R43))
*  Updated the `docLink` property of the `TextControlPlugin` class to match the correct documentation URL for the input text component ([link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-707b783556eac182d54138ee29fd68b050c8998fe310ddee763b7afebeaa1691L44-R44))
*  Modified the `body` property of the `defaultFlexColumnSchema` function in `Layout/FlexPluginBase.tsx` to include a template component that renders the title of the flex column ([link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-0c77368e9183efe6a72ad9cdc7339d1c15ab5f70f8518721c1bda55460262a07L19-R30))
*  Corrected the `description` property of the `Layout_fixed` class in `Layout/Layout_fixed.tsx` to use the term "CSS Fixed" instead of "CSS Flex" ([link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-45079898a44e6d9ee2efd488a30addd8905e0ddee7e8b3ec913152e193c86da1L11-R11))
*  Added the `previewSchema` property to the `Layout_fixed` class in `Layout/Layout_fixed.tsx` to define the schema of the component that is rendered in the preview mode of the editor ([link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-45079898a44e6d9ee2efd488a30addd8905e0ddee7e8b3ec913152e193c86da1R28-R37))
*  Commented out the `min-height` property of the `.ae-RendererThumb` class in `_renderers.scss` to avoid unnecessary vertical space for the thumbnails of the renderers in the editor ([link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-6e7960b12d473fe4486c3c9e687f8f2838fae8c56880def0e76236b6c74f9f2cL247-R247))
*  Commented out the `overflow` property of the `.ae-RendererThumb .ae-RendererThumb-body` class in `_renderers.scss` to allow the content of the thumbnails to be fully visible without clipping or scrolling ([link](https://github.com/baidu/amis/pull/8586/files?diff=unified&w=0#diff-6e7960b12d473fe4486c3c9e687f8f2838fae8c56880def0e76236b6c74f9f2cL274-R274))
