### PR TITLE
feat: 开放static组件, 增加static事件配置

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Static.tsx
+++ b/packages/amis-editor/src/plugin/Form/Static.tsx
@@ -4,7 +4,8 @@ import {
   defaultValue,
   getSchemaTpl,
   setSchemaTpl,
-  tipedLabel
+  tipedLabel,
+  RendererPluginEvent
 } from 'amis-editor-core';
 import {registerEditorPlugin} from 'amis-editor-core';
 import {BaseEventContext, BasePlugin} from 'amis-editor-core';
@@ -263,7 +264,6 @@ export class StaticControlPlugin extends BasePlugin {
   // 组件名称
   name = '静态展示框';
   isBaseComponent = true;
-  disabledRendererPlugin = true;
   icon = 'fa fa-info';
   pluginIcon = 'static-plugin';
   description = '纯用来展示数据，可用来展示 json、date、image、progress 等数据';
@@ -299,13 +299,6 @@ export class StaticControlPlugin extends BasePlugin {
           {
             title: '基本',
             body: [
-              {
-                type: 'alert',
-                inline: false,
-                level: 'warning',
-                className: 'text-sm',
-                body: '<p>当前组件已停止维护，建议您使用<a href="/amis/zh-CN/components/form/formitem#%E9%85%8D%E7%BD%AE%E9%9D%99%E6%80%81%E5%B1%95%E7%A4%BA" target="_blank">静态展示</a>新特性实现表单项的静态展示。</p>'
-              },
               getSchemaTpl('formItemName', {
                 required: false
               }),
@@ -389,6 +382,76 @@ export class StaticControlPlugin extends BasePlugin {
     }
     return props;
   }
+
+  // 事件定义
+  events: RendererPluginEvent[] = [
+    {
+      eventName: 'click',
+      eventLabel: '点击',
+      description: '点击时触发',
+      dataSchema: [
+        {
+          type: 'object',
+          properties: {
+            context: {
+              type: 'object',
+              title: '上下文',
+              properties: {
+                nativeEvent: {
+                  type: 'object',
+                  title: '鼠标事件对象'
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      eventName: 'mouseenter',
+      eventLabel: '鼠标移入',
+      description: '鼠标移入时触发',
+      dataSchema: [
+        {
+          type: 'object',
+          properties: {
+            context: {
+              type: 'object',
+              title: '上下文',
+              properties: {
+                nativeEvent: {
+                  type: 'object',
+                  title: '鼠标事件对象'
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      eventName: 'mouseleave',
+      eventLabel: '鼠标移出',
+      description: '鼠标移出时触发',
+      dataSchema: [
+        {
+          type: 'object',
+          properties: {
+            context: {
+              type: 'object',
+              title: '上下文',
+              properties: {
+                nativeEvent: {
+                  type: 'object',
+                  title: '鼠标事件对象'
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  ];
 
   /*exchangeRenderer(id: string) {
     this.manager.showReplacePanel(id, '展示');

--- a/packages/amis-editor/src/plugin/index.ts
+++ b/packages/amis-editor/src/plugin/index.ts
@@ -66,6 +66,7 @@ export * from './Form/UUID'; // UUID
 export * from './Form/LocationPicker'; // 地理位置
 export * from './Form/InputSubForm'; // 子表单项
 export * from './Form/Hidden'; // 隐藏域
+export * from './Form/Static'; // 静态展示框
 
 // 功能
 export * from './Button'; // 按钮
@@ -137,7 +138,6 @@ export * from './Form/InputMonthRange';
 export * from './Form/InputPassword';
 export * from './Form/InputQuarter';
 export * from './Form/InputQuarterRange';
-export * from './Form/Static';
 export * from './Form/InputTime';
 export * from './Form/InputTimeRange';
 export * from './Form/TreeSelect';


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b4ff676</samp>

Updated the `Static` plugin for the amis-editor to support events and remove deprecated features. Fixed a duplicate export issue in the `plugin` index file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b4ff676</samp>

> _Oh we're the crew of the `StaticControlPlugin`_
> _We update and we fix and we add some events_
> _We heave away and haul away with `RendererPluginEvent`_
> _And we don't need no duplicate `Static` module export_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b4ff676</samp>

* Import `RendererPluginEvent` type to define events for `StaticControlPlugin` class ([link](https://github.com/baidu/amis/pull/8705/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261L7-R8))
* Remove `disabledRendererPlugin` property from `StaticControlPlugin` class, as it is no longer needed ([link](https://github.com/baidu/amis/pull/8705/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261L266))
* Remove alert component from `StaticControlPlugin` class, as it is no longer necessary to warn users about deprecation of static component ([link](https://github.com/baidu/amis/pull/8705/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261L302-L308))
* Add `events` property to `StaticControlPlugin` class, to define click, mouseenter and mouseleave events for static component, and their data schema ([link](https://github.com/baidu/amis/pull/8705/files?diff=unified&w=0#diff-f82eb4fe84e709eb1e02117da1c4cd586d9c67912ee6366b1c1bc0ac39ad6261R386-R455))
* Export `Static` module from `plugin` index file (`packages/amis-editor/src/plugin/index.ts`) to make it available for the editor ([link](https://github.com/baidu/amis/pull/8705/files?diff=unified&w=0#diff-932f531ae9519592dd3c4d5b344142b81879a4366812780b429dfa5a17fc675bR69))
* Remove duplicate export of `Static` module from `plugin` index file ([link](https://github.com/baidu/amis/pull/8705/files?diff=unified&w=0#diff-932f531ae9519592dd3c4d5b344142b81879a4366812780b429dfa5a17fc675bL140))
