### PR TITLE
fix: crud2编辑器提示卡死问题修复、table2 autoFillHeight属性支持滚动

### DIFF
--- a/packages/amis-ui/src/components/table/index.tsx
+++ b/packages/amis-ui/src/components/table/index.tsx
@@ -270,7 +270,6 @@ export class Table extends React.PureComponent<TableProps, TableState> {
       leading: false
     }
   );
-  timer: ReturnType<typeof setTimeout>;
 
   componentDidMount() {
     this.props?.onRef?.(this);
@@ -322,6 +321,15 @@ export class Table extends React.PureComponent<TableProps, TableState> {
       this.setState({
         dataSource: [...this.props.dataSource]
       });
+    }
+
+    if (
+      prevProps.autoFillHeight !== this.props.autoFillHeight ||
+      ((!isEqual(prevState.dataSource, this.state.dataSource) ||
+        prevProps.loading !== this.props.loading) &&
+        this.props.autoFillHeight)
+    ) {
+      this.updateAutoFillHeight();
     }
 
     // 选择项发生了变化触发
@@ -417,8 +425,6 @@ export class Table extends React.PureComponent<TableProps, TableState> {
 
     this.updateTableInfoLazy.cancel();
     this.updateAutoFillHeightLazy.cancel();
-
-    clearTimeout(this.timer);
   }
 
   /**
@@ -427,26 +433,16 @@ export class Table extends React.PureComponent<TableProps, TableState> {
    */
   @autobind
   updateAutoFillHeight() {
-    const {autoFillHeight} = this.props;
-    if (!autoFillHeight) {
-      return;
-    }
     const tableContent = this.containerDom.current as HTMLElement;
 
     if (!tableContent) {
       return;
     }
 
-    // 可能数据还没到，没有渲染 footer
-    // 也可能是弹窗中，弹窗还在动画中，等一下再执行
-    if (
-      !tableContent.offsetHeight ||
-      tableContent.getBoundingClientRect().height / tableContent.offsetHeight <
-        0.8
-    ) {
-      this.timer = setTimeout(() => {
-        this.updateAutoFillHeight();
-      }, 100);
+    tableContent.removeAttribute('style');
+
+    const {autoFillHeight} = this.props;
+    if (!autoFillHeight) {
       return;
     }
 
@@ -506,6 +502,7 @@ export class Table extends React.PureComponent<TableProps, TableState> {
 
     if (tableContentHeight > 0) {
       tableContent.style[heightField] = `${tableContentHeight}px`;
+      tableContent.style['overflow'] = 'auto';
     }
   }
 

--- a/packages/amis/src/renderers/CRUD2.tsx
+++ b/packages/amis/src/renderers/CRUD2.tsx
@@ -21,6 +21,7 @@ import {findDOMNode} from 'react-dom';
 import {evalExpression, filter} from 'amis-core';
 import {isEffectiveApi, isApiOutdated} from 'amis-core';
 import findIndex from 'lodash/findIndex';
+import isEqual from 'lodash/isEqual';
 import {Html, SpinnerExtraProps} from 'amis-ui';
 import {
   BaseSchema,
@@ -394,7 +395,7 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
     } else if (!props.api && isPureVariable(props.source)) {
       const next = resolveVariableAndFilter(props.source, props.data, '| raw');
 
-      if (!this.lastData || this.lastData !== next) {
+      if (!this.lastData || !isEqual(this.lastData, next)) {
         store.initFromScope(props.data, props.source, {
           columns: store.columns ?? props.columns
         });

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -476,7 +476,8 @@ export default class Table2 extends React.Component<Table2Props, object> {
     'primaryField',
     'hideQuickSaveBtn',
     'selected',
-    'placeholder'
+    'placeholder',
+    'autoFillHeight'
   ];
 
   renderedToolbars: Array<string> = [];
@@ -518,7 +519,7 @@ export default class Table2 extends React.Component<Table2Props, object> {
     this.expandable = this.buildExpandable();
     this.reactions.push(
       reaction(
-        () => store.currentSelectedRowKeys,
+        () => store.currentSelectedRowKeys.join(','),
         () => {
           this.rowSelection = this.buildRowSelection();
           this.forceUpdate();
@@ -527,7 +528,7 @@ export default class Table2 extends React.Component<Table2Props, object> {
     );
     this.reactions.push(
       reaction(
-        () => store.currentExpandedKeys,
+        () => store.currentExpandedKeys.join(','),
         () => {
           this.expandable = this.buildExpandable();
           this.forceUpdate();


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7b50e75</samp>

This pull request enhances the table components in `amis-ui` and `amis` by optimizing the height adjustment, data source comparison, and rendering logic. It fixes a bug that caused unnecessary re-rendering of `Table2` and removes redundant code.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7b50e75</samp>

> _`Table` height adjusts_
> _No more timer or timeout_
> _Autumn leaves fall fast_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7b50e75</samp>

*  Remove the `timer` property and the delayed execution of the `updateAutoFillHeight` method in the `Table` class ([link](https://github.com/baidu/amis/pull/8763/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L273), [link](https://github.com/baidu/amis/pull/8763/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L420-L421))
*  Call the `updateAutoFillHeight` method more frequently and conditionally based on the `autoFillHeight` prop and the `dataSource` state in the `Table` class ([link](https://github.com/baidu/amis/pull/8763/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R326-R338), [link](https://github.com/baidu/amis/pull/8763/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L430-L433))
*  Remove the `style` attribute and set the `overflow` style of the `tableContent` element in the `updateAutoFillHeight` method in the `Table` class, to adjust the table height and enable the scrollbars ([link](https://github.com/baidu/amis/pull/8763/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L440-R449), [link](https://github.com/baidu/amis/pull/8763/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R509))
*  Import and use the `isEqual` function from the `lodash` library to compare the data sources for the table store in the `CRUD2` component ([link](https://github.com/baidu/amis/pull/8763/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaR24), [link](https://github.com/baidu/amis/pull/8763/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL397-R398))
*  Use the `join` method to convert the arrays of keys to strings in the reaction functions for the `currentSelectedRowKeys` and `currentExpandedKeys` observables in the `Table2` component, to avoid unnecessary reactions ([link](https://github.com/baidu/amis/pull/8763/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L521-R521), [link](https://github.com/baidu/amis/pull/8763/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L530-R530))
