### PR TITLE
fix:动作没指定目标组件标识时则执行当前组件 Close #8749

### DIFF
--- a/packages/amis-core/src/actions/CmptAction.ts
+++ b/packages/amis-core/src/actions/CmptAction.ts
@@ -50,17 +50,14 @@ export class CmptAction implements RendererAction {
       }
     }
 
-    if (!key) {
-      console.warn('请提供目标组件的componentId或componentName');
-      return;
-    }
-
+    // 如果key没指定，则默认是当前组件
     let component = key
       ? event.context.scoped?.[
           action.componentId ? 'getComponentById' : 'getComponentByName'
         ](key)
-      : null;
+      : renderer;
 
+    // 如果key指定来，但是没找到组件，则报错
     if (key && !component) {
       const msg =
         '尝试执行一个不存在的目标组件动作，请检查目标组件非隐藏状态，且正确指定了componentId或componentName';


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 96d7b32</samp>

Fix CmptAction bug when key is missing. Add comment and assign renderer to component in `packages/amis-core/src/actions/CmptAction.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 96d7b32</samp>

> _`key` is optional_
> _use current component then_
> _autumn bug is fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 96d7b32</samp>

* Fix a bug where CmptAction does not work properly when the key is omitted ([link](https://github.com/baidu/amis/pull/8757/files?diff=unified&w=0#diff-9fcca25fc37554994f4168d09ade3ba52487964b8f897e0a9de38442dc6b1ceaL53-R60))
