### PR TITLE
fix(amis-editor): Calendar文档链接拼写错误

### DIFF
--- a/packages/amis-editor/src/plugin/Calendar.tsx
+++ b/packages/amis-editor/src/plugin/Calendar.tsx
@@ -20,7 +20,7 @@ export class CalendarPlugin extends BasePlugin {
   panelTitle = '日历日程';
 
   description = '展示日历及日程。';
-  docLink = '/amis/zh-CN/components/calendor';
+  docLink = '/amis/zh-CN/components/calendar';
   tags = ['展示'];
 
   scaffold = {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3d11208</samp>

Fixed a typo in the `docLink` property of the `CalendarPlugin` class in `Calendar.tsx`. This ensures that the plugin's documentation link works as expected.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3d11208</samp>

> _`docLink` was wrong_
> _Calendar spelling fixed_
> _Spring of clarity_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3d11208</samp>

* Fix the `docLink` property of the `CalendarPlugin` class to use the correct spelling of `calendar` in the URL ([link](https://github.com/baidu/amis/pull/8641/files?diff=unified&w=0#diff-aa42249f05b7b76df59f07697b763b6f6657b8ff0de5393b5a160dddd4edd284L23-R23)). This improves the documentation and user experience of the plugin.
