### PR TITLE
fix: 修复自定义外观部分属性添加important不生效问题

### DIFF
--- a/packages/amis-core/src/utils/style-helper.ts
+++ b/packages/amis-core/src/utils/style-helper.ts
@@ -163,7 +163,11 @@ export function formatStyle(
       const styles: string[] = [];
       const fn = (key: string, value: string) => {
         key = valueMap[key] || key;
-        styles.push(`${kebabCase(key)}: ${value};`);
+        styles.push(
+          `${kebabCase(key)}: ${
+            value + (weights?.important ? ' !important' : '')
+          };`
+        );
       };
       Object.keys(statusMap[status]).forEach(key => {
         if (key !== '$$id') {
@@ -191,15 +195,11 @@ export function formatStyle(
           } else {
             const value = style;
             if (key === 'iconSize') {
-              fn('width', value + (weights?.important ? ' !important' : ''));
-              fn('height', value + (weights?.important ? ' !important' : ''));
-              fn(
-                'font-size',
-                value + (weights?.important ? ' !important' : '')
-              );
+              fn('width', value);
+              fn('height', value);
+              fn('font-size', value);
             } else {
-              value &&
-                fn(key, value + (weights?.important ? ' !important' : ''));
+              value && fn(key, value);
             }
           }
         }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a7366b</samp>

This pull request enhances the style helper module in `amis-core` by adding `!important` support and refactoring the code. This enables the user to customize the styles more easily and makes the code more maintainable.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3a7366b</samp>

> _Rise from the ashes of default styles_
> _Break the chains of duplication_
> _With `!important` you can rule the world_
> _Style helper is your salvation_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3a7366b</samp>

* Add option to append `!important` to style values based on `weights` parameter ([link](https://github.com/baidu/amis/pull/8639/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL166-R170))
* Simplify code by removing redundant concatenation of `!important` in `style-helper.ts` ([link](https://github.com/baidu/amis/pull/8639/files?diff=unified&w=0#diff-88c19ba9cfdee71815b3588145b852d3cf251fd59988a415c771cd58dec9befdL194-R202))
