### PR TITLE
fix: 修复 quickSaveImmediately 同时配置 api 时上下文信息错误 Close: #8587

### DIFF
--- a/packages/amis-ui/scss/_properties.scss
+++ b/packages/amis-ui/scss/_properties.scss
@@ -5,11 +5,13 @@ $remFactor: 16px;
 /* 此处放置需要override的变量，因为部分变量已经在variables.scss中定义 */
 $Table-strip-bg: transparent;
 
-:root,
-.AMISCSSWrapper {
+:root {
   --affix-offset-top: 0px;
   --affix-offset-bottom: 0px;
+}
 
+:root,
+.AMISCSSWrapper {
   --white: var(--colors-neutral-text-11);
   --primary: var(--colors-brand-5);
   --primary-onHover: var(--colors-brand-6);

--- a/packages/amis/__tests__/renderers/Table.test.tsx
+++ b/packages/amis/__tests__/renderers/Table.test.tsx
@@ -1243,3 +1243,78 @@ test('Renderer:table-column-quickEdit-inline', async () => {
     expect(container.querySelector('.is-checked')).toBeInTheDocument();
   });
 });
+
+test('Renderer:table-column-quickEdit-saveImmediately', async () => {
+  const fetcher = jest
+    .fn()
+    .mockImplementation(() =>
+      Promise.resolve({status: 200, data: {status: 0, msg: 'ok'}})
+    );
+  const {container, getByText} = render(
+    amisRender(
+      {
+        type: 'table',
+        title: '表格',
+        data: {
+          items: [
+            {
+              engine: 'Trident - wixp4',
+              browser: 'Internet Explorer 4.0',
+              platform: 'Win 95+',
+              version: '4',
+              grade: 'X',
+              badgeText: '默认',
+              id: 1
+            }
+          ]
+        },
+        columns: [
+          {
+            name: 'engine',
+            label: 'Engine',
+            id: 'u:2e5658776790'
+          },
+          {
+            name: 'version',
+            label: 'Version',
+            id: 'u:5c41ffc2ecb0',
+            quickEdit: {
+              type: 'input-text',
+              saveImmediately: {
+                api: '/api/mock2/saveImmediately/${id}'
+              }
+            }
+          }
+        ]
+      },
+      {},
+      makeEnv({
+        fetcher: fetcher
+      })
+    )
+  );
+
+  await wait(200);
+  const btn = container.querySelector('.cxd-Field-quickEditBtn');
+  expect(btn).toBeInTheDocument();
+  fireEvent.click(btn!);
+  await wait(200);
+  const input = container.querySelector('input[name=version]');
+  expect(input).toBeInTheDocument();
+  fireEvent.change(input!, {target: {value: '5'}});
+
+  await wait(200);
+  expect(getByText('确认')).toBeInTheDocument();
+  fireEvent.click(getByText('确认'));
+  await wait(500);
+  expect(fetcher).toBeCalledTimes(1);
+  expect(fetcher.mock.calls[0][0].data).toMatchObject({
+    engine: 'Trident - wixp4',
+    browser: 'Internet Explorer 4.0',
+    platform: 'Win 95+',
+    version: '5',
+    grade: 'X',
+    badgeText: '默认',
+    id: 1
+  });
+});

--- a/packages/amis/src/renderers/Cards.tsx
+++ b/packages/amis/src/renderers/Cards.tsx
@@ -430,7 +430,7 @@ export default class Cards extends React.Component<GridProps, object> {
           api: saveImmediately.api,
           reload: options?.reload
         },
-        values
+        item.locals
       );
       return;
     }

--- a/packages/amis/src/renderers/List.tsx
+++ b/packages/amis/src/renderers/List.tsx
@@ -496,7 +496,7 @@ export default class List extends React.Component<ListProps, object> {
           api: saveImmediately.api,
           reload: options?.reload
         },
-        values
+        item.locals
       );
       return;
     }

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -1149,7 +1149,7 @@ export default class Table extends React.Component<TableProps, object> {
           api: saveImmediately.api,
           reload: options?.reload
         },
-        values
+        item.locals
       );
       return;
     }

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -1161,7 +1161,7 @@ export default class Table2 extends React.Component<Table2Props, object> {
             api: saveImmediately.api,
             reload: options?.reload
           },
-          values
+          item.locals
         );
       return;
     }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f5f46f</samp>

This pull request fixes a CSS variable conflict for the `Affix` component and adds a feature to pass the correct data context to the action handler for the `Cards`, `List`, `Table`, and `Table2` renderers. The changes are related to issues #2479 and #2480.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2f5f46f</samp>

> _`item.locals` passed_
> _to action handler in renderers_
> _autumn data flows_

### Why

Close: #8587 

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2f5f46f</samp>

*  Move CSS variables for affix offset to root selector to avoid conflicts ([link](https://github.com/baidu/amis/pull/8588/files?diff=unified&w=0#diff-11e33167cf3700a03b633f75ed54c24b2e57771a316f2e113cf09c791919c795L8-R14))
*  Pass item.locals instead of values to onAction handler in various renderers to support data override feature ([link](https://github.com/baidu/amis/pull/8588/files?diff=unified&w=0#diff-83895e4b0993db67cbfb774b8539e7625318f250de1b4a848611cabedf9e828bL433-R433), [link](https://github.com/baidu/amis/pull/8588/files?diff=unified&w=0#diff-6551e087ba390220793c5f644f0d1a67ba14aa330dcd0afab19c252f6f38d37dL499-R499), [link](https://github.com/baidu/amis/pull/8588/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1152-R1152), [link](https://github.com/baidu/amis/pull/8588/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L1164-R1164))
