### PR TITLE
feat: 支持屏蔽组件中展示msg信息，默认展示

### DIFF
--- a/packages/amis-core/src/env.tsx
+++ b/packages/amis-core/src/env.tsx
@@ -28,7 +28,8 @@ export interface wsObject {
 }
 
 export interface RendererEnv {
-  hiddenEditorShowMsg?: boolean;
+  /* 强制隐藏组件内部的报错信息，会覆盖组件内部属性 */
+  forceSilenceInsideError?: boolean;
   session?: string;
   fetcher: (api: Api, data?: any, options?: object) => Promise<Payload>;
   isCancel: (val: any) => boolean;

--- a/packages/amis-core/src/env.tsx
+++ b/packages/amis-core/src/env.tsx
@@ -28,6 +28,7 @@ export interface wsObject {
 }
 
 export interface RendererEnv {
+  hiddenEditorShowMsg?: boolean;
   session?: string;
   fetcher: (api: Api, data?: any, options?: object) => Promise<Payload>;
   isCancel: (val: any) => boolean;

--- a/packages/amis-editor-core/src/env.ts
+++ b/packages/amis-editor-core/src/env.ts
@@ -51,6 +51,6 @@ export const env: RenderOptions = {
       ? toast[type](msg, type === 'error' ? '系统错误' : '系统消息')
       : console.warn('[Notify]', type, msg);
   },
-  // 屏蔽组件中展示msg，默认展示
-  hiddenEditorShowMsg: false
+  /* 强制隐藏组件内部的报错信息，会覆盖组件内部属性 */
+  forceSilenceInsideError: false
 };

--- a/packages/amis-editor-core/src/env.ts
+++ b/packages/amis-editor-core/src/env.ts
@@ -50,5 +50,7 @@ export const env: RenderOptions = {
     toast[type]
       ? toast[type](msg, type === 'error' ? '系统错误' : '系统消息')
       : console.warn('[Notify]', type, msg);
-  }
+  },
+  // 屏蔽组件中展示msg，默认展示
+  hiddenEditorShowMsg: false
 };

--- a/packages/amis/src/renderers/Dialog.tsx
+++ b/packages/amis/src/renderers/Dialog.tsx
@@ -500,6 +500,7 @@ export default class Dialog extends React.Component<DialogProps> {
     const {
       store,
       render,
+      env,
       classnames: cx,
       showErrorMsg,
       showLoading,
@@ -514,7 +515,9 @@ export default class Dialog extends React.Component<DialogProps> {
             {showLoading !== false ? (
               <Spinner size="sm" key="info" show={store.loading} />
             ) : null}
-            {store.error && showErrorMsg !== false ? (
+            {!env.hiddenEditorShowMsg &&
+            store.error &&
+            showErrorMsg !== false ? (
               <span className={cx('Dialog-error')}>{store.msg}</span>
             ) : null}
           </div>

--- a/packages/amis/src/renderers/Dialog.tsx
+++ b/packages/amis/src/renderers/Dialog.tsx
@@ -515,7 +515,7 @@ export default class Dialog extends React.Component<DialogProps> {
             {showLoading !== false ? (
               <Spinner size="sm" key="info" show={store.loading} />
             ) : null}
-            {!env.hiddenEditorShowMsg &&
+            {!env.forceSilenceInsideError &&
             store.error &&
             showErrorMsg !== false ? (
               <span className={cx('Dialog-error')}>{store.msg}</span>

--- a/packages/amis/src/renderers/Drawer.tsx
+++ b/packages/amis/src/renderers/Drawer.tsx
@@ -491,6 +491,7 @@ export default class Drawer extends React.Component<DrawerProps> {
     const {
       store,
       render,
+      env,
       classnames: cx,
       showErrorMsg,
       footerClassName
@@ -501,7 +502,7 @@ export default class Drawer extends React.Component<DrawerProps> {
         {store.loading || store.error ? (
           <div className={cx('Drawer-info')}>
             <Spinner size="sm" key="info" show={store.loading} />
-            {showErrorMsg && store.error ? (
+            {!env.hiddenEditorShowMsg && showErrorMsg && store.error ? (
               <span className={cx('Drawer-error')}>{store.msg}</span>
             ) : null}
           </div>

--- a/packages/amis/src/renderers/Drawer.tsx
+++ b/packages/amis/src/renderers/Drawer.tsx
@@ -502,7 +502,7 @@ export default class Drawer extends React.Component<DrawerProps> {
         {store.loading || store.error ? (
           <div className={cx('Drawer-info')}>
             <Spinner size="sm" key="info" show={store.loading} />
-            {!env.hiddenEditorShowMsg && showErrorMsg && store.error ? (
+            {!env.forceSilenceInsideError && showErrorMsg && store.error ? (
               <span className={cx('Drawer-error')}>{store.msg}</span>
             ) : null}
           </div>

--- a/packages/amis/src/renderers/Page.tsx
+++ b/packages/amis/src/renderers/Page.tsx
@@ -896,7 +896,9 @@ export default class Page extends React.Component<PageProps> {
               loadingConfig={loadingConfig}
             />
 
-            {store.error && showErrorMsg !== false ? (
+            {!env.hiddenEditorShowMsg &&
+            store.error &&
+            showErrorMsg !== false ? (
               <Alert
                 level="danger"
                 showCloseButton

--- a/packages/amis/src/renderers/Page.tsx
+++ b/packages/amis/src/renderers/Page.tsx
@@ -897,7 +897,7 @@ export default class Page extends React.Component<PageProps> {
               loadingConfig={loadingConfig}
             />
 
-            {!env.hiddenEditorShowMsg &&
+            {!env.forceSilenceInsideError &&
             store.error &&
             showErrorMsg !== false ? (
               <Alert

--- a/packages/amis/src/renderers/Page.tsx
+++ b/packages/amis/src/renderers/Page.tsx
@@ -853,6 +853,7 @@ export default class Page extends React.Component<PageProps> {
       body,
       bodyClassName,
       render,
+      env,
       aside,
       asideClassName,
       classnames: cx,

--- a/packages/amis/src/renderers/Service.tsx
+++ b/packages/amis/src/renderers/Service.tsx
@@ -785,6 +785,7 @@ export default class Service extends React.Component<ServiceProps> {
       style,
       store,
       render,
+      env,
       classPrefix: ns,
       classnames: cx,
       loadingConfig,
@@ -793,7 +794,7 @@ export default class Service extends React.Component<ServiceProps> {
 
     return (
       <div className={cx(`${ns}Service`, className)} style={style}>
-        {store.error && showErrorMsg !== false ? (
+        {!env.hiddenEditorShowMsg && store.error && showErrorMsg !== false ? (
           <Alert
             level="danger"
             showCloseButton

--- a/packages/amis/src/renderers/Service.tsx
+++ b/packages/amis/src/renderers/Service.tsx
@@ -794,7 +794,9 @@ export default class Service extends React.Component<ServiceProps> {
 
     return (
       <div className={cx(`${ns}Service`, className)} style={style}>
-        {!env.hiddenEditorShowMsg && store.error && showErrorMsg !== false ? (
+        {!env.forceSilenceInsideError &&
+        store.error &&
+        showErrorMsg !== false ? (
           <Alert
             level="danger"
             showCloseButton


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e31540</samp>

Added a new feature to control the visibility of error messages from the store in various amis renderers. This feature is based on a new property `hiddenEditorShowMsg` in the `env` object and the `wsObject` interface.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8e31540</samp>

> _To hide errors from hidden editors_
> _We added some props and some getters_
> _The `env` object has a flag_
> _That the `wsObject` can drag_
> _And the `Service` component respects it_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8e31540</samp>

*  Add a new optional property `hiddenEditorShowMsg` to the `wsObject` interface to control the error message display in the editor components ([link](https://github.com/baidu/amis/pull/8722/files?diff=unified&w=0#diff-62f2e14b837dfa7b7f5f94ee2a856825f211639ddf0f85d783c666dbcd7f8d0dR31))
*  Extend the `env` object with a new property `hiddenEditorShowMsg` and initialize it to `false` by default ([link](https://github.com/baidu/amis/pull/8722/files?diff=unified&w=0#diff-d925f9b5a4ca7881b911fc829bdb900bc2321ac9ac0c91e10882c36113f02920L53-R55))
*  Pass the `env` object as a prop to the `Dialog`, `Drawer`, `Page`, and `Service` components, which are used to render different types of content ([link](https://github.com/baidu/amis/pull/8722/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bR503), [link](https://github.com/baidu/amis/pull/8722/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8R494), [link](https://github.com/baidu/amis/pull/8722/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0R856), [link](https://github.com/baidu/amis/pull/8722/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852R788))
*  Modify the condition for rendering the error message from the store in the `Dialog`, `Drawer`, `Page`, and `Service` components to check the `env.hiddenEditorShowMsg` property as well. If this property is `true`, the error message will not be rendered, otherwise it will be rendered as before ([link](https://github.com/baidu/amis/pull/8722/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL517-R520), [link](https://github.com/baidu/amis/pull/8722/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L504-R505), [link](https://github.com/baidu/amis/pull/8722/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L899-R902), [link](https://github.com/baidu/amis/pull/8722/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852L796-R797))
