### PR TITLE
fix(amis-editor): 修复选择弹窗类型错误,弹窗path不正确导致页面初始化失败的问题

### DIFF
--- a/packages/amis-editor-core/src/component/factory.tsx
+++ b/packages/amis-editor-core/src/component/factory.tsx
@@ -227,8 +227,6 @@ export function makeWrapper(
   return Wrapper as any;
 }
 
-// 将之前选择的弹窗和本次现有弹窗schema替换为$ref引用
-
 /**
  * 将之前选择的弹窗和本次现有弹窗schema替换为$ref引用
  * @param schema
@@ -240,7 +238,7 @@ function replaceDialogtoRef(
   dialogId: string,
   dialogRefsName: string
 ) {
-  let replacedSchema = null;
+  let replacedSchema = schema;
   const dialog = JSONGetById(schema, dialogId);
   if (dialog) {
     replacedSchema = JSONUpdate(schema, dialogId, {$ref: dialogRefsName}, true);
@@ -512,7 +510,7 @@ function SchemaFrom({
         // 添加弹窗事件后自动选中弹窗
         if (store.activeDialogPath) {
           let activeId = store.getSchemaByPath(
-            store.activeDialogPath.split('/')
+            store.activeDialogPath.split('/').filter(item => item !== '')
           )?.$$id;
           activeId && store.setPreviewDialogId(activeId);
           store.setActiveDialogPath('');

--- a/packages/amis-editor/src/renderer/event-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/event-control/helper.tsx
@@ -3300,7 +3300,7 @@ export const getEventControlConfig = (
           // 选择现有弹窗后为了使之前的弹窗和现有弹窗$$id唯一，这里重新生成一下
           let newDialogId = guid();
           action.actionType = dialogType;
-          action.dialog = {
+          action[dialogType] = {
             $$id: newDialogId,
             type: dialogType
           };


### PR DESCRIPTION
修复：
1.选择弹窗后弹窗类型不正确
2.选择已有的现有弹窗$$id不存在导致的报错
3.弹窗动作path不正确导致页面初始化等事件打开弹窗预览出错

