### PR TITLE
chore: 图片展示默认图片关闭放大功能

### DIFF
--- a/packages/amis/src/renderers/Image.tsx
+++ b/packages/amis/src/renderers/Image.tsx
@@ -594,6 +594,7 @@ export class ImageField extends React.Component<
       defaultImage && !value
         ? filter(defaultImage, data, '| raw')
         : imagePlaceholder;
+
     return (
       <div
         className={cx(
@@ -623,7 +624,7 @@ export class ImageField extends React.Component<
             thumbMode={thumbMode}
             thumbRatio={thumbRatio}
             originalSrc={filter(originalSrc, data, '| raw') ?? value}
-            enlargeAble={enlargeAble && value !== defaultValue}
+            enlargeAble={enlargeAble && value && value !== defaultValue}
             onEnlarge={this.handleEnlarge}
             imageMode={imageMode}
             imageControlClassName={setThemeClassName(


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aa95c1b</samp>

This pull request enhances the `Image` renderer by improving its code style and preventing unnecessary enlargement. It modifies the file `packages/amis/src/renderers/Image.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at aa95c1b</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The `Image` renderer, a marvel of design,_
> _Who added a line of space, like a breath of air,_
> _And stopped the image from growing, like a bear_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aa95c1b</samp>

* Fix a bug that prevented image enlargement from working correctly when the value was empty or undefined ([link](https://github.com/baidu/amis/pull/8733/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9L626-R627))
* Add an empty line to separate the imports from the rest of the code in `Image.tsx` ([link](https://github.com/baidu/amis/pull/8733/files?diff=unified&w=0#diff-7ab35ec2a2ed3ed03e80ec3b97a20e4563f98f0ffbc7939138cbf4c2043ac2c9R597))
