### PR TITLE
fix: crud的perPageAvailable下发到分页工具中

### DIFF
--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -1949,7 +1949,13 @@ export default class CRUD extends React.Component<CRUDProps, any> {
   }
 
   renderPagination(toolbar: SchemaNode) {
-    const {store, render, classnames: cx, alwaysShowPagination} = this.props;
+    const {
+      store,
+      render,
+      classnames: cx,
+      alwaysShowPagination,
+      perPageAvailable
+    } = this.props;
     const {page, lastPage} = store;
 
     if (
@@ -1970,6 +1976,11 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       | 'perPageAvailable'
       | 'showPerPage'
     > = {};
+
+    // 下发 perPageAvailable
+    if (Array.isArray(perPageAvailable)) {
+      extraProps.perPageAvailable = perPageAvailable;
+    }
 
     /** 优先级：showPageInput显性配置 > (lastPage > 9) */
     if (typeof toolbar !== 'string') {


### PR DESCRIPTION
### 问题
目前editor的老版crud组件配置 `perPageAvailable` 是在 crud 层；
当crud是以下配置时，`perPageAvailable` 无法下发到分页组件中，导致失效；
（新版crud支持直接配置分页的perPageAvailable属性）

例如 [issue](https://github.com/baidu/amis/issues/1677)，直接复制wiki里的 picker 代码，然后配置此属性会失效
```
{
  "type": "crud",
  "perPageAvailable": [
    5
  ],
  "footerToolbar": [
    "statistics",
    {
      "type": "pagination",
      "showPageInput": true,
      "layout": "perPage,pager,go"
    }
  ]
}
```
因此需要下发属性