### PR TITLE
fix: 快速弹窗子编辑器bug

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Static.tsx
+++ b/packages/amis-editor/src/plugin/Form/Static.tsx
@@ -87,7 +87,7 @@ setSchemaTpl('quickEdit', (patch: any, manager: any) => ({
             delete value.mode;
           }
           value =
-            value.body && !['input-group'].includes(value.type)
+            value.body && ['container', 'wrapper'].includes(value.type)
               ? {
                   // schema中存在容器，用自己的就行
                   type: 'container',

--- a/packages/amis-editor/src/plugin/Form/Static.tsx
+++ b/packages/amis-editor/src/plugin/Form/Static.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import get from 'lodash/get';
+import {getVariable} from 'amis-core';
 import {Button} from 'amis';
 import {
   defaultValue,
@@ -22,6 +24,15 @@ setSchemaTpl('quickEdit', (patch: any, manager: any) => ({
   hiddenOnDefault: true,
   formType: 'extend',
   pipeIn: (value: any) => !!value,
+  trueValue: {
+    mode: 'popOver',
+    type: 'container',
+    body: []
+  },
+  isChecked: (e: any) => {
+    const {data, name} = e;
+    return !!get(data, name);
+  },
   form: {
     body: [
       {
@@ -67,19 +78,34 @@ setSchemaTpl('quickEdit', (patch: any, manager: any) => ({
         children: ({value, onChange, data}: any) => {
           if (value === true) {
             value = {};
+          } else if (typeof value === 'undefined') {
+            value = getVariable(data, 'quickEdit');
           }
-
-          const originMode = value.mode;
-
-          value = {
-            type: 'input-text',
-            name: data.name,
-            ...value
-          };
-          delete value.mode;
+          value = {...value};
+          const originMode = value.mode || 'popOver';
+          if (value.mode) {
+            delete value.mode;
+          }
+          value = value.body
+            ? {
+                // schema中存在容器，用自己的就行
+                type: 'container',
+                body: [],
+                ...value
+              }
+            : {
+                // schema中不存在容器，打开子编辑器时需要包裹一层
+                type: 'container',
+                body: [
+                  {
+                    type: 'input-text',
+                    name: data.name,
+                    ...value
+                  }
+                ]
+              };
 
           // todo 多个快速编辑表单模式看来只能代码模式编辑了。
-
           return (
             <Button
               block
@@ -88,12 +114,6 @@ setSchemaTpl('quickEdit', (patch: any, manager: any) => ({
                 manager.openSubEditor({
                   title: '配置快速编辑类型',
                   value: value,
-                  slot: {
-                    type: 'form',
-                    mode: 'normal',
-                    body: ['$$'],
-                    wrapWithPanel: false
-                  },
                   onChange: (value: any) =>
                     onChange(
                       {

--- a/packages/amis-editor/src/plugin/Form/Static.tsx
+++ b/packages/amis-editor/src/plugin/Form/Static.tsx
@@ -86,25 +86,25 @@ setSchemaTpl('quickEdit', (patch: any, manager: any) => ({
           if (value.mode) {
             delete value.mode;
           }
-          value = value.body
-            ? {
-                // schema中存在容器，用自己的就行
-                type: 'container',
-                body: [],
-                ...value
-              }
-            : {
-                // schema中不存在容器，打开子编辑器时需要包裹一层
-                type: 'container',
-                body: [
-                  {
-                    type: 'input-text',
-                    name: data.name,
-                    ...value
-                  }
-                ]
-              };
-
+          value =
+            value.body && !['input-group'].includes(value.type)
+              ? {
+                  // schema中存在容器，用自己的就行
+                  type: 'container',
+                  body: [],
+                  ...value
+                }
+              : {
+                  // schema中不存在容器，打开子编辑器时需要包裹一层
+                  type: 'container',
+                  body: [
+                    {
+                      type: 'input-text',
+                      name: data.name,
+                      ...value
+                    }
+                  ]
+                };
           // todo 多个快速编辑表单模式看来只能代码模式编辑了。
           return (
             <Button

--- a/packages/amis-editor/src/plugin/Others/TableCell.tsx
+++ b/packages/amis-editor/src/plugin/Others/TableCell.tsx
@@ -1,5 +1,6 @@
 import {Button} from 'amis';
 import React from 'react';
+import get from 'lodash/get';
 import {getI18nEnabled, registerEditorPlugin} from 'amis-editor-core';
 import {
   BasePlugin,
@@ -69,6 +70,10 @@ export class TableCellPlugin extends BasePlugin {
             getSchemaTpl('switch', {
               name: 'quickEdit',
               label: '启用快速编辑',
+              isChecked: (e: any) => {
+                const {data, name} = e;
+                return !!get(data, name);
+              },
               pipeIn: (value: any) => !!value
             }),
 
@@ -120,18 +125,31 @@ export class TableCellPlugin extends BasePlugin {
                 } else if (typeof value === 'undefined') {
                   value = getVariable(data, 'quickEdit');
                 }
-
-                const originMode = value.mode;
-
-                value = {
-                  type: 'input-text',
-                  name: data.name,
-                  ...value
-                };
-                delete value.mode;
+                value = {...value};
+                const originMode = value.mode || 'popOver';
+                if (value.mode) {
+                  delete value.mode;
+                }
+                value = value.body
+                  ? {
+                      // schema中存在容器，用自己的就行
+                      type: 'container',
+                      body: [],
+                      ...value
+                    }
+                  : {
+                      // schema中不存在容器，打开子编辑器时需要包裹一层
+                      type: 'container',
+                      body: [
+                        {
+                          type: 'input-text',
+                          name: data.name,
+                          ...value
+                        }
+                      ]
+                    };
 
                 // todo 多个快速编辑表单模式看来只能代码模式编辑了。
-
                 return (
                   <Button
                     level="info"
@@ -142,12 +160,6 @@ export class TableCellPlugin extends BasePlugin {
                       this.manager.openSubEditor({
                         title: '配置快速编辑类型',
                         value: value,
-                        slot: {
-                          type: 'form',
-                          mode: 'normal',
-                          body: ['$$'],
-                          wrapWithPanel: false
-                        },
                         onChange: value =>
                           onChange(
                             {

--- a/packages/amis-editor/src/plugin/Others/TableCell.tsx
+++ b/packages/amis-editor/src/plugin/Others/TableCell.tsx
@@ -130,24 +130,25 @@ export class TableCellPlugin extends BasePlugin {
                 if (value.mode) {
                   delete value.mode;
                 }
-                value = value.body
-                  ? {
-                      // schema中存在容器，用自己的就行
-                      type: 'container',
-                      body: [],
-                      ...value
-                    }
-                  : {
-                      // schema中不存在容器，打开子编辑器时需要包裹一层
-                      type: 'container',
-                      body: [
-                        {
-                          type: 'input-text',
-                          name: data.name,
-                          ...value
-                        }
-                      ]
-                    };
+                value =
+                  value.body && !['input-group'].includes(value.type)
+                    ? {
+                        // schema中存在容器，用自己的就行
+                        type: 'container',
+                        body: [],
+                        ...value
+                      }
+                    : {
+                        // schema中不存在容器，打开子编辑器时需要包裹一层
+                        type: 'container',
+                        body: [
+                          {
+                            type: 'input-text',
+                            name: data.name,
+                            ...value
+                          }
+                        ]
+                      };
 
                 // todo 多个快速编辑表单模式看来只能代码模式编辑了。
                 return (

--- a/packages/amis-editor/src/plugin/Others/TableCell.tsx
+++ b/packages/amis-editor/src/plugin/Others/TableCell.tsx
@@ -131,7 +131,7 @@ export class TableCellPlugin extends BasePlugin {
                   delete value.mode;
                 }
                 value =
-                  value.body && !['input-group'].includes(value.type)
+                  value.body && ['container', 'wrapper'].includes(value.type)
                     ? {
                         // schema中存在容器，用自己的就行
                         type: 'container',

--- a/packages/amis-editor/src/plugin/TableCell2.tsx
+++ b/packages/amis-editor/src/plugin/TableCell2.tsx
@@ -431,17 +431,14 @@ export class TableCell2Plugin extends BasePlugin {
         mode: 'normal',
         formType: 'extend',
         bulk: true,
-        defaultData: {
-          quickEdit: {
-            mode: 'popOver'
-          }
-        },
         trueValue: {
-          mode: 'popOver'
+          mode: 'popOver',
+          type: 'container',
+          body: []
         },
         isChecked: (e: any) => {
           const {data, name} = e;
-          return get(data, name);
+          return !!get(data, name);
         },
         form: {
           body: [
@@ -489,27 +486,30 @@ export class TableCell2Plugin extends BasePlugin {
                 } else if (typeof value === 'undefined') {
                   value = getVariable(data, 'quickEdit');
                 }
-
-                const originMode = value?.mode || 'popOver';
-
-                value = {
-                  ...value,
-                  type: 'form',
-                  mode: 'normal',
-                  wrapWithPanel: false,
-                  body: value?.body?.length
-                    ? value.body
-                    : [
-                        {
-                          type: 'input-text',
-                          name: data.key
-                        }
-                      ]
-                };
-
+                value = {...value};
+                const originMode = value.mode || 'popOver';
                 if (value.mode) {
                   delete value.mode;
                 }
+                value = value.body
+                  ? {
+                      // schema中存在容器，用自己的就行
+                      type: 'container',
+                      body: [],
+                      ...value
+                    }
+                  : {
+                      // schema中不存在容器，打开子编辑器时需要包裹一层
+                      type: 'container',
+                      body: [
+                        {
+                          type: 'input-text',
+                          name: data.name,
+                          ...value
+                        }
+                      ]
+                    };
+
                 // todo 多个快速编辑表单模式看来只能代码模式编辑了。
                 return (
                   <Button

--- a/packages/amis-editor/src/plugin/TableCell2.tsx
+++ b/packages/amis-editor/src/plugin/TableCell2.tsx
@@ -492,7 +492,7 @@ export class TableCell2Plugin extends BasePlugin {
                   delete value.mode;
                 }
                 value =
-                  value.body && !['input-group'].includes(value.type)
+                  value.body && ['container', 'wrapper'].includes(value.type)
                     ? {
                         // schema中存在容器，用自己的就行
                         type: 'container',

--- a/packages/amis-editor/src/plugin/TableCell2.tsx
+++ b/packages/amis-editor/src/plugin/TableCell2.tsx
@@ -491,24 +491,25 @@ export class TableCell2Plugin extends BasePlugin {
                 if (value.mode) {
                   delete value.mode;
                 }
-                value = value.body
-                  ? {
-                      // schema中存在容器，用自己的就行
-                      type: 'container',
-                      body: [],
-                      ...value
-                    }
-                  : {
-                      // schema中不存在容器，打开子编辑器时需要包裹一层
-                      type: 'container',
-                      body: [
-                        {
-                          type: 'input-text',
-                          name: data.name,
-                          ...value
-                        }
-                      ]
-                    };
+                value =
+                  value.body && !['input-group'].includes(value.type)
+                    ? {
+                        // schema中存在容器，用自己的就行
+                        type: 'container',
+                        body: [],
+                        ...value
+                      }
+                    : {
+                        // schema中不存在容器，打开子编辑器时需要包裹一层
+                        type: 'container',
+                        body: [
+                          {
+                            type: 'input-text',
+                            name: data.name,
+                            ...value
+                          }
+                        ]
+                      };
 
                 // todo 多个快速编辑表单模式看来只能代码模式编辑了。
                 return (


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0af15b3</samp>

This pull request improves the quick edit functionality for static and table cell components in the `amis-editor` plugin. It makes the static component more dynamic and configurable, and simplifies the schema and value handling for table cells. It also refactors some code and imports some utility functions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0af15b3</samp>

> _`amis-editor`_
> _enhances static components_
> _with data and forms_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0af15b3</samp>

*  Import `get` and `getVariable` functions from `lodash` and `amis-core` modules to access data properties and variables ([link](https://github.com/baidu/amis/pull/8633/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261R2-R3), [link](https://github.com/baidu/amis/pull/8633/files?diff=unified&w=0#diff-6255acc5c33482efec7af39b45b627e4c5a26a025506fe9a302aabd18c2102bdR3))
* Add `trueValue` and `isChecked` properties to `StaticPlugin`, `TableCellPlugin`, and `TableCell2Plugin` classes to define default schema and condition for rendering quick edit button for static and table cell components ([link](https://github.com/baidu/amis/pull/8633/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261R27-R35), [link](https://github.com/baidu/amis/pull/8633/files?diff=unified&w=0#diff-6255acc5c33482efec7af39b45b627e4c5a26a025506fe9a302aabd18c2102bdR73-R76), [link](https://github.com/baidu/amis/pull/8633/files?diff=unified&w=0#diff-c7da298719acb9527ea1c1920686a38dbb5ccbebfe4a6a745d59df3271c28ed7L434-R441))
* Modify logic for handling `value` variable, which represents schema for quick edit form, to check for undefined value, assign from `quickEdit` variable in data, wrap with container component if not already, and delete `mode` property ([link](https://github.com/baidu/amis/pull/8633/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261L70-R108), [link](https://github.com/baidu/amis/pull/8633/files?diff=unified&w=0#diff-6255acc5c33482efec7af39b45b627e4c5a26a025506fe9a302aabd18c2102bdL123-R152), [link](https://github.com/baidu/amis/pull/8633/files?diff=unified&w=0#diff-c7da298719acb9527ea1c1920686a38dbb5ccbebfe4a6a745d59df3271c28ed7L492-R512))
* Remove `slot` property from `popOver` component in `Static.tsx` and `TableCell.tsx`, and render quick edit form directly from `value` variable, which is now a container component ([link](https://github.com/baidu/amis/pull/8633/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261L91-L96), [link](https://github.com/baidu/amis/pull/8633/files?diff=unified&w=0#diff-6255acc5c33482efec7af39b45b627e4c5a26a025506fe9a302aabd18c2102bdL145-L150))
