### PR TITLE
fix: table2编辑器列选中样式问题修复

### DIFF
--- a/packages/amis-editor/src/plugin/TableCell2.tsx
+++ b/packages/amis-editor/src/plugin/TableCell2.tsx
@@ -61,12 +61,12 @@ export class TableCell2Plugin extends BasePlugin {
         wrapperResolve: (dom: HTMLDivElement) => {
           // 固定这种结构 amis里改了 这里也得改
           const parent = dom.parentElement?.parentElement;
-          const groupId = parent?.getAttribute('data-group-id');
+          const col = parent?.getAttribute('data-col');
           const wrapper = dom.closest('table')!.parentElement?.parentElement;
           return [].slice.call(
             wrapper?.querySelectorAll(
-              `th[data-group-id="${groupId}"],
-              td[data-group-id="${groupId}"]`
+              `th[data-col="${col}"],
+              td[data-col="${col}"]`
             )
           );
         }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 09feac6</samp>

Updated the table cell plugin to work with the new table header and group rendering in amis. Replaced `data-group-id` with `data-col` for column selection in `TableCell2.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 09feac6</samp>

> _`data-col` used_
> _table headers changed by amis_
> _plugin adapts - fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 09feac6</samp>

* Use `data-col` attribute to select table cells in the same column ([link](https://github.com/baidu/amis/pull/8754/files?diff=unified&w=0#diff-c7da298719acb9527ea1c1920686a38dbb5ccbebfe4a6a745d59df3271c28ed7L64-R69))
