### PR TITLE
fix: 修复label为schema时star位置错误问题 Close: #8634

### DIFF
--- a/packages/amis-ui/scss/components/form/_form.scss
+++ b/packages/amis-ui/scss/components/form/_form.scss
@@ -61,6 +61,7 @@
 
   > span {
     position: relative;
+    display: inline-block;
   }
 }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4424f83</samp>

This pull request enhances the form components in the `amis-ui` library by making them more flexible and adaptive to different screen sizes. It modifies the `form-group` class in the `_form.scss` file to enable horizontal alignment of form elements.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4424f83</samp>

> _`form-group` changes_
> _align elements in a row_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4424f83</samp>

* Add `display: inline-block` property to `.form-group` selector to align form group elements horizontally ([link](https://github.com/baidu/amis/pull/8771/files?diff=unified&w=0#diff-f325489c306f0106cb368664288efa079f007a051f746e29ad32d88cde2abb4dR64))
