### PR TITLE
fix: CRUD组件使用非严格比较导致部分场景query无法更新问题

### DIFF
--- a/packages/amis-core/src/store/crud.ts
+++ b/packages/amis-core/src/store/crud.ts
@@ -141,7 +141,32 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
             ...values
           };
 
-      if (isObjectShallowModified(originQuery, query, false)) {
+      /**
+       * 非严格模式下也需要严格比较的CASE
+       * @reference https://tc39.es/ecma262/#sec-islooselyequal
+       */
+      const exceptedLooselyRules: [any, any][] = [
+        [0, ''],
+        [false, ''],
+        [false, '0'],
+        [false, 0],
+        [true, 1],
+        [true, '1']
+      ];
+
+      if (
+        isObjectShallowModified(originQuery, query, (lhs: any, rhs: any) => {
+          if (
+            exceptedLooselyRules.some(
+              rule => rule.includes(lhs) && rule.includes(rhs)
+            )
+          ) {
+            return lhs === rhs;
+          }
+
+          return lhs == rhs;
+        })
+      ) {
         if (query[pageField || 'page']) {
           self.page = parseInt(query[pageField || 'page'], 10);
         }

--- a/packages/amis-core/src/utils/helper.ts
+++ b/packages/amis-core/src/utils/helper.ts
@@ -251,7 +251,7 @@ export function rmUndefined(obj: PlainObject) {
 export function isObjectShallowModified(
   prev: any,
   next: any,
-  strictMode: boolean = true,
+  strictModeOrFunc: boolean | ((lhs: any, rhs: any) => boolean) = true,
   ignoreUndefined: boolean = false,
   statck: Array<any> = []
 ): boolean {
@@ -262,7 +262,7 @@ export function isObjectShallowModified(
           isObjectShallowModified(
             prev,
             next[index],
-            strictMode,
+            strictModeOrFunc,
             ignoreUndefined,
             statck
           )
@@ -281,7 +281,11 @@ export function isObjectShallowModified(
     isObservable(prev) ||
     isObservable(next)
   ) {
-    return strictMode ? prev !== next : prev != next;
+    if (strictModeOrFunc && typeof strictModeOrFunc === 'function') {
+      return strictModeOrFunc(prev, next);
+    }
+
+    return strictModeOrFunc ? prev !== next : prev != next;
   }
 
   if (ignoreUndefined) {
@@ -311,7 +315,7 @@ export function isObjectShallowModified(
       isObjectShallowModified(
         prev[key],
         next[key],
-        strictMode,
+        strictModeOrFunc,
         ignoreUndefined,
         statck
       )


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7c951e3</samp>

The pull request improves the `isObjectShallowModified` helper function to support custom comparison functions and fixes a bug in the `updateQuery` function of the CRUD store that caused the page number to reset when switching between loosely equal query parameters. The affected files are `packages/amis-core/src/utils/helper.ts` and `packages/amis-core/src/store/crud.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7c951e3</samp>

> _Sing, O Muse, of the cunning code change that fixed the bug_
> _That vexed the noble developers, who toiled with skill and care_
> _To sync the query parameters with the CRUD store state_
> _And trigger the fetch action when `isObjectShallowModified` was true._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7c951e3</samp>

* Fix a bug where the page number would reset to 1 when switching between loosely equal query parameters in CRUD store ([link](https://github.com/baidu/amis/pull/8631/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL144-R169))
* Modify the `isObjectShallowModified` helper function to accept a custom comparison logic as a function argument ([link](https://github.com/baidu/amis/pull/8631/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL254-R254), [link](https://github.com/baidu/amis/pull/8631/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL265-R265), [link](https://github.com/baidu/amis/pull/8631/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL284-R288), [link](https://github.com/baidu/amis/pull/8631/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL314-R318))
* Update the recursive calls of the `isObjectShallowModified` function to pass the custom comparison logic to the nested properties if provided ([link](https://github.com/baidu/amis/pull/8631/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL265-R265), [link](https://github.com/baidu/amis/pull/8631/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL314-R318))
