### PR TITLE
fix(amis-editor): calendar组件默认schema多了外层page

### DIFF
--- a/packages/amis-editor/src/plugin/Calendar.tsx
+++ b/packages/amis-editor/src/plugin/Calendar.tsx
@@ -24,11 +24,7 @@ export class CalendarPlugin extends BasePlugin {
   tags = ['展示'];
 
   scaffold = {
-    type: 'page',
-    body: {
-      type: 'calendar',
-      value: ''
-    }
+    type: 'calendar'
   };
   previewSchema = {
     ...this.scaffold


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19924e9</samp>

Simplified the scaffold schema of the `CalendarPlugin` in `packages/amis-editor/src/plugin/Calendar.tsx` to match other plugins.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 19924e9</samp>

> _Scaffold is trimmed_
> _`CalendarPlugin` now sleek_
> _Autumn leaves schema_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 19924e9</samp>

*  Simplify the `scaffold` property of the `CalendarPlugin` class by removing the unnecessary `page` and `body` wrappers around the `calendar` component ([link](https://github.com/baidu/amis/pull/8730/files?diff=unified&w=0#diff-aa42249f05b7b76df59f07697b763b6f6657b8ff0de5393b5a160dddd4edd284L27-R28))
