### PR TITLE
fix: 快速弹窗子编辑器bug 

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Static.tsx
+++ b/packages/amis-editor/src/plugin/Form/Static.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import get from 'lodash/get';
+import {getVariable} from 'amis-core';
 import {Button} from 'amis';
 import {
   defaultValue,
@@ -21,6 +23,15 @@ setSchemaTpl('quickEdit', (patch: any, manager: any) => ({
   hiddenOnDefault: true,
   formType: 'extend',
   pipeIn: (value: any) => !!value,
+  trueValue: {
+    mode: 'popOver',
+    type: 'container',
+    body: []
+  },
+  isChecked: (e: any) => {
+    const {data, name} = e;
+    return !!get(data, name);
+  },
   form: {
     body: [
       {
@@ -66,19 +77,34 @@ setSchemaTpl('quickEdit', (patch: any, manager: any) => ({
         children: ({value, onChange, data}: any) => {
           if (value === true) {
             value = {};
+          } else if (typeof value === 'undefined') {
+            value = getVariable(data, 'quickEdit');
           }
-
-          const originMode = value.mode;
-
-          value = {
-            type: 'input-text',
-            name: data.name,
-            ...value
-          };
-          delete value.mode;
-
+          value = {...value};
+          const originMode = value.mode || 'popOver';
+          if (value.mode) {
+            delete value.mode;
+          }
+          value =
+            value.body && ['container', 'wrapper'].includes(value.type)
+              ? {
+                  // schema中存在容器，用自己的就行
+                  type: 'container',
+                  body: [],
+                  ...value
+                }
+              : {
+                  // schema中不存在容器，打开子编辑器时需要包裹一层
+                  type: 'container',
+                  body: [
+                    {
+                      type: 'input-text',
+                      name: data.name,
+                      ...value
+                    }
+                  ]
+                };
           // todo 多个快速编辑表单模式看来只能代码模式编辑了。
-
           return (
             <Button
               block
@@ -87,12 +113,6 @@ setSchemaTpl('quickEdit', (patch: any, manager: any) => ({
                 manager.openSubEditor({
                   title: '配置快速编辑类型',
                   value: value,
-                  slot: {
-                    type: 'form',
-                    mode: 'normal',
-                    body: ['$$'],
-                    wrapWithPanel: false
-                  },
                   onChange: (value: any) =>
                     onChange(
                       {

--- a/packages/amis-editor/src/plugin/TableCell2.tsx
+++ b/packages/amis-editor/src/plugin/TableCell2.tsx
@@ -1,7 +1,7 @@
 import {Button, Icon} from 'amis';
 import React from 'react';
 import {getVariable} from 'amis-core';
-
+import get from 'lodash/get';
 import {
   BasePlugin,
   BasicRendererInfo,
@@ -155,8 +155,14 @@ export class TableCell2Plugin extends BasePlugin {
         mode: 'normal',
         formType: 'extend',
         bulk: true,
-        defaultData: {
-          mode: 'popOver'
+        trueValue: {
+          mode: 'popOver',
+          type: 'container',
+          body: []
+        },
+        isChecked: (e: any) => {
+          const {data, name} = e;
+          return !!get(data, name);
         },
         form: {
           body: [
@@ -196,25 +202,31 @@ export class TableCell2Plugin extends BasePlugin {
                 } else if (typeof value === 'undefined') {
                   value = getVariable(data, 'quickEdit');
                 }
-
-                const originMode = value?.mode || 'popOver';
-
-                value = {
-                  ...value,
-                  type: 'form',
-                  mode: 'normal',
-                  wrapWithPanel: false,
-                  body: [
-                    {
-                      type: 'input-text',
-                      name: data.key
-                    }
-                  ]
-                };
-
+                value = {...value};
+                const originMode = value.mode || 'popOver';
                 if (value.mode) {
                   delete value.mode;
                 }
+                value =
+                  value.body && ['container', 'wrapper'].includes(value.type)
+                    ? {
+                        // schema中存在容器，用自己的就行
+                        type: 'container',
+                        body: [],
+                        ...value
+                      }
+                    : {
+                        // schema中不存在容器，打开子编辑器时需要包裹一层
+                        type: 'container',
+                        body: [
+                          {
+                            type: 'input-text',
+                            name: data.name,
+                            ...value
+                          }
+                        ]
+                      };
+
                 // todo 多个快速编辑表单模式看来只能代码模式编辑了。
                 return (
                   <Button


### PR DESCRIPTION
* fix: 快速弹窗bug

* 子编辑器传值增加input-group的处理

* 子编辑器传值处理

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at beeacb2</samp>

This pull request enhances the quick edit feature for various components in the `amis-editor` plugin. It allows users to define custom schemas and access data and variables more easily. It modifies the files `Static.tsx`, `TableCell.tsx`, and `TableCell2.tsx` in the `packages/amis-editor/src/plugin` directory.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at beeacb2</samp>

> _Quick edit feature_
> _Enhanced for `amis-editor`_
> _Autumn of schemas_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at beeacb2</samp>

*  Import `get` function from `lodash` to access data from schema and context in `Static.tsx`, `TableCell.tsx`, and `TableCell2.tsx` ([link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261R2-R3), [link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-6255acc5c33482efec7af39b45b627e4c5a26a025506fe9a302aabd18c2102bdR3), [link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-c7da298719acb9527ea1c1920686a38dbb5ccbebfe4a6a745d59df3271c28ed7L4-R4))
* Import `getVariable` function from `amis-core` to access variables from context in `Static.tsx` ([link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261R2-R3))
* Add `trueValue` property to `StaticPlugin`, `TableCellPlugin`, and `TableCell2Plugin` classes to define default schema for quick edit mode when value is true ([link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261R26-R34), [link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-6255acc5c33482efec7af39b45b627e4c5a26a025506fe9a302aabd18c2102bdR73-R76), [link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-c7da298719acb9527ea1c1920686a38dbb5ccbebfe4a6a745d59df3271c28ed7L158-R166))
* Add `isChecked` property to `StaticPlugin`, `TableCellPlugin`, and `TableCell2Plugin` classes to define function that checks if value is truthy ([link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261R26-R34), [link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-6255acc5c33482efec7af39b45b627e4c5a26a025506fe9a302aabd18c2102bdR73-R76), [link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-c7da298719acb9527ea1c1920686a38dbb5ccbebfe4a6a745d59df3271c28ed7L158-R166))
* Modify `renderButton` function in `StaticPlugin`, `TableCellPlugin`, and `TableCell2Plugin` classes to handle different cases of value for quick edit mode ([link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261L69-R107), [link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-6255acc5c33482efec7af39b45b627e4c5a26a025506fe9a302aabd18c2102bdL123-R153), [link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-c7da298719acb9527ea1c1920686a38dbb5ccbebfe4a6a745d59df3271c28ed7L199-R229))
  * Check if value is undefined and use `quickEdit` variable from context ([link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261L69-R107))
  * Check if value has `body` property and `container` or `wrapper` type and use value as schema ([link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261L69-R107), [link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-6255acc5c33482efec7af39b45b627e4c5a26a025506fe9a302aabd18c2102bdL123-R153), [link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-c7da298719acb9527ea1c1920686a38dbb5ccbebfe4a6a745d59df3271c28ed7L199-R229))
  * Otherwise, wrap value with `container` type and `input-text` type ([link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261L69-R107), [link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-6255acc5c33482efec7af39b45b627e4c5a26a025506fe9a302aabd18c2102bdL123-R153), [link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-c7da298719acb9527ea1c1920686a38dbb5ccbebfe4a6a745d59df3271c28ed7L199-R229))
  * Remove deletion of `mode` property from value since it is not used in quick edit mode ([link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261L69-R107), [link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-6255acc5c33482efec7af39b45b627e4c5a26a025506fe9a302aabd18c2102bdL123-R153), [link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-c7da298719acb9527ea1c1920686a38dbb5ccbebfe4a6a745d59df3271c28ed7L199-R229))
* Remove `slot` property from `popOver` component in `renderButton` function since it is replaced by `trueValue` property in classes ([link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261L90-L95), [link](https://github.com/baidu/amis/pull/8649/files?diff=unified&w=0#diff-6255acc5c33482efec7af39b45b627e4c5a26a025506fe9a302aabd18c2102bdL145-L150))
