### PR TITLE
feat: Table2支持双击事件

### DIFF
--- a/packages/amis-editor/src/plugin/Table2.tsx
+++ b/packages/amis-editor/src/plugin/Table2.tsx
@@ -208,6 +208,32 @@ export const Table2RenderereEvent: RendererPluginEvent[] = [
       }
     ]
   },
+   {
+    eventName: 'rowDbClick',
+    eventLabel: '行双击',
+    description: '双击整行事件',
+    dataSchema: [
+      {
+        type: 'object',
+        properties: {
+          data: {
+            type: 'object',
+            title: '数据',
+            properties: {
+              item: {
+                type: 'object',
+                title: '当前行记录'
+              },
+              index: {
+                type: 'number',
+                title: '当前行索引'
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
   {
     eventName: 'rowMouseEnter',
     eventLabel: '鼠标移入行事件',

--- a/packages/amis-ui/src/components/table/Row.tsx
+++ b/packages/amis-ui/src/components/table/Row.tsx
@@ -41,6 +41,7 @@ export interface Props extends ThemeProps {
   onMouseEnter: Function;
   onMouseLeave: Function;
   onClick: Function;
+  onDoubleClick: Function;
   onChange: Function;
   childrenColumnName: string;
   selectable: boolean;
@@ -84,6 +85,15 @@ export default class BodyRow extends React.PureComponent<Props> {
   onClick(event: React.ChangeEvent<any>, record?: any, rowIndex?: number) {
     const {onClick} = this.props;
     onClick && onClick(event, record, rowIndex);
+  }
+
+  onDoubleClick(
+    event: React.ChangeEvent<any>,
+    record?: any,
+    rowIndex?: number
+  ) {
+    const {onDoubleClick} = this.props;
+    onDoubleClick && onDoubleClick(event, record, rowIndex);
   }
 
   getExpandedIcons() {
@@ -321,6 +331,7 @@ export default class BodyRow extends React.PureComponent<Props> {
         onMouseEnter={e => this.onMouseEnter(e, data, rowIndex)}
         onMouseLeave={e => this.onMouseLeave(e, data, rowIndex)}
         onClick={e => this.onClick(e, data, rowIndex)}
+        onDoubleClick={e => this.onDoubleClick(e, data, rowIndex)}
       >
         {draggable ? (
           <Cell

--- a/packages/amis-ui/src/components/table/index.tsx
+++ b/packages/amis-ui/src/components/table/index.tsx
@@ -116,6 +116,7 @@ export interface OnRowProps {
   onRowMouseEnter?: Function;
   onRowMouseLeave?: Function;
   onRowClick?: Function;
+  onRowDbClick?: Function;
 }
 
 export interface SortProps {
@@ -804,6 +805,22 @@ export class Table extends React.PureComponent<TableProps, TableState> {
   }
 
   @autobind
+  async onRowDbClick(
+    event: React.ChangeEvent<any>,
+    record?: any,
+    rowIndex?: number
+  ) {
+    const {onRow} = this.props;
+
+    if (onRow && onRow.onRowDbClick) {
+      const prevented = await onRow.onRowDbClick(event, record, rowIndex);
+      if (prevented) {
+        return;
+      }
+    }
+  }
+
+  @autobind
   async onRowMouseEnter(
     event: React.ChangeEvent<any>,
     record?: any,
@@ -1067,6 +1084,7 @@ export class Table extends React.PureComponent<TableProps, TableState> {
         onMouseEnter={this.onRowMouseEnter}
         onMouseLeave={this.onRowMouseLeave}
         onClick={this.onRowClick}
+        onDoubleClick={this.onRowDbClick}
         onChange={this.onRowChange}
         childrenColumnName={this.getChildrenColumnName()}
         keyField={keyField}

--- a/packages/amis-ui/src/components/table/index.tsx
+++ b/packages/amis-ui/src/components/table/index.tsx
@@ -814,7 +814,7 @@ export class Table extends React.PureComponent<TableProps, TableState> {
 
     if (onRow && onRow.onRowDbClick) {
       const prevented = await onRow.onRowDbClick(event, record, rowIndex);
-      if (prevented) {
+      if (prevented === false) {
         return;
       }
     }

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -1609,6 +1609,7 @@ export default class Table2 extends React.Component<Table2Props, object> {
     if (rowItem && onRow) {
       onRow.onRowDbClick && onRow.onRowDbClick(event, rowItem, rowIndex);
     }
+    return true;
   }
 
   @autobind

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -1603,12 +1603,11 @@ export default class Table2 extends React.Component<Table2Props, object> {
     );
 
     if (rendererEvent?.prevented) {
-      return;
+      return false;
     }
 
     if (rowItem && onRow) {
-      onRow.onRowDbClick &&
-        onRow.onRowDbClick(event, rowItem, rowIndex);
+      onRow.onRowDbClick && onRow.onRowDbClick(event, rowItem, rowIndex);
     }
   }
 

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -1590,6 +1590,29 @@ export default class Table2 extends React.Component<Table2Props, object> {
   }
 
   @autobind
+  async handleRowDbClick(
+    event: React.ChangeEvent<any>,
+    rowItem: any,
+    rowIndex?: number
+  ) {
+    const {dispatchEvent, data, onRow} = this.props;
+
+    const rendererEvent = await dispatchEvent(
+      'rowDbClick',
+      createObject(data, {item: rowItem, index: rowIndex})
+    );
+
+    if (rendererEvent?.prevented) {
+      return;
+    }
+
+    if (rowItem && onRow) {
+      onRow.onRowDbClick &&
+        onRow.onRowDbClick(event, rowItem, rowIndex);
+    }
+  }
+
+  @autobind
   async handleRowMouseEnter(
     event: React.MouseEvent<HTMLTableRowElement>,
     rowItem: any,
@@ -1837,6 +1860,7 @@ export default class Table2 extends React.Component<Table2Props, object> {
         onRow={{
           ...onRow,
           onRowClick: this.handleRowClick,
+          onRowDbClick: this.handleRowDbClick,
           onRowMouseEnter: this.handleRowMouseEnter,
           onRowMouseLeave: this.handleRowMouseLeave
         }}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d08fd1d</samp>

This pull request adds a new feature to enable custom actions on double-clicking table rows in `amis-ui`, `amis`, and `amis-editor`. It introduces a new prop `onRowDbClick` to the `Table` and `Table2` components and plugins, and a new event `rowDbClick` to the `Table2` plugin. It also updates the corresponding `Row` components and renderers to handle the double-click events.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d08fd1d</samp>

> _`Table2` listens_
> _to double clicks on rows_
> _autumn leaves fall fast_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d08fd1d</samp>

*  Add a new event definition for `rowDbClick` to the `Table2` plugin in `amis-editor` ([link](https://github.com/baidu/amis/pull/8761/files?diff=unified&w=0#diff-ef341bca5195871956dc16f3feee9e62a37cf83eef9503a90d30903c7a99a5dcR211-R236))
*  Add a new prop `onRowDbClick` to the `OnRowProps` interface in `amis-ui` ([link](https://github.com/baidu/amis/pull/8761/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R119))
*  Add a new method `onRowDbClick` to the `Table` component in `amis-ui` that calls the prop function if it exists ([link](https://github.com/baidu/amis/pull/8761/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R808-R823))
*  Pass the `onRowDbClick` method as the `onDoubleClick` prop to the `Row` component in the `Table` component in `amis-ui` ([link](https://github.com/baidu/amis/pull/8761/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R1087))
*  Add a new prop `onDoubleClick` to the `Row` component in `amis-ui` ([link](https://github.com/baidu/amis/pull/8761/files?diff=unified&w=0#diff-b67ee1840a67cd05e70b4cee6f5bea762ca49962761545c6a4594d59df0fb1e3R44))
*  Add a new method `onDoubleClick` to the `Row` component in `amis-ui` that calls the prop function if it exists ([link](https://github.com/baidu/amis/pull/8761/files?diff=unified&w=0#diff-b67ee1840a67cd05e70b4cee6f5bea762ca49962761545c6a4594d59df0fb1e3R90-R98))
*  Bind the `onDoubleClick` method to the `onDoubleClick` attribute of the `tr` element in the `Row` component in `amis-ui` ([link](https://github.com/baidu/amis/pull/8761/files?diff=unified&w=0#diff-b67ee1840a67cd05e70b4cee6f5bea762ca49962761545c6a4594d59df0fb1e3R334))
*  Add a new method `handleRowDbClick` to the `Table2` renderer in `amis` that dispatches the `rowDbClick` event and calls the `onRow` prop function if it exists ([link](https://github.com/baidu/amis/pull/8761/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R1593-R1615))
*  Pass the `handleRowDbClick` method as the `onRowDbClick` prop to the `Table` component in the `Table2` renderer in `amis` ([link](https://github.com/baidu/amis/pull/8761/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R1863))
