### PR TITLE
修复日期展示和走势图外观配置不生效问题

### DIFF
--- a/packages/amis-editor/src/plugin/Datetime.tsx
+++ b/packages/amis-editor/src/plugin/Datetime.tsx
@@ -121,10 +121,10 @@ export class DatetimePlugin extends DatePlugin {
                   label: '日期时间值'
                 },
                 {
-                  type: 'select', // nested-select
+                  type: 'nested-select',
                   name: 'format',
-                  searchable: true,
-                  selectMode: 'tree', // tree、chained
+                  // searchable: true,
+                  // selectMode: 'chained', // tree、chained
                   hideNodePathLabel: true,
                   onlyLeaf: true,
                   label: tipedLabel(
@@ -132,8 +132,7 @@ export class DatetimePlugin extends DatePlugin {
                     '请参考 <a href="https://momentjs.com/" target="_blank">moment</a> 中的格式用法。'
                   ),
                   clearable: true,
-                  creatable: true,
-                  createBtnLabel: '自定义时间格式',
+                  // creatable: true,
                   options: dateFormatOptions,
                   pipeIn: defaultValue('YYYY-MM-DD HH:mm:ss')
                 },

--- a/packages/amis-editor/src/plugin/Datetime.tsx
+++ b/packages/amis-editor/src/plugin/Datetime.tsx
@@ -121,10 +121,10 @@ export class DatetimePlugin extends DatePlugin {
                   label: '日期时间值'
                 },
                 {
-                  type: 'nested-select',
+                  type: 'select', // nested-select
                   name: 'format',
-                  // searchable: true,
-                  // selectMode: 'chained', // tree、chained
+                  searchable: true,
+                  selectMode: 'tree', // tree、chained
                   hideNodePathLabel: true,
                   onlyLeaf: true,
                   label: tipedLabel(
@@ -132,7 +132,8 @@ export class DatetimePlugin extends DatePlugin {
                     '请参考 <a href="https://momentjs.com/" target="_blank">moment</a> 中的格式用法。'
                   ),
                   clearable: true,
-                  // creatable: true,
+                  creatable: true,
+                  createBtnLabel: '自定义时间格式',
                   options: dateFormatOptions,
                   pipeIn: defaultValue('YYYY-MM-DD HH:mm:ss')
                 },

--- a/packages/amis-ui/src/components/SparkLine.tsx
+++ b/packages/amis-ui/src/components/SparkLine.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
-import {localeable, LocaleProps} from 'amis-core';
-import {themeable, ThemeProps} from 'amis-core';
+import {
+  localeable,
+  LocaleProps,
+  RendererProps,
+  themeable,
+  ThemeProps,
+  setThemeClassName
+} from 'amis-core';
 import type {PlainObject} from 'amis-core';
 
 export interface SparkLineProps extends ThemeProps, LocaleProps {
@@ -16,6 +22,9 @@ export interface SparkLineProps extends ThemeProps, LocaleProps {
   >;
   placeholder?: string;
   onClick?: (e: React.MouseEvent, value?: PlainObject) => void;
+  id?: string;
+  wrapperCustomStyle?: any;
+  themeCss?: any;
 }
 
 export class SparkLine extends React.Component<SparkLineProps> {
@@ -80,7 +89,10 @@ export class SparkLine extends React.Component<SparkLineProps> {
       height,
       placeholder,
       translate: __,
-      onClick
+      onClick,
+      id,
+      wrapperCustomStyle,
+      themeCss
     } = this.props;
 
     return (
@@ -88,7 +100,9 @@ export class SparkLine extends React.Component<SparkLineProps> {
         className={cx(
           'Sparkline',
           className,
-          onClick ? 'Sparkline--clickable' : ''
+          onClick ? 'Sparkline--clickable' : '',
+          setThemeClassName('baseControlClassName', id, themeCss),
+          setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
         )}
         style={style}
         onClick={onClick}

--- a/packages/amis/src/renderers/Date.tsx
+++ b/packages/amis/src/renderers/Date.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import {Renderer, RendererProps, normalizeDate} from 'amis-core';
+import {
+  Renderer,
+  RendererProps,
+  normalizeDate,
+  CustomStyle,
+  setThemeClassName
+} from 'amis-core';
 import moment, {Moment} from 'moment';
 import 'moment-timezone';
 import {BaseSchema} from '../Schema';
@@ -117,7 +123,13 @@ export class DateField extends React.Component<DateProps, DateState> {
       classnames: cx,
       locale,
       translate: __,
-      displayTimeZone
+      displayTimeZone,
+      data,
+      id,
+      wrapperCustomStyle,
+      env,
+      themeCss,
+      baseControlClassName
     } = this.props;
     let viewValue: React.ReactNode = (
       <span className="text-muted">{placeholder}</span>
@@ -152,13 +164,33 @@ export class DateField extends React.Component<DateProps, DateState> {
     );
 
     return (
-      <span
-        className={cx('DateField', className)}
-        style={style}
-        title={fromNow && date ? date : undefined}
-      >
-        {viewValue}
-      </span>
+      <>
+        <span
+          style={style}
+          title={fromNow && date ? date : undefined}
+          className={cx(
+            'DateField',
+            className,
+            setThemeClassName('baseControlClassName', id, themeCss),
+            setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
+          )}
+        >
+          {viewValue}
+        </span>
+        <CustomStyle
+          config={{
+            wrapperCustomStyle,
+            id,
+            themeCss,
+            classNames: [
+              {
+                key: 'baseControlClassName'
+              }
+            ]
+          }}
+          env={env}
+        />
+      </>
     );
   }
 }

--- a/packages/amis/src/renderers/SparkLine.tsx
+++ b/packages/amis/src/renderers/SparkLine.tsx
@@ -1,10 +1,16 @@
 import {SparkLine} from 'amis-ui';
-import {Renderer, RendererProps} from 'amis-core';
+import {
+  Renderer,
+  RendererProps,
+  autobind,
+  createObject,
+  getPropValue,
+  CustomStyle
+} from 'amis-core';
 import React from 'react';
 import {resolveVariableAndFilter} from 'amis-core';
 import {BaseSchema, SchemaClassName} from '../Schema';
 import {ActionSchema} from './Action';
-import {autobind, createObject, getPropValue} from 'amis-core';
 
 export interface SparkLineSchema extends BaseSchema {
   type: 'sparkline';
@@ -95,15 +101,31 @@ export class SparkLineRenderer extends React.Component<SparkLineRendProps> {
   }
 
   render() {
-    const {value, name, data, clickAction} = this.props;
+    const {value, name, clickAction, id, wrapperCustomStyle, env, themeCss} =
+      this.props;
     const finalValue = getPropValue(this.props) || [1, 1];
 
     return (
-      <SparkLine
-        onClick={clickAction ? this.handleClick : undefined}
-        {...this.props}
-        value={finalValue}
-      />
+      <>
+        <SparkLine
+          onClick={clickAction ? this.handleClick : undefined}
+          {...this.props}
+          value={finalValue}
+        />
+        <CustomStyle
+          config={{
+            wrapperCustomStyle,
+            id,
+            themeCss,
+            classNames: [
+              {
+                key: 'baseControlClassName'
+              }
+            ]
+          }}
+          env={env}
+        />
+      </>
     );
   }
 }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19f630c</samp>

Added theme and custom style props to `SparkLine` and `DateField` components. Refactored the imports and render methods to use the new features from `amis-core`. Updated the `SparkLine` component and renderer in `amis-ui` and `amis` packages.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 19f630c</samp>

> _`SparkLine` gets props_
> _Custom style and theme class_
> _Autumn leaves change color_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 19f630c</samp>

*  Add `CustomStyle` and `setThemeClassName` imports from `amis-core` to use them for customizing the style of date and sparkline components ([link](https://github.com/baidu/amis/pull/8618/files?diff=unified&w=0#diff-188bc66aba5ad522e2544d7bf9d65cc7f39668ef53d9f897d5ce92f721a121f2L2-R9), [link](https://github.com/baidu/amis/pull/8618/files?diff=unified&w=0#diff-99868377e5cc4f861282cececed447fd142a22ffd407e29b1989ceae065441b9L2-R8), [link](https://github.com/baidu/amis/pull/8618/files?diff=unified&w=0#diff-dfd060cb7eb0fbe68a872074b93dde6514501061ea391e6430b821fc5ced1782L2-R13))
* Extend `SparkLineProps` interface to include `id`, `wrapperCustomStyle` and `themeCss` props for `SparkLine` component ([link](https://github.com/baidu/amis/pull/8618/files?diff=unified&w=0#diff-188bc66aba5ad522e2544d7bf9d65cc7f39668ef53d9f897d5ce92f721a121f2R25-R27))
* Destructure the new props from `this.props` and apply them to the root element of `SparkLine` component using `setThemeClassName` helper function ([link](https://github.com/baidu/amis/pull/8618/files?diff=unified&w=0#diff-188bc66aba5ad522e2544d7bf9d65cc7f39668ef53d9f897d5ce92f721a121f2L83-R95), [link](https://github.com/baidu/amis/pull/8618/files?diff=unified&w=0#diff-188bc66aba5ad522e2544d7bf9d65cc7f39668ef53d9f897d5ce92f721a121f2L91-R105))
* Wrap `DateField` and `SparkLineRenderer` components with fragments and render `CustomStyle` components after them to inject the theme class name and the wrapper custom style using `setThemeClassName` helper function ([link](https://github.com/baidu/amis/pull/8618/files?diff=unified&w=0#diff-99868377e5cc4f861282cececed447fd142a22ffd407e29b1989ceae065441b9L120-R132), [link](https://github.com/baidu/amis/pull/8618/files?diff=unified&w=0#diff-99868377e5cc4f861282cececed447fd142a22ffd407e29b1989ceae065441b9L155-R193), [link](https://github.com/baidu/amis/pull/8618/files?diff=unified&w=0#diff-dfd060cb7eb0fbe68a872074b93dde6514501061ea391e6430b821fc5ced1782L98-R128))
