### PR TITLE
fix: crud编辑器组件面板提示导致页面卡死问题修复

### DIFF
--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -686,7 +686,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     } else if (!props.api && isPureVariable(props.source)) {
       const next = resolveVariableAndFilter(props.source, props.data, '| raw');
 
-      if (!this.lastData || this.lastData !== next) {
+      if (!this.lastData || !isEqual(this.lastData, next)) {
         store.initFromScope(props.data, props.source, {
           columns: store.columns ?? props.columns
         });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 798032f</samp>

Use `isEqual` function to compare data in CRUD component. This fixes a bug where the component would not update correctly for complex data types.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 798032f</samp>

> _`isEqual` checks deep_
> _CRUD component updates_
> _Autumn leaves change too_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 798032f</samp>

* Use `isEqual` function to compare data values in CRUD component ([link](https://github.com/baidu/amis/pull/8779/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L689-R689)). This fixes a bug where the component would not update correctly for array or object data sources. The file `packages/amis/src/renderers/CRUD.tsx` contains this change.
