### PR TITLE
style: 调整 textarea 的 counter 结构方便定制样式

### DIFF
--- a/packages/amis-ui/scss/components/form/_textarea.scss
+++ b/packages/amis-ui/scss/components/form/_textarea.scss
@@ -48,6 +48,10 @@
     color: var(--input-count-multi-color);
     font-size: var(--input-count-multi-fontSize);
 
+    > i {
+      font-style: normal;
+    }
+
     &.is-empty {
       color: var(--input-count-multi-color);
     }

--- a/packages/amis-ui/src/components/Textarea.tsx
+++ b/packages/amis-ui/src/components/Textarea.tsx
@@ -233,9 +233,13 @@ export class Textarea extends React.Component<TextAreaProps, TextAreaState> {
               'is-clearable': clearable && !disabled && value
             })}
           >
-            {`${counter}${
-              typeof maxLength === 'number' && maxLength ? `/${maxLength}` : ''
-            }`}
+            <span>{counter}</span>
+            {typeof maxLength === 'number' && maxLength ? (
+              <>
+                <i>/</i>
+                <span>{maxLength}</span>
+              </>
+            ) : null}
           </span>
         ) : null}
       </div>

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/textarea.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/textarea.test.tsx.snap
@@ -140,7 +140,15 @@ exports[`Renderer:textarea with maxLength & clearable & resetValue 1`] = `
             <span
               class="cxd-TextareaControl-counter is-clearable"
             >
-              16/9
+              <span>
+                16
+              </span>
+              <i>
+                /
+              </i>
+              <span>
+                9
+              </span>
             </span>
           </div>
           <ul
@@ -321,7 +329,9 @@ exports[`Renderer:textarea with trimContents & showCounter 1`] = `
             <span
               class="cxd-TextareaControl-counter"
             >
-              5
+              <span>
+                5
+              </span>
             </span>
           </div>
         </div>

--- a/packages/amis/__tests__/renderers/Form/textarea.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/textarea.test.tsx
@@ -101,7 +101,7 @@ test('Renderer:textarea with trimContents & showCounter', async () => {
   expect(
     (container.querySelector('.cxd-TextareaControl-counter') as Element)
       .innerHTML
-  ).toBe('3');
+  ).toBe('<span>3</span>');
 
   fireEvent.change(textarea, {target: {value: '   12345   '}});
   fireEvent.blur(textarea);
@@ -111,7 +111,7 @@ test('Renderer:textarea with trimContents & showCounter', async () => {
   expect(
     (container.querySelector('.cxd-TextareaControl-counter') as Element)
       .innerHTML
-  ).toBe('5');
+  ).toBe('<span>5</span>');
 
   expect(container).toMatchSnapshot();
 });
@@ -136,7 +136,7 @@ test('Renderer:textarea with maxLength & clearable & resetValue', async () => {
   expect(
     (container.querySelector('.cxd-TextareaControl-counter') as Element)
       .innerHTML
-  ).toBe('3/9');
+  ).toBe('<span>3</span><i>/</i><span>9</span>');
 
   fireEvent.click(container.querySelector('.cxd-TextareaControl-clear')!);
   await waitFor(() => {
@@ -144,7 +144,7 @@ test('Renderer:textarea with maxLength & clearable & resetValue', async () => {
     expect(
       (container.querySelector('.cxd-TextareaControl-counter') as Element)
         .innerHTML
-    ).toBe('16/9');
+    ).toBe('<span>16</span><i>/</i><span>9</span>');
   });
 
   const submitBtn = container.querySelector(


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 125f498</samp>

This pull request updates the textarea input component and its test code to use separate elements for the counter parts. This makes the counter more customizable and consistent in appearance.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 125f498</samp>

> _`i` for slash mark_
> _counter gets more flexible_
> _autumn leaves change style_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 125f498</samp>

*  Refactor the counter element of the textarea input to use span and `i` elements instead of a template literal ([link](https://github.com/baidu/amis/pull/8627/files?diff=unified&w=0#diff-4814feb9b8ef8a7c7d84419efa4154cdc0d620e75a0992de3fb158851913959aL236-R242), [link](https://github.com/baidu/amis/pull/8627/files?diff=unified&w=0#diff-b7020c82803bdf4520f4b02de4d52defde92ce287a7ddbd2abeec8999f41d8d5R51-R54))
  * Modify the JSX code in `Textarea.tsx` to render separate elements for the current length, the slash character, and the maximum length of the input ([link](https://github.com/baidu/amis/pull/8627/files?diff=unified&w=0#diff-4814feb9b8ef8a7c7d84419efa4154cdc0d620e75a0992de3fb158851913959aL236-R242))
  * Add a style rule in `_textarea.scss` to make the slash character look consistent with the numbers by setting the font-style to normal ([link](https://github.com/baidu/amis/pull/8627/files?diff=unified&w=0#diff-b7020c82803bdf4520f4b02de4d52defde92ce287a7ddbd2abeec8999f41d8d5R51-R54))
* Update the test cases in `textarea.test.tsx` to match the new structure of the counter element ([link](https://github.com/baidu/amis/pull/8627/files?diff=unified&w=0#diff-e80f805cd87706768a972665434690afa9e678ebc068b2dcd74df462980866e5L104-R104), [link](https://github.com/baidu/amis/pull/8627/files?diff=unified&w=0#diff-e80f805cd87706768a972665434690afa9e678ebc068b2dcd74df462980866e5L114-R114), [link](https://github.com/baidu/amis/pull/8627/files?diff=unified&w=0#diff-e80f805cd87706768a972665434690afa9e678ebc068b2dcd74df462980866e5L139-R139), [link](https://github.com/baidu/amis/pull/8627/files?diff=unified&w=0#diff-e80f805cd87706768a972665434690afa9e678ebc068b2dcd74df462980866e5L147-R147))
  * Change the expected innerHTML of the counter element to include the span and `i` tags in each test case ([link](https://github.com/baidu/amis/pull/8627/files?diff=unified&w=0#diff-e80f805cd87706768a972665434690afa9e678ebc068b2dcd74df462980866e5L104-R104), [link](https://github.com/baidu/amis/pull/8627/files?diff=unified&w=0#diff-e80f805cd87706768a972665434690afa9e678ebc068b2dcd74df462980866e5L114-R114), [link](https://github.com/baidu/amis/pull/8627/files?diff=unified&w=0#diff-e80f805cd87706768a972665434690afa9e678ebc068b2dcd74df462980866e5L139-R139), [link](https://github.com/baidu/amis/pull/8627/files?diff=unified&w=0#diff-e80f805cd87706768a972665434690afa9e678ebc068b2dcd74df462980866e5L147-R147))
