### PR TITLE
fix(amis-editor): 容器类组件/定位模式切换成特殊布局后设置默认层级，避免被遮挡导致不能选中

### DIFF
--- a/packages/amis-editor/src/tpl/layout.tsx
+++ b/packages/amis-editor/src/tpl/layout.tsx
@@ -53,20 +53,22 @@ setSchemaTpl(
       pipeOut: config?.pipeOut,
       onChange: (value: string, oldValue: string, model: any, form: any) => {
         if (value === 'static') {
-          form.setValueByName('style.inset', undefined);
-          form.setValueByName('style.zIndex', undefined);
-          form.setValueByName('originPosition', undefined);
+          form.deleteValueByName('style.inset');
+          form.deleteValueByName('style.zIndex');
+          form.deleteValueByName('originPosition');
         } else if (value === 'fixed' || value === 'absolute') {
-          // 默认使用右下角进行相对定位
+          form.setValueByName('style.zIndex', 1); // 避免被页面其他内容元素遮挡（导致不能选中）
           form.setValueByName('style.inset', 'auto 50px 50px auto');
+          // 默认使用右下角进行相对定位
           form.setValueByName('originPosition', 'right-bottom');
         } else if (value === 'relative') {
+          form.setValueByName('style.zIndex', 1);
           form.setValueByName('style.inset', 'auto');
-          form.setValueByName('originPosition', undefined);
+          form.deleteValueByName('originPosition');
         }
         if (value !== 'sticky') {
           // 非滚动吸附定位
-          form.setValueByName('stickyStatus', undefined);
+          form.deleteValueByName('stickyStatus');
         }
       },
       options: [
@@ -273,10 +275,10 @@ setSchemaTpl(
       pipeOut: config?.pipeOut,
       onChange: (value: string, oldValue: string, model: any, form: any) => {
         if (value !== 'flex' && value !== 'inline-flex') {
-          form.setValueByName('style.flexDirection', undefined);
-          form.setValueByName('style.justifyContent', undefined);
-          form.setValueByName('style.alignItems', undefined);
-          form.setValueByName('style.flexWrap', undefined);
+          form.deleteValueByName('style.flexDirection');
+          form.deleteValueByName('style.justifyContent');
+          form.deleteValueByName('style.alignItems');
+          form.deleteValueByName('style.flexWrap');
         }
       }
     };
@@ -582,33 +584,33 @@ setSchemaTpl(
           // 弹性
           if (config?.isFlexColumnItem) {
             // form.setValueByName('style.overflowY', 'auto');
-            form.setValueByName('style.height', undefined);
+            form.deleteValueByName('style.height');
           } else {
             // form.setValueByName('style.overflowX', 'auto');
-            form.setValueByName('style.width', undefined);
+            form.deleteValueByName('style.width');
           }
         } else if (value === '0 0 150px') {
           // 固定
-          form.setValueByName('style.flexGrow', undefined);
+          form.deleteValueByName('style.flexGrow');
           form.setValueByName('style.flexBasis', '150px');
 
           if (config?.isFlexColumnItem) {
-            form.setValueByName('style.height', undefined);
+            form.deleteValueByName('style.height');
           } else {
-            form.setValueByName('style.width', undefined);
+            form.deleteValueByName('style.width');
           }
         } else if (value === '0 0 auto') {
           // 适配
-          form.setValueByName('style.flexGrow', undefined);
-          form.setValueByName('style.flexBasis', undefined);
-          form.setValueByName('style.overflowX', undefined);
-          form.setValueByName('style.overflowY', undefined);
-          form.setValueByName('style.overflow', undefined);
+          form.deleteValueByName('style.flexGrow');
+          form.deleteValueByName('style.flexBasis');
+          form.deleteValueByName('style.overflowX');
+          form.deleteValueByName('style.overflowY');
+          form.deleteValueByName('style.overflow');
 
           if (config?.isFlexColumnItem) {
-            form.setValueByName('style.height', undefined);
+            form.deleteValueByName('style.height');
           } else {
-            form.setValueByName('style.width', undefined);
+            form.deleteValueByName('style.width');
           }
         }
       }
@@ -719,11 +721,11 @@ setSchemaTpl(
       onChange: (value: boolean, oldValue: boolean, model: any, form: any) => {
         if (value) {
           // 固定宽度时，剔除最大宽度、最小宽度
-          form.setValueByName('style.maxWidth', undefined);
-          form.setValueByName('style.minWidth', undefined);
+          form.deleteValueByName('style.maxWidth');
+          form.deleteValueByName('style.minWidth');
         } else {
           // 非固定宽度时，剔除宽度数值
-          form.setValueByName('style.width', undefined);
+          form.deleteValueByName('style.width');
         }
         if (config?.onChange) {
           config.onChange(value);
@@ -959,11 +961,11 @@ setSchemaTpl(
       onChange: (value: boolean, oldValue: boolean, model: any, form: any) => {
         if (value) {
           // 固定高度时，剔除最大高度、最小高度
-          form.setValueByName('style.maxHeight', undefined);
-          form.setValueByName('style.minHeight', undefined);
+          form.deleteValueByName('style.maxHeight');
+          form.deleteValueByName('style.minHeight');
         } else {
           // 非固定高度时，剔除高度数值
-          form.setValueByName('style.height', undefined);
+          form.deleteValueByName('style.height');
         }
         if (config?.onChange) {
           config.onChange(value);
@@ -1199,7 +1201,7 @@ setSchemaTpl(
             } else {
               form.setValueByName('style.inset', 'auto 0px auto auto');
             }
-            form.setValueByName('style.transform', undefined);
+            form.deleteValueByName('style.transform');
           } else {
             // 靠左
             if (form.data?.sorptionPosition === 'top') {
@@ -1211,11 +1213,11 @@ setSchemaTpl(
             } else {
               form.setValueByName('style.inset', 'auto auto auto 0px');
             }
-            form.setValueByName('style.transform', undefined);
+            form.deleteValueByName('style.transform');
           }
         } else {
           // 靠左
-          form.setValueByName('style.transform', undefined);
+          form.deleteValueByName('style.transform');
         }
       }
     };
@@ -1342,8 +1344,8 @@ setSchemaTpl('layout:sticky', {
       form.setValueByName('style.zIndex', 10);
     } else {
       form.setValueByName('style.position', 'static');
-      form.setValueByName('style.inset', undefined);
-      form.setValueByName('style.zIndex', undefined);
+      form.deleteValueByName('style.inset');
+      form.deleteValueByName('style.zIndex');
     }
   }
 });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5510ac8</samp>

This pull request enhances the layout editor of `amis-editor` by removing unnecessary or conflicting style properties from the layout model when the user modifies some key fields. This simplifies the layout editing process and avoids unexpected style behaviors.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5510ac8</samp>

> _`style` properties_
> _change with user input now_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5510ac8</samp>

*  Delete irrelevant style properties based on the values of `style.position`, `style.display`, `style.flex`, `style.widthFixed`, `style.heightFixed`, and `originPosition` fields in the layout editor ([link](https://github.com/baidu/amis/pull/8622/files?diff=unified&w=0#diff-45bfed43c25dfce3e1aae45c4315a2b224141c06f2ca5ecc7a029ea995ac473bL56-R71), [link](https://github.com/baidu/amis/pull/8622/files?diff=unified&w=0#diff-45bfed43c25dfce3e1aae45c4315a2b224141c06f2ca5ecc7a029ea995ac473bL276-R281), [link](https://github.com/baidu/amis/pull/8622/files?diff=unified&w=0#diff-45bfed43c25dfce3e1aae45c4315a2b224141c06f2ca5ecc7a029ea995ac473bL585-R613), [link](https://github.com/baidu/amis/pull/8622/files?diff=unified&w=0#diff-45bfed43c25dfce3e1aae45c4315a2b224141c06f2ca5ecc7a029ea995ac473bL722-R728), [link](https://github.com/baidu/amis/pull/8622/files?diff=unified&w=0#diff-45bfed43c25dfce3e1aae45c4315a2b224141c06f2ca5ecc7a029ea995ac473bL962-R968), [link](https://github.com/baidu/amis/pull/8622/files?diff=unified&w=0#diff-45bfed43c25dfce3e1aae45c4315a2b224141c06f2ca5ecc7a029ea995ac473bL1202-R1204), [link](https://github.com/baidu/amis/pull/8622/files?diff=unified&w=0#diff-45bfed43c25dfce3e1aae45c4315a2b224141c06f2ca5ecc7a029ea995ac473bL1214-R1220), [link](https://github.com/baidu/amis/pull/8622/files?diff=unified&w=0#diff-45bfed43c25dfce3e1aae45c4315a2b224141c06f2ca5ecc7a029ea995ac473bL1345-R1348)) in `layout.tsx`
