### PR TITLE
fix:事件文档里json格式

### DIFF
--- a/docs/zh-CN/concepts/event-action.md
+++ b/docs/zh-CN/concepts/event-action.md
@@ -75,42 +75,42 @@ order: 9
 
 ```schema
 {
-  type: 'page',
-  body: [
+  "type": "page",
+  "body": [
     {
-      type: 'button',
-      label: '尝试点击、鼠标移入/移出',
-      level: 'primary',
-      onEvent: {
-        click: {
-          actions: [
+      "type": "button",
+      "label": "尝试点击、鼠标移入/移出",
+      "level": "primary",
+      "onEvent": {
+        "click": {
+          "actions": [
             {
-              actionType: 'toast',
-              args: {
-                msgType: 'info',
-                msg: '派发点击事件'
+              "actionType": "toast",
+              "args": {
+                "msgType": "info",
+                "msg": "派发点击事件"
               }
             }
           ]
         },
-        mouseenter: {
-          actions: [
+        "mouseenter": {
+          "actions": [
             {
-              actionType: 'toast',
-              args: {
-                msgType: 'info',
-                msg: '派发鼠标移入事件'
+              "actionType": "toast",
+              "args": {
+                "msgType": "info",
+                "msg": "派发鼠标移入事件"
               }
             }
           ]
         },
-        mouseleave: {
-          actions: [
+        "mouseleave": {
+          "actions": [
             {
-              actionType: 'toast',
-              args: {
-                msgType: 'info',
-                msg: '派发鼠标移出事件'
+              "actionType": "toast",
+              "args": {
+                "msgType": "info",
+                "msg": "派发鼠标移出事件"
               }
             }
           ]


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7cf867d</samp>

Formatted JSON schema in `event-action.md` to use double quotes. This change enhances the code quality and style of the documentation.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7cf867d</samp>

> _`onEvent` schema_
> _Double quotes for JSON_
> _Winter clarity_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7cf867d</samp>

* Formatted the JSON schema in the `onEvent` section to use double quotes ([link](https://github.com/baidu/amis/pull/8685/files?diff=unified&w=0#diff-9802ca5a2390dc6e213b3d844669c50fb10948dad8ad72a0d360c886731fbd3dL78-R113))
