### PR TITLE
fix(amis-editor): 修复flex布局容器快捷功能键icon丢失问题

### DIFF
--- a/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
+++ b/packages/amis-editor/src/plugin/Layout/FlexPluginBase.tsx
@@ -245,11 +245,11 @@ export class FlexPluginBase extends LayoutBasePlugin {
   ];
 
   buildEditorToolbar(
-    {id, info, schema}: BaseEventContext,
+    {id, info, schema, node}: BaseEventContext,
     toolbars: Array<BasicToolbarItem>
   ) {
-    const store = this.manager.store;
-    const parent = store.getSchemaParentById(id);
+    // const store = this.manager.store;
+    const parent = node.parent?.schema; // 或者 store.getSchemaParentById(id, true);
     const draggableContainer = this.manager.draggableContainer(id);
     const isFlexItem = this.manager?.isFlexItem(id);
     const isFlexColumnItem = this.manager?.isFlexColumnItem(id);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7f9e33c</samp>

Refactored `FlexPluginBase` to use `node` parameter instead of `store` variable for toolbar rendering. This improves performance and avoids using a deprecated method.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7f9e33c</samp>

> _`node` replaces `store`_
> _toolbar renders faster, better_
> _autumn leaves the old_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7f9e33c</samp>

* Replace deprecated `store.getSchemaParentById` method with `node.parentSchema` to access parent schema of current node in `buildEditorToolbar` method of `FlexPluginBase` class ([link](https://github.com/baidu/amis/pull/8609/files?diff=unified&w=0#diff-0c77368e9183efe6a72ad9cdc7339d1c15ab5f70f8518721c1bda55460262a07L248-R252))
