### PR TITLE
fix: Options使用上下文变量数据源被错误分页处理问题

### DIFF
--- a/packages/amis-core/src/store/formItem.ts
+++ b/packages/amis-core/src/store/formItem.ts
@@ -858,12 +858,12 @@ export const FormItemStore = StoreNode.named('FormItemStore')
           ...(ctx?.perPage ? {perPage: ctx?.perPage} : {}),
           total: options.length
         };
-      }
 
-      options = options.slice(
-        (self.pagination.page - 1) * self.pagination.perPage,
-        self.pagination.page * self.pagination.perPage
-      );
+        options = options.slice(
+          (self.pagination.page - 1) * self.pagination.perPage,
+          self.pagination.page * self.pagination.perPage
+        );
+      }
 
       setOptions(options, onChange, ctx);
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1bd7f70</samp>

Fix select options update bug by conditionally slicing `options` array. Modify `packages/amis-core/src/store/formItem.ts` to check for `self.pagination` before slicing.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1bd7f70</samp>

> _`options` sliced_
> _only with pagination_
> _winter bug is fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1bd7f70</samp>

* Fix a bug where the options of a select component are not updated when the source changes ([link](https://github.com/baidu/amis/pull/8691/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L861-R867))
