### PR TITLE
fix: 补充card组件按钮禁用态样式 Close: #8643

### DIFF
--- a/packages/amis-ui/scss/components/_card.scss
+++ b/packages/amis-ui/scss/components/_card.scss
@@ -162,6 +162,7 @@
 
       &.is-disabled {
         color: var(--text--muted-color);
+        cursor: not-allowed;
 
         &:hover {
           text-decoration: none;

--- a/packages/amis/src/renderers/Card.tsx
+++ b/packages/amis/src/renderers/Card.tsx
@@ -471,7 +471,10 @@ export class CardRenderer extends React.Component<CardProps> {
                   filterClassNameObject(
                     action.className || `${size ? `Card-action--${size}` : ''}`,
                     data
-                  )
+                  ),
+                  {
+                    'is-disabled': isDisabled(action, data)
+                  }
                 ),
                 componentClass: 'a',
                 onAction: this.handleAction


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bd06e96</samp>

This pull request adds a feature to disable card actions based on data conditions. It modifies the `Card.tsx` renderer to apply a `is-disabled` class name to the action element, and the `_card.scss` style sheet to change the cursor appearance for disabled actions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bd06e96</samp>

> _`Card-action` style_
> _Changes cursor when disabled_
> _Winter of data_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bd06e96</samp>

*  Add feature to disable card actions based on data conditions ([link](https://github.com/baidu/amis/pull/8729/files?diff=unified&w=0#diff-59494d55be682a8d8a886550c69737cbc2ed44c74989aa914fb452f51eaa2558R165), [link](https://github.com/baidu/amis/pull/8729/files?diff=unified&w=0#diff-4150c48e95a705cc618511fd041790dbdad4cd6a7b0673b1758fe73be7a33a2fL474-R477))
  - Set cursor to not-allowed for disabled actions in `_card.scss` ([link](https://github.com/baidu/amis/pull/8729/files?diff=unified&w=0#diff-59494d55be682a8d8a886550c69737cbc2ed44c74989aa914fb452f51eaa2558R165))
  - Add `is-disabled` class name to action element in `Card.tsx` based on `isDisabled` helper function ([link](https://github.com/baidu/amis/pull/8729/files?diff=unified&w=0#diff-4150c48e95a705cc618511fd041790dbdad4cd6a7b0673b1758fe73be7a33a2fL474-R477))
