### PR TITLE
fix: 修复模型组件转成公共组件后功能异常问题

### DIFF
--- a/packages/amis-editor-core/src/component/CommonConfigWrapper.tsx
+++ b/packages/amis-editor-core/src/component/CommonConfigWrapper.tsx
@@ -43,7 +43,7 @@ export class CommonConfigWrapper extends NodeWrapper {
     let {$$editor, $$node, $schema, store, ...rest} = this.props;
     const renderer = $$editor.renderer;
 
-    rest = JSONPipeOut(rest);
+    rest = JSONPipeOut(rest, false);
 
     if ($$editor.filterProps) {
       rest = $$editor.filterProps.call($$editor.plugin, rest, $$node);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec6b93f</samp>

Fixed a bug in `CommonConfigWrapper` that caused rendering errors for some components. Changed the `JSONPipeOut` function to preserve the structure of object and array values.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ec6b93f</samp>

> _`JSONPipeOut` changed_
> _No more stringifying objects_
> _Winter bug is fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ec6b93f</samp>

* Changed the second argument of `JSONPipeOut` to `false` to preserve the structure of the output value ([link](https://github.com/baidu/amis/pull/8603/files?diff=unified&w=0#diff-3b765233b6b081d086d810996214965984e4e1b74d4133fb71d6fe65ece8e569L46-R46)). This fixed a bug that caused errors in rendering some components that used the `CommonConfigWrapper` component from `packages/amis-editor-core/src/component/CommonConfigWrapper.tsx`.
