### PR TITLE
fix: 修复ts报错

### DIFF
--- a/packages/amis-editor-core/src/plugin.ts
+++ b/packages/amis-editor-core/src/plugin.ts
@@ -304,7 +304,9 @@ export interface RendererInfo extends RendererScaffoldInfo {
   sharedContext?: Record<string, any>;
   dialogTitle?: string; //弹窗标题用于弹窗大纲的展示
   dialogType?: string; //区分确认对话框类型
-  getSubEditorVariable: (schema?: any) => Array<{label: string; children: any}>; // 传递给子编辑器的组件自定义变量，如listSelect的选项名称和值
+  getSubEditorVariable?: (
+    schema?: any
+  ) => Array<{label: string; children: any}>; // 传递给子编辑器的组件自定义变量，如listSelect的选项名称和值
 }
 
 export type BasicRendererInfo = Omit<


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77a8c56</samp>

Made `getSubEditorVariable` optional in `RendererInfo` interface to fix TypeScript error. This allows renderers to omit this property if they do not need custom variables for their sub-editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 77a8c56</samp>

> _`getSubEditorVariable`_
> _Optional now, no more errors_
> _Autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 77a8c56</samp>

* Make `getSubEditorVariable` property optional for `RendererInfo` interface ([link](https://github.com/baidu/amis/pull/8664/files?diff=unified&w=0#diff-2eb003bbc6f49ecb3f8b56411f1c1d02f055f595b7d9998f326a9c7ff41cc266L307-R309)) to fix TypeScript error when some renderers do not implement it
