### PR TITLE
fix: 「页面设计器」Page组件支持组件静态数据配置

### DIFF
--- a/packages/amis-editor/src/plugin/Page.tsx
+++ b/packages/amis-editor/src/plugin/Page.tsx
@@ -228,13 +228,7 @@ export class PagePlugin extends BasePlugin {
               {
                 title: '数据',
                 body: [
-                  // page组件下掉组件静态数据配置项，可通过页面变量来定义页面中的变量
-                  // getSchemaTpl('combo-container', {
-                  //   type: 'input-kv',
-                  //   mode: 'normal',
-                  //   name: 'data',
-                  //   label: '组件静态数据'
-                  // }),
+                  getSchemaTpl('pageData'),
                   getSchemaTpl('apiControl', {
                     name: 'initApi',
                     mode: 'row',

--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -779,6 +779,19 @@ setSchemaTpl('combo-container', (config: SchemaObject) => {
 });
 
 /**
+ * Page组件静态数据
+ */
+setSchemaTpl(
+  'pageData',
+  getSchemaTpl('combo-container', {
+    type: 'input-kv',
+    mode: 'normal',
+    name: 'data',
+    label: '组件静态数据'
+  })
+);
+
+/**
  * 所有组件的状态
  */
 setSchemaTpl(


### PR DESCRIPTION
### What

【问题】页面设计器本地启动时添加静态数据不太方便还需要写schema
【修改】放开page组件的静态数据配置，在saas重写了pageData的tpl，做了隐藏配置项的处理

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 14e66a7</samp>

* Extract the common logic for the page component's static data into a new schema template `pageData` in `common.tsx` ([link](https://github.com/baidu/amis/pull/8750/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05R782-R794))
* Replace the commented out code for the `combo-container` schema template in `Page.tsx` with a call to `getSchemaTpl('pageData')` to use the new template ([link](https://github.com/baidu/amis/pull/8750/files?diff=unified&w=0#diff-4e3988acdee43b9a8f0c6fa2a99f1a94dc43fae57be0bffca0890574a1af5552L231-R231))
