### PR TITLE
 时间展示、日期展示和日期时间展示 3个组件合并成一个，并升级外观配置

### DIFF
--- a/packages/amis-editor/src/plugin/Date.tsx
+++ b/packages/amis-editor/src/plugin/Date.tsx
@@ -40,6 +40,7 @@ export class DatePlugin extends BasePlugin {
   // 组件名称
   name = '日期展示';
   isBaseComponent = true;
+  disabledRendererPlugin = true; // 可用 DatetimePlugin 实现
   description =
     '主要用来关联字段名做日期展示，支持各种格式如：X（时间戳），YYYY-MM-DD HH:mm:ss。';
   docLink = '/amis/zh-CN/components/date';

--- a/packages/amis-editor/src/plugin/Datetime.tsx
+++ b/packages/amis-editor/src/plugin/Datetime.tsx
@@ -2,27 +2,80 @@ import {registerEditorPlugin, tipedLabel} from 'amis-editor-core';
 import {BaseEventContext} from 'amis-editor-core';
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {DatePlugin} from './Date';
+import {truncate} from 'lodash';
 
 const dateFormatOptions = [
   {
-    label: 'X(时间戳)',
-    value: 'X'
+    label: '时间戳',
+    children: [
+      {
+        label: 'X(时间戳)',
+        value: 'X'
+      },
+      {
+        label: 'x(毫秒时间戳)',
+        value: 'x'
+      }
+    ]
   },
   {
-    label: 'x(毫秒时间戳)',
-    value: 'x'
+    label: '日期格式',
+    children: [
+      {
+        label: 'YYYY-MM-DD',
+        value: 'YYYY-MM-DD'
+      },
+      {
+        label: 'YYYY/MM/DD',
+        value: 'YYYY/MM/DD'
+      },
+      {
+        label: 'YYYY年MM月DD日',
+        value: 'YYYY年MM月DD日'
+      }
+    ]
   },
   {
-    label: 'YYYY-MM-DD HH:mm:ss',
-    value: 'YYYY-MM-DD HH:mm:ss'
+    label: '时间格式',
+    children: [
+      {
+        label: 'HH:mm:ss',
+        value: 'HH:mm:ss',
+        timeFormat: 'HH:mm:ss'
+      },
+      {
+        label: 'HH:mm',
+        value: 'HH:mm',
+        timeFormat: 'HH:mm'
+      },
+      {
+        label: 'HH时mm分',
+        value: 'HH时mm分',
+        timeFormat: 'HH:mm'
+      },
+      {
+        label: 'HH时mm分ss秒',
+        value: 'HH时mm分ss秒',
+        timeFormat: 'HH:mm:ss'
+      }
+    ]
   },
   {
-    label: 'YYYY/MM/DD HH:mm:ss',
-    value: 'YYYY/MM/DD HH:mm:ss'
-  },
-  {
-    label: 'YYYY年MM月DD日 HH时mm分ss秒',
-    value: 'YYYY年MM月DD日 HH时mm分ss秒'
+    label: '日期时间格式',
+    children: [
+      {
+        label: 'YYYY-MM-DD HH:mm:ss',
+        value: 'YYYY-MM-DD HH:mm:ss'
+      },
+      {
+        label: 'YYYY/MM/DD HH:mm:ss',
+        value: 'YYYY/MM/DD HH:mm:ss'
+      },
+      {
+        label: 'YYYY年MM月DD日 HH时mm分ss秒',
+        value: 'YYYY年MM月DD日 HH时mm分ss秒'
+      }
+    ]
   }
 ];
 const valueDateFormatOptions = [
@@ -39,11 +92,13 @@ export class DatetimePlugin extends DatePlugin {
 
   scaffold = {
     type: 'datetime',
+    format: 'YYYY-MM-DD HH:mm:ss',
     value: Math.round(Date.now() / 1000)
   };
 
   name = '日期时间展示';
   isBaseComponent = true;
+  disabledRendererPlugin = false; // 避免被 DatePlugin 覆盖
   pluginIcon = 'datetime-plugin';
   docLink = '/amis/zh-CN/components/date';
   previewSchema = {
@@ -67,13 +122,18 @@ export class DatetimePlugin extends DatePlugin {
                   label: '日期时间值'
                 },
                 {
-                  type: 'input-text',
+                  type: 'nested-select',
                   name: 'format',
+                  // searchable: true,
+                  // selectMode: 'chained', // tree、chained
+                  hideNodePathLabel: true,
+                  onlyLeaf: true,
                   label: tipedLabel(
                     '显示格式',
                     '请参考 <a href="https://momentjs.com/" target="_blank">moment</a> 中的格式用法。'
                   ),
                   clearable: true,
+                  // creatable: true,
                   options: dateFormatOptions,
                   pipeIn: defaultValue('YYYY-MM-DD HH:mm:ss')
                 },

--- a/packages/amis-editor/src/plugin/Datetime.tsx
+++ b/packages/amis-editor/src/plugin/Datetime.tsx
@@ -2,7 +2,6 @@ import {registerEditorPlugin, tipedLabel} from 'amis-editor-core';
 import {BaseEventContext} from 'amis-editor-core';
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {DatePlugin} from './Date';
-import {truncate} from 'lodash';
 
 const dateFormatOptions = [
   {
@@ -157,7 +156,24 @@ export class DatetimePlugin extends DatePlugin {
             getSchemaTpl('status')
           ])
         },
-        getSchemaTpl('onlyClassNameTab')
+        {
+          title: '外观',
+          body: getSchemaTpl('collapseGroup', [
+            ...getSchemaTpl('theme:common', {
+              exclude: ['layout'],
+              baseExtra: [
+                getSchemaTpl('theme:font', {
+                  label: '文字',
+                  name: 'themeCss.baseControlClassName.font'
+                })
+              ]
+            }),
+            {
+              title: 'CSS类名',
+              body: [getSchemaTpl('className')]
+            }
+          ])
+        }
       ])
     ];
   };

--- a/packages/amis-editor/src/plugin/Time.tsx
+++ b/packages/amis-editor/src/plugin/Time.tsx
@@ -38,6 +38,7 @@ export class TimePlugin extends DatePlugin {
   rendererName = 'time';
   name = '时间展示';
   isBaseComponent = true;
+  disabledRendererPlugin = true; // 可用 DatetimePlugin 实现
 
   pluginIcon = 'time-plugin';
   docLink = '/amis/zh-CN/components/date';


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5012a3e</samp>

This pull request enhances the `DatetimePlugin` for the amis-editor, by adding more format, appearance, and renderer options. It also removes the redundant `DatePlugin` and `TimePlugin` as renderer plugins, since they can be replaced by the `DatetimePlugin`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5012a3e</samp>

> _Sing, O Muse, of the cunning code that changed the amis-editor_
> _How the wise developers disabled the `DatePlugin` and the `TimePlugin`_
> _And enhanced the `DatetimePlugin` with many options and renderers_
> _Making it more friendly, flexible, and fair to the eyes of the users_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5012a3e</samp>

*  Disable `DatePlugin` and `TimePlugin` as renderer plugins, since they are redundant with `DatetimePlugin` ([link](https://github.com/baidu/amis/pull/8611/files?diff=unified&w=0#diff-188c9ca195f01b7becbfe70a8c7a8355d2fefe7868b8a96206525ccdef57db4dR43), [link](https://github.com/baidu/amis/pull/8611/files?diff=unified&w=0#diff-d81ad22d457fdd80935898ee407669ff90994f495a20fc98a6a0fd1728a47e8cR41))
*  Reorganize `dateFormatOptions` array into a nested structure with four categories for clarity and usability ([link](https://github.com/baidu/amis/pull/8611/files?diff=unified&w=0#diff-e5677cc0de000158cc72358e52f4aaf1ed4133f2b7861803c4ee142e8dd13e29L8-R77))
*  Add a default value of `YYYY-MM-DD HH:mm:ss` for the `format` property of `DatetimePlugin` ([link](https://github.com/baidu/amis/pull/8611/files?diff=unified&w=0#diff-e5677cc0de000158cc72358e52f4aaf1ed4133f2b7861803c4ee142e8dd13e29R94))
*  Enable `DatetimePlugin` as a renderer plugin and prevent it from being overwritten by `DatePlugin` ([link](https://github.com/baidu/amis/pull/8611/files?diff=unified&w=0#diff-e5677cc0de000158cc72358e52f4aaf1ed4133f2b7861803c4ee142e8dd13e29R100))
*  Change the type of the `format` field from `input-text` to `nested-select`, which allows the user to select from the `dateFormatOptions` array ([link](https://github.com/baidu/amis/pull/8611/files?diff=unified&w=0#diff-e5677cc0de000158cc72358e52f4aaf1ed4133f2b7861803c4ee142e8dd13e29L70-R129))
*  Comment out the `creatable` property of the `nested-select` field, which is not needed for the `format` field ([link](https://github.com/baidu/amis/pull/8611/files?diff=unified&w=0#diff-e5677cc0de000158cc72358e52f4aaf1ed4133f2b7861803c4ee142e8dd13e29R135))
*  Add a new tab to the `DatetimePlugin` schema, called `外观` (Appearance), which contains theme and style options for the date time component ([link](https://github.com/baidu/amis/pull/8611/files?diff=unified&w=0#diff-e5677cc0de000158cc72358e52f4aaf1ed4133f2b7861803c4ee142e8dd13e29L100-R176))
