### PR TITLE
fix: CRUD组件快捷操作配置操作按钮后，删除按钮，再通过快捷配置弹窗配置无效

### DIFF
--- a/packages/amis-editor/src/plugin/CRUD.tsx
+++ b/packages/amis-editor/src/plugin/CRUD.tsx
@@ -751,10 +751,36 @@ export class CRUDPlugin extends BasePlugin {
               }
             }
           });
-        const hasOperate = valueSchema.columns.find(
+
+        const originOperateIndex = valueSchema.columns.findIndex(
           (item: any) => item.type === 'operation'
         );
-        hasFeatures && !hasOperate && valueSchema.columns.push(oper);
+        const originOperate = valueSchema.columns.find(
+          (item: any) => item.type === 'operation'
+        );
+        if (hasFeatures && !originOperate) {
+          // 原来无 需新增操作栏
+          valueSchema.columns.push(oper);
+        } else if (!hasFeatures && originOperate) {
+          // 原来有 需删除操作栏
+          valueSchema.columns.splice(originOperateIndex, 1);
+        } else if (hasFeatures && originOperate) {
+          // 原来有 需更新操作栏 保留原有操作按钮配置
+          const originButtons: ActionSchema[] = originOperate.buttons || [];
+          const newButtons = oper.buttons || [];
+          const buttons = newButtons.map(item => {
+            const originIndex = originButtons.findIndex(
+              btn => btn.label === item.label
+            );
+            return originIndex === -1 ? item : originButtons[originIndex];
+          });
+          valueSchema.columns.splice(originOperateIndex, 1);
+          valueSchema.columns.push({
+            type: 'operation',
+            label: '操作',
+            buttons
+          });
+        }
         return valueSchema;
       },
       canRebuild: true


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a0265f0</samp>

Fixed a bug that caused duplicate operation buttons in CRUD table. Modified `CRUD.tsx` to clear existing operation column before adding a new one.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a0265f0</samp>

> _`operation` column_
> _cleared before adding new one_
> _autumn bug sweeping_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a0265f0</samp>

* Fix a bug that causes duplicate operation buttons in CRUD table (#2529)
  - Remove any existing operation column before adding a new one ([link](https://github.com/baidu/amis/pull/8645/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aL754-R761))
