### PR TITLE
feat: InputRichText组件TinyMCE默认支持图片尺寸调整

### DIFF
--- a/packages/amis-ui/src/components/Tinymce.tsx
+++ b/packages/amis-ui/src/components/Tinymce.tsx
@@ -41,6 +41,9 @@ import 'tinymce/plugins/help/js/i18n/keynav/zh_CN';
 import 'tinymce/plugins/help/js/i18n/keynav/en';
 import 'tinymce/plugins/help/js/i18n/keynav/de';
 
+// @ts-ignore
+import ContentUICSS from 'tinymce/skins/ui/oxide/content.min.css?inline';
+
 import {LocaleProps} from 'amis-core';
 
 interface TinymceEditorProps extends LocaleProps {
@@ -73,10 +76,18 @@ export default class TinymceEditor extends React.Component<TinymceEditorProps> {
     const locale = this.props.locale;
 
     const {onLoaded, ...rest} = this.props.config || {};
+    const injectedCSS = [
+      /** 包含Image Resize必要的CSS样式，会注入编辑器的iframe中 */
+      ContentUICSS,
+      // 很诡异的问题，video 会被复制放在光标上，直接用样式隐藏先
+      '[data-mce-bogus] video {display:none;}'
+    ];
+
     this.config = {
       inline: false,
       skin: false,
       content_css: false,
+      content_style: injectedCSS.join('\n'),
       height: 400,
       language: !locale || locale === 'zh-CN' ? 'zh_CN' : 'en',
       branding: false,
@@ -147,8 +158,9 @@ export default class TinymceEditor extends React.Component<TinymceEditorProps> {
         help: {title: 'Help', items: 'help'}
       },
       paste_data_images: true,
-      // 很诡异的问题，video 会被复制放在光标上，直接用样式隐藏先
-      content_style: '[data-mce-bogus] video {display:none;}',
+      /** 允许调整图片尺寸 */
+      object_resizing: 'img',
+      image_caption: true,
       ...rest,
       target: this.elementRef.current,
       readOnly: this.props.disabled,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fb54cde</samp>

Improved image editing features in `Tinymce` component. Imported CSS file and enabled config properties to allow image resizing and captioning.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fb54cde</samp>

> _To edit images with more ease_
> _We import a CSS file, if you please_
> _And enable some props_
> _To resize and crop_
> _And add captions to pictures with `tinymce`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fb54cde</samp>

*  Inject and apply CSS styles from `tinymce` package to enable image resizing and hiding bogus video elements in the editor ([link](https://github.com/baidu/amis/pull/8665/files?diff=unified&w=0#diff-d6c65c2dcd820338178339a1d3f5272f5f7d2cfb02ba4977bdb04516544de8fbR44-R46), [link](https://github.com/baidu/amis/pull/8665/files?diff=unified&w=0#diff-d6c65c2dcd820338178339a1d3f5272f5f7d2cfb02ba4977bdb04516544de8fbL76-R90))
*  Enable `object_resizing` and `image_caption` options in the editor config to allow user to resize and caption images ([link](https://github.com/baidu/amis/pull/8665/files?diff=unified&w=0#diff-d6c65c2dcd820338178339a1d3f5272f5f7d2cfb02ba4977bdb04516544de8fbL150-R163))
