### PR TITLE
fix: 修复 envOverwrite 存在副作用的问题 Close: #8745

### DIFF
--- a/packages/amis-core/src/envOverwrite.ts
+++ b/packages/amis-core/src/envOverwrite.ts
@@ -2,26 +2,31 @@
  * @file 用于在移动端或不同语言环境下使用不同配置
  */
 
-import {findObjectsWithKey} from './utils/helper';
+import {JSONValueMap, findObjectsWithKey} from './utils/helper';
+import isPlainObject from 'lodash/isPlainObject';
 const isMobile = (window as any).matchMedia?.('(max-width: 768px)').matches
   ? true
   : false;
 
 // 这里不能用 addSchemaFilter 是因为还需要更深层的替换，比如 select 里的 options
 export const envOverwrite = (schema: any, locale?: string) => {
-  if (locale) {
-    let schemaNodes = findObjectsWithKey(schema, locale);
-    for (let schemaNode of schemaNodes) {
-      Object.assign(schemaNode, schemaNode[locale]);
-      delete schemaNode[locale];
-    }
-  }
+  return JSONValueMap(
+    schema,
+    (value: any) => {
+      if (!isPlainObject(value)) {
+        return value;
+      }
 
-  if (isMobile) {
-    let schemaNodes = findObjectsWithKey(schema, 'mobile');
-    for (let schemaNode of schemaNodes) {
-      Object.assign(schemaNode, schemaNode['mobile']);
-      delete schemaNode['mobile'];
-    }
-  }
+      if (locale && value[locale]) {
+        const newValue = Object.assign({}, value, value[locale]);
+        delete newValue[locale];
+        return newValue;
+      } else if (isMobile && value.mobile) {
+        const newValue = Object.assign({}, value, value.mobile);
+        delete newValue.mobile;
+        return newValue;
+      }
+    },
+    true
+  );
 };

--- a/packages/amis-core/src/index.tsx
+++ b/packages/amis-core/src/index.tsx
@@ -308,7 +308,7 @@ function AMISRenderer({
   }
 
   // 根据环境覆盖 schema，这个要在最前面做，不然就无法覆盖 validations
-  envOverwrite(schema, locale);
+  schema = envOverwrite(schema, locale);
   schema = replaceText(schema, options.replaceText, env.replaceTextIgnoreKeys);
 
   return (


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2489667</samp>

Refactored the `envOverwrite` function to use a new utility function `JSONValueMap` that can map and replace values in a JSON schema more efficiently and flexibly. Added a `deepFirst` parameter to `JSONValueMap` to control the traversal order. Updated the `AMISRenderer` function to use the new `envOverwrite` function.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2489667</samp>

> _Sing, O Muse, of the skillful coder who refashioned_
> _The `envOverwrite` function, a mighty tool of rendering,_
> _And made it use the `JSONValueMap`, a clever invention_
> _That traverses and transforms the schema, like Zeus his lightning._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2489667</samp>

*  Rewrite `envOverwrite` function to recursively replace schema properties based on locale and mobile environment ([link](https://github.com/baidu/amis/pull/8766/files?diff=unified&w=0#diff-dd2c28625f8a3b0bdf1d3e2e0b8b650f67af03785e123359a9dc02685040ed74L5-R6), [link](https://github.com/baidu/amis/pull/8766/files?diff=unified&w=0#diff-dd2c28625f8a3b0bdf1d3e2e0b8b650f67af03785e123359a9dc02685040ed74L12-R31))
*  Use `JSONValueMap` function instead of `findObjectsWithKey` function to apply mapper function to every value in a JSON object or array ([link](https://github.com/baidu/amis/pull/8766/files?diff=unified&w=0#diff-dd2c28625f8a3b0bdf1d3e2e0b8b650f67af03785e123359a9dc02685040ed74L5-R6), [link](https://github.com/baidu/amis/pull/8766/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aR1957), [link](https://github.com/baidu/amis/pull/8766/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1969-R1979), [link](https://github.com/baidu/amis/pull/8766/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1978-R1994), [link](https://github.com/baidu/amis/pull/8766/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1996-R2005))
*  Add `deepFirst` parameter to `JSONValueMap` function to control the traversal order ([link](https://github.com/baidu/amis/pull/8766/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aR1957), [link](https://github.com/baidu/amis/pull/8766/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1969-R1979))
*  Assign result of `envOverwrite` function to schema variable instead of modifying it in place in `AMISRenderer` function in `packages/amis-core/src/index.tsx` ([link](https://github.com/baidu/amis/pull/8766/files?diff=unified&w=0#diff-ed2759a19afd843ed555f6c368bef12e2d0dab8b1b113f0ff059a4575bad00c2L311-R311))
*  Improve variable names in `JSONValueMap` function for readability and consistency ([link](https://github.com/baidu/amis/pull/8766/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1978-R1994), [link](https://github.com/baidu/amis/pull/8766/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL1996-R2005))
