### PR TITLE
chore(amis-editor): CRUD2列配置控件始终展示顶部操作区

### DIFF
--- a/packages/amis-editor/src/renderer/crud2-control/CRUDColumnControl.tsx
+++ b/packages/amis-editor/src/renderer/crud2-control/CRUDColumnControl.tsx
@@ -449,19 +449,29 @@ export class CRUDColumnControl extends React.Component<
             size="sm"
             className={cx('flex')}
           />
-        ) : Array.isArray(options) && options.length > 0 ? (
+        ) : (
           <>
             {this.renderHeader()}
-            <ul className={cx('ae-CRUDConfigControl-list')} ref={this.dragRef}>
-              {options.map((item, index) => {
-                return this.renderOption(item, index);
-              })}
-            </ul>
+            {Array.isArray(options) && options.length > 0 ? (
+              <ul
+                className={cx('ae-CRUDConfigControl-list')}
+                ref={this.dragRef}
+              >
+                {options.map((item, index) => {
+                  return this.renderOption(item, index);
+                })}
+              </ul>
+            ) : (
+              <ul
+                className={cx('ae-CRUDConfigControl-list')}
+                ref={this.dragRef}
+              >
+                <p className={cx(`ae-CRUDConfigControl-placeholder`)}>
+                  暂无数据
+                </p>
+              </ul>
+            )}
           </>
-        ) : (
-          <ul className={cx('ae-CRUDConfigControl-list')} ref={this.dragRef}>
-            <p className={cx(`ae-CRUDConfigControl-placeholder`)}>暂无数据</p>
-          </ul>
         )}
 
         {showAddModal ? (


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c329a19</samp>

Refactored the rendering logic of `CRUDColumnControl.tsx` to avoid duplication and improve readability.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c329a19</samp>

> _`<ul>` and `ref` props_
> _refactored in one fragment_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c329a19</samp>

*  Refactor conditional rendering to avoid repetition ([link](https://github.com/baidu/amis/pull/8626/files?diff=unified&w=0#diff-c45f0bbd226c1402b4a6485aa6fd8d6e9e8e65d33dcafdbfac64e2dc8b4ae595L452-R474))
