### PR TITLE
fix: 数字输入框配置面板固定为单侧按钮模式

### DIFF
--- a/packages/amis-editor/src/plugin/Form/InputNumber.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputNumber.tsx
@@ -19,6 +19,7 @@ import {defaultValue, getSchemaTpl, tipedLabel} from 'amis-editor-core';
 import {ValidatorTag} from '../../validator';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
 import {inputStateTpl} from '../../renderer/style-control/helper';
+import {Schema} from 'amis-core';
 
 export class NumberControlPlugin extends BasePlugin {
   static id = 'NumberControlPlugin';
@@ -177,16 +178,20 @@ export class NumberControlPlugin extends BasePlugin {
                 getSchemaTpl('kilobitSeparator'),
 
                 getSchemaTpl('valueFormula', {
-                  rendererSchema: context?.schema,
+                  rendererSchema: (schema: Schema) => ({
+                    ...schema,
+                    displayMode: 'base'
+                  }),
                   valueType: 'number' // 期望数值类型
                 }),
 
                 getSchemaTpl('valueFormula', {
                   name: 'min',
-                  rendererSchema: {
-                    ...context?.schema,
-                    value: context?.schema.min
-                  },
+                  rendererSchema: (schema: Schema) => ({
+                    ...schema,
+                    value: context?.schema.min,
+                    displayMode: 'base'
+                  }),
                   needDeleteProps: ['min'], // 避免自我限制
                   label: '最小值',
                   valueType: 'number'
@@ -194,10 +199,11 @@ export class NumberControlPlugin extends BasePlugin {
 
                 getSchemaTpl('valueFormula', {
                   name: 'max',
-                  rendererSchema: {
-                    ...context?.schema,
-                    value: context?.schema.max
-                  },
+                  rendererSchema: (schema: Schema) => ({
+                    ...schema,
+                    value: context?.schema.max,
+                    displayMode: 'base'
+                  }),
                   needDeleteProps: ['max'], // 避免自我限制
                   label: '最大值',
                   valueType: 'number'


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 645cd3b</samp>

This pull request improves the schema template for the number input control in the amis-editor plugin. It uses the `Schema` type from `amis-core` and avoids formula editors for the `valueFormula` fields in `InputNumber.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 645cd3b</samp>

> _`Schema` template_
> _Number input gets updated_
> _`displayMode`: `base`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 645cd3b</samp>

*  Import `Schema` type from `amis-core` to use as parameter type for `rendererSchema` function in `getSchemaTpl` helper function ([link](https://github.com/baidu/amis/pull/8681/files?diff=unified&w=0#diff-c459de2eb5b316e5e49ab103c7fa1a03c20cf7693bd79b8e039e782b48c5731aR22))
*  Set `displayMode` property to `'base'` for `valueFormula` fields (`value`, `min`, and `max`) in `rendererSchema` function to avoid rendering them as formula editors, which are not suitable for number input control ([link](https://github.com/baidu/amis/pull/8681/files?diff=unified&w=0#diff-c459de2eb5b316e5e49ab103c7fa1a03c20cf7693bd79b8e039e782b48c5731aL180-R184), [link](https://github.com/baidu/amis/pull/8681/files?diff=unified&w=0#diff-c459de2eb5b316e5e49ab103c7fa1a03c20cf7693bd79b8e039e782b48c5731aL186-R194), [link](https://github.com/baidu/amis/pull/8681/files?diff=unified&w=0#diff-c459de2eb5b316e5e49ab103c7fa1a03c20cf7693bd79b8e039e782b48c5731aL197-R206))
