### PR TITLE
fix: 修复document.requestFullscreen()时弹窗和抽屉不可见的问题

### DIFF
--- a/packages/amis-ui/src/components/Drawer.tsx
+++ b/packages/amis-ui/src/components/Drawer.tsx
@@ -17,6 +17,7 @@ import cx from 'classnames';
 import {current, addModal, removeModal} from './ModalManager';
 import {ClassNamesFn, themeable} from 'amis-core';
 import {noop, autobind, getScrollbarWidth} from 'amis-core';
+import {getContainerWithFullscreen} from './Modal';
 
 type DrawerPosition = 'top' | 'right' | 'bottom' | 'left';
 
@@ -318,7 +319,7 @@ export class Drawer extends React.Component<DrawerProps, DrawerState> {
     const bodyStyle = this.getDrawerStyle();
 
     return (
-      <Portal container={container}>
+      <Portal container={getContainerWithFullscreen(container)}>
         <Transition
           mountOnEnter
           unmountOnExit

--- a/packages/amis-ui/src/components/Modal.tsx
+++ b/packages/amis-ui/src/components/Modal.tsx
@@ -18,6 +18,23 @@ import {Icon} from './icons';
 import {LocaleProps, localeable} from 'amis-core';
 import {autobind, getScrollbarWidth} from 'amis-core';
 
+export const getContainerWithFullscreen =
+  (container?: () => HTMLElement | HTMLElement | null) => () => {
+    const envContainer =
+      typeof container === 'function' ? container() : container;
+
+    // 获取当前全屏元素
+    const fullscreenElement = document.fullscreenElement;
+
+    if (
+      fullscreenElement &&
+      (!envContainer || !fullscreenElement.contains(envContainer))
+    ) {
+      return fullscreenElement as HTMLElement;
+    }
+    return envContainer || null;
+  };
+
 export interface ModalProps extends ThemeProps, LocaleProps {
   className?: string;
   contentClassName?: string;
@@ -300,7 +317,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
         onEntered={this.handleEntered}
       >
         {(status: string) => (
-          <Portal container={container}>
+          <Portal container={getContainerWithFullscreen(container)}>
             <div
               ref={this.modalRef}
               role="dialog"


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 73a032f</samp>

This pull request enhances the fullscreen mode support for the `Drawer` and `Modal` components in `amis-ui`. It refactors the logic of finding the correct container element for rendering the components into a shared utility function.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 73a032f</samp>

> _To make fullscreen mode more compatible_
> _We use a function that's adaptable_
> _It checks the container prop_
> _And adjusts it on the spot_
> _It's called `getContainerWithFullscreen` and it's quite practical_

### Why

<!-- author to complete -->

当使用 document.requestFullscreen() 使元素全屏后，可能会遇到一个问题：
在全屏模式下，<dialog> 元素无法正确显示。
这是因为当元素进入全屏模式时，它会创建一个新的堆叠上下文，这可能会导致其他不在全屏元素内的元素（如 dialog）无法正确显示

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 73a032f</samp>

*  Import and apply `getContainerWithFullscreen` function to render modal and drawer components inside fullscreen element if present ([link](https://github.com/baidu/amis/pull/8739/files?diff=unified&w=0#diff-af434e78c73360a5d5fe4788da3162224190222f4cdb9c9bf02550e01d000163R20), [link](https://github.com/baidu/amis/pull/8739/files?diff=unified&w=0#diff-af434e78c73360a5d5fe4788da3162224190222f4cdb9c9bf02550e01d000163L321-R322), [link](https://github.com/baidu/amis/pull/8739/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0R21-R41), [link](https://github.com/baidu/amis/pull/8739/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L303-R324))
*  Define `getContainerWithFullscreen` function in `Modal.tsx` to return the container element for rendering modal or drawer, based on the container prop and the fullscreen element ([link](https://github.com/baidu/amis/pull/8739/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0R21-R41))
