### PR TITLE
fix: combo组件数据为空时，无法打开公式编辑器

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Combo.tsx
+++ b/packages/amis-editor/src/plugin/Form/Combo.tsx
@@ -680,7 +680,7 @@ export class ComboControlPlugin extends BasePlugin {
     }`;
     let isColumnChild = false;
 
-    if (trigger) {
+    if (trigger && items) {
       isColumnChild = someTree(items.children, item => item.id === trigger?.id);
 
       if (isColumnChild) {
@@ -699,7 +699,7 @@ export class ComboControlPlugin extends BasePlugin {
       }
     }
 
-    const pool = items.children.concat();
+    const pool = items?.children?.concat() || [];
 
     while (pool.length) {
       const current = pool.shift() as EditorNodeType;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5dc0d25</samp>

Fix combo control bug in `amis-editor` plugin. Add null checks for remote items in `Form/Combo.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5dc0d25</samp>

> _Sing, O Muse, of the valiant coder who fixed the bug_
> _That plagued the combo control, a cunning device of skill_
> _That fetched from far-off sources many items to display_
> _But crashed when `items` or `items.children` were null or void_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5dc0d25</samp>

*  Prevent runtime errors when `items` or `items.children` are undefined or null in combo control ([link](https://github.com/baidu/amis/pull/8714/files?diff=unified&w=0#diff-785d17e956a3abfd5fcf93db4ac2b50aed00bb5bf2eb2a3f9c3776e81774d097L683-R683), [link](https://github.com/baidu/amis/pull/8714/files?diff=unified&w=0#diff-785d17e956a3abfd5fcf93db4ac2b50aed00bb5bf2eb2a3f9c3776e81774d097L702-R702))
