### PR TITLE
fix: crud2中列宽调整不生效和开启列宽会始终出现横向滚动条的问题

### DIFF
--- a/packages/amis-ui/scss/components/_table2.scss
+++ b/packages/amis-ui/scss/components/_table2.scss
@@ -677,6 +677,11 @@
           }
         }
       }
+      > thead > tr > .#{$ns}Table-cell-last {
+        .#{$ns}Table-thead-resizable {
+          right: 0;
+        }
+      }
     }
   }
 

--- a/packages/amis-ui/src/components/table/index.tsx
+++ b/packages/amis-ui/src/components/table/index.tsx
@@ -833,7 +833,9 @@ export class Table extends React.PureComponent<TableProps, TableState> {
 
     const column = this.tdColumns[index];
     this.resizeIndex = index;
-    this.resizeWidth = this.state.colWidths[column.name].width;
+    this.resizeWidth =
+      this.state.colWidths[column.name].width ??
+      this.state.colWidths[column.name].realWidth;
     this.resizeTarget!.classList.add('is-resizing');
 
     document.addEventListener('mousemove', this.onResizeMouseMove);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4fc97e9</samp>

This pull request fixes a bug and improves the user experience of the Table component in `amis-ui`. It adjusts the position of the resize handle for the last column header and adds a fallback value for the column width when resizing.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4fc97e9</samp>

> _`resizeWidth` set_
> _table columns adjust smoothly_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4fc97e9</samp>

* Fix a bug where the resizable handle for the last column header in a table would be hidden by the scrollbar when the table is scrollable horizontally ([link](https://github.com/baidu/amis/pull/8738/files?diff=unified&w=0#diff-454e6ead402be0ea4c02bde78c3cb25833f8c6ee15c4f067be5f388c1a5ab80bR680-R684))
* Add a fallback value for the resizeWidth variable in the Table component to handle the case where the column width is not explicitly set by the user, but calculated by the table based on the content ([link](https://github.com/baidu/amis/pull/8738/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L836-R838))
