### PR TITLE
feat: icon组件兼容sdk下使用svg object的情况

### DIFF
--- a/packages/amis-ui/src/components/icons.tsx
+++ b/packages/amis-ui/src/components/icons.tsx
@@ -3,7 +3,7 @@
  * @description
  * @author fex
  */
-import React, {useState, useEffect, useRef} from 'react';
+import React, {createElement} from 'react';
 import cxClass from 'classnames';
 import CloseIcon from '../icons/close.svg';
 import CloseSmallIcon from '../icons/close-small.svg';
@@ -346,22 +346,35 @@ export function Icon({
     typeof (icon as IconCheckedSchema).id === 'string' &&
     (icon as IconCheckedSchema).id.startsWith('svg-')
   ) {
-    return (
-      <svg
-        onClick={onClick}
-        className={cx('icon', 'icon-object', className, classNameProp)}
-        style={style}
-      >
-        <use
-          xlinkHref={`#${(icon as IconCheckedSchema).id.replace(/^svg-/, '')}`}
-        ></use>
-      </svg>
-    );
+    const svg = icon as IconCheckedSchema;
+    const id = `${svg.id.replace(/^svg-/, '')}`;
+    if (!document.getElementById(id)) {
+      // 如果svg symbol不存在，则尝试将svg字符串赋值给icon，走svg字符串的逻辑
+      icon = svg.svg?.replace(/'/g, '');
+    } else {
+      return (
+        <svg
+          onClick={onClick}
+          className={cx('icon', 'icon-object', className, classNameProp)}
+          style={style}
+        >
+          <use xlinkHref={'#' + id}></use>
+        </svg>
+      );
+    }
   }
 
   // 直接传入svg字符串
   if (typeof icon === 'string' && icon.startsWith('<svg')) {
-    return <i dangerouslySetInnerHTML={{__html: icon}} />;
+    const svgStr = /<svg .*?>(.*?)<\/svg>/.exec(icon);
+    const svgHTML = createElement('svg', {
+      onClick,
+      className: cx('icon', className, classNameProp),
+      style,
+      dangerouslySetInnerHTML: {__html: svgStr ? svgStr[1] : ''},
+      viewBox: '0 0 16 16'
+    });
+    return svgHTML;
   }
 
   // icon是链接


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 69f0826</samp>

Fixed icon rendering issues and improved import efficiency in `icons.tsx`. Added support for custom svg icons in icon schema.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 69f0826</samp>

> _A bug in the icon rendering_
> _Made some symbols look quite dismaying_
> _But `icons.tsx`_
> _Got a simple fix_
> _With a fallback logic displaying_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 69f0826</samp>

* Fix icon rendering bug when svg symbol is not found ([link](https://github.com/baidu/amis/pull/8602/files?diff=unified&w=0#diff-1db9a23d0ea625849dbe5c523e7ccab192bfa73c87891759c8a7de36e2d874efL349-R377))
* Simplify import statement to only import `createElement` from `react` ([link](https://github.com/baidu/amis/pull/8602/files?diff=unified&w=0#diff-1db9a23d0ea625849dbe5c523e7ccab192bfa73c87891759c8a7de36e2d874efL6-R6))
