### PR TITLE
pref: 设计器patch方法性能调优

### DIFF
--- a/packages/amis-editor-core/src/store/node.ts
+++ b/packages/amis-editor-core/src/store/node.ts
@@ -14,7 +14,7 @@ import {
 import uniq from 'lodash/uniq';
 import {RegionConfig, RendererInfo} from '../plugin';
 import {guid, JSONPipeIn} from '../util';
-import {filterSchema} from 'amis';
+import {filterSchema, isObjectShallowModified} from 'amis';
 import React from 'react';
 import {EditorStoreType} from './editor';
 import findIndex from 'lodash/findIndex';
@@ -670,7 +670,7 @@ export const EditorNode = types
             component?.props
           ) || patched;
 
-        if (patched !== schema) {
+        if (patched !== schema && isObjectShallowModified(patched, schema)) {
           root.changeValueById(
             info.id,
             JSONPipeIn(patched),


### PR DESCRIPTION
### What

当页面中存在grid组件较多时，在code面板中通过粘贴代码的方式添加组件设计器会存在一定时间的卡顿

### Why
在schemaFilter中，存在对grid、hbox组件的兼容处理，直接给schema重新赋值了
<img width="853" alt="image" src="https://github.com/baidu/amis/assets/34541195/cd101942-9ca0-471b-91ed-434b87b21fbe">
在patch方法中，schema是否需要更新是根据引用地址判断的，因此对于grid组件，即使格式正确，也还是会进行更新
<img width="539" alt="image" src="https://github.com/baidu/amis/assets/34541195/14283f90-87bd-47bf-892d-c45be5d7a01d">

### How

如果schema经过兼容处理，引用地址变更了，在进行一下属性对比，判断是否schema属性有变更
