### PR TITLE
fix: 修复 column static 属性影响到 quickEdit 中的问题

### DIFF
--- a/packages/amis/__tests__/renderers/Form/static.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/static.test.tsx
@@ -66,7 +66,7 @@ test('Renderer:static', async () => {
   expect(container).toMatchSnapshot();
 });
 
-test('Renderer:static', async () => {
+test('Renderer:static2', async () => {
   const {container} = render(
     amisRender(
       {
@@ -188,4 +188,40 @@ test('Renderer:staticOn', async () => {
 
   const text = getByText('123');
   expect(text).toBeInTheDocument();
+});
+
+test('Renderer:staticInColumn', async () => {
+  const {container, getByText} = render(
+    amisRender(
+      {
+        type: 'crud',
+        source: '${items}',
+        columns: [
+          {
+            type: 'input-text',
+            name: 'a',
+            label: 'a',
+            static: true,
+            quickEdit: {
+              type: 'input-text',
+              mode: 'inline'
+            }
+          }
+        ],
+        submitText: null,
+        actions: []
+      },
+      {
+        data: {
+          items: [{a: '1'}]
+        }
+      },
+      makeEnv()
+    )
+  );
+
+  await wait(200);
+
+  expect(container.querySelector('input[name="a"]')).toBeInTheDocument();
+  expect((container.querySelector('input[name="a"]') as any).value).toBe('1');
 });

--- a/packages/amis/src/renderers/QuickEdit.tsx
+++ b/packages/amis/src/renderers/QuickEdit.tsx
@@ -512,7 +512,7 @@ export const HocQuickEdit =
           >
             {render('quick-edit-form', this.buildSchema(), {
               value: undefined,
-              static: false,
+              defaultStatic: false,
               onSubmit: this.handleSubmit,
               onAction: this.handleAction,
               onChange: null,
@@ -577,7 +577,8 @@ export const HocQuickEdit =
             mode: 'normal',
             value: value ?? '',
             onChange: this.handleFormItemChange,
-            ref: this.formItemRef
+            ref: this.formItemRef,
+            defaultStatic: false
           });
         }
 
@@ -591,7 +592,8 @@ export const HocQuickEdit =
           onChange: this.handleChange,
           formLazyChange: false,
           canAccessSuperData,
-          disabled
+          disabled,
+          defaultStatic: false
         });
       }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8827c14</samp>

Renamed and propagated `static` prop of `quick-edit-form` renderer to allow more flexible control over form editability. Updated `QuickEdit.tsx` and related files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8827c14</samp>

> _To make forms more consistent and neat_
> _`static` prop had to face defeat_
> _It became `defaultStatic`_
> _A change quite pragmatic_
> _For editability state to complete_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8827c14</samp>

*  Rename `static` prop of `quick-edit-form` renderer to `defaultStatic` to avoid confusion with `form-item` renderer ([link](https://github.com/baidu/amis/pull/8677/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L515-R515))
*  Pass down `defaultStatic` prop from `quick-edit-form` renderer to `form-item` and `form` renderers to inherit default editability state ([link](https://github.com/baidu/amis/pull/8677/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L580-R581), [link](https://github.com/baidu/amis/pull/8677/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L594-R596))
*  Update `QuickEdit.tsx` file to reflect the prop name change and pass down the prop value ([link](https://github.com/baidu/amis/pull/8677/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L515-R515), [link](https://github.com/baidu/amis/pull/8677/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L580-R581), [link](https://github.com/baidu/amis/pull/8677/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L594-R596))
