### PR TITLE
feat: 移动端日期选择器显示年月日单位 & 月份选择器显示年月日单位

### DIFF
--- a/packages/amis-ui/src/components/calendar/DaysView.tsx
+++ b/packages/amis-ui/src/components/calendar/DaysView.tsx
@@ -239,7 +239,7 @@ export class CustomDaysView extends React.Component<CustomDaysViewProps> {
     const dateBoundary = this.props.getDateBoundary(currentDate);
     const columns = this.props.getColumns(types, dateBoundary);
     this.state = {
-      columns,
+      columns: this.getColumnsWithUnit(columns),
       types,
       pickerValue: currentDate.toArray(),
       uniqueTag: new Date().valueOf()
@@ -275,6 +275,19 @@ export class CustomDaysView extends React.Component<CustomDaysViewProps> {
         );
       }
     });
+  }
+
+  getColumnsWithUnit(columns: {options: PickerOption[]}[]) {
+    return this.props.locale === 'zh-CN' && columns.length === 3
+      ? columns.map((item, index) => {
+          item.options?.map((option: any) => {
+            option.text =
+              option.text + (index === 0 ? '年' : index === 1 ? '月' : '日');
+            return option;
+          });
+          return item;
+        })
+      : columns;
   }
 
   updateSelectedDate = (event: React.MouseEvent<any>) => {
@@ -767,7 +780,9 @@ export class CustomDaysView extends React.Component<CustomDaysViewProps> {
       );
       const dateBoundary = this.props.getDateBoundary(selectDate);
       this.setState({
-        columns: this.props.getColumns(this.state.types, dateBoundary),
+        columns: this.getColumnsWithUnit(
+          this.props.getColumns(this.state.types, dateBoundary)
+        ),
         pickerValue: value
       });
     }

--- a/packages/amis-ui/src/components/calendar/MonthsView.tsx
+++ b/packages/amis-ui/src/components/calendar/MonthsView.tsx
@@ -63,7 +63,7 @@ export class CustomMonthsView extends React.Component<CustomMonthsViewProps> {
     const dateBoundary = this.props.getDateBoundary(currentDate);
     const columns = this.props.getColumns(['year', 'month'], dateBoundary);
     this.state = {
-      columns,
+      columns: this.getColumnsWithUnit(columns),
       pickerValue: currentDate.toArray()
     };
 
@@ -141,6 +141,18 @@ export class CustomMonthsView extends React.Component<CustomMonthsViewProps> {
     this.props.updateSelectedDate(event);
   }
 
+  getColumnsWithUnit(columns: {options: PickerOption[]}[]) {
+    return this.props.locale === 'zh-CN' && columns.length === 2
+      ? columns.map((item, index) => {
+          item.options?.map((option: any) => {
+            option.text = option.text + (index === 0 ? '年' : '月');
+            return option;
+          });
+          return item;
+        })
+      : columns;
+  }
+
   renderMonth = (
     props: any,
     month: number,
@@ -205,7 +217,10 @@ export class CustomMonthsView extends React.Component<CustomMonthsViewProps> {
           };
         })
       };
-      this.setState({columns, pickerValue: value});
+      this.setState({
+        columns: this.getColumnsWithUnit(columns),
+        pickerValue: value
+      });
     }
   };
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1204fe2</samp>

This pull request enhances the calendar picker components to show units of time in Chinese when the locale is `zh-CN`. It adds a new method `getColumnsWithUnit` to `CustomDaysView` and `CustomMonthsView` to handle the unit formatting.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1204fe2</samp>

> _Oh we are the coders of the calendar picker_
> _We make it work for every locale and user_
> _We use `getColumnsWithUnit` to show the date_
> _And we pull and push and merge and test and wait_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1204fe2</samp>

*  Add year, month, and day units to the picker options of the `CustomDaysView` component if the locale is `zh-CN` ([link](https://github.com/baidu/amis/pull/8636/files?diff=unified&w=0#diff-206e06fca060056b2ec3db9f17011b6ceeeb01ac290df0fdeb7d49c7ab7e91d7L242-R242), [link](https://github.com/baidu/amis/pull/8636/files?diff=unified&w=0#diff-206e06fca060056b2ec3db9f17011b6ceeeb01ac290df0fdeb7d49c7ab7e91d7R280-R292), [link](https://github.com/baidu/amis/pull/8636/files?diff=unified&w=0#diff-206e06fca060056b2ec3db9f17011b6ceeeb01ac290df0fdeb7d49c7ab7e91d7L770-R785))
  * Define a helper function `getColumnsWithUnit` in `DaysView.tsx` that appends the units to the text of each option ([link](https://github.com/baidu/amis/pull/8636/files?diff=unified&w=0#diff-206e06fca060056b2ec3db9f17011b6ceeeb01ac290df0fdeb7d49c7ab7e91d7R280-R292))
  * Use `getColumnsWithUnit` to initialize and update the state of the `CustomDaysView` component ([link](https://github.com/baidu/amis/pull/8636/files?diff=unified&w=0#diff-206e06fca060056b2ec3db9f17011b6ceeeb01ac290df0fdeb7d49c7ab7e91d7L242-R242), [link](https://github.com/baidu/amis/pull/8636/files?diff=unified&w=0#diff-206e06fca060056b2ec3db9f17011b6ceeeb01ac290df0fdeb7d49c7ab7e91d7L770-R785))
* Add year and month units to the picker options of the `CustomMonthsView` component if the locale is `zh-CN` ([link](https://github.com/baidu/amis/pull/8636/files?diff=unified&w=0#diff-a1d87a4f9a113c63c0221c6177dc332382a29833c41ff8d034e2b062026f5f96L66-R66), [link](https://github.com/baidu/amis/pull/8636/files?diff=unified&w=0#diff-a1d87a4f9a113c63c0221c6177dc332382a29833c41ff8d034e2b062026f5f96R144-R155), [link](https://github.com/baidu/amis/pull/8636/files?diff=unified&w=0#diff-a1d87a4f9a113c63c0221c6177dc332382a29833c41ff8d034e2b062026f5f96L208-R223))
  * Define a helper function `getColumnsWithUnit` in `MonthsView.tsx` that appends the units to the text of each option ([link](https://github.com/baidu/amis/pull/8636/files?diff=unified&w=0#diff-a1d87a4f9a113c63c0221c6177dc332382a29833c41ff8d034e2b062026f5f96R144-R155))
  * Use `getColumnsWithUnit` to initialize and update the state of the `CustomMonthsView` component ([link](https://github.com/baidu/amis/pull/8636/files?diff=unified&w=0#diff-a1d87a4f9a113c63c0221c6177dc332382a29833c41ff8d034e2b062026f5f96L66-R66), [link](https://github.com/baidu/amis/pull/8636/files?diff=unified&w=0#diff-a1d87a4f9a113c63c0221c6177dc332382a29833c41ff8d034e2b062026f5f96L208-R223))
