### PR TITLE
fix: 修复迭代过程中renderer丢失问题 Close：#8228

### DIFF
--- a/packages/amis-core/src/actions/CmptAction.ts
+++ b/packages/amis-core/src/actions/CmptAction.ts
@@ -41,7 +41,7 @@ export class CmptAction implements RendererAction {
       ? event.context.scoped?.[
           action.componentId ? 'getComponentById' : 'getComponentByName'
         ](key)
-      : null;
+      : renderer;
 
     if (key && !component) {
       const msg =


### PR DESCRIPTION
### What

[修复bug：Amis 3.3.0以上版本的Broadcast事件失效](https://github.com/baidu/amis/issues/8228)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a0e4d7e</samp>

> _`component` null_
> _`renderer` fills the gap_
> _autumn bug is fixed_

### Why

[历史迭代](https://github.com/baidu/amis/blob/59f8a3ec2dab200292c86869abc2a906f0ad7f60/packages/amis-core/src/actions/CmptAction.ts#L52)中 将默认 `renderer`弄丢了，导致无法触发组件事件。
<img width="1191" alt="image" src="https://github.com/baidu/amis/assets/116187210/45991457-4821-4cbe-abe2-8db6996427c4">


### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a0e4d7e</samp>

* Fix a bug where the `component` variable would be null if the `key` variable was undefined or empty, causing an error when trying to access its properties. Assign the `renderer` variable to the `component` variable if the `key` variable is falsy. ([link](https://github.com/baidu/amis/pull/8666/files?diff=unified&w=0#diff-9fcca25fc37554994f4168d09ade3ba52487964b8f897e0a9de38442dc6b1ceaL44-R44))
