### PR TITLE
feat: 公式支持uuid生成

### DIFF
--- a/packages/amis-formula/__tests__/evalute.test.ts
+++ b/packages/amis-formula/__tests__/evalute.test.ts
@@ -564,7 +564,14 @@ test('evalute:Math', () => {
 });
 
 test('evalute:UUID', () => {
-  expect(evaluate('${UUID()}', {}).length).toBe(32);
+  function isUUIDv4(value: string) {
+    return /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i.test(
+      value
+    );
+  }
+
+  expect(isUUIDv4(evaluate('${UUID()}', {}))).toBe(true);
+  expect(evaluate('${UUID()}', {}).length).toBe(36);
   expect(evaluate('${UUID(8)}', {}).length).toBe(8);
 });
 

--- a/packages/amis-formula/src/evalutor.ts
+++ b/packages/amis-formula/src/evalutor.ts
@@ -1524,8 +1524,8 @@ export class Evaluator {
    *
    * @returns {string} 生成的UUID字符串
    */
-  fnUUID(length: number = 32) {
-    const len = Math.min(Math.max(length, 0), 32);
+  fnUUID(length: number = 36) {
+    const len = Math.min(Math.max(length, 0), 36);
     return uuidv4().slice(0, len);
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 78c34a3</samp>

Updated the `UUID` function and its test case to use the UUIDv4 format, which has 36 characters including hyphens. This ensures the generated values are valid and consistent with the standard.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 78c34a3</samp>

> _`fnUUID` length_
> _Changed to match UUIDv4_
> _Winter of refactor_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 78c34a3</samp>

* Change the `UUID` function to generate and return a valid UUIDv4 value with 36 characters including hyphens ([link](https://github.com/baidu/amis/pull/8678/files?diff=unified&w=0#diff-6e98a1dfcecf7c45fc01fdf27b5c21e037dc90466a0761a63998e1736958b433L1527-R1528), [link](https://github.com/baidu/amis/pull/8678/files?diff=unified&w=0#diff-12afc0d8fc19329d900d849d7b791da51b3e399126e9e38059c4a30ba33e9c9dL567-R574))
* Update the test case for the `UUID` function to check the validity and length of the generated value in `packages/amis-formula/__tests__/evalute.test.ts` ([link](https://github.com/baidu/amis/pull/8678/files?diff=unified&w=0#diff-12afc0d8fc19329d900d849d7b791da51b3e399126e9e38059c4a30ba33e9c9dL567-R574))
