### PR TITLE
fix:分页组件事件问题

### DIFF
--- a/docs/zh-CN/components/pagination.md
+++ b/docs/zh-CN/components/pagination.md
@@ -68,9 +68,111 @@ order: 73
 | disabled         | `boolean`                  | false                                    | 是否禁用                                                  |
 | onPageChange     | page、perPage 改变时会触发 | (page: number, perPage: number) => void; | 分页改变触发                                              |
 
+## 事件表
+
 当前组件会对外派发以下事件，可以通过`onEvent`来监听这些事件，并通过`actions`来配置执行的动作，在`actions`中可以通过`${事件参数名}`或`${event.data.[事件参数名]}`来获取事件产生的数据，详细请查看[事件动作](../../docs/concepts/event-action)。
 
 > `[name]`表示当前组件绑定的名称，即`name`属性，如果没有配置`name`属性，则通过`value`取值。
 > | 事件名称 | 事件参数 | 说明 |
 > | -------- | ------------------------------------- | ------------------------------------------- |
-> | change | `[value]: object` 当前页码的值<br/> | 当前页码值改变时触发 |
+> | change | `page: number` 当前页码的值<br/>`perPage: number` 每页显示多条数据 | 当前页码值改变时触发 |
+
+### change
+
+切换页码时，通过更新 service 数据域中的 page 来实现联动刷新 table 表格数据。
+
+```schema: scope="body"
+{
+    "type": "service",
+    "id": "service_01",
+    "api": "/api/mock2/crud/table?page=${page}",
+    "data": {
+        "page": 1
+    },
+    "body": [
+        {
+        "type": "table",
+        "title": "表格1",
+        "source": "$rows",
+        "columns": [
+          {
+            "name": "engine",
+            "label": "Engine"
+          },
+          {
+            "name": "version",
+            "label": "Version"
+          }
+        ]
+      },
+        {
+            "type": "pagination",
+            "activePage": "${page}",
+            "hasNext": true,
+            "onEvent": {
+                "change": {
+                    "actions": [
+                        {
+                            "actionType": "setValue",
+                            "componentId": "service_01",
+                            "args": {
+                                "value": {
+                                    "page": "${event.data.page}"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+```
+
+切换页码时，通过向 service 发送 page 并重新加载 service 数据来实现联动刷新 table 表格数据。
+
+```schema: scope="body"
+{
+    "type": "service",
+    "id": "service_02",
+    "api": "/api/mock2/crud/table?page=${page}",
+    "data": {
+        "page": 1
+    },
+    "body": [
+        {
+        "type": "table",
+        "title": "表格1",
+        "source": "$rows",
+        "columns": [
+          {
+            "name": "engine",
+            "label": "Engine"
+          },
+          {
+            "name": "version",
+            "label": "Version"
+          }
+        ]
+      },
+        {
+            "type": "pagination",
+            "activePage": "${page}",
+            "hasNext": true,
+            "onEvent": {
+                "change": {
+                    "actions": [
+                        {
+                            "actionType": "reload",
+                            "componentId": "service_02",
+                            "data": {
+                                "page": "${event.data.page}"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+```

--- a/packages/amis-ui/src/components/Pagination.tsx
+++ b/packages/amis-ui/src/components/Pagination.tsx
@@ -94,7 +94,6 @@ export interface BasicPaginationProps {
   popOverContainerSelector?: string;
 
   onPageChange?: (page: number, perPage?: number, dir?: string) => void;
-  dispatchEvent?: Function;
 }
 export interface PaginationProps
   extends BasicPaginationProps,
@@ -141,20 +140,13 @@ export class Pagination extends React.Component<
   }
 
   async handlePageNumChange(page: number, perPage?: number, dir?: string) {
-    const {disabled, onPageChange, dispatchEvent} = this.props;
+    const {disabled, onPageChange} = this.props;
     const _page = isNaN(Number(page)) || Number(page) < 1 ? 1 : page;
 
     if (disabled) {
       return;
     }
 
-    const rendererEvent = await dispatchEvent?.(
-      'change',
-      resolveEventData(this.props, {_page})
-    );
-    if (rendererEvent?.prevented) {
-      return;
-    }
     onPageChange?.(_page, perPage, dir);
   }
 

--- a/packages/amis/src/renderers/Pagination.tsx
+++ b/packages/amis/src/renderers/Pagination.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import {
   Renderer,
   RendererProps,
+  autobind,
+  createObject,
   isPureVariable,
+  resolveEventData,
   resolveVariableAndFilter
 } from 'amis-core';
 import {BaseSchema} from '../Schema';
@@ -103,11 +106,31 @@ export default class Pagination extends React.Component<PaginationProps> {
     return result ?? defaultValue;
   }
 
+  @autobind
+  async onPageChange(page: number, perPage?: number, dir?: string) {
+    const {onPageChange, dispatchEvent, data} = this.props;
+
+    const rendererEvent = await dispatchEvent?.(
+      'change',
+      createObject(data, {
+        page: page,
+        perPage: perPage
+      })
+    );
+
+    if (rendererEvent?.prevented) {
+      return;
+    }
+
+    onPageChange?.(page, perPage, dir);
+  }
+
   render() {
     const {maxButtons, activePage, total, perPage} = this.props;
     return (
       <BasicPagination
         {...this.props}
+        onPageChange={this.onPageChange}
         maxButtons={this.formatNumber(maxButtons)}
         activePage={this.formatNumber(activePage)}
         total={this.formatNumber(total)}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b13a55</samp>

This pull request improves the pagination component and its documentation. It simplifies the event handling by using the `onEvent` prop, and adds a `change` event to the `PaginationRenderer` module. It also updates the `docs/zh-CN/components/pagination.md` file to explain the new event parameter and usage.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2b13a55</samp>

> _`Pagination` is the key to control the data flow_
> _But the events are complex and hard to know_
> _We simplify the logic with the `onEvent` prop_
> _And dispatch the `change` event to make the table rock_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2b13a55</samp>

*  Add a new section `事件表` to the pagination component documentation, which describes the events that the component can emit and handle ([link](https://github.com/baidu/amis/pull/8723/files?diff=unified&w=0#diff-1da73cb2fc22abc5be2ab0e300d0866a5f385bc80da6bfc925a3a27306cc408dR71-R72))
*  Modify the `属性表` section of the pagination component documentation, which describes the props that the component can accept. Change the event parameter of the `change` event from an object with a `value` property to two separate properties: `page` and `perPage`, which represent the current page number and the number of items per page respectively. Add two examples of how to use the `change` event to refresh the table data, either by updating the service data or by reloading the service with the new page parameter ([link](https://github.com/baidu/amis/pull/8723/files?diff=unified&w=0#diff-1da73cb2fc22abc5be2ab0e300d0866a5f385bc80da6bfc925a3a27306cc408dL76-R178))
*  Remove the `dispatchEvent` prop from the `BasicPaginationProps` interface and the `handlePageNumChange` method of the `Pagination` class, which implements the pagination component. This prop was used to dispatch custom events from the component, but it is no longer needed since the component now uses the `onEvent` prop to handle events ([link](https://github.com/baidu/amis/pull/8723/files?diff=unified&w=0#diff-9f4ffe40c3a6919ed9fe3a053551b4fed76b87dfff5fe8725e284178292b4cb3L97), [link](https://github.com/baidu/amis/pull/8723/files?diff=unified&w=0#diff-9f4ffe40c3a6919ed9fe3a053551b4fed76b87dfff5fe8725e284178292b4cb3L144-R143))
*  Remove the code that dispatches the `change` event from the `handlePageNumChange` method of the `Pagination` class. This code was used to trigger custom actions based on the event, but it is no longer needed since the component now uses the `onEvent` prop to handle events ([link](https://github.com/baidu/amis/pull/8723/files?diff=unified&w=0#diff-9f4ffe40c3a6919ed9fe3a053551b4fed76b87dfff5fe8725e284178292b4cb3L151-L157))
*  Add some imports to the `PaginationRenderer` module, which renders the pagination component in the amis framework. Import the `autobind`, `createObject`, and `resolveEventData` functions from the `amis-core` package, which are used to bind the `onPageChange` method, create a new data object with the page and perPage properties, and resolve the event data with the component data respectively ([link](https://github.com/baidu/amis/pull/8723/files?diff=unified&w=0#diff-d2238ac46ca3ef96930fecea8b5e8eaec08e95e85c776aded5af850328757079L5-R8))
*  Add a new method `onPageChange` to the `PaginationRenderer` class, which handles the page change event from the pagination component. Dispatch the `change` event with the new page and perPage values, and check if the event is prevented by any custom actions. If not, call the `onPageChange` prop, which is a callback function passed from the parent component to update the page state ([link](https://github.com/baidu/amis/pull/8723/files?diff=unified&w=0#diff-d2238ac46ca3ef96930fecea8b5e8eaec08e95e85c776aded5af850328757079R109-R127))
