### PR TITLE
fix(amis-editor): combo组件数据为空时，无法打开公式编辑器

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Combo.tsx
+++ b/packages/amis-editor/src/plugin/Form/Combo.tsx
@@ -679,7 +679,7 @@ export class ComboControlPlugin extends BasePlugin {
     }`;
     let isColumnChild = false;
 
-    if (trigger) {
+    if (trigger && items) {
       isColumnChild = someTree(items.children, item => item.id === trigger?.id);
 
       if (isColumnChild) {
@@ -698,7 +698,7 @@ export class ComboControlPlugin extends BasePlugin {
       }
     }
 
-    const pool = items.children.concat();
+    const pool = items?.children?.concat() || [];
 
     while (pool.length) {
       const current = pool.shift() as EditorNodeType;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9904d5a</samp>

Fix combo control bug with remote items and column trigger. Add null checks for `items` and `items.children` in `Combo.tsx`.
![image](https://github.com/baidu/amis/assets/34541195/769801a1-5e52-41ab-8b8a-c7c88175e116)
![image](https://github.com/baidu/amis/assets/34541195/14acab7c-49a9-4a16-a0df-cbf52fc978a7)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9904d5a</samp>

> _Sing, O Muse, of the cunning coder who fixed the bug_
> _That plagued the combo control, a wondrous work of skill_
> _When the trigger was a column and the items came from afar_
> _He added null checks for `items` and `items.children`, averting disaster_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9904d5a</samp>

*  Add null checks for `items` and `items.children` to prevent combo control crash ([link](https://github.com/baidu/amis/pull/8709/files?diff=unified&w=0#diff-785d17e956a3abfd5fcf93db4ac2b50aed00bb5bf2eb2a3f9c3776e81774d097L682-R682), [link](https://github.com/baidu/amis/pull/8709/files?diff=unified&w=0#diff-785d17e956a3abfd5fcf93db4ac2b50aed00bb5bf2eb2a3f9c3776e81774d097L701-R701))
