### PR TITLE
fix(amis-editor): api中心类型的接口校验设置弹窗中含表达式的query等参数初次渲染不正确

### DIFF
--- a/packages/amis-editor/src/renderer/ValidationControl.tsx
+++ b/packages/amis-editor/src/renderer/ValidationControl.tsx
@@ -330,6 +330,7 @@ export default class ValidationControl extends React.Component<
 
   renderValidateApiControl() {
     const {onBulkChange, render} = this.props;
+
     return (
       <div className="ae-ValidationControl-item">
         {render('validate-api-control', {
@@ -340,7 +341,6 @@ export default class ValidationControl extends React.Component<
           wrapperComponent: 'div',
           mode: 'horizontal',
           data: {
-            validateApi: this.props.data.validateApi,
             switchStatus: this.props.data.validateApi !== undefined
           },
           preventEnterSubmit: true,
@@ -369,6 +369,10 @@ export default class ValidationControl extends React.Component<
               className: 'ae-ExtendMore ae-ValidationControl-item-input',
               bodyClassName: 'w-full',
               visibleOn: 'this.switchStatus',
+              data: {
+                // 放在form中则包含的表达式会被求值
+                validateApi: this.props.data.validateApi
+              },
               body: [
                 getSchemaTpl('apiControl', {
                   name: 'validateApi',


### PR DESCRIPTION

![302246cb28f7260214edf0e8cd6867df](https://github.com/baidu/amis/assets/92133492/ab30fa11-058d-4b4c-847f-90439a3c3bd4)

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3395924</samp>

Simplify `validateApi` prop for `SchemaApi` component in `amis-editor`. Allow expressions in `validateApi` value.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3395924</samp>

> _`validateApi`_
> _now part of `data` prop_
> _simpler expressions_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3395924</samp>

*  Remove `validateApi` prop from `SchemaApi` component and pass it as part of `data` prop instead ([link](https://github.com/baidu/amis/pull/8600/files?diff=unified&w=0#diff-1845950896a98c0d1091a85a09550577f5dd9da74fcdf7fb004643fbbf003298L343), [link](https://github.com/baidu/amis/pull/8600/files?diff=unified&w=0#diff-1845950896a98c0d1091a85a09550577f5dd9da74fcdf7fb004643fbbf003298R372-R375))
*  Add an empty line to improve readability of `ValidationControl.tsx` ([link](https://github.com/baidu/amis/pull/8600/files?diff=unified&w=0#diff-1845950896a98c0d1091a85a09550577f5dd9da74fcdf7fb004643fbbf003298R333))
