### PR TITLE
feat : dialog支持拖拽移动位置

### DIFF
--- a/packages/amis-editor/src/plugin/Dialog.tsx
+++ b/packages/amis-editor/src/plugin/Dialog.tsx
@@ -261,6 +261,11 @@ export class DialogPlugin extends BasePlugin {
                 name: 'showLoading',
                 value: true
               }),
+              getSchemaTpl('switch', {
+                label: '是否可拖拽',
+                name: 'draggable',
+                value: false
+              }),
               getSchemaTpl('dataMap')
             ]
           }

--- a/packages/amis-ui/scss/components/_modal.scss
+++ b/packages/amis-ui/scss/components/_modal.scss
@@ -65,6 +65,10 @@
     }
   }
 
+  &-draggable > &-header {
+    cursor: move;
+  }
+
   &-overlay {
     transition: ease-in-out opacity var(--animation-duration);
     position: fixed;

--- a/packages/amis-ui/src/components/Modal.tsx
+++ b/packages/amis-ui/src/components/Modal.tsx
@@ -17,6 +17,13 @@ import {ClassNamesFn, themeable, ThemeProps} from 'amis-core';
 import {Icon} from './icons';
 import {LocaleProps, localeable} from 'amis-core';
 import {autobind, getScrollbarWidth} from 'amis-core';
+import {
+  DraggableCore,
+  type DraggableBounds,
+  type DraggableData,
+  type DraggableEvent
+} from 'react-draggable';
+import isNumber from 'lodash/isNumber';
 
 export const getContainerWithFullscreen =
   (container?: () => HTMLElement | HTMLElement | null) => () => {
@@ -53,8 +60,14 @@ export interface ModalProps extends ThemeProps, LocaleProps {
   children?: React.ReactNode | Array<React.ReactNode>;
   modalClassName?: string;
   modalMaskClassName?: string;
+  draggable?: boolean;
 }
-export interface ModalState {}
+
+export interface ModalState {
+  bounds?: DraggableBounds;
+  dragPos?: {x: number; y: number};
+}
+
 const fadeStyles: {
   [propName: string]: string;
 } = {
@@ -62,6 +75,7 @@ const fadeStyles: {
   [ENTERED]: 'in',
   [EXITING]: 'out'
 };
+
 const contentFadeStyles: {
   [propName: string]: string;
 } = {
@@ -69,11 +83,13 @@ const contentFadeStyles: {
   [ENTERED]: '',
   [EXITING]: 'out'
 };
+
 export class Modal extends React.Component<ModalProps, ModalState> {
   static defaultProps = {
     container: document.body,
     size: '',
-    overlay: true
+    overlay: true,
+    draggable: false
   };
 
   isRootClosed = false;
@@ -172,6 +188,8 @@ export class Modal extends React.Component<ModalProps, ModalState> {
       </div>
     )
   );
+
+  state: Readonly<ModalState> = {dragPos: undefined};
 
   componentDidMount() {
     if (this.props.show) {
@@ -283,6 +301,87 @@ export class Modal extends React.Component<ModalProps, ModalState> {
     this.isRootClosed && !e.defaultPrevented && onHide(e);
   }
 
+  // #region 处理dialog拖动
+
+  handleDragStart = (_event: DraggableEvent, uiData: DraggableData) => {
+    const node = uiData.node;
+    const {offsetParent} = node;
+    if (!node || !offsetParent) {
+      return;
+    }
+    const {clientWidth, clientHeight} = window.document.documentElement;
+    const nodeStyle = getComputedStyle(node);
+    const marginTop = parseInt(nodeStyle.marginTop, 10);
+    const nodeWidth = parseInt(nodeStyle.width, 10);
+    const nodeHeight = parseInt(nodeStyle.height, 10);
+    const bounds = {
+      left: 0,
+      right: clientWidth - nodeWidth,
+      top: -marginTop,
+      bottom: clientHeight - nodeHeight - marginTop
+    };
+    const parentRect = offsetParent.getBoundingClientRect();
+    const clientRect = node.getBoundingClientRect();
+    const cLeft = clientRect.left;
+    const pLeft = parentRect.left;
+    const cTop = clientRect.top;
+    const pTop = parentRect.top;
+    const left = cLeft - pLeft + offsetParent.scrollLeft;
+    const top = cTop - pTop + offsetParent.scrollTop - marginTop;
+    this.setState({dragPos: {x: left, y: top}, bounds});
+    // 阻止冒泡  存在弹窗里面套弹窗
+    _event.stopPropagation();
+  };
+
+  handleDrag = (e: DraggableEvent, {deltaX, deltaY}: DraggableData) => {
+    e.stopPropagation();
+    if (!this.state.dragPos) {
+      return;
+    }
+    const {
+      dragPos: {x, y},
+      bounds
+    } = this.state;
+
+    let calcY = y + deltaY;
+    let calcX = x + deltaX;
+
+    // 防止拖动到屏幕外 处理边界
+    if (isNumber(bounds?.right)) {
+      calcX = Math.min(calcX, bounds!.right);
+    }
+    if (isNumber(bounds?.bottom)) {
+      calcY = Math.min(calcY, bounds!.bottom);
+    }
+    if (isNumber(bounds?.left)) {
+      calcX = Math.max(calcX, bounds!.left);
+    }
+    if (isNumber(bounds?.top)) {
+      calcY = Math.max(calcY, bounds!.top);
+    }
+    this.setState({dragPos: {x: calcX, y: calcY}});
+  };
+
+  handleDragStop = (e: DraggableEvent) => {
+    e.stopPropagation();
+  };
+
+  getDragStyle = (): React.CSSProperties => {
+    const {draggable} = this.props;
+    const {dragPos} = this.state;
+    if (!dragPos || !draggable) {
+      return {};
+    }
+    const {x, y} = dragPos;
+    return {
+      top: `${y}px`,
+      left: `${x}px`,
+      position: 'absolute'
+    };
+  };
+
+  // #endregion
+
   render() {
     const {
       className,
@@ -297,7 +396,10 @@ export class Modal extends React.Component<ModalProps, ModalState> {
       height,
       modalClassName,
       modalMaskClassName,
-      classnames: cx
+      classnames: cx,
+      mobileUI,
+      draggable,
+      classPrefix
     } = this.props;
 
     let _style = {
@@ -338,18 +440,27 @@ export class Modal extends React.Component<ModalProps, ModalState> {
                   )}
                 />
               ) : null}
-              <div
-                className={cx(
-                  `Modal-content`,
-                  size === 'custom' ? 'Modal-content-custom' : '',
-                  contentClassName,
-                  modalClassName,
-                  contentFadeStyles[status]
-                )}
-                style={_style}
+              <DraggableCore
+                disabled={!draggable || mobileUI}
+                onStart={this.handleDragStart}
+                onDrag={this.handleDrag}
+                onStop={this.handleDragStop}
+                handle={`.${classPrefix}Modal-header`}
               >
-                {status === EXITED ? null : children}
-              </div>
+                <div
+                  className={cx(
+                    `Modal-content`,
+                    draggable && !mobileUI ? 'Modal-draggable' : '',
+                    size === 'custom' ? 'Modal-content-custom' : '',
+                    contentClassName,
+                    modalClassName,
+                    contentFadeStyles[status]
+                  )}
+                  style={{..._style, ...this.getDragStyle()}}
+                >
+                  {status === EXITED ? null : children}
+                </div>
+              </DraggableCore>
             </div>
           </Portal>
         )}

--- a/packages/amis/src/renderers/Dialog.tsx
+++ b/packages/amis/src/renderers/Dialog.tsx
@@ -123,6 +123,10 @@ export interface DialogSchema extends BaseSchema {
    * 弹框类型 confirm 确认弹框
    */
   dialogType?: 'confirm';
+  /**
+   * 可拖拽
+   */
+  draggable?: boolean;
 }
 
 export type DialogSchemaBase = Omit<DialogSchema, 'type'>;
@@ -164,7 +168,8 @@ export default class Dialog extends React.Component<DialogProps> {
     'showErrorMsg',
     'actions',
     'popOverContainer',
-    'overlay'
+    'overlay',
+    'draggable'
   ];
   static defaultProps = {
     title: 'Dialog.title',


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 764a155</samp>

This pull request adds a new feature to make the dialog and modal components draggable in the amis framework. It uses the `react-draggable` library and adds a `draggable` option to the dialog schema and plugin. It also updates the modal component and the corresponding CSS style to support the drag behavior.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 764a155</samp>

> _`dialog` can move_
> _dragging by the modal head_
> _a breeze in summer_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 764a155</samp>

*  Add a draggable feature to the dialog renderer and the modal component, allowing users to move the modal by dragging the header ([link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-d3bebdf8ee046a9260ff973d8fc59a35ef327db18d55902021b571b045359e1aR264-R268), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-c76c418ad30430f01cd68aa78422398e032dc3750b37b2869b9d448a4e0b5c51R68-R71), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0R20-R26), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L56-R70), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0R78), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L72-R92), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0R192-R193), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0R304-R384), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L300-R402), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L341-R463), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bR126-R129), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL167-R172))
  * Import the `react-draggable` library and use the `DraggableCore` component to wrap the modal content div in `Modal.tsx` ([link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0R20-R26), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L341-R463))
  * Add a `draggable` prop to the `Modal` component and the `Dialog` schema, defaulting to false, and pass it from the dialog renderer to the modal component ([link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L56-R70), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L72-R92), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L300-R402), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bR126-R129), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL167-R172))
  * Add a `bounds` prop to the `Modal` component to define the limits of the drag movement, and calculate it based on the modal size and the window size in the `handleDragStart` method ([link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L56-R70), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0R304-R384))
  * Add a `dragPos` state to the `Modal` component to store the current position of the modal after dragging, and update it in the `handleDrag` method ([link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0R78), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0R192-R193), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0R304-R384))
  * Add a `handleDragStop` method to the `Modal` component to stop the drag event propagation ([link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0R304-R384))
  * Add a `getDragStyle` method to the `Modal` component to return a CSS style object based on the `dragPos` state ([link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0R304-R384))
  * Add a `mobileUI` prop to the `Modal` component to indicate whether the modal is rendered in a mobile device or not, and use it to conditionally apply the drag style and class name to the modal content div ([link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L300-R402), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L341-R463))
  * Add a `classPrefix` prop to the `Modal` component to prefix the modal class names, and use it to specify the modal header as the handle selector for the `DraggableCore` component ([link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L300-R402), [link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-571245655a9b1e83ba93f874b494abfd95b0fbb7b17a8a0a0055709cf65a43f0L341-R463))
  * Add a CSS style to the modal header in `_modal.scss`, setting the cursor to move when the modal is draggable ([link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-c76c418ad30430f01cd68aa78422398e032dc3750b37b2869b9d448a4e0b5c51R68-R71))
  * Add a switch option to the schema template of the dialog plugin in `Dialog.tsx`, allowing users to enable or disable the draggable feature of the dialog ([link](https://github.com/baidu/amis/pull/8781/files?diff=unified&w=0#diff-d3bebdf8ee046a9260ff973d8fc59a35ef327db18d55902021b571b045359e1aR264-R268))
