### PR TITLE
chore: Scoped组件reolad方法时增加fallback，找不到对应名称组件则继续寻找对应ID组件

### DIFF
--- a/packages/amis-core/src/Scoped.tsx
+++ b/packages/amis-core/src/Scoped.tsx
@@ -274,7 +274,8 @@ function createScopedTools(
             location.reload();
           }
         } else {
-          const component = scoped.getComponentByName(name);
+          const component =
+            scoped.getComponentByName(name) || scoped.getComponentById(name);
           component &&
             component.reload &&
             component.reload(subPath, query, ctx);


### PR DESCRIPTION
…找到叔伯的子孙组件

### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f6b67b</samp>

Improve scoped component reloading by enabling `createScopedTools` to locate components by id. Update `Scoped.tsx` to implement this feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2f6b67b</samp>

> _`createScopedTools`_
> _Finds components by id now_
> _Autumn of duplicates_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2f6b67b</samp>

* Enable scoped component reloading by adding a `reloadScoped` method to the `ScopedContext` interface and the `Scoped` component class (                           F0L153
