### PR TITLE
feat: 开放static组件, 增加static事件配置

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Static.tsx
+++ b/packages/amis-editor/src/plugin/Form/Static.tsx
@@ -4,7 +4,8 @@ import {
   defaultValue,
   getSchemaTpl,
   setSchemaTpl,
-  tipedLabel
+  tipedLabel,
+  RendererPluginEvent
 } from 'amis-editor-core';
 import {registerEditorPlugin} from 'amis-editor-core';
 import {BaseEventContext, BasePlugin} from 'amis-editor-core';
@@ -263,7 +264,6 @@ export class StaticControlPlugin extends BasePlugin {
   // 组件名称
   name = '静态展示框';
   isBaseComponent = true;
-  disabledRendererPlugin = true;
   icon = 'fa fa-info';
   pluginIcon = 'static-plugin';
   description = '纯用来展示数据，可用来展示 json、date、image、progress 等数据';
@@ -299,13 +299,6 @@ export class StaticControlPlugin extends BasePlugin {
           {
             title: '基本',
             body: [
-              {
-                type: 'alert',
-                inline: false,
-                level: 'warning',
-                className: 'text-sm',
-                body: '<p>当前组件已停止维护，建议您使用<a href="/amis/zh-CN/components/form/formitem#%E9%85%8D%E7%BD%AE%E9%9D%99%E6%80%81%E5%B1%95%E7%A4%BA" target="_blank">静态展示</a>新特性实现表单项的静态展示。</p>'
-              },
               getSchemaTpl('formItemName', {
                 required: false
               }),
@@ -389,6 +382,76 @@ export class StaticControlPlugin extends BasePlugin {
     }
     return props;
   }
+
+  // 事件定义
+  events: RendererPluginEvent[] = [
+    {
+      eventName: 'click',
+      eventLabel: '点击',
+      description: '点击时触发',
+      dataSchema: [
+        {
+          type: 'object',
+          properties: {
+            context: {
+              type: 'object',
+              title: '上下文',
+              properties: {
+                nativeEvent: {
+                  type: 'object',
+                  title: '鼠标事件对象'
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      eventName: 'mouseenter',
+      eventLabel: '鼠标移入',
+      description: '鼠标移入时触发',
+      dataSchema: [
+        {
+          type: 'object',
+          properties: {
+            context: {
+              type: 'object',
+              title: '上下文',
+              properties: {
+                nativeEvent: {
+                  type: 'object',
+                  title: '鼠标事件对象'
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      eventName: 'mouseleave',
+      eventLabel: '鼠标移出',
+      description: '鼠标移出时触发',
+      dataSchema: [
+        {
+          type: 'object',
+          properties: {
+            context: {
+              type: 'object',
+              title: '上下文',
+              properties: {
+                nativeEvent: {
+                  type: 'object',
+                  title: '鼠标事件对象'
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  ];
 
   /*exchangeRenderer(id: string) {
     this.manager.showReplacePanel(id, '展示');

--- a/packages/amis-editor/src/plugin/index.ts
+++ b/packages/amis-editor/src/plugin/index.ts
@@ -63,6 +63,7 @@ export * from './Form/UUID'; // UUID
 export * from './Form/LocationPicker'; // 地理位置
 export * from './Form/InputSubForm'; // 子表单项
 export * from './Form/Hidden'; // 隐藏域
+export * from './Form/Static'; // 静态展示框
 
 // 功能
 export * from './Button'; // 按钮
@@ -135,7 +136,6 @@ export * from './Form/InputMonthRange';
 export * from './Form/InputPassword';
 export * from './Form/InputQuarter';
 export * from './Form/InputQuarterRange';
-export * from './Form/Static';
 export * from './Form/InputTime';
 export * from './Form/InputTimeRange';
 export * from './Form/TreeSelect';


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1c3fc33</samp>

Added a new feature of static display for form items in `amis-editor`. Updated the `StaticControlPlugin` class to handle the rendering and events of the static control. Exported the `Static` module from the `plugin` index file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1c3fc33</samp>

> _`Static` module exports_
> _Form items show as static_
> _No warning in fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1c3fc33</samp>

* Import `RendererPluginEvent` type to define static control plugin events ([link](https://github.com/baidu/amis/pull/8621/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261L7-R8))
* Remove `disabledRendererPlugin` property from `StaticControlPlugin` class, as static control is now supported by static display feature ([link](https://github.com/baidu/amis/pull/8621/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261L266))
* Remove alert component that warned about static control deprecation from `StaticControlPlugin` class ([link](https://github.com/baidu/amis/pull/8621/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261L302-L308))
* Add `events` property to `StaticControlPlugin` class, to handle click, mouseenter, and mouseleave events for static control and define data schema for each event ([link](https://github.com/baidu/amis/pull/8621/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261R386-R455))
* Export `Static` module from `plugin` index file, to make static control plugin available for editor ([link](https://github.com/baidu/amis/pull/8621/files?diff=unified&w=0#diff-932f531ae9519592dd3c4d5b344142b81879a4366812780b429dfa5a17fc675bR66))
