### PR TITLE
fix: 修复字段集标题CSS类名，边框生效页面展示缺失

### DIFF
--- a/packages/amis-ui/scss/components/form/_fieldset.scss
+++ b/packages/amis-ui/scss/components/form/_fieldset.scss
@@ -47,11 +47,11 @@ fieldset.#{$ns}Collapse {
       var(--fieldSet-legend-paddingRight) var(--fieldSet-legend-paddingBottom)
       var(--fieldSet-legend-paddingLeft);
     cursor: pointer;
-    border-bottom: none !important;
     background: transparent;
     display: inline-flex !important;
     flex-direction: row-reverse;
     justify-content: flex-end;
+    box-sizing: content-box;
     // width: 100%;
 
     .#{$ns}TplField {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5295f15</samp>

This pull request updates the fieldset component in `amis`, both in the documentation and the style. It fixes some inconsistencies in the schema, adds some new properties to customize the appearance and behavior, and improves the layout of the legend.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5295f15</samp>

> _`fieldset` updated_
> _lowercase types, new props_
> _spring cleaning the code_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5295f15</samp>

*  Update the schema of the fieldset component to match the latest version of amis and demonstrate its features ([link](https://github.com/baidu/amis/pull/8778/files?diff=unified&w=0#diff-540493f71f255957c552600782d87511d288fa9341d9f71b8342ebffb0a52025L19-R38))
*  Remove the border-bottom property of the legend element and add the box-sizing property to fix the style issues of the fieldset component ([link](https://github.com/baidu/amis/pull/8778/files?diff=unified&w=0#diff-c71274767e39957bc8e2a63d9d9921ae316dd2746b242ffd26e51734e6fbd0c7L50-R54))
*  Add the headingClassName property to the fieldset component to allow customizing the legend style ([link](https://github.com/baidu/amis/pull/8778/files?diff=unified&w=0#diff-540493f71f255957c552600782d87511d288fa9341d9f71b8342ebffb0a52025L19-R38))
