### PR TITLE
feat: App多页应用组件侧边导航栏箭头显示优化 Close: #8595

### DIFF
--- a/packages/amis/src/renderers/App.tsx
+++ b/packages/amis/src/renderers/App.tsx
@@ -362,7 +362,12 @@ export default class App extends React.Component<AppProps, object> {
               return null;
             }
 
-            if (!subHeader && link.children && link.children.length) {
+            if (
+              !subHeader &&
+              link.children &&
+              link.children.filter((item: {visible: boolean}) => item?.visible)
+                .length
+            ) {
               children.push(
                 <span
                   key="expand-toggle"

--- a/packages/amis/src/renderers/App.tsx
+++ b/packages/amis/src/renderers/App.tsx
@@ -365,8 +365,7 @@ export default class App extends React.Component<AppProps, object> {
             if (
               !subHeader &&
               link.children &&
-              link.children.filter((item: {visible: boolean}) => item?.visible)
-                .length
+              link.children.some((item: {visible: boolean}) => item?.visible)
             ) {
               children.push(
                 <span


### PR DESCRIPTION
### What

多页应用模式下，使用App组件配置/page/:id动态路由时，当一级菜单下仅有一个动态路由时，期望导航栏隐藏右侧“展开”箭头。#8595
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9b01341</samp>

> _`span` only shows_
> _visible children now_
> _bug fixed in autumn_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9b01341</samp>

* Fix a bug where invisible children of a link would cause misalignment in the navigation menu by only rendering a span element for visible children ([link](https://github.com/baidu/amis/pull/8599/files?diff=unified&w=0#diff-b3a4d413575f4fe07501c750c75d47f53100ca6a9536c98886c7b67d63542d39L365-R370) in `App.tsx`)
