### PR TITLE
fix: 修复 each #8452 导致的取数据变化 breakchange Close: #8616

### DIFF
--- a/packages/amis/src/renderers/Each.tsx
+++ b/packages/amis/src/renderers/Each.tsx
@@ -27,8 +27,7 @@ function EachItem(props: EachExtraProps) {
   const ctx = React.useMemo(
     () =>
       createObject(data, {
-        ...(isObject(item) ? item : {}),
-        [name]: item,
+        ...(isObject(item) ? {index, ...item} : {[name]: item}),
         [itemKeyName || 'item']: item,
         [indexKeyName || 'index']: index
       }),


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 407490a</samp>

Simplify data object creation in `Each.tsx` renderer. Use spread operator and handle non-object items.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 407490a</samp>

> _`Each` renders faster_
> _Spreading item with index_
> _Autumn leaves simplify_

### Why

Close: #8616

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 407490a</samp>

*  Simplify the logic of creating an object with the item data and the index in the Each renderer ([link](https://github.com/baidu/amis/pull/8768/files?diff=unified&w=0#diff-004324fd9c356174caedccb3450d00ee36b0de65d751179c5ee3a97dc396c7d8L30-R30))
