### PR TITLE
feat:inputTable支持initDrag动作 Close #8712

### DIFF
--- a/docs/zh-CN/components/form/input-table.md
+++ b/docs/zh-CN/components/form/input-table.md
@@ -1574,6 +1574,7 @@ order: 54
 | setValue   | `value: object \| Array<object>` 替换的值<br /> `index?: number` 可选，替换第几行数据，如果没有指定，则替换全部表格数据            | 替换表格数据                                                         |
 | clear      | -                                                                                                                                  | 清空表格数据                                                         |
 | reset      | -                                                                                                                                  | 将表格数据重置为`resetValue`，若没有配置`resetValue`，则清空表格数据 |
+| initDrag   | -                                                                                                                                  | 开启表格拖拽排序功能                                                 |
 
 ### addItem
 
@@ -2146,6 +2147,86 @@ order: 54
           "b": "b-resetValue2"
         }
       ],
+      "columns": [
+        {
+          "name": "a",
+          "label": "A"
+        },
+        {
+          "name": "b",
+          "label": "B"
+        }
+      ],
+      "addable": true,
+      "footerAddBtn": {
+        "label": "新增",
+        "icon": "fa fa-plus",
+        "hidden": true
+      },
+      "strictMode": true,
+      "minLength": 0,
+      "needConfirm": false,
+      "showTableAddBtn": false
+    }
+  ],
+  "data": {
+    "table": [
+      {
+        "id": 1,
+        "a": "a1",
+        "b": "b1"
+      },
+      {
+        "id": 2,
+        "a": "a2",
+        "b": "b2"
+      },
+      {
+        "id": 3,
+        "a": "a3",
+        "b": "b3"
+      },
+      {
+        "id": 4,
+        "a": "a4",
+        "b": "b4"
+      },
+      {
+        "id": 5,
+        "a": "a5",
+        "b": "b5"
+      }
+    ]
+  }
+}
+```
+
+### initDrag
+
+```schema: scope="body"
+{
+  "type": "form",
+  "api": "/api/mock2/form/saveForm",
+  "body": [
+    {
+      "type": "button",
+      "label": "开始表格排序",
+      "onEvent": {
+        "click": {
+          "actions": [
+            {
+              "componentId": "drag-input-table",
+              "actionType": "initDrag"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "input-table",
+      "label": "表格表单",
+      "id": "drag-input-table",
+      "name": "table",
       "columns": [
         {
           "name": "a",

--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -299,6 +299,7 @@ export default class FormTable extends React.Component<TableProps, TableState> {
   subFormItems: any = {};
   rowPrinstine: Array<any> = [];
   editting: any = {};
+  table: any;
 
   constructor(props: TableProps) {
     super(props);
@@ -587,6 +588,10 @@ export default class FormTable extends React.Component<TableProps, TableState> {
       );
 
       return;
+    } else if (actionType === 'initDrag') {
+      const tableStore = this.table?.props?.store;
+      tableStore?.stopDragging();
+      tableStore?.toggleDragging();
     }
     return onAction && onAction(action, ctx, ...rest);
   }
@@ -1550,6 +1555,7 @@ export default class FormTable extends React.Component<TableProps, TableState> {
     while (ref && ref.getWrappedInstance) {
       ref = ref.getWrappedInstance();
     }
+    this.table = ref;
   }
 
   computedAddBtnDisabled() {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8c2036d</samp>

This pull request adds drag and drop support to the `InputTable` component, which allows users to sort the table rows by dragging them. It also updates the documentation of the component with the new `initDrag` action and an example.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8c2036d</samp>

> _Drag and drop the rows of doom_
> _Sort the data as you please_
> _`initDrag` is your power tool_
> _`InputTable` will make them freeze_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8c2036d</samp>

* Add a new action `initDrag` to the `input-table` component that enables the table drag and drop sorting feature ([link](https://github.com/baidu/amis/pull/8725/files?diff=unified&w=0#diff-99a693306fa319133a72b7b8e485f3768df28babc3ded5053f98bf702cd1619eR1577), [link](https://github.com/baidu/amis/pull/8725/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cR591-R594))
* Add a new property `table` to the `InputTable` class that holds a reference to the table component instance ([link](https://github.com/baidu/amis/pull/8725/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cR302), [link](https://github.com/baidu/amis/pull/8725/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cR1558))
* Add an example schema to the documentation of the `reset` action that shows how to use the `initDrag` action to start the table sorting feature with a button click ([link](https://github.com/baidu/amis/pull/8725/files?diff=unified&w=0#diff-99a693306fa319133a72b7b8e485f3768df28babc3ded5053f98bf702cd1619eR2203-R2282))
