### PR TITLE
feat: markdown 支持公式渲染 Closes #7833

### DIFF
--- a/docs/zh-CN/components/markdown.md
+++ b/docs/zh-CN/components/markdown.md
@@ -81,6 +81,30 @@ order: 58
 
 可以使用 `![text](video.mp4)` 语法来嵌入视频。
 
+## 支持 latex
+
+> 3.6.0 及以上版本
+
+公式渲染使用 KaTeX 实现，由于体积太大默认不提供，需要自己去[下载](https://github.com/KaTeX/KaTeX/releases)，在页面中引入以下三个文件：
+
+```
+<link rel="stylesheet" href="katex/katex.min.css">
+<script src="katex/katex.min.js"></script>
+<script src="katex/contrib/auto-render.min.js"></script>
+```
+
+markdown 中的 `$` 或 `$$` 包裹的内容就能以公式展现，比如 `$\sqrt{a^2 + b^2}$`，如果是在代码中 `\` 要转义为 `\\`
+
+```schema
+{
+    "type": "page",
+    "body": {
+        "type": "markdown",
+        "value": "$$\\hat{f} (\\xi)=\\int_{-\\infty}^{\\infty}f(x)e^{-2\\pi ix\\xi}dx$$"
+    }
+}
+```
+
 ## 高级配置
 
 > 1.8.1 及以上版本

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       rel="stylesheet"
       href="/node_modules/@fortawesome/fontawesome-free/css/v4-shims.css"
     />
+    <link rel="stylesheet" href="/node_modules/katex/dist/katex.min.css" />
     <link rel="stylesheet" href="/node_modules/prismjs/themes/prism.css" />
     <link rel="stylesheet" href="/examples/doc.css" />
 
@@ -93,5 +94,10 @@
       const initialState = {};
       bootstrap(document.getElementById('root'), initialState);
     </script>
+    <script defer src="/node_modules/katex/dist/katex.min.js"></script>
+    <script
+      defer
+      src="/node_modules/katex/dist/contrib/auto-render.min.js"
+    ></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     ]
   },
   "dependencies": {
+    "path-to-regexp": "^6.2.0",
     "postcss": "^8.4.14",
-    "qs": "6.9.7",
-    "path-to-regexp": "^6.2.0"
+    "qs": "6.9.7"
   },
   "devDependencies": {
     "@babel/generator": "^7.22.9",
@@ -79,6 +79,7 @@
     "jest": "^29.0.3",
     "jest-environment-jsdom": "^29.0.3",
     "js-yaml": "^4.1.0",
+    "katex": "^0.16.9",
     "lerna": "^6.6.2",
     "lint-staged": "^12.1.2",
     "magic-string": "^0.26.7",

--- a/packages/amis-ui/src/components/Markdown.tsx
+++ b/packages/amis-ui/src/components/Markdown.tsx
@@ -55,6 +55,17 @@ export default class Markdown extends React.Component<MarkdownProps> {
   async _render() {
     const {content, options} = this.props;
     this.dom.innerHTML = markdown(content, options);
+
+    // @ts-ignore 需要用户手动加载 katex
+    if (typeof renderMathInElement === 'function') {
+      // @ts-ignore
+      renderMathInElement(this.dom, {
+        delimiters: [
+          {left: '$$', right: '$$', display: true},
+          {left: '$', right: '$', display: false}
+        ]
+      });
+    }
   }
 
   render() {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8d7a5f8</samp>

This pull request adds support for latex rendering in amis using the KaTeX library. It modifies the `index.html`, `package.json`, `docs/zh-CN/components/markdown.md`, and `packages/amis-ui/src/components/Markdown.tsx` files to enable and document this feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8d7a5f8</samp>

> _If you want to write math in amis_
> _You can use latex syntax with ease_
> _Just load KaTeX in `index.html`_
> _And use schema to make it swell_
> _The `Markdown.tsx` component will render with cheese_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8d7a5f8</samp>

*  Add latex support for markdown component ([link](https://github.com/baidu/amis/pull/8716/files?diff=unified&w=0#diff-86a98d2b284681325560e22ccd2ecc0a498c3392664a50e72e5e9bf2f43bf461R84-R107), [link](https://github.com/baidu/amis/pull/8716/files?diff=unified&w=0#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R27), [link](https://github.com/baidu/amis/pull/8716/files?diff=unified&w=0#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R97-R101), [link](https://github.com/baidu/amis/pull/8716/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R82), [link](https://github.com/baidu/amis/pull/8716/files?diff=unified&w=0#diff-9ecc070ac7178abd0ff6b44f1c6f7249c718de490725d2596eb81adf4141b2ceR58-R68))
* Reorder dependencies in `package.json` alphabetically for readability ([link](https://github.com/baidu/amis/pull/8716/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L43-R45))
