### PR TITLE
feat: 新增forceSilenceInsideError环境变量支持屏蔽组件中展示msg信息

### DIFF
--- a/packages/amis-core/src/env.tsx
+++ b/packages/amis-core/src/env.tsx
@@ -28,6 +28,8 @@ export interface WsObject {
 }
 
 export interface RendererEnv {
+  /* 强制隐藏组件内部的报错信息，会覆盖组件内部属性 */
+  forceSilenceInsideError?: boolean;
   session?: string;
   fetcher: (api: Api, data?: any, options?: object) => Promise<Payload>;
   isCancel: (val: any) => boolean;

--- a/packages/amis-editor-core/src/env.ts
+++ b/packages/amis-editor-core/src/env.ts
@@ -51,5 +51,7 @@ export const env: RenderOptions = {
     toast[type]
       ? toast[type](msg, type === 'error' ? '系统错误' : '系统消息')
       : console.warn('[Notify]', type, msg);
-  }
+  },
+  /* 强制隐藏组件内部的报错信息，会覆盖组件内部属性 */
+  forceSilenceInsideError: false
 };

--- a/packages/amis/src/renderers/Dialog.tsx
+++ b/packages/amis/src/renderers/Dialog.tsx
@@ -502,6 +502,7 @@ export default class Dialog extends React.Component<DialogProps> {
     const {
       store,
       render,
+      env,
       classnames: cx,
       showErrorMsg,
       showLoading,
@@ -517,7 +518,9 @@ export default class Dialog extends React.Component<DialogProps> {
             {showLoading !== false ? (
               <Spinner size="sm" key="info" show={store.loading} />
             ) : null}
-            {store.error && showErrorMsg !== false ? (
+            {!env.forceSilenceInsideError &&
+            store.error &&
+            showErrorMsg !== false ? (
               <span className={cx('Dialog-error')}>{store.msg}</span>
             ) : null}
           </div>

--- a/packages/amis/src/renderers/Drawer.tsx
+++ b/packages/amis/src/renderers/Drawer.tsx
@@ -497,6 +497,7 @@ export default class Drawer extends React.Component<DrawerProps> {
     const {
       store,
       render,
+      env,
       classnames: cx,
       showErrorMsg,
       footerClassName,
@@ -515,7 +516,7 @@ export default class Drawer extends React.Component<DrawerProps> {
         {store.loading || store.error ? (
           <div className={cx('Drawer-info')}>
             <Spinner size="sm" key="info" show={store.loading} />
-            {showErrorMsg && store.error ? (
+            {!env.forceSilenceInsideError && showErrorMsg && store.error ? (
               <span className={cx('Drawer-error')}>{store.msg}</span>
             ) : null}
           </div>

--- a/packages/amis/src/renderers/Page.tsx
+++ b/packages/amis/src/renderers/Page.tsx
@@ -924,7 +924,9 @@ export default class Page extends React.Component<PageProps> {
               loadingConfig={loadingConfig}
             />
 
-            {store.error && showErrorMsg !== false ? (
+            {!env.forceSilenceInsideError &&
+            store.error &&
+            showErrorMsg !== false ? (
               <Alert
                 level="danger"
                 showCloseButton

--- a/packages/amis/src/renderers/Service.tsx
+++ b/packages/amis/src/renderers/Service.tsx
@@ -793,6 +793,7 @@ export default class Service extends React.Component<ServiceProps> {
       style,
       store,
       render,
+      env,
       classPrefix: ns,
       classnames: cx,
       loadingConfig,
@@ -801,7 +802,9 @@ export default class Service extends React.Component<ServiceProps> {
 
     return (
       <div className={cx(`${ns}Service`, className)} style={style}>
-        {store.error && showErrorMsg !== false ? (
+        {!env.forceSilenceInsideError &&
+        store.error &&
+        showErrorMsg !== false ? (
           <Alert
             level="danger"
             showCloseButton


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5ea6c1b</samp>

This pull request adds a new feature to the AMIS framework that allows hiding the error messages inside the components based on the `env.forceSilenceInsideError` flag. This feature affects the `Dialog`, `Drawer`, `Service` and `Page` components, as well as the `env` object and its interface.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5ea6c1b</samp>

> _We're sailing on the AMIS ship, with `env` as our guide_
> _We'll hide the errors if we wish, or show them with some pride_
> _Heave ho, my hearties, heave ho, on the count of three_
> _We'll update all the components, with `forceSilenceInsideError`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5ea6c1b</samp>

*  Add a new property `forceSilenceInsideError` to the `WsObject` interface and the `env` object to control whether to hide the error messages inside the components ([link](https://github.com/baidu/amis/pull/8751/files?diff=unified&w=0#diff-62f2e14b837dfa7b7f5f94ee2a856825f211639ddf0f85d783c666dbcd7f8d0dR31-R32), [link](https://github.com/baidu/amis/pull/8751/files?diff=unified&w=0#diff-d925f9b5a4ca7881b911fc829bdb900bc2321ac9ac0c91e10882c36113f02920L54-R56))
*  Pass the `env` object as a prop to the `Dialog`, `Drawer` and `Service` components, which are used to render different types of UI elements with data fetching or actions ([link](https://github.com/baidu/amis/pull/8751/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bR505), [link](https://github.com/baidu/amis/pull/8751/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8R500), [link](https://github.com/baidu/amis/pull/8751/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852R796))
*  Add a condition to check the `env.forceSilenceInsideError` value before rendering the error message in the `Dialog`, `Drawer`, `Page` and `Service` components, which are used to display the error message when the data fetching or actions fail ([link](https://github.com/baidu/amis/pull/8751/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL520-R523), [link](https://github.com/baidu/amis/pull/8751/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L518-R519), [link](https://github.com/baidu/amis/pull/8751/files?diff=unified&w=0#diff-0cabfa9fa58a1f6676a43fc3115a2250e283dc4956cf2d47f7e06facad0082a0L927-R929), [link](https://github.com/baidu/amis/pull/8751/files?diff=unified&w=0#diff-f4c13b6e5694f810f702716ed47ef2ad429b09d783bb288b0a7092b500556852L804-R807))
