### PR TITLE
优化状态容器配置 & listSelect自定义label value适配

### DIFF
--- a/packages/amis-editor-core/src/plugin.ts
+++ b/packages/amis-editor-core/src/plugin.ts
@@ -304,7 +304,7 @@ export interface RendererInfo extends RendererScaffoldInfo {
   sharedContext?: Record<string, any>;
   dialogTitle?: string; //弹窗标题用于弹窗大纲的展示
   dialogType?: string; //区分确认对话框类型
-  subEditorVariable?: Array<{label: string; children: any}>; // 传递给子编辑器的组件自定义变量，如listSelect的选项名称和值
+  getSubEditorVariable: (schema?: any) => Array<{label: string; children: any}>; // 传递给子编辑器的组件自定义变量，如listSelect的选项名称和值
 }
 
 export type BasicRendererInfo = Omit<
@@ -1051,7 +1051,7 @@ export abstract class BasePlugin implements PluginInterface {
         isListComponent: plugin.isListComponent,
         rendererName: plugin.rendererName,
         memberImmutable: plugin.memberImmutable,
-        subEditorVariable: plugin.subEditorVariable
+        getSubEditorVariable: plugin.getSubEditorVariable
       };
     }
   }

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -1224,7 +1224,10 @@ export async function resolveVariablesFromScope(node: any, manager: any) {
   // 子编辑器内读取的host节点自定义变量，非数据域方式，如listSelect的选项值
   let hostNodeVaraibles = [];
   if (manager?.store?.isSubEditor) {
-    hostNodeVaraibles = manager.config?.hostNode?.info?.subEditorVariable || [];
+    hostNodeVaraibles =
+      manager.config?.hostNode?.info?.getSubEditorVariable?.(
+        manager.config?.hostNode.schema
+      ) || [];
   }
 
   const variables: VariableItem[] =

--- a/packages/amis-editor/src/plugin/Form/ListSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/ListSelect.tsx
@@ -109,21 +109,26 @@ export class ListControlPlugin extends BasePlugin {
     }
   ];
 
-  subEditorVariable: Array<{label: string; children: any}> = [
-    {
-      label: '当前选项',
-      children: [
-        {
-          label: '选项名称',
-          value: 'label'
-        },
-        {
-          label: '选项值',
-          value: 'value'
-        }
-      ]
-    }
-  ];
+  getSubEditorVariable(schema: any): Array<{label: string; children: any}> {
+    let labelField = schema?.labelField || 'label';
+    let valueField = schema?.valueField || 'value';
+
+    return [
+      {
+        label: '当前选项',
+        children: [
+          {
+            label: '选项名称',
+            value: labelField
+          },
+          {
+            label: '选项值',
+            value: valueField
+          }
+        ]
+      }
+    ];
+  }
 
   panelBodyCreator = (context: BaseEventContext) => {
     return formItemControl(
@@ -201,7 +206,7 @@ export class ListControlPlugin extends BasePlugin {
                     body: [
                       {
                         type: 'tpl',
-                        tpl: `\${${this.getDisplayField(value)}}`,
+                        tpl: `\${${this.getDisplayField(data)}}`,
                         wrapperComponent: '',
                         inline: true
                       }
@@ -275,16 +280,7 @@ export class ListControlPlugin extends BasePlugin {
   }
 
   getDisplayField(data: any) {
-    if (
-      data.source ||
-      (data.map &&
-        Array.isArray(data.map) &&
-        data.map[0] &&
-        Object.keys(data.map[0]).length > 1)
-    ) {
-      return data.labelField ?? 'label';
-    }
-    return 'label';
+    return data?.labelField ?? 'label';
   }
 
   editDetail(id: string, field: string) {

--- a/packages/amis-editor/src/plugin/SwitchContainer.tsx
+++ b/packages/amis-editor/src/plugin/SwitchContainer.tsx
@@ -321,6 +321,7 @@ export class SwitchContainerPlugin extends LayoutBasePlugin {
                 name: 'items',
                 label: '状态列表',
                 addTip: '新增组件状态',
+                minLength: 1,
                 items: [
                   {
                     type: 'input-text',
@@ -356,6 +357,10 @@ export class SwitchContainerPlugin extends LayoutBasePlugin {
         title: '外观',
         className: 'p-none',
         body: getSchemaTpl('collapseGroup', [
+          getSchemaTpl('theme:base', {
+            collapsed: false,
+            extra: []
+          }),
           {
             title: '布局',
             body: [
@@ -460,7 +465,15 @@ export class SwitchContainerPlugin extends LayoutBasePlugin {
               getSchemaTpl('layout:stickyPosition')
             ]
           },
-          ...getSchemaTpl('theme:common', {exclude: ['layout']})
+          {
+            title: '自定义样式',
+            body: [
+              {
+                type: 'theme-cssCode',
+                label: false
+              }
+            ]
+          }
         ])
       },
       {

--- a/packages/amis-editor/src/renderer/ListItemControl.tsx
+++ b/packages/amis-editor/src/renderer/ListItemControl.tsx
@@ -7,7 +7,7 @@ import {findDOMNode} from 'react-dom';
 import cx from 'classnames';
 import get from 'lodash/get';
 import Sortable from 'sortablejs';
-import {FormItem, Button, Icon, render as amisRender} from 'amis';
+import {FormItem, Button, Icon, render as amisRender, toast} from 'amis';
 import {autobind} from 'amis-editor-core';
 import type {Option} from 'amis';
 import {createObject, FormControlProps} from 'amis-core';
@@ -30,7 +30,6 @@ export type SourceType = 'custom' | 'api' | 'apicenter' | 'variable';
 
 export interface OptionControlState {
   items: Array<PlainObject>;
-  api: SchemaApi;
   labelField: string;
   valueField: string;
 }
@@ -50,7 +49,6 @@ export default class ListItemControl extends React.Component<
 
     this.state = {
       items: this.transformOptions(props),
-      api: props.data.source,
       labelField: props.data.labelField || 'title',
       valueField: props.data.valueField
     };
@@ -173,6 +171,12 @@ export default class ListItemControl extends React.Component<
    */
   handleDelete(index: number) {
     const items = this.state.items.concat();
+    const minLength = this.props.minLength;
+
+    if (minLength > 0 && items.length <= minLength) {
+      toast.warning(`列表项数目不能少于${minLength}`);
+      return;
+    }
 
     items.splice(index, 1);
     this.setState({items}, () => this.onChange());

--- a/packages/amis/src/renderers/Each.tsx
+++ b/packages/amis/src/renderers/Each.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import {Renderer, RendererProps, buildStyle, isPureVariable} from 'amis-core';
+import {
+  CustomStyle,
+  Renderer,
+  RendererProps,
+  buildStyle,
+  isPureVariable,
+  setThemeClassName
+} from 'amis-core';
 import {Schema} from 'amis-core';
 import {resolveVariable, resolveVariableAndFilter} from 'amis-core';
 import {createObject, getPropValue, isObject} from 'amis-core';
@@ -96,7 +103,11 @@ export default class Each extends React.Component<EachProps> {
       indexKeyName,
       placeholder,
       classnames: cx,
-      translate: __
+      translate: __,
+      env,
+      id,
+      wrapperCustomStyle,
+      themeCss
     } = this.props;
 
     const value = getPropValue(this.props, props =>
@@ -124,7 +135,14 @@ export default class Each extends React.Component<EachProps> {
     }
 
     return (
-      <div className={cx('Each', className)} style={buildStyle(style, data)}>
+      <div
+        className={cx(
+          'Each',
+          className,
+          setThemeClassName('baseControlClassName', id, themeCss)
+        )}
+        style={buildStyle(style, data)}
+      >
         {Array.isArray(arr) && arr.length && items ? (
           arr.map((item: any, index: number) => (
             <EachItem
@@ -144,6 +162,20 @@ export default class Each extends React.Component<EachProps> {
             {render('placeholder', __(placeholder))}
           </div>
         )}
+
+        <CustomStyle
+          config={{
+            wrapperCustomStyle,
+            id,
+            themeCss,
+            classNames: [
+              {
+                key: 'baseControlClassName'
+              }
+            ]
+          }}
+          env={env}
+        />
       </div>
     );
   }

--- a/packages/amis/src/renderers/SwitchContainer.tsx
+++ b/packages/amis/src/renderers/SwitchContainer.tsx
@@ -80,7 +80,7 @@ export default class SwitchContainer extends React.Component<
 
   componentDidUpdate(preProps: SwitchContainerProps) {
     const items = this.props.items || [];
-    if (this.state.activeIndex >= 0 && !items[this.state.activeIndex]) {
+    if (this.state.activeIndex > 0 && !items[this.state.activeIndex]) {
       this.setState({
         activeIndex: 0
       });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2c140f6</samp>

This pull request enhances the AMIS editor plugins for list controls and switch containers, and fixes some bugs related to them. It introduces a new `getSubEditorVariable` function to support dynamic variables based on the schema, and adds some new options and validations to the plugins. It also fixes a bug in the `SwitchContainer` renderer that caused the active index to be reset when the items array was empty.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2c140f6</samp>

> _We are the masters of the switch container_
> _We create and edit with dynamic power_
> _We resolve the variables from the scope_
> _We fix the bugs and never lose hope_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2c140f6</samp>

*  Change the `subEditorVariable` property of the `RendererInfo` interface and the `BasePlugin` class to a function `getSubEditorVariable` that takes an optional schema argument and returns an array of custom variables for the sub-editor. This allows the sub-editor variables to be dynamically generated based on the schema of the host node. ([link](https://github.com/baidu/amis/pull/8663/files?diff=unified&w=0#diff-2eb003bbc6f49ecb3f8b56411f1c1d02f055f595b7d9998f326a9c7ff41cc266L307-R307), [link](https://github.com/baidu/amis/pull/8663/files?diff=unified&w=0#diff-2eb003bbc6f49ecb3f8b56411f1c1d02f055f595b7d9998f326a9c7ff41cc266L1054-R1054))
*  Update the `resolveVariablesFromScope` function in `util.ts` to use the `getSubEditorVariable` function of the host node info instead of the `subEditorVariable` property. This allows the variables to be resolved based on the schema of the host node. ([link](https://github.com/baidu/amis/pull/8663/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL1227-R1230))
*  Implement the `getSubEditorVariable` function in the `ListControlPlugin` class in `ListSelect.tsx` to return the label and value fields of the current option based on the schema of the list select control. ([link](https://github.com/baidu/amis/pull/8663/files?diff=unified&w=0#diff-235237c89adc972d4bf87380300ca947a5a5de87d01b59c1bff98b4c95fa6f27L112-R132))
*  Fix a bug in the `ListControlPlugin` class in `ListSelect.tsx` where the option label was not displayed correctly when the value was an object. Use the `data` variable instead of the `value` variable in the template of the option label. ([link](https://github.com/baidu/amis/pull/8663/files?diff=unified&w=0#diff-235237c89adc972d4bf87380300ca947a5a5de87d01b59c1bff98b4c95fa6f27L204-R209))
*  Simplify the `getDisplayField` function in the `ListControlPlugin` class in `ListSelect.tsx`. Return the label field of the data or the default 'label' field. Remove the unnecessary logic for handling the source and map properties of the data, which are not relevant for the list select control. ([link](https://github.com/baidu/amis/pull/8663/files?diff=unified&w=0#diff-235237c89adc972d4bf87380300ca947a5a5de87d01b59c1bff98b4c95fa6f27L278-R283))
*  Add a `minLength` property to the `items` field of the schema in the `SwitchContainerPlugin` class in `SwitchContainer.tsx`. This property specifies the minimum number of items that the switch container should have. This is used to prevent deleting items below the minimum length in the sub-editor. ([link](https://github.com/baidu/amis/pull/8663/files?diff=unified&w=0#diff-18d06e16be36803587241f507167ed3f2bc2198983ec1d464e0688aa61a1c6f3R324))
*  Add a `theme:base` schema template to the `theme` field of the schema in the `SwitchContainerPlugin` class in `SwitchContainer.tsx`. This template provides some common theme properties for the switch container, such as collapsed and extra. ([link](https://github.com/baidu/amis/pull/8663/files?diff=unified&w=0#diff-18d06e16be36803587241f507167ed3f2bc2198983ec1d464e0688aa61a1c6f3R360-R363))
*  Add a `theme-cssCode` type to the schema in the `SwitchContainerPlugin` class in `SwitchContainer.tsx`. This type allows the user to customize the CSS style of the switch container using a code editor. ([link](https://github.com/baidu/amis/pull/8663/files?diff=unified&w=0#diff-18d06e16be36803587241f507167ed3f2bc2198983ec1d464e0688aa61a1c6f3L463-R476))
*  Import the `toast` function from `amis` in `ListItemControl.tsx`. This function is used to show a warning message when the user tries to delete an item below the minimum length in the sub-editor. ([link](https://github.com/baidu/amis/pull/8663/files?diff=unified&w=0#diff-97b736bac53ad15fb2a475900ea870d2b3d1362117bc8fb8a9bac97610b1e51cL10-R10))
*  Remove the unused and redundant `api` property of the `OptionControlState` interface and the `OptionControl` class in `ListItemControl.tsx`. Use the `source` property of the data instead. ([link](https://github.com/baidu/amis/pull/8663/files?diff=unified&w=0#diff-97b736bac53ad15fb2a475900ea870d2b3d1362117bc8fb8a9bac97610b1e51cL33), [link](https://github.com/baidu/amis/pull/8663/files?diff=unified&w=0#diff-97b736bac53ad15fb2a475900ea870d2b3d1362117bc8fb8a9bac97610b1e51cL53))
*  Check the `minLength` property of the props before deleting an item in the `handleDelete` function of the `OptionControl` class in `ListItemControl.tsx`. If the minimum length is greater than zero and the items length is equal or less than the minimum length, show a warning message using the `toast` function and return without deleting the item. This prevents deleting items below the minimum length in the sub-editor. ([link](https://github.com/baidu/amis/pull/8663/files?diff=unified&w=0#diff-97b736bac53ad15fb2a475900ea870d2b3d1362117bc8fb8a9bac97610b1e51cL176-R180))
