### PR TITLE
feat: 支持屏蔽组件中展示msg信息，默认展示

### DIFF
--- a/packages/amis-core/src/env.tsx
+++ b/packages/amis-core/src/env.tsx
@@ -28,6 +28,7 @@ export interface wsObject {
 }
 
 export interface RendererEnv {
+  hiddenEditorShowMsg?: boolean;
   session?: string;
   fetcher: (api: Api, data?: any, options?: object) => Promise<Payload>;
   isCancel: (val: any) => boolean;

--- a/packages/amis-editor-core/src/env.ts
+++ b/packages/amis-editor-core/src/env.ts
@@ -50,5 +50,7 @@ export const env: RenderOptions = {
     toast[type]
       ? toast[type](msg, type === 'error' ? '系统错误' : '系统消息')
       : console.warn('[Notify]', type, msg);
-  }
+  },
+  // 屏蔽组件中展示msg，默认展示
+  hiddenEditorShowMsg: false
 };

--- a/packages/amis/src/renderers/Dialog.tsx
+++ b/packages/amis/src/renderers/Dialog.tsx
@@ -500,6 +500,7 @@ export default class Dialog extends React.Component<DialogProps> {
     const {
       store,
       render,
+      env,
       classnames: cx,
       showErrorMsg,
       showLoading,
@@ -514,7 +515,9 @@ export default class Dialog extends React.Component<DialogProps> {
             {showLoading !== false ? (
               <Spinner size="sm" key="info" show={store.loading} />
             ) : null}
-            {store.error && showErrorMsg !== false ? (
+            {!env.hiddenEditorShowMsg &&
+            store.error &&
+            showErrorMsg !== false ? (
               <span className={cx('Dialog-error')}>{store.msg}</span>
             ) : null}
           </div>

--- a/packages/amis/src/renderers/Drawer.tsx
+++ b/packages/amis/src/renderers/Drawer.tsx
@@ -491,6 +491,7 @@ export default class Drawer extends React.Component<DrawerProps> {
     const {
       store,
       render,
+      env,
       classnames: cx,
       showErrorMsg,
       footerClassName
@@ -501,7 +502,7 @@ export default class Drawer extends React.Component<DrawerProps> {
         {store.loading || store.error ? (
           <div className={cx('Drawer-info')}>
             <Spinner size="sm" key="info" show={store.loading} />
-            {showErrorMsg && store.error ? (
+            {!env.hiddenEditorShowMsg && showErrorMsg && store.error ? (
               <span className={cx('Drawer-error')}>{store.msg}</span>
             ) : null}
           </div>

--- a/packages/amis/src/renderers/Page.tsx
+++ b/packages/amis/src/renderers/Page.tsx
@@ -896,7 +896,9 @@ export default class Page extends React.Component<PageProps> {
               loadingConfig={loadingConfig}
             />
 
-            {store.error && showErrorMsg !== false ? (
+            {!env.hiddenEditorShowMsg &&
+            store.error &&
+            showErrorMsg !== false ? (
               <Alert
                 level="danger"
                 showCloseButton

--- a/packages/amis/src/renderers/Service.tsx
+++ b/packages/amis/src/renderers/Service.tsx
@@ -785,6 +785,7 @@ export default class Service extends React.Component<ServiceProps> {
       style,
       store,
       render,
+      env,
       classPrefix: ns,
       classnames: cx,
       loadingConfig,
@@ -793,7 +794,7 @@ export default class Service extends React.Component<ServiceProps> {
 
     return (
       <div className={cx(`${ns}Service`, className)} style={style}>
-        {store.error && showErrorMsg !== false ? (
+        {!env.hiddenEditorShowMsg && store.error && showErrorMsg !== false ? (
           <Alert
             level="danger"
             showCloseButton


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6781eb8</samp>

This pull request adds a new property `hiddenEditorShowMsg` to the `env` object and the `wsObject` interface, and modifies several renderers (`Dialog`, `Drawer`, `Service`, and `Page`) to respect this property. The purpose of this change is to allow the amis editor to control whether to show or hide the error messages from the server in the modal dialog, the drawer, or the page.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6781eb8</samp>

> _Oh, we are the coders of the `amis` crew_
> _We make the editor smart and smooth_
> _We hide the errors when we need to_
> _With the `hiddenEditorShowMsg` flag we use_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6781eb8</samp>

*  Add a new property `hiddenEditorShowMsg` to control the error message display in the editor ([link](https://github.com/baidu/amis/pull/8717/files?diff=unified&w=0#diff-62f2e14b837dfa7b7f5f94ee2a856825f211639ddf0f85d783c666dbcd7f8d0dR31), [link](https://github.com/baidu/amis/pull/8717/files?diff=unified&w=0#diff-d925f9b5a4ca7881b911fc829bdb900bc2321ac9ac0c91e10882c36113f02920L53-R55))
*  Pass the `env` object as a prop to the `Dialog`, `Drawer`, and `Service` components to access the `hiddenEditorShowMsg` property ([link](https://github.com/baidu/amis/pull/8717/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bR503), [link](https://github.com/baidu/amis/pull/8717/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8R494), [link](https://github.com/baidu/amis/pull/8717/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852R788))
*  Add conditions to check the `hiddenEditorShowMsg` property before rendering the error messages in the `Dialog`, `Drawer`, `Page`, and `Service` components ([link](https://github.com/baidu/amis/pull/8717/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL517-R520), [link](https://github.com/baidu/amis/pull/8717/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L504-R505), [link](https://github.com/baidu/amis/pull/8717/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L899-R901), [link](https://github.com/baidu/amis/pull/8717/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852L796-R797))
