### PR TITLE
feat(amis-editor): InputTable配置面板补充属性

### DIFF
--- a/packages/amis-editor/src/plugin/Form/InputTable.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTable.tsx
@@ -1071,6 +1071,16 @@ export class TableControlPlugin extends BasePlugin {
                 name: 'affixHeader',
                 label: '是否固定表头',
                 pipeIn: defaultValue(false)
+              }),
+              getSchemaTpl('switch', {
+                name: 'showFooterAddBtn',
+                label: '展示底部新增按钮',
+                pipeIn: defaultValue(true)
+              }),
+              getSchemaTpl('switch', {
+                name: 'showTableAddBtn',
+                label: '展示操作列新增按钮',
+                pipeIn: defaultValue(true)
               })
             ]
           },
@@ -1080,6 +1090,10 @@ export class TableControlPlugin extends BasePlugin {
               getSchemaTpl('className', {
                 name: 'rowClassName',
                 label: '行样式'
+              }),
+              getSchemaTpl('className', {
+                name: 'toolbarClassName',
+                label: '工具栏'
               })
             ]
           })


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1b22ca7</samp>

Added new options to the `table` control plugin schema in `Form/InputTable.tsx` to allow users to control the table layout and actions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1b22ca7</samp>

> _To make tables more flexible and fun_
> _This pull request adds options, not one_
> _But three in the schema_
> _`showAddButton`, `className`, and `showOperationColumn`_
> _Now you can customize how they look and run_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1b22ca7</samp>

* Add switch options to toggle add buttons and operation column in table control plugin schema ([link](https://github.com/baidu/amis/pull/8629/files?diff=unified&w=0#diff-01999eae047ec7fdb8502c22801699d39f7a54c994a9414462c0fbe21634ecd8R1074-R1083))
* Add className option to customize toolbar element in table control plugin schema ([link](https://github.com/baidu/amis/pull/8629/files?diff=unified&w=0#diff-01999eae047ec7fdb8502c22801699d39f7a54c994a9414462c0fbe21634ecd8R1093-R1096))
