### PR TITLE
feat: InputDateTime在closeOnSelect为false时开启确认模式; chore: datetime类选择器首次选择时时间设置为当前值

### DIFF
--- a/docs/zh-CN/components/form/input-datetime.md
+++ b/docs/zh-CN/components/form/input-datetime.md
@@ -379,6 +379,34 @@ order: 14
 }
 ```
 
+## 确认模式
+
+> `3.6.0`及以上版本
+
+设置`"closeOnSelect": false`，点选日期时间后，不会自动关闭浮层，需要点击底部工具栏的确认才会关闭。点击**取消按钮**或者**浮层外部区域**也会关闭浮层，并将值重置为初始状态。
+
+> 注意：该特性仅对`input-datetime`有效，其他日期时间组件无效。开启内嵌模式后，该特性无效。
+
+```schema: scope="body"
+{
+    "type": "form",
+    "api": "/api/mock2/form/saveForm",
+    "debug": true,
+    "body": [
+        {
+            "type": "input-datetime",
+            "name": "datetime",
+            "label": "日期时间",
+            "shortcuts": ["yesterday", "today", "tomorrow"],
+            "closeOnSelect": false,
+            "valueFormat": "YYYY-MM-DD HH:mm:ss",
+            "displayFormat": "YYYY-MM-DD HH:mm:ss",
+            "clearable": true
+        }
+    ]
+}
+```
+
 ## 属性表
 
 除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置

--- a/packages/amis-ui/src/components/DatePicker.tsx
+++ b/packages/amis-ui/src/components/DatePicker.tsx
@@ -13,18 +13,22 @@ import {
   isExpression,
   FormulaExec,
   filterDate,
-  string2regExp
+  string2regExp,
+  autobind
 } from 'amis-core';
 import PopUp from './PopUp';
 import {Overlay} from 'amis-core';
-import {ClassNamesFn, themeable, ThemeProps} from 'amis-core';
+import {themeable, ThemeProps} from 'amis-core';
 import Calendar from './calendar/Calendar';
 import {localeable, LocaleProps, TranslateFn} from 'amis-core';
 import {ucFirst} from 'amis-core';
 import CalendarMobile from './CalendarMobile';
 import Input from './Input';
-import type {PlainObject} from 'amis-core';
-import type {RendererEnv} from 'amis-core';
+import Button from './Button';
+
+import type {Moment} from 'moment';
+import type {PlainObject, RendererEnv} from 'amis-core';
+import type {ChangeEventViewMode, MutableUnitOfTime} from './calendar/Calendar';
 
 const availableShortcuts: {[propName: string]: any} = {
   now: {
@@ -344,6 +348,7 @@ export interface DatePickerState {
   inputValue: string | undefined; // 手动输入的值
   curTimeFormat: string; // 根据displayFormat / inputFormat 计算展示的时间粒度
   curDateFormat: string; // 根据displayFormat / inputFormat 计算展示的日期粒度
+  isModified: boolean;
 }
 
 export class DatePicker extends React.Component<DateProps, DatePickerState> {
@@ -420,7 +425,8 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
           displayFormat || inputFormat
         ) || '',
       curTimeFormat,
-      curDateFormat
+      curDateFormat,
+      isModified: false
     } as DatePickerState;
   }
 
@@ -490,6 +496,14 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
     }
   }
 
+  isConfirmMode() {
+    const {closeOnSelect, embed, mobileUI} = this.props;
+    const {curTimeFormat} = this.state;
+
+    /** 日期时间选择器才支持confirm */
+    return closeOnSelect === false && !!curTimeFormat && !embed && !mobileUI;
+  }
+
   focus() {
     if (!this.dom) {
       return;
@@ -545,9 +559,22 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
   }
 
   close() {
-    this.setState({
-      isOpened: false
-    });
+    const isConfirmMode = this.isConfirmMode();
+
+    if (isConfirmMode) {
+      const {value, valueFormat, format, displayFormat, inputFormat} =
+        this.props;
+
+      this.setState({
+        value: normalizeDate(value, valueFormat || format),
+        inputValue:
+          normalizeDate(value, valueFormat || format)?.format(
+            displayFormat || inputFormat
+          ) || ''
+      });
+    }
+
+    this.setState({isOpened: false, isModified: false});
   }
 
   clearValue(e: React.MouseEvent<any>) {
@@ -555,14 +582,14 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
     e.stopPropagation();
     const onChange = this.props.onChange;
     onChange('');
-    this.setState({inputValue: ''});
+    this.setState({inputValue: '', isModified: false});
   }
 
   // 清空
   clear() {
     const onChange = this.props.onChange;
     onChange('');
-    this.setState({inputValue: ''});
+    this.setState({inputValue: '', isModified: false});
   }
 
   // 重置
@@ -576,11 +603,16 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
     this.setState({
       inputValue: normalizeDate(resetValue, valueFormat || format)?.format(
         displayFormat || inputFormat || ''
-      )
+      ),
+      isModified: false
     });
   }
 
-  handleChange(value: moment.Moment) {
+  /**
+   * 如果为日期时间选择器，则单独处理时间选择事件，点击确认的时候才触发onChange
+   */
+  @autobind
+  handleConfirm() {
     const {
       onChange,
       format,
@@ -589,14 +621,12 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
       maxDate,
       inputFormat,
       displayFormat,
-      closeOnSelect,
-      utc,
-      viewMode
+      utc
     } = this.props;
+    let value = this.state.value;
+    const isConfirmMode = this.isConfirmMode();
 
-    const {curDateFormat, curTimeFormat} = this.state;
-
-    if (!moment.isMoment(value)) {
+    if (!isConfirmMode || !value) {
       return;
     }
 
@@ -611,15 +641,86 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
         ? moment.utc(value).format(valueFormat || format)
         : value.format(valueFormat || format)
     );
-    if (closeOnSelect && curDateFormat && !curTimeFormat) {
-      this.close();
-    }
 
     this.setState({
       inputValue: utc
         ? moment.utc(value).format(displayFormat || inputFormat)
-        : value.format(displayFormat || inputFormat)
+        : value.format(displayFormat || inputFormat),
+      isOpened: false,
+      isModified: true
     });
+  }
+
+  handleChange(value: Moment, viewMode?: ChangeEventViewMode) {
+    const {
+      onChange,
+      format,
+      valueFormat,
+      minDate,
+      maxDate,
+      inputFormat,
+      displayFormat,
+      closeOnSelect,
+      utc,
+      value: defaultValue
+    } = this.props;
+    const {curDateFormat, curTimeFormat, isModified} = this.state;
+    const isConfirmMode = this.isConfirmMode();
+
+    if (!moment.isMoment(value)) {
+      return;
+    }
+
+    if (minDate && value && value.isBefore(minDate, 'second')) {
+      value = minDate;
+    } else if (maxDate && value && value.isAfter(maxDate, 'second')) {
+      value = maxDate;
+    }
+
+    /** 首次选择且当前未绑定值，则默认使用当前时间 */
+    if (!defaultValue && !!curTimeFormat && !isModified) {
+      const now = moment();
+      const timePart: Record<MutableUnitOfTime, number> = {
+        date: value.get('date'),
+        hour: value.get('hour'),
+        minute: value.get('minute'),
+        second: value.get('second'),
+        millisecond: value.get('millisecond')
+      };
+
+      Object.keys(timePart).forEach((unit: MutableUnitOfTime) => {
+        /** 首次选择时间，日期使用当前时间; 将未设置过的时间字段设置为当前值 */
+        if (
+          (unit === 'date' && viewMode === 'time') ||
+          (unit !== 'date' && timePart[unit] === 0)
+        ) {
+          timePart[unit] = now.get(unit);
+        }
+      });
+
+      value.set(timePart);
+    }
+
+    const updatedValue = utc
+      ? moment.utc(value).format(valueFormat || format)
+      : value.format(valueFormat || format);
+    const updatedInputValue = utc
+      ? moment.utc(value).format(displayFormat || inputFormat)
+      : value.format(displayFormat || inputFormat);
+
+    if (isConfirmMode) {
+      this.setState({value, inputValue: updatedInputValue});
+      this.inputValueCache = updatedInputValue;
+    } else {
+      onChange(updatedValue);
+
+      if (closeOnSelect && curDateFormat && !curTimeFormat) {
+        this.close();
+      }
+
+      this.setState({inputValue: updatedInputValue});
+    }
+    this.setState({isModified: true});
   }
 
   // 手动输入日期
@@ -850,13 +951,24 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
       env,
       onClick,
       onMouseEnter,
-      onMouseLeave
+      onMouseLeave,
+      closeOnSelect
     } = this.props;
 
     const __ = this.props.translate;
-    const {curTimeFormat, curDateFormat} = this.state;
-    const isOpened = this.state.isOpened;
+    const {curTimeFormat, curDateFormat, isOpened} = this.state;
+    const isConfirmMode = this.isConfirmMode();
     let date: moment.Moment | undefined = this.state.value;
+    let isConfirmBtnDisbaled = false;
+
+    if (isConfirmMode) {
+      const lastModifiedValue = normalizeDate(value, valueFormat || format);
+
+      isConfirmBtnDisbaled =
+        date && lastModifiedValue
+          ? moment(date).isSame(lastModifiedValue, 'second')
+          : date === lastModifiedValue;
+    }
 
     const calendarMobile = (
       <CalendarMobile
@@ -1041,6 +1153,22 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
                 onMouseLeave={onMouseLeave}
                 // utc={utc}
               />
+              {isConfirmMode ? (
+                <div className={`${ns}DateRangePicker-actions`}>
+                  <Button size="sm" onClick={this.close}>
+                    {__('cancel')}
+                  </Button>
+                  <Button
+                    level="primary"
+                    size="sm"
+                    disabled={isConfirmBtnDisbaled}
+                    className={cx('m-l-sm')}
+                    onClick={this.handleConfirm}
+                  >
+                    {__('confirm')}
+                  </Button>
+                </div>
+              ) : null}
             </PopOver>
           </Overlay>
         ) : null}

--- a/packages/amis-ui/src/components/calendar/Calendar.tsx
+++ b/packages/amis-ui/src/components/calendar/Calendar.tsx
@@ -14,7 +14,9 @@ import {
 import {PickerOption} from '../PickerColumn';
 import 'moment/locale/zh-cn';
 import 'moment/locale/de';
+
 import type {RendererEnv} from 'amis-core';
+import type {unitOfTime} from 'moment';
 
 /** 视图模式 */
 export type ViewMode = 'days' | 'months' | 'years' | 'time' | 'quarters';
@@ -26,6 +28,16 @@ export type DateType =
   | 'hours'
   | 'minutes'
   | 'seconds';
+
+/** 底层View组件修改的值类型：time时间、days日期 */
+export type ChangeEventViewMode = Extract<ViewMode, 'time' | 'days'>;
+
+/** 可改变的时间单位 */
+export type MutableUnitOfTime = Extract<
+  unitOfTime.All,
+  'date' | 'hour' | 'minute' | 'second' | 'millisecond'
+>;
+
 export interface BoundaryObject {
   max: number;
   min: number;
@@ -69,7 +81,7 @@ interface BaseDatePickerProps {
   onMouseEnter?: (date: moment.Moment) => any;
   onMouseLeave?: (date: moment.Moment) => any;
   onClose?: () => void;
-  onChange?: (value: any, viewMode?: Extract<ViewMode, 'time'>) => void;
+  onChange?: (value: any, viewMode?: ChangeEventViewMode) => void;
   isEndDate?: boolean;
   minDate?: moment.Moment;
   maxDate?: moment.Moment;
@@ -595,7 +607,7 @@ class BaseDatePicker extends React.Component<
       }
     }
 
-    that.props.onChange(date);
+    that.props.onChange(date, 'days');
   };
 
   getDateBoundary = (currentDate: moment.Moment) => {

--- a/packages/amis-ui/src/components/calendar/DaysView.tsx
+++ b/packages/amis-ui/src/components/calendar/DaysView.tsx
@@ -21,6 +21,7 @@ import {PickerOption} from '../PickerColumn';
 import {DateType} from './Calendar';
 import {Icon} from '../icons';
 
+import type {Moment} from 'moment';
 import type {TimeScale} from './TimeView';
 import type {ViewMode} from './Calendar';
 
@@ -252,12 +253,33 @@ export class CustomDaysView extends React.Component<CustomDaysViewProps> {
 
   componentDidMount() {
     const {timeFormat, selectedDate, viewDate, isEndDate} = this.props;
+    const date = selectedDate || (isEndDate ? viewDate.endOf('day') : viewDate);
+    this.setupTime(date, timeFormat, 'init');
+  }
+
+  componentDidUpdate(
+    prevProps: Readonly<CustomDaysViewProps>,
+    prevState: Readonly<{}>,
+    snapshot?: any
+  ): void {
+    const currentDate = this.props.selectedDate;
+
+    if (
+      moment.isMoment(currentDate) &&
+      currentDate.isValid() &&
+      !currentDate.isSame(prevProps.selectedDate)
+    ) {
+      const {timeFormat} = this.props;
+      this.setupTime(currentDate, timeFormat);
+    }
+  }
+
+  setupTime(date: Moment, timeFormat: string, mode?: 'init') {
     const formatMap = {
       hours: 'HH',
       minutes: 'mm',
       seconds: 'ss'
     };
-    const date = selectedDate || (isEndDate ? viewDate.endOf('day') : viewDate);
     timeFormat.split(':').forEach((format, i) => {
       const type = /h/i.test(format)
         ? 'hours'
@@ -271,7 +293,7 @@ export class CustomDaysView extends React.Component<CustomDaysViewProps> {
           type,
           parseInt(date.format(formatMap[type]), 10),
           i,
-          'init'
+          mode
         );
       }
     });

--- a/packages/amis/__tests__/renderers/Form/datetime.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/datetime.test.tsx
@@ -81,3 +81,152 @@ test('Renderer:datetime displayFormat valueFormat', async () => {
     moment(1559826660, 'X').format('YYYY/MM/DD HH:mm:ss')
   );
 });
+
+/**
+ * CASE: 日期时间选择器确认模式
+ * 前提条件：
+ *   - 当前组件为input-datetime类型
+ *   - closeOnSelect为false
+ *   - 未开启内嵌模式
+ *   - 非移动端交互
+ * 预期：
+ *   1. 选择日期后，点击取消按钮，值重置
+ *   2. 选择日期后，点击确定按钮，值更新
+ */
+test('Renderer:InputDateTime confirm mode', async () => {
+  const {container} = render(
+    amisRender({
+      type: 'form',
+      body: [
+        {
+          "name": "datetime",
+          "label": "日期",
+          "type": "input-datetime",
+          "closeOnSelect": false
+        }
+      ],
+      title: 'The form',
+      actions: []
+    }, {}, makeEnv({}))
+  );
+
+  const trigger = container.querySelector('.cxd-DatePicker')!;
+  const inputEl = (container.querySelector(".cxd-DatePicker-input") as HTMLInputElement)!;
+  const getCancelBtn = () => (container.querySelector('.cxd-DateRangePicker-actions > button[type=button]')!);
+  const getConfirmBtn = () => (container.querySelector('.cxd-DateRangePicker-actions > .cxd-Button.cxd-Button--primary')!);
+  expect(trigger).toBeInTheDocument();
+
+  fireEvent.click(trigger);
+  wait(200);
+  /** 未选择新值，确认按钮禁用 */
+  expect(getConfirmBtn()).toHaveClass('is-disabled');
+
+  let todayEl = document.querySelector('.rdtDay.rdtToday')!;
+  let yesterdayEl = todayEl?.previousSibling!;
+  let tomorrowEl = todayEl?.nextSibling!;
+
+  if (yesterdayEl) {
+    fireEvent.click(yesterdayEl);
+  }
+  else {
+    fireEvent.click(tomorrowEl);
+  }
+  wait(200);
+
+  /** 选择日期之后禁用消失 */
+  expect(getConfirmBtn()).not.toHaveClass('is-disabled');
+
+  fireEvent.click(getCancelBtn());
+  wait(200);
+  /** 取消之后重置值 */
+  expect(inputEl?.value).toEqual('');
+
+  fireEvent.click(trigger);
+  wait(200);
+
+  todayEl = document.querySelector('.rdtDay.rdtToday')!;
+  yesterdayEl = todayEl?.previousSibling!;
+  tomorrowEl = todayEl?.nextSibling!;
+
+  if (yesterdayEl) {
+    fireEvent.click(yesterdayEl);
+  }
+  else {
+    fireEvent.click(tomorrowEl);
+  }
+  wait(200);
+
+  fireEvent.click(getConfirmBtn());
+  wait(200);
+  /** 确定之后有值 */
+  expect(inputEl?.value).not.toEqual('');
+}, 7000);
+
+/**
+ * CASE: 日期时间选择器首次选择日期或时间后，时间自动设置为当前时间
+ * 前提条件：
+ *   - 当前组件为input-datetime或者input-datetime-range类型
+ *   - 当前组件未绑定值
+ *   - 当前操作为首次编辑
+ * 预期：
+ *   1. 选择日期后，时间自动设置为当前时间
+ *   2. 选择时间后（H、m、s），所选择时间为点选值，其他时间字段自动设置为当前时间
+ *   3. 后续选择日期或者时间，不会改变点选值
+ *   4. 如果为范围选择器，先选择结束时间，则开始时间不能超过结束时间
+ */
+test('Renderer:InputDateTime Picker selects date or time for the first time', async () => {
+  const {container} = render(
+    amisRender({
+      type: 'form',
+      body: [
+        {
+          "name": "datetime",
+          "label": "日期",
+          "type": "input-datetime",
+          "valueFormat": "YYYY-MM-DD HH:mm:ss",
+          "displayFormat": "YYYY-MM-DD HH:mm:ss",
+          "closeOnSelect": false
+        }
+      ],
+      title: 'The form',
+      actions: []
+    }, {}, makeEnv({}))
+  );
+
+  const trigger = container.querySelector('.cxd-DatePicker')!;
+  const inputEl = (container.querySelector(".cxd-DatePicker-input") as HTMLInputElement)!;
+  const getConfirmBtn = () => (container.querySelector('.cxd-DateRangePicker-actions > .cxd-Button.cxd-Button--primary')!);
+  expect(trigger).toBeInTheDocument();
+
+  fireEvent.click(trigger);
+  wait(200);
+
+  let todayEl = document.querySelector('.rdtDay.rdtToday')!;
+  let yesterdayEl = todayEl?.previousSibling!;
+  let tomorrowEl = todayEl?.nextSibling!;
+
+  const currentTime = new Date();
+  const currentSeconds = currentTime.getSeconds();
+
+  /** 跳过0秒，用于后续测试值和00:00:00的Diff */
+  if (currentSeconds === 0) {
+    wait(1000);
+  }
+
+  if (yesterdayEl) {
+    fireEvent.click(yesterdayEl);
+  }
+  else {
+    fireEvent.click(tomorrowEl);
+  }
+  wait(200);
+  const timeStr = inputEl?.value?.split(/\s+/)?.[1];
+  /** 时间值设置为当前时间 */
+  expect(timeStr !== '00:00:00').toEqual(true);
+
+  fireEvent.click(todayEl);
+  wait(200);
+  const newTimeStr = inputEl?.value?.split(/\s+/)?.[1];
+  /** 切换日期后时间不会再变 */
+  expect(newTimeStr === timeStr).toEqual(true);
+}, 7000);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a5d552e</samp>

This pull request adds a confirmation mode to the `input-datetime` component, which lets the user select a date and time and then confirm or cancel the selection with buttons. It also updates the documentation and the test cases to reflect this new feature. The confirmation mode is controlled by the `closeOnSelect` option in the component schema. The changes affect the files `DatePicker.tsx`, `input-datetime.md`, and `datetime.test.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a5d552e</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A new mode for the `input-datetime` component, wise_
> _And cunning, who gave the users a choice to confirm_
> _Or cancel their selections, like Zeus who can affirm_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a5d552e</samp>

*  Add a new option `closeOnSelect` to the `input-datetime` component, which enables the confirmation mode ([link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-1df5e88733871e92d86ce0af46616a0c2d8e894285da4e8726c0db67081cfbbcR382-R410), [link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cR497-R504), [link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL548-R575), [link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL583-R612), [link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL592-R627), [link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL614-R696), [link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL853-R943), [link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cR1127-R1142))
*  Import the `autobind` decorator, the `Button` component and the `Moment` type to the `DatePicker` component ([link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL16-R21), [link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL26-R32))
*  Rename the `handleChange` method to `handleConfirm` and remove the unused `viewMode` prop in the `DatePicker` component ([link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL583-R612))
*  Add a condition to the `close` method to reset the state value and inputValue in the confirmation mode in the `DatePicker` component ([link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL548-R575))
*  Add a condition to the `handleChange` method to set the state value and inputValue but not call the onChange prop or close the popup in the confirmation mode in the `DatePicker` component ([link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL614-R696))
*  Add a variable `isConfirmMode` to store the result of calling the `isConfirmMode` method and a variable `isConfirmBtnDisabled` to store the boolean value for the confirm button in the `render` method of the `DatePicker` component ([link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL853-R943))
*  Remove the unused props `onClick`, `onMouseEnter` and `onMouseLeave` from the destructuring assignment in the `render` method of the `DatePicker` component ([link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cL853-R943))
*  Add a new JSX element to render the confirmation and cancel buttons in the confirmation mode in the `render` method of the `DatePicker` component ([link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-367a3428236d072316734b2dcd3d6d5d97e483cc5b43f9d13e1c94a02a47f39cR1127-R1142))
*  Add a new test case to test the functionality of the confirmation mode of the `input-datetime` component in the `datetime.test.tsx` file ([link](https://github.com/baidu/amis/pull/8726/files?diff=unified&w=0#diff-60a8e953613680cb4d1f5439b263df1f345ef0435633b235db19d275f2303db3R84-R153))
