### PR TITLE
fix: 变量赋值动作去除多余属性

### DIFF
--- a/packages/amis-editor/src/renderer/event-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/event-control/helper.tsx
@@ -1244,8 +1244,6 @@ export const ACTION_TYPE_TREE = (manager: any): RendererPluginAction[] => {
             'path',
             'value',
             'index',
-            'fromPage',
-            'fromApp',
             '__valueInput',
             '__comboType',
             '__containerType'
@@ -1283,29 +1281,34 @@ export const ACTION_TYPE_TREE = (manager: any): RendererPluginAction[] => {
           supportComponents: 'byComponent',
           schema: [
             {
-              name: '__actionSubType',
-              type: 'radios',
-              label: '动作类型',
-              mode: 'horizontal',
-              options: [
-                {label: '组件变量', value: 'cmpt'},
-                {label: '页面变量', value: 'page'},
-                {label: '内存变量', value: 'app'}
-              ],
-              value:
-                '${args.fromApp ? "app" : args.fromPage ? "page" : "cmpt"}',
-              onChange: (value: string, oldVal: any, data: any, form: any) => {
-                form.setValueByName('__valueInput', undefined);
-                form.setValueByName('args.value', undefined);
-                form.deleteValueByName('args.path');
-                form.deleteValueByName('args.fromApp');
-                form.deleteValueByName('args.fromPage');
-
-                if (value === 'page') {
-                  form.setValueByName('args.fromPage', true);
-                } else if (value === 'app') {
-                  form.setValueByName('args.fromApp', true);
-                }
+              children: ({render, data}: any) => {
+                const path = data?.args?.path || '';
+                return render('setValueType', {
+                  name: '__actionSubType',
+                  type: 'radios',
+                  label: '动作类型',
+                  mode: 'horizontal',
+                  options: [
+                    {label: '组件变量', value: 'cmpt'},
+                    {label: '页面变量', value: 'page'},
+                    {label: '内存变量', value: 'app'}
+                  ],
+                  value: /^appVariables/.test(path) // 只需要初始化时更新value
+                    ? 'app'
+                    : /^(__page|__query)/.test(path)
+                    ? 'page'
+                    : 'cmpt',
+                  onChange: (
+                    value: string,
+                    oldVal: any,
+                    data: any,
+                    form: any
+                  ) => {
+                    form.setValueByName('__valueInput', undefined);
+                    form.setValueByName('args.value', undefined);
+                    form.deleteValueByName('args.path');
+                  }
+                });
               }
             },
             // 组件变量
@@ -3376,9 +3379,7 @@ export const getEventControlConfig = (
           /** 应用变量赋值 */
           action.args = {
             path: config.args.path,
-            value: config.args?.value ?? '',
-            fromPage: action.args?.fromPage,
-            fromApp: action.args?.fromApp
+            value: config.args?.value ?? ''
           };
 
           action.hasOwnProperty('componentId') && delete action.componentId;

--- a/packages/amis-editor/src/renderer/textarea-formula/TextareaFormulaControl.tsx
+++ b/packages/amis-editor/src/renderer/textarea-formula/TextareaFormulaControl.tsx
@@ -148,7 +148,7 @@ export class TextareaFormulaControl extends React.Component<
   constructor(props: TextareaFormulaControlProps) {
     super(props);
     this.state = {
-      value: '',
+      value: this.props.value || '',
       variables: [],
       formulaPickerOpen: false,
       formulaPickerValue: '',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 423b3be</samp>

This pull request improves the event control and textarea formula components in the `amis-editor` package. It simplifies the action type configuration for event control and fixes a bug that prevented the textarea formula from showing the initial value.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 423b3be</samp>

> _`TextareaFormulaControl` is the key_
> _To render formulas with mastery_
> _But the value must be set_
> _Or the editing will be wrecked_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 423b3be</samp>

*  Remove `fromPage` and `fromApp` properties from action type configuration and schema, as they are redundant and can be inferred from `path` property ([link](https://github.com/baidu/amis/pull/8674/files?diff=unified&w=0#diff-f55d29e93a330da662e7a91960e5ed88c12f80e9e38564d3a4497ff543da26b8L1247-L1248), [link](https://github.com/baidu/amis/pull/8674/files?diff=unified&w=0#diff-f55d29e93a330da662e7a91960e5ed88c12f80e9e38564d3a4497ff543da26b8L1286-R1311), [link](https://github.com/baidu/amis/pull/8674/files?diff=unified&w=0#diff-f55d29e93a330da662e7a91960e5ed88c12f80e9e38564d3a4497ff543da26b8L3379-R3382) in `helper.tsx`)
