### PR TITLE
feat: qr-code 增加下载事件 Closes #5915

### DIFF
--- a/docs/zh-CN/components/qrcode.md
+++ b/docs/zh-CN/components/qrcode.md
@@ -203,8 +203,41 @@ order: 61
     }
   ]
 }
-
 ```
+
+## 下载二维码
+
+> 3.6.0 及以上版本
+
+基于事件动作实现
+
+```schema: scope="body"
+[
+  {
+    "type": "action",
+    "label": "下载二维码",
+    "onEvent": {
+        "click": {
+          "actions": [
+            {
+              "actionType": "saveAs",
+              "componentId": "qr-code-download",
+              "name": "download.svg"
+            }
+          ]
+        }
+      }
+  },
+  {
+    "type": "qr-code",
+    "id": "qr-code-download",
+    "codeSize": 128,
+    "value": "https://www.baidu.com"
+ }
+]
+```
+
+需要注意这种方式不支持嵌入图片，如果要嵌入图片建议直接截图
 
 ## 属性表
 
@@ -225,3 +258,11 @@ order: 61
 | imageSettings.x        | `number`                             | 默认水平居中              | 图片水平方向偏移量                                                                                                                    |
 | imageSettings.y        | `number`                             | 默认垂直居中              | 图片垂直方向偏移量                                                                                                                    |
 | imageSettings.excavate | `boolean`                            | `false`                   | 图片是否挖孔嵌入                                                                                                                      |
+
+## 动作表
+
+当前组件对外暴露以下特性动作，其他组件可以通过指定`actionType: 动作名称`、`componentId: 该组件id`来触发这些动作，动作配置可以通过`args: {动作配置项名称: xxx}`来配置具体的参数，详细请查看[事件动作](../../docs/concepts/event-action#触发其他组件的动作)。
+
+| 动作名称 | 动作配置               | 说明     |
+| -------- | ---------------------- | -------- |
+| saveAs   | `name?: string` 文件名 | 下载文档 |

--- a/docs/zh-CN/components/qrcode.md
+++ b/docs/zh-CN/components/qrcode.md
@@ -222,7 +222,9 @@ order: 61
             {
               "actionType": "saveAs",
               "componentId": "qr-code-download",
-              "name": "download.svg"
+              "args": {
+                "name": "download.svg"
+              }
             }
           ]
         }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba1ad0d</samp>

This pull request improves the `QRCode` component and its documentation. It adds a new `saveAs` action to download the QR code as an SVG file, and updates the `./docs/zh-CN/components/qrcode.md` file to describe this feature. It also refactors the component code to use the `amis-core` types and components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ba1ad0d</samp>

> _Sing, O Muse, of the skillful coder who enhanced the QR code_
> _The `QRCode` component, swift and versatile, that scans and saves with ease_
> _He updated the documentation, removing the blank line that marred the page_
> _And added a new section, like a wise and generous sage_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ba1ad0d</samp>

*  Add documentation for QR code component actions in `docs/zh-CN/components/qrcode.md` ([link](https://github.com/baidu/amis/pull/8727/files?diff=unified&w=0#diff-2b65983f91fb6e69c8a734b9079ce3642c3352b15bf9521452c2ff17d827fec8L206-R241), [link](https://github.com/baidu/amis/pull/8727/files?diff=unified&w=0#diff-2b65983f91fb6e69c8a734b9079ce3642c3352b15bf9521452c2ff17d827fec8R261-R268))
*  Import types and component from `amis-core` to use in QR code component implementation in `packages/amis/src/renderers/QRCode.tsx` ([link](https://github.com/baidu/amis/pull/8727/files?diff=unified&w=0#diff-d5b288e35bae3f3ce1d36cf6db0207299e2ab1c1377580d275af5b3124225820R4-R5), [link](https://github.com/baidu/amis/pull/8727/files?diff=unified&w=0#diff-d5b288e35bae3f3ce1d36cf6db0207299e2ab1c1377580d275af5b3124225820L9-R12))
*  Add helper function to download blob as file in `packages/amis/src/renderers/QRCode.tsx` ([link](https://github.com/baidu/amis/pull/8727/files?diff=unified&w=0#diff-d5b288e35bae3f3ce1d36cf6db0207299e2ab1c1377580d275af5b3124225820R21-R33))
*  Add ref property and attribute to QR code component class and div element to access the QR code DOM element in `packages/amis/src/renderers/QRCode.tsx` ([link](https://github.com/baidu/amis/pull/8727/files?diff=unified&w=0#diff-d5b288e35bae3f3ce1d36cf6db0207299e2ab1c1377580d275af5b3124225820R106-R112), [link](https://github.com/baidu/amis/pull/8727/files?diff=unified&w=0#diff-d5b288e35bae3f3ce1d36cf6db0207299e2ab1c1377580d275af5b3124225820L143-R190))
*  Add `doAction` method to QR code component class to handle the `saveAs` action and download the QR code as SVG file in `packages/amis/src/renderers/QRCode.tsx` ([link](https://github.com/baidu/amis/pull/8727/files?diff=unified&w=0#diff-d5b288e35bae3f3ce1d36cf6db0207299e2ab1c1377580d275af5b3124225820R145-R164))
*  Add `contextType` property, constructor, and `componentWillUnmount` method to QR code component class to use the `ScopedContext` component and register and unregister the component with the scoped context in `packages/amis/src/renderers/QRCode.tsx` ([link](https://github.com/baidu/amis/pull/8727/files?diff=unified&w=0#diff-d5b288e35bae3f3ce1d36cf6db0207299e2ab1c1377580d275af5b3124225820L172-R233))
