### PR TITLE
perf👌: isObjectShallowModified去除react元素和实例的对比

### DIFF
--- a/packages/amis-core/src/utils/helper.ts
+++ b/packages/amis-core/src/utils/helper.ts
@@ -248,6 +248,20 @@ export function rmUndefined(obj: PlainObject) {
   return newObj;
 }
 
+function isReactElementOrRef(prev: any) {
+  if (React.isValidElement(prev)) {
+    return true;
+  }
+  if (
+    prev?.type?.prototype &&
+    (prev.type.prototype instanceof React.Component ||
+      prev.type.prototype instanceof React.PureComponent)
+  ) {
+    return true;
+  }
+  return false;
+}
+
 export function isObjectShallowModified(
   prev: any,
   next: any,
@@ -255,6 +269,10 @@ export function isObjectShallowModified(
   ignoreUndefined: boolean = false,
   statck: Array<any> = []
 ): boolean {
+  if (isReactElementOrRef(prev) || isReactElementOrRef(next)) {
+    return prev !== next;
+  }
+
   if (Array.isArray(prev) && Array.isArray(next)) {
     return prev.length !== next.length
       ? true


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at baf59bd</samp>

This pull request optimizes the shallow comparison of React props in amis by using a new helper function `isReactElementOrRef` to skip unnecessary re-rendering of components. The file `packages/amis-core/src/utils/helper.ts` is modified to implement this change.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at baf59bd</samp>

> _Sing, O Muse, of the swift and skillful coder_
> _Who sought to enhance the amis of React_
> _And with a clever helper and a modifier_
> _He made the components render less and act._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at baf59bd</samp>

*  Add a new helper function `isReactElementOrRef` to check if a value is a React element or a reference ([link](https://github.com/baidu/amis/pull/8737/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aR251-R264))
*  Update `isObjectShallowModified` to return true if either value is a React element or a reference and they are not strictly equal, to avoid unnecessary re-rendering of React components ([link](https://github.com/baidu/amis/pull/8737/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aR272-R275))
