### PR TITLE
chore: rich-text组件配置更新时，对应富文本编辑器也更新配置

### DIFF
--- a/packages/amis-ui/src/components/RichText.tsx
+++ b/packages/amis-ui/src/components/RichText.tsx
@@ -44,7 +44,6 @@ import 'froala-editor/js/languages/zh_cn.js';
 // Require Editor CSS files.
 // import 'froala-editor/css/froala_style.min.css';
 // import 'froala-editor/css/froala_editor.pkgd.min.css';
-import {anyChanged} from 'amis-core';
 
 export interface FroalaEditorComponentProps {
   config: any;

--- a/packages/amis-ui/src/components/RichText.tsx
+++ b/packages/amis-ui/src/components/RichText.tsx
@@ -100,6 +100,11 @@ class FroalaEditorComponent extends React.Component<FroalaEditorComponentProps> 
       this.config = {...this.config};
       this.editor = new FroalaEditor(this.element, this.config);
     }
+
+    if (JSON.stringify(this.oldModel) == JSON.stringify(this.props.model)) {
+      return;
+    }
+    this.setContent();
   }
 
   // Return cloned object
@@ -304,7 +309,6 @@ export default class extends React.Component<any, any> {
   }
 
   render() {
-    console.log('FroalaEditorComponent');
     return (
       <FroalaEditorComponent
         config={this.props.config}

--- a/packages/amis-ui/src/components/RichText.tsx
+++ b/packages/amis-ui/src/components/RichText.tsx
@@ -44,6 +44,7 @@ import 'froala-editor/js/languages/zh_cn.js';
 // Require Editor CSS files.
 // import 'froala-editor/css/froala_style.min.css';
 // import 'froala-editor/css/froala_editor.pkgd.min.css';
+import {anyChanged} from 'amis-core';
 
 export interface FroalaEditorComponentProps {
   config: any;
@@ -92,12 +93,13 @@ class FroalaEditorComponent extends React.Component<FroalaEditorComponentProps> 
     this.destroyEditor();
   }
 
-  componentDidUpdate() {
-    if (JSON.stringify(this.oldModel) == JSON.stringify(this.props.model)) {
-      return;
+  componentDidUpdate(prevProps: Readonly<FroalaEditorComponentProps>) {
+    if (this.props.config !== prevProps.config) {
+      this.editor?.destroy();
+      this.config = this.clone(this.props.config || this.config);
+      this.config = {...this.config};
+      this.editor = new FroalaEditor(this.element, this.config);
     }
-
-    this.setContent();
   }
 
   // Return cloned object
@@ -302,6 +304,7 @@ export default class extends React.Component<any, any> {
   }
 
   render() {
+    console.log('FroalaEditorComponent');
     return (
       <FroalaEditorComponent
         config={this.props.config}

--- a/packages/amis-ui/src/components/Tinymce.tsx
+++ b/packages/amis-ui/src/components/Tinymce.tsx
@@ -41,7 +41,7 @@ import 'tinymce/plugins/help/js/i18n/keynav/zh_CN';
 import 'tinymce/plugins/help/js/i18n/keynav/en';
 import 'tinymce/plugins/help/js/i18n/keynav/de';
 
-import {LocaleProps, autobind, anyChanged} from 'amis-core';
+import {LocaleProps, autobind} from 'amis-core';
 
 interface TinymceEditorProps extends LocaleProps {
   model: string;

--- a/packages/amis-ui/src/components/Tinymce.tsx
+++ b/packages/amis-ui/src/components/Tinymce.tsx
@@ -41,7 +41,7 @@ import 'tinymce/plugins/help/js/i18n/keynav/zh_CN';
 import 'tinymce/plugins/help/js/i18n/keynav/en';
 import 'tinymce/plugins/help/js/i18n/keynav/de';
 
-import {LocaleProps} from 'amis-core';
+import {LocaleProps, autobind, anyChanged} from 'amis-core';
 
 interface TinymceEditorProps extends LocaleProps {
   model: string;
@@ -69,7 +69,34 @@ export default class TinymceEditor extends React.Component<TinymceEditorProps> {
 
   elementRef: React.RefObject<HTMLTextAreaElement> = React.createRef();
 
-  async componentDidMount() {
+  componentDidMount() {
+    this.initTiny();
+  }
+
+  componentDidUpdate(prevProps: TinymceEditorProps) {
+    console.log('componentDidUpdate', prevProps);
+    const props = this.props;
+
+    if (
+      props.model !== prevProps.model &&
+      props.model !== this.currentContent
+    ) {
+      this.editorInitialized && this.editor?.setContent(props.model || '');
+    }
+
+    if (this.props.config !== prevProps.config) {
+      tinymce.remove(this.editor);
+      this.initTiny();
+    }
+  }
+
+  componentWillUnmount() {
+    tinymce.remove(this.editor);
+    this.unmounted = true;
+  }
+
+  @autobind
+  async initTiny() {
     const locale = this.props.locale;
 
     const {onLoaded, ...rest} = this.props.config || {};
@@ -165,22 +192,6 @@ export default class TinymceEditor extends React.Component<TinymceEditorProps> {
 
     await onLoaded?.(tinymce);
     this.unmounted || tinymce.init(this.config);
-  }
-
-  componentDidUpdate(prevProps: TinymceEditorProps) {
-    const props = this.props;
-
-    if (
-      props.model !== prevProps.model &&
-      props.model !== this.currentContent
-    ) {
-      this.editorInitialized && this.editor?.setContent(props.model || '');
-    }
-  }
-
-  componentWillUnmount() {
-    tinymce.remove(this.editor);
-    this.unmounted = true;
   }
 
   initEditor(e: any, editor: any) {

--- a/packages/amis-ui/src/components/Tinymce.tsx
+++ b/packages/amis-ui/src/components/Tinymce.tsx
@@ -74,7 +74,6 @@ export default class TinymceEditor extends React.Component<TinymceEditorProps> {
   }
 
   componentDidUpdate(prevProps: TinymceEditorProps) {
-    console.log('componentDidUpdate', prevProps);
     const props = this.props;
 
     if (

--- a/packages/amis/src/renderers/Form/InputRichText.tsx
+++ b/packages/amis/src/renderers/Form/InputRichText.tsx
@@ -391,6 +391,6 @@ export default class RichTextControl extends React.Component<
 @FormItem({
   type: 'input-rich-text',
   sizeMutable: false,
-  detectProps: ['options']
+  detectProps: ['options', 'buttons']
 })
 export class RichTextControlRenderer extends RichTextControl {}

--- a/packages/amis/src/renderers/Form/InputRichText.tsx
+++ b/packages/amis/src/renderers/Form/InputRichText.tsx
@@ -125,16 +125,7 @@ export default class RichTextControl extends React.Component<
     if (finnalVendor === 'froala') {
       if (
         anyChanged(
-          [
-            'receiver',
-            'data',
-            'imageEditable',
-            'options',
-            'editorClass',
-            'placeholder',
-            'url',
-            'buttons'
-          ],
+          ['options', 'editorClass', 'placeholder', 'buttons'],
           prevProps,
           props
         )
@@ -144,13 +135,7 @@ export default class RichTextControl extends React.Component<
         });
       }
     } else if (finnalVendor === 'tinymce') {
-      if (
-        anyChanged(
-          ['receiver', 'data', 'imageEditable', 'options', 'fileField'],
-          prevProps,
-          props
-        )
-      ) {
+      if (anyChanged(['options', 'fileField'], prevProps, props)) {
         this.setState({
           config: this.getConfig(props)
         });

--- a/packages/amis/src/renderers/Form/InputRichText.tsx
+++ b/packages/amis/src/renderers/Form/InputRichText.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   FormItem,
   FormControlProps,
-  FormBaseControl,
   buildApi,
   qsstringify,
   resolveEventData,
@@ -10,9 +9,8 @@ import {
 } from 'amis-core';
 import cx from 'classnames';
 import {LazyComponent} from 'amis-core';
-import {tokenize} from 'amis-core';
 import {normalizeApi} from 'amis-core';
-import {ucFirst} from 'amis-core';
+import {ucFirst, anyChanged} from 'amis-core';
 import type {FormBaseControlSchema, SchemaApi} from '../../Schema';
 
 /**
@@ -105,17 +103,65 @@ export default class RichTextControl extends React.Component<
   };
 
   state = {
+    config: null,
     focused: false
   };
-  config: any = null;
+
   constructor(props: RichTextProps) {
     super(props);
 
-    const finnalVendor =
-      props.vendor || (props.env.richTextToken ? 'froala' : 'tinymce');
     this.handleFocus = this.handleFocus.bind(this);
     this.handleBlur = this.handleBlur.bind(this);
     this.handleChange = this.handleChange.bind(this);
+
+    this.state.config = this.getConfig(props);
+  }
+
+  componentDidUpdate(prevProps: Readonly<RichTextProps>): void {
+    const props = this.props;
+    const finnalVendor =
+      props.vendor || (props.env.richTextToken ? 'froala' : 'tinymce');
+
+    if (finnalVendor === 'froala') {
+      if (
+        anyChanged(
+          [
+            'receiver',
+            'data',
+            'imageEditable',
+            'options',
+            'editorClass',
+            'placeholder',
+            'url',
+            'buttons'
+          ],
+          prevProps,
+          props
+        )
+      ) {
+        this.setState({
+          config: this.getConfig(props)
+        });
+      }
+    } else if (finnalVendor === 'tinymce') {
+      if (
+        anyChanged(
+          ['receiver', 'data', 'imageEditable', 'options', 'fileField'],
+          prevProps,
+          props
+        )
+      ) {
+        this.setState({
+          config: this.getConfig(props)
+        });
+      }
+    }
+  }
+
+  getConfig(props: RichTextProps) {
+    const finnalVendor =
+      props.vendor || (props.env.richTextToken ? 'froala' : 'tinymce');
+
     const imageReceiver = normalizeApi(
       props.receiver,
       props.receiver?.method || 'post'
@@ -133,7 +179,7 @@ export default class RichTextControl extends React.Component<
       const videoApi = buildApi(videoReceiver, props.data, {
         method: props.videoReceiver.method || 'post'
       });
-      this.config = {
+      return {
         imageAllowedTypes: ['jpeg', 'jpg', 'png', 'gif'],
         imageDefaultAlign: 'left',
         imageEditButtons: props.imageEditable
@@ -174,15 +220,12 @@ export default class RichTextControl extends React.Component<
           blur: this.handleBlur
         },
         language:
-          !this.props.locale || this.props.locale === 'zh-CN' ? 'zh_cn' : ''
+          !this.props.locale || this.props.locale === 'zh-CN' ? 'zh_cn' : '',
+        ...(props.buttons ? {toolbarButtons: props.buttons} : {})
       };
-
-      if (props.buttons) {
-        this.config.toolbarButtons = props.buttons;
-      }
     } else {
       const fetcher = props.env.fetcher;
-      this.config = {
+      return {
         ...props.options,
         onLoaded: this.handleTinyMceLoaded,
         images_upload_handler: (blobInfo: any, progress: any) =>
@@ -335,7 +378,7 @@ export default class RichTextControl extends React.Component<
           onModelChange={this.handleChange}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
-          config={this.config}
+          config={this.state.config}
           disabled={disabled}
           locale={locale}
           translate={translate}
@@ -347,6 +390,7 @@ export default class RichTextControl extends React.Component<
 
 @FormItem({
   type: 'input-rich-text',
-  sizeMutable: false
+  sizeMutable: false,
+  detectProps: ['options']
 })
 export class RichTextControlRenderer extends RichTextControl {}

--- a/packages/amis/src/renderers/Form/InputRichText.tsx
+++ b/packages/amis/src/renderers/Form/InputRichText.tsx
@@ -117,7 +117,7 @@ export default class RichTextControl extends React.Component<
     this.state.config = this.getConfig(props);
   }
 
-  componentDidUpdate(prevProps: Readonly<RichTextProps>): void {
+  componentDidUpdate(prevProps: Readonly<RichTextProps>) {
     const props = this.props;
     const finnalVendor =
       props.vendor || (props.env.richTextToken ? 'froala' : 'tinymce');


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1da043e</samp>

This pull request enhances the functionality and performance of the `RichText` and `Tinymce` components in `amis-ui` and `amis-core` by improving their prop reactivity, editor initialization, and lifecycle management. It also adds some debugging and utility code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1da043e</samp>

> _To make `RichText` more reactive_
> _We use `anyChanged` detective_
> _And recreate the `editor`_
> _With new config and better_
> _Lifecycle management directive_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1da043e</samp>

*  Import `anyChanged` function from `amis-core` to compare props in `componentDidUpdate` methods of `FroalaEditorComponent` and `RichTextControl` ([link](https://github.com/baidu/amis/pull/8608/files?diff=unified&w=0#diff-d1c163fef540f545bcf929dda99f5afb3b0f2c9d14c184546e265d61914ab950R47), [link](https://github.com/baidu/amis/pull/8608/files?diff=unified&w=0#diff-d6c65c2dcd820338178339a1d3f5272f5f7d2cfb02ba4977bdb04516544de8fbL44-R44), [link](https://github.com/baidu/amis/pull/8608/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15L13-R13))
*  Refactor `componentDidMount` method of `TinymceEditorComponent` to extract editor initialization logic into `initTiny` method and use `autobind` decorator ([link](https://github.com/baidu/amis/pull/8608/files?diff=unified&w=0#diff-d6c65c2dcd820338178339a1d3f5272f5f7d2cfb02ba4977bdb04516544de8fbL72-R99))
*  Add `componentDidUpdate` and `componentWillUnmount` methods to `TinymceEditorComponent` to handle dynamic changes in `config` prop and editor removal ([link](https://github.com/baidu/amis/pull/8608/files?diff=unified&w=0#diff-d6c65c2dcd820338178339a1d3f5272f5f7d2cfb02ba4977bdb04516544de8fbL72-R99))
*  Remove unused `FormBaseControl` import from `InputRichText.tsx` ([link](https://github.com/baidu/amis/pull/8608/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15L5))
*  Move editor config initialization from constructor to `getConfig` method of `RichTextControl` and store config in state ([link](https://github.com/baidu/amis/pull/8608/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15L108-R164), [link](https://github.com/baidu/amis/pull/8608/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15L136-R182), [link](https://github.com/baidu/amis/pull/8608/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15L177-R228))
*  Add `componentDidUpdate` method to `RichTextControl` to update state config when props change ([link](https://github.com/baidu/amis/pull/8608/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15L108-R164))
*  Pass state config to `FroalaEditorComponent` or `TinymceEditorComponent` instead of instance property ([link](https://github.com/baidu/amis/pull/8608/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15L338-R381))
*  Add `detectProps` option to `FormItem` decorator of `RichTextControlRenderer` to trigger re-render when props change ([link](https://github.com/baidu/amis/pull/8608/files?diff=unified&w=0#diff-e1350ae9ec131bde1820e064b1d18297f11fd57e531554661d21d233dfbe1a15L350-R394))
*  Modify `componentDidUpdate` method of `FroalaEditorComponent` to destroy and recreate editor instance when `config` prop changes ([link](https://github.com/baidu/amis/pull/8608/files?diff=unified&w=0#diff-d1c163fef540f545bcf929dda99f5afb3b0f2c9d14c184546e265d61914ab950L95-R102))
*  Add console log statement for debugging in `FroalaEditorComponent` ([link](https://github.com/baidu/amis/pull/8608/files?diff=unified&w=0#diff-d1c163fef540f545bcf929dda99f5afb3b0f2c9d14c184546e265d61914ab950R307))
