### PR TITLE
fix: 修复列过滤选择与实际展示不一致问题

### DIFF
--- a/packages/amis-ui/scss/components/_table.scss
+++ b/packages/amis-ui/scss/components/_table.scss
@@ -1108,3 +1108,13 @@
     }
   }
 }
+
+.#{$ns}AutoFilterToolbar {
+  display: block;
+  text-align: right;
+  white-space: nowrap;
+
+  > .#{$ns}Button {
+    margin-top: 0;
+  }
+}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1c0415c</samp>

This pull request enhances the auto filter feature of the table renderer in `amis`, a low-code framework for building admin interfaces. It fixes a bug, improves the UI, and refactors some code in `AutoFilterForm.tsx` and adds a new SCSS class in `_table.scss` for the auto filter toolbar.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1c0415c</samp>

> _To render a table with flair_
> _We added a toolbar with care_
> _It has `auto-filter`_
> _And an `expander` fixer_
> _And some SCSS class for its hair_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1c0415c</samp>

* Fix a bug in the auto filter toolbar that showed the expander button when all searchable columns were hidden or disabled ([link](https://github.com/baidu/amis/pull/8647/files?diff=unified&w=0#diff-03a51986279bffed94f6e37c43135adf37dcffbb10d28e1486500b395cfc9982L74-R74))
* Add a new SCSS class for the auto filter toolbar and apply it to the button container ([link](https://github.com/baidu/amis/pull/8647/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dR1111-R1120), [link](https://github.com/baidu/amis/pull/8647/files?diff=unified&w=0#diff-03a51986279bffed94f6e37c43135adf37dcffbb10d28e1486500b395cfc9982L103-R103))
* Refactor the rendering of the checkbox components for the auto filter form using a children function ([link](https://github.com/baidu/amis/pull/8647/files?diff=unified&w=0#diff-03a51986279bffed94f6e37c43135adf37dcffbb10d28e1486500b395cfc9982L117-R141))
* Adjust the styles and spacing of the submit and reset buttons for the auto filter form ([link](https://github.com/baidu/amis/pull/8647/files?diff=unified&w=0#diff-03a51986279bffed94f6e37c43135adf37dcffbb10d28e1486500b395cfc9982L150-R177))
* Improve the user experience of the auto filter form by only expanding it when a column is toggled on for search ([link](https://github.com/baidu/amis/pull/8647/files?diff=unified&w=0#diff-03a51986279bffed94f6e37c43135adf37dcffbb10d28e1486500b395cfc9982L230-R230))
