### PR TITLE
fix: CRUD 导出 excel 支持 children 节点 Closes #3563

### DIFF
--- a/examples/components/CRUD/ExportCSVExcel.jsx
+++ b/examples/components/CRUD/ExportCSVExcel.jsx
@@ -9,6 +9,46 @@ export default {
       },
       items: [
         {
+          link: 'https://www.microsoft1.com/',
+          icon: __uri('../../static/ie.png'),
+          browser: 'Internet Explorer 4.2 2',
+          platform: 'Win 95+',
+          notExport: '1',
+          grade: 'A',
+          engine: {
+            name: 'Trident1',
+            version: '4/2'
+          },
+          date: '1591326307',
+          num: '12312334234234523',
+          children: [
+            {
+              link: 'https://www.microsoft2.com/',
+              engine: {
+                name: 'Trident2',
+                version: '4/2'
+              },
+              browser: 'Internet Explorer 4.0',
+              platform: 'Win 95+',
+              version: '4',
+              grade: 'X',
+              id: 1001
+            },
+            {
+              link: 'https://www.microsoft3.com/',
+              engine: {
+                name: 'Trident3',
+                version: '3/2'
+              },
+              browser: 'Internet Explorer 5.0',
+              platform: 'Win 95+',
+              version: '5',
+              grade: 'C',
+              id: 1002
+            }
+          ]
+        },
+        {
           link: 'https://www.microsoft.com/',
           icon: __uri('../../static/ie.png'),
           browser: 'Internet Explorer 4.2',

--- a/packages/amis/src/renderers/Table/exportExcel.ts
+++ b/packages/amis/src/renderers/Table/exportExcel.ts
@@ -10,6 +10,7 @@ import {
   getVariable,
   removeHTMLTag,
   decodeEntity,
+  flattenTree,
   createObject
 } from 'amis-core';
 import {isPureVariable, resolveVariableAndFilter} from 'amis-core';
@@ -325,6 +326,8 @@ export async function exportExcel(
   }
   // 前置总结行
   rowIndex = renderSummary(worksheet, data, prefixRow, rowIndex);
+  // children 展开
+  rows = flattenTree(rows, item => item);
   for (const row of rows) {
     const rowData = createObject(data, row.data);
     rowIndex += 1;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9e82c00</samp>

This pull request enhances the `Table` renderer to support exporting nested data to Excel. It also updates the `ExportCSVExcel` component example to show how the export options work with nested data.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9e82c00</samp>

> _Oh we are the coders of the `ExportCSVExcel`_
> _We can handle nested data with a bit of skill_
> _We flatten the tree with a handy function_
> _And we skip the rows with the `notExport` option_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9e82c00</samp>

* Flatten nested data for Excel export using `flattenTree` function ([link](https://github.com/baidu/amis/pull/8734/files?diff=unified&w=0#diff-8814befa6c6247c465ab39fa28f3db15c2280e238d8254286fa1f29d29500c51R13),[link](https://github.com/baidu/amis/pull/8734/files?diff=unified&w=0#diff-8814befa6c6247c465ab39fa28f3db15c2280e238d8254286fa1f29d29500c51R329-R330))
* Add a new row of data with `notExport` and `children` properties to demonstrate export options ([link](https://github.com/baidu/amis/pull/8734/files?diff=unified&w=0#diff-77b473f79a97cfa505ba4f7f306487c5a1d3fda83053e968d30ac472a7f9e936R12-R51))
