### PR TITLE
fix: 修复 quickEdit inline 模式 name 为带层级时发送的数据不符合预期 Close: #8756

### DIFF
--- a/packages/amis-core/src/utils/object.ts
+++ b/packages/amis-core/src/utils/object.ts
@@ -127,8 +127,13 @@ export function setVariable(
 
   const parts = convertKeyToPath !== false ? keyToPath(key) : [key];
   const last = parts.pop() as string;
+  const stack: Array<{
+    host: Record<string, any>;
+    key: string;
+  }> = [];
 
   while (parts.length) {
+    let host = data;
     let key = parts.shift() as string;
     if (isPlainObject(data[key])) {
       data = data[key] = {
@@ -143,9 +148,25 @@ export function setVariable(
       data[key] = {};
       data = data[key];
     } else {
+      // 如果是数字，那么就是数组
+      if (/^\d+$/.test(key) && stack.length) {
+        const prev = stack[stack.length - 1];
+        if (
+          !Array.isArray(prev.host[prev.key]) &&
+          !Object.keys(prev.host[prev.key]).length
+        ) {
+          host = data = prev.host[prev.key] = [];
+        }
+      }
+
       data[key] = {};
       data = data[key];
     }
+
+    stack.push({
+      host,
+      key
+    });
   }
 
   data[last] = value;

--- a/packages/amis/src/renderers/QuickEdit.tsx
+++ b/packages/amis/src/renderers/QuickEdit.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import {findDOMNode} from 'react-dom';
-import {RendererProps, getRendererByName, noop} from 'amis-core';
+import {RendererProps, getRendererByName, noop, setVariable} from 'amis-core';
 import hoistNonReactStatic from 'hoist-non-react-statics';
 import {ActionObject} from 'amis-core';
 import keycode from 'keycode';
@@ -353,8 +353,10 @@ export const HocQuickEdit =
       handleFormItemChange(value: any) {
         const {onQuickChange, quickEdit, name} = this.props;
 
+        const data = {};
+        setVariable(data, name!, value);
         onQuickChange(
-          {[name!]: value},
+          data,
           (quickEdit as QuickEditConfig).saveImmediately,
           false,
           quickEdit as QuickEditConfig


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 92a652c</samp>

This pull request improves the handling of nested data variables in `QuickEdit` components. It uses an enhanced `setVariable` function from `amis-core` that can deal with numeric keys and arrays.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 92a652c</samp>

> _We're setting variables with a stack and a key_
> _We're creating arrays when we need them, aye_
> _We're using `setVariable` from `amis-core`_
> _We're heaving together on the count of three_

### Why

Close: #8756

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 92a652c</samp>

* Improve the logic of setting a variable with a nested key in `amis-core` ([link](https://github.com/baidu/amis/pull/8759/files?diff=unified&w=0#diff-59e272ba9fc180f46d655081bd34bd278fa2930abbbc286d4e8701145ab0f263L130-R136), [link](https://github.com/baidu/amis/pull/8759/files?diff=unified&w=0#diff-59e272ba9fc180f46d655081bd34bd278fa2930abbbc286d4e8701145ab0f263L146-R169))
* Use the `setVariable` function from `amis-core` in the `QuickEdit` component in `amis` ([link](https://github.com/baidu/amis/pull/8759/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L8-R8), [link](https://github.com/baidu/amis/pull/8759/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L356-R359))
