### PR TITLE
feat:inputTable支持orderChange、rowClick、rowDbClick、rowMouseEnter、rowMouseLeave事件 Close #8291

### DIFF
--- a/docs/zh-CN/components/form/input-table.md
+++ b/docs/zh-CN/components/form/input-table.md
@@ -917,6 +917,11 @@ order: 54
 | deleteSuccess | `index: number` 所在行记录索引 <br /> `item: object` 所在行记录 <br/> `[name]: object[]`列表记录                                                          | 配置了`deleteApi`，调用接口成功时触发                                |
 | deleteFail    | `index: number` 所在行记录索引 <br /> `item: object` 所在行记录 <br/> `[name]: object[]`列表记录<br />`error: object` `deleteApi`请求失败后返回的错误信息 | 配置了`deleteApi`，调用接口失败时触发                                |
 | change        | `[name]: object[]` 列表记录                                                                                                                               | 组件数据发生改变时触发                                               |
+| orderChange   | `movedItems: item[]` 已排序数据                                                                                                                           | 手动拖拽行排序时触发                                                 |
+| rowClick      | `item: object` 行点击数据<br/>`index: number` 行索引                                                                                                      | 单击整行时触发                                                       |
+| rowDbClick    | `item: object` 行点击数据<br/>`index: number` 行索引                                                                                                      | 双击整行时触发                                                       |
+| rowMouseEnter | `item: object` 行移入数据<br/>`index: number` 行索引                                                                                                      | 移入整行时触发                                                       |
+| rowMouseLeave | `item: object` 行移出数据<br/>`index: number` 行索引                                                                                                      | 移出整行时触发                                                       |
 
 ### add
 
@@ -1553,6 +1558,287 @@ order: 54
                 "position": "top-right",
                 "title": "change事件",
                 "msg": "value: ${event.data.value | json}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+### orderChange
+
+在开启拖拽排序行记录后才会用到，排序确认后触发。
+
+```schema: scope="body"
+{
+  "type": "form",
+  "api": "/api/mock2/form/saveForm",
+  "data": {
+    "table": [
+      {
+        "id": 1,
+        "a": "a1",
+        "b": "b1"
+      },
+      {
+        "id": 2,
+        "a": "a2",
+        "b": "b2"
+      }
+    ]
+  },
+  "body": [
+    {
+      "showIndex": true,
+      "type": "input-table",
+      "name": "table",
+      "columns": [
+        {
+          "name": "a",
+          "label": "A"
+        },
+        {
+          "name": "b",
+          "label": "B"
+        }
+      ],
+      "addable": true,
+      "draggable": true,
+      "onEvent": {
+          "orderChange": {
+              "actions": [
+                  {
+                      "actionType": "toast",
+                      "args": {
+                          "msgType": "info",
+                          "msg": "${event.data.movedItems.length|json}行发生移动"
+                      }
+                  }
+              ]
+          }
+      }
+    }
+  ]
+}
+```
+
+### rowClick
+
+点击行记录。
+
+```schema: scope="body"
+{
+  "type": "form",
+  "api": "/api/mock2/form/saveForm",
+  "data": {
+    "table": [
+      {
+        "id": 1,
+        "a": "a1",
+        "b": "b1"
+      },
+      {
+        "id": 2,
+        "a": "a2",
+        "b": "b2"
+      }
+    ]
+  },
+  "body": [
+    {
+      "showIndex": true,
+      "type": "input-table",
+      "name": "table",
+      "columns": [
+        {
+          "name": "a",
+          "label": "A"
+        },
+        {
+          "name": "b",
+          "label": "B"
+        }
+      ],
+      "addable": true,
+      "onEvent": {
+        "rowClick": {
+          "actions": [
+            {
+              "actionType": "toast",
+              "args": {
+                "msgType": "info",
+                "msg": "行单击数据：${event.data.item|json}；行索引：${event.data.index}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+### rowDbClick
+
+双击行记录。
+
+```schema: scope="body"
+{
+  "type": "form",
+  "api": "/api/mock2/form/saveForm",
+  "data": {
+    "table": [
+      {
+        "id": 1,
+        "a": "a1",
+        "b": "b1"
+      },
+      {
+        "id": 2,
+        "a": "a2",
+        "b": "b2"
+      }
+    ]
+  },
+  "body": [
+    {
+      "showIndex": true,
+      "type": "input-table",
+      "name": "table",
+      "columns": [
+        {
+          "name": "a",
+          "label": "A"
+        },
+        {
+          "name": "b",
+          "label": "B"
+        }
+      ],
+      "addable": true,
+      "onEvent": {
+        "rowDbClick": {
+          "actions": [
+            {
+              "actionType": "toast",
+              "args": {
+                "msgType": "info",
+                "msg": "行单击数据：${event.data.item|json}；行索引：${event.data.index}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+### rowMouseEnter
+
+鼠标移入行记录。
+
+```schema: scope="body"
+{
+  "type": "form",
+  "api": "/api/mock2/form/saveForm",
+  "data": {
+    "table": [
+      {
+        "id": 1,
+        "a": "a1",
+        "b": "b1"
+      },
+      {
+        "id": 2,
+        "a": "a2",
+        "b": "b2"
+      }
+    ]
+  },
+  "body": [
+    {
+      "showIndex": true,
+      "type": "input-table",
+      "name": "table",
+      "columns": [
+        {
+          "name": "a",
+          "label": "A"
+        },
+        {
+          "name": "b",
+          "label": "B"
+        }
+      ],
+      "addable": true,
+      "onEvent": {
+        "rowMouseEnter": {
+          "actions": [
+            {
+              "actionType": "toast",
+              "args": {
+                "msgType": "info",
+                "msg": "行索引：${event.data.index}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+### rowMouseLeave
+
+鼠标移出行记录。
+
+```schema: scope="body"
+{
+  "type": "form",
+  "api": "/api/mock2/form/saveForm",
+  "data": {
+    "table": [
+      {
+        "id": 1,
+        "a": "a1",
+        "b": "b1"
+      },
+      {
+        "id": 2,
+        "a": "a2",
+        "b": "b2"
+      }
+    ]
+  },
+  "body": [
+    {
+      "showIndex": true,
+      "type": "input-table",
+      "name": "table",
+      "columns": [
+        {
+          "name": "a",
+          "label": "A"
+        },
+        {
+          "name": "b",
+          "label": "B"
+        }
+      ],
+      "addable": true,
+      "onEvent": {
+        "rowMouseLeave": {
+          "actions": [
+            {
+              "actionType": "toast",
+              "args": {
+                "msgType": "info",
+                "msg": "行索引：${event.data.index}"
               }
             }
           ]

--- a/docs/zh-CN/components/table.md
+++ b/docs/zh-CN/components/table.md
@@ -2324,6 +2324,70 @@ popOver 的其它配置请参考 [popover](./popover)
 }
 ```
 
+### rowDbClick
+
+双击整行时触发。
+
+```schema: scope="body"
+{
+    "type": "service",
+    "api": "/api/mock2/sample?perPage=10",
+    "body": [
+        {
+            "type": "table",
+            "source": "$rows",
+            "onEvent": {
+                "rowDbClick": {
+                    "actions": [
+                        {
+                            "actionType": "toast",
+                            "args": {
+                                "msgType": "info",
+                                "msg": "行单击数据：${event.data.item|json}；行索引：${event.data.index}"
+                            }
+                        }
+                    ]
+                }
+            },
+            "columns": [
+                {
+                    "name": "id",
+                    "label": "ID",
+                    "searchable": true
+                },
+                {
+                    "name": "engine",
+                    "label": "Rendering engine",
+                    "filterable": {
+                        "options": [
+                            "Internet Explorer 4.0",
+                            "Internet Explorer 5.0"
+                        ]
+                    }
+                },
+                {
+                    "name": "browser",
+                    "label": "Browser",
+                    "sortable": true
+                },
+                {
+                    "name": "platform",
+                    "label": "Platform(s)"
+                },
+                {
+                    "name": "version",
+                    "label": "Engine version"
+                },
+                {
+                    "name": "grade",
+                    "label": "CSS grade"
+                }
+            ]
+        }
+    ]
+}
+```
+
 ### rowMouseEnter
 
 鼠标移入行记录。

--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -1592,7 +1592,8 @@ export default class FormTable extends React.Component<TableProps, TableState> {
       static: isStatic,
       showFooterAddBtn,
       footerAddBtn,
-      toolbarClassName
+      toolbarClassName,
+      onEvent
     } = this.props;
     const maxLength = this.resolveVariableProps(this.props, 'maxLength');
 
@@ -1627,7 +1628,8 @@ export default class FormTable extends React.Component<TableProps, TableState> {
             prefixRow,
             affixRow,
             autoFillHeight,
-            tableContentClassName
+            tableContentClassName,
+            onEvent
           },
           {
             ref: this.tableRef.bind(this),


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f14d62b</samp>

This pull request adds the `onEvent` feature to the `input-table` component, which enables users to define custom actions for various events on the table. It also updates the Chinese documentation with examples of using the `onEvent` property. The changes affect the files `packages/amis/src/renderers/Form/InputTable.tsx` and `docs/zh-CN/components/form/input-table.md`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f14d62b</samp>

> _If you want to make your table interactive_
> _You can use the `onEvent` directive_
> _It lets you define actions_
> _For various reactions_
> _And make your UI more attractive_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f14d62b</samp>

* Implement the `onEvent` feature for the `input-table` component, which allows users to define actions to be triggered by different events on the table rows ([link](https://github.com/baidu/amis/pull/8728/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1595-R1596), [link](https://github.com/baidu/amis/pull/8728/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1630-R1632))
* Pass the `onEvent` prop to the `Table` component in `InputTable.tsx`, which handles the events and executes the actions according to the `onEvent` configuration ([link](https://github.com/baidu/amis/pull/8728/files?diff=unified&w=0#diff-5d3d1bb84e06b69c5e9bf32e49e38dd6ce16276286459d917522e0ab5f3b2e6cL1630-R1632))
* Add four examples of using the `onEvent` feature in the Chinese documentation of the `input-table` component in `input-table.md`, showing how to use the `event.data` object and the `actionType` and `args` properties to perform various actions such as displaying a toast message ([link](https://github.com/baidu/amis/pull/8728/files?diff=unified&w=0#diff-99a693306fa319133a72b7b8e485f3768df28babc3ded5053f98bf702cd1619eR1566-R1790))
