### PR TITLE
fix:组件特性动作中执行全局变量修改

### DIFF
--- a/packages/amis-core/src/actions/CmptAction.ts
+++ b/packages/amis-core/src/actions/CmptAction.ts
@@ -36,6 +36,19 @@ export class CmptAction implements RendererAction {
      */
     const key = action.componentId || action.componentName;
     const dataMergeMode = action.dataMergeMode || 'merge';
+    const path = action.args?.path;
+
+    /** 如果args中携带path参数, 则认为是全局变量赋值, 否则认为是组件变量赋值 */
+    if (action.actionType === 'setValue' && path && typeof path === 'string') {
+      const beforeSetData = renderer?.props?.env?.beforeSetData;
+      if (beforeSetData && typeof beforeSetData === 'function') {
+        const res = await beforeSetData(renderer, action, event);
+
+        if (res === false) {
+          return;
+        }
+      }
+    }
 
     if (!key) {
       console.warn('请提供目标组件的componentId或componentName');
@@ -59,23 +72,6 @@ export class CmptAction implements RendererAction {
     }
 
     if (action.actionType === 'setValue') {
-      const beforeSetData = renderer?.props?.env?.beforeSetData;
-      const path = action.args?.path;
-
-      /** 如果args中携带path参数, 则认为是全局变量赋值, 否则认为是组件变量赋值 */
-      if (
-        path &&
-        typeof path === 'string' &&
-        beforeSetData &&
-        typeof beforeSetData === 'function'
-      ) {
-        const res = await beforeSetData(renderer, action, event);
-
-        if (res === false) {
-          return;
-        }
-      }
-
       if (component?.setData) {
         return component?.setData(
           action.args?.value,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 28b3376</samp>

This pull request enhances component actions and improves code quality. It allows using global variables in `setValue` actions, and adds a new hook `beforeSetData` in `CmptAction.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 28b3376</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A way to use global variables in `setValue` actions,_
> _And who, with cunning, cleared away the cluttered code_
> _That hindered the performance of the component hooks._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 28b3376</samp>

*  Add a hook for custom logic before setting global variables in component actions ([link](https://github.com/baidu/amis/pull/8650/files?diff=unified&w=0#diff-9fcca25fc37554994f4168d09ade3ba52487964b8f897e0a9de38442dc6b1ceaL39-R52))
*  Remove redundant code for handling the hook in `CmptAction.ts` ([link](https://github.com/baidu/amis/pull/8650/files?diff=unified&w=0#diff-9fcca25fc37554994f4168d09ade3ba52487964b8f897e0a9de38442dc6b1ceaL62-L78))
