### PR TITLE
fix:文档中广播效果失效问题&添加warning提示

### DIFF
--- a/docs/zh-CN/concepts/event-action.md
+++ b/docs/zh-CN/concepts/event-action.md
@@ -2281,7 +2281,7 @@ run action ajax
     },
     {
       type: 'form',
-      id: 'form_001_form_01',
+      id: 'form_001',
       title: '表单1（优先级低）',
       name: 'sub-form1',
       body: [
@@ -2298,6 +2298,7 @@ run action ajax
           actions: [
             {
               actionType: 'reload',
+              componentId: 'form_001',
               data: {
                 myname: '${myrole}', // 从事件数据中取
               }
@@ -2340,6 +2341,7 @@ run action ajax
           actions: [
             {
               actionType: 'reload',
+              componentId: 'form_002',
               data: {
                 myrole: '${myrole}',
                 age: '${age}'
@@ -2378,6 +2380,7 @@ run action ajax
           actions: [
             {
               actionType: 'reload',
+              componentId: 'form_003',
               data: {
                 job: '${myrole}'
               }

--- a/packages/amis-core/src/actions/CmptAction.ts
+++ b/packages/amis-core/src/actions/CmptAction.ts
@@ -37,6 +37,11 @@ export class CmptAction implements RendererAction {
     const key = action.componentId || action.componentName;
     const dataMergeMode = action.dataMergeMode || 'merge';
 
+    if (!key) {
+      console.warn('请提供目标组件的componentId或componentName');
+      return;
+    }
+
     let component = key
       ? event.context.scoped?.[
           action.componentId ? 'getComponentById' : 'getComponentByName'


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6af4d2</samp>

Fixed a bug and improved the reliability of broadcast actions in the event-action concept document. Added a warning message for missing `key` parameter in the `CmptAction` class.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a6af4d2</samp>

> _No `key` for the component, you're doomed to fail_
> _A warning message echoes in the console of hell_
> _But you can fix the bug and broadcast your rage_
> _With `id` and `componentId`, you control the stage_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a6af4d2</samp>

* Fix a bug where broadcast actions would not work as expected for form components in `docs/zh-CN/concepts/event-action.md` ([link](https://github.com/baidu/amis/pull/8624/files?diff=unified&w=0#diff-9802ca5a2390dc6e213b3d844669c50fb10948dad8ad72a0d360c886731fbd3dL2284-R2284), [link](https://github.com/baidu/amis/pull/8624/files?diff=unified&w=0#diff-9802ca5a2390dc6e213b3d844669c50fb10948dad8ad72a0d360c886731fbd3dR2301), [link](https://github.com/baidu/amis/pull/8624/files?diff=unified&w=0#diff-9802ca5a2390dc6e213b3d844669c50fb10948dad8ad72a0d360c886731fbd3dR2344), [link](https://github.com/baidu/amis/pull/8624/files?diff=unified&w=0#diff-9802ca5a2390dc6e213b3d844669c50fb10948dad8ad72a0d360c886731fbd3dR2383))
* Add a warning message for missing `key` parameter in `CmptAction` class in `packages/amis-core/src/actions/CmptAction.ts` ([link](https://github.com/baidu/amis/pull/8624/files?diff=unified&w=0#diff-9fcca25fc37554994f4168d09ade3ba52487964b8f897e0a9de38442dc6b1ceaR40-R44))
