### PR TITLE
chore(amis-editor): Form配置面板中表达式使用变量，避免data被赋值导致取值错误

### DIFF
--- a/packages/amis-editor/src/plugin/CRUD.tsx
+++ b/packages/amis-editor/src/plugin/CRUD.tsx
@@ -578,7 +578,7 @@ export class CRUDPlugin extends BasePlugin {
               name: 'filterColumnCount'
             }
           ],
-          visibleOn: 'data.features && data.features.includes("filter")'
+          visibleOn: "${features && features.includes('filter')}"
         },
         {
           name: 'columns',

--- a/packages/amis-editor/src/plugin/Form/Form.tsx
+++ b/packages/amis-editor/src/plugin/Form/Form.tsx
@@ -474,7 +474,7 @@ export class FormPlugin extends BasePlugin {
                 return {
                   type: 'container',
                   className: 'form-item-gap',
-                  visibleOn: `data.feat === '${feat.value}' && (!data.dsType || data.dsType === '${builderKey}')`,
+                  visibleOn: `$\{feat === '${feat.value}' && (!dsType || dsType === '${builderKey}')}`,
                   body: flatten([
                     builder.makeSourceSettingForm({
                       feat: feat.value,
@@ -685,26 +685,28 @@ export class FormPlugin extends BasePlugin {
       const dsSettings = flatten(
         this.Features.map(feat =>
           this.dsManager.buildCollectionFromBuilders(
-            (builder, builderKey, index) => ({
-              type: 'container',
-              className: 'form-item-gap',
-              visibleOn: `data.feat === '${
-                feat.value
-              }' && (data.dsType == null ? '${builderKey}' === '${
-                defaultDsType || ApiDSBuilderKey
-              }' : data.dsType === '${builderKey}')`,
-              body: flatten([
-                builder.makeSourceSettingForm({
-                  feat: feat.value,
-                  renderer: 'form',
-                  inScaffold: false,
-                  sourceSettings: {
-                    renderLabel: true,
-                    userOrders: false
-                  }
-                })
-              ])
-            })
+            (builder, builderKey, index) => {
+              return {
+                type: 'container',
+                className: 'form-item-gap',
+                visibleOn: `$\{feat === '${
+                  feat.value
+                }' && (dsType == null ? '${builderKey}' === '${
+                  defaultDsType || ApiDSBuilderKey
+                }' : dsType === '${builderKey}')}`,
+                body: flatten([
+                  builder.makeSourceSettingForm({
+                    feat: feat.value,
+                    renderer: 'form',
+                    inScaffold: false,
+                    sourceSettings: {
+                      renderLabel: true,
+                      userOrders: false
+                    }
+                  })
+                ])
+              };
+            }
           )
         )
       );


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a165991</samp>

This pull request improves the code quality and fixes a bug in the `amis-editor` plugin. It simplifies some `visibleOn` expressions in `Form.tsx` and ensures the filter button is always visible in `CRUD.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a165991</samp>

> _We'll fix the bugs and make the code shine_
> _With template literals and `visibleOn` fine_
> _Heave away, me hearties, heave away_
> _We'll pull the request and sail another day_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a165991</samp>

*  Fix filter button visibility bug in `CRUDPlugin` by using template literals for `features` ([link](https://github.com/baidu/amis/pull/8680/files?diff=unified&w=0#diff-344f079b19e00d12da1c3020e58b9d59213791fc02c9f7b667a30ccaa60e2a0aL581-R581))
*  Simplify `visibleOn` expressions for source setting forms in `FormPlugin` by using template literals for `feat` and `dsType` ([link](https://github.com/baidu/amis/pull/8680/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL477-R477), [link](https://github.com/baidu/amis/pull/8680/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL688-R709))
*  Add `return` statement to arrow function for consistency in `FormPlugin` ([link](https://github.com/baidu/amis/pull/8680/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL688-R709))
