### PR TITLE
fix: cards外观修复

### DIFF
--- a/packages/amis/src/renderers/Cards.tsx
+++ b/packages/amis/src/renderers/Cards.tsx
@@ -11,7 +11,9 @@ import {
   difference,
   ucFirst,
   autobind,
-  createObject
+  createObject,
+  CustomStyle,
+  setThemeClassName
 } from 'amis-core';
 import {
   isPureVariable,
@@ -923,7 +925,10 @@ export default class Cards extends React.Component<GridProps, object> {
       translate: __,
       loading = false,
       loadingConfig,
-      env
+      env,
+      id,
+      wrapperCustomStyle,
+      themeCss
     } = this.props;
 
     this.renderedToolbars = []; // 用来记录哪些 toolbar 已经渲染了，已经渲染了就不重复渲染了。
@@ -973,9 +978,15 @@ export default class Cards extends React.Component<GridProps, object> {
     return (
       <div
         ref={this.bodyRef}
-        className={cx('Cards', className, {
-          'Cards--unsaved': !!store.modified || !!store.moved
-        })}
+        className={cx(
+          'Cards',
+          className,
+          {
+            'Cards--unsaved': !!store.modified || !!store.moved
+          },
+          setThemeClassName('baseControlClassName', id, themeCss),
+          setThemeClassName('wrapperCustomStyle', id, wrapperCustomStyle)
+        )}
         style={buildStyle(style, data)}
       >
         {affixHeader ? (
@@ -1007,6 +1018,20 @@ export default class Cards extends React.Component<GridProps, object> {
 
         {footer}
         <Spinner loadingConfig={loadingConfig} overlay show={loading} />
+
+        <CustomStyle
+          config={{
+            wrapperCustomStyle,
+            id,
+            themeCss,
+            classNames: [
+              {
+                key: 'baseControlClassName'
+              }
+            ]
+          }}
+          env={env}
+        />
       </div>
     );
   }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 45f4f4c</samp>

Enhanced the cards component to support theme-based custom styles and class names. Used `CustomStyle` and `setThemeClassName` from `amis-core` to implement the feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 45f4f4c</samp>

> _Sing, O Muse, of the skillful coder who enhanced the cards_
> _With `CustomStyle` and `setThemeClassName`, functions divine_
> _That from `amis-core` he borrowed, to adorn them with various arts_
> _And make them shine like stars in the sky, or jewels in a shrine_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 45f4f4c</samp>

* Import and use `CustomStyle` and `setThemeClassName` functions from `amis-core` to apply custom styles and class names to the cards component based on the theme configuration ([link](https://github.com/baidu/amis/pull/8628/files?diff=unified&w=0#diff-83895e4b0993db67cbfb774b8539e7625318f250de1b4a848611cabedf9e828bL14-R16), [link](https://github.com/baidu/amis/pull/8628/files?diff=unified&w=0#diff-83895e4b0993db67cbfb774b8539e7625318f250de1b4a848611cabedf9e828bL926-R931), [link](https://github.com/baidu/amis/pull/8628/files?diff=unified&w=0#diff-83895e4b0993db67cbfb774b8539e7625318f250de1b4a848611cabedf9e828bL976-R989), [link](https://github.com/baidu/amis/pull/8628/files?diff=unified&w=0#diff-83895e4b0993db67cbfb774b8539e7625318f250de1b4a848611cabedf9e828bR1021-R1034))
* Destructure `id`, `wrapperCustomStyle`, and `themeCss` props from `this.props` and pass them to the `CustomStyle` and `setThemeClassName` functions ([link](https://github.com/baidu/amis/pull/8628/files?diff=unified&w=0#diff-83895e4b0993db67cbfb774b8539e7625318f250de1b4a848611cabedf9e828bL926-R931))
* Render `CustomStyle` component as a child of the cards component and pass `config`, `env`, and `children` props to create a style tag with the custom styles ([link](https://github.com/baidu/amis/pull/8628/files?diff=unified&w=0#diff-83895e4b0993db67cbfb774b8539e7625318f250de1b4a848611cabedf9e828bR1021-R1034))
