### PR TITLE
fix(amis-editor): CRUD2工具栏为空时添加错误; chore: 工具栏控件更新逻辑

### DIFF
--- a/packages/amis-core/src/renderers/wrapControl.tsx
+++ b/packages/amis-core/src/renderers/wrapControl.tsx
@@ -179,14 +179,6 @@ export function wrapControl<
             }
 
             if (!name) {
-              // 一般情况下这些表单项都是需要 name 的，提示一下
-              if (
-                typeof type === 'string' &&
-                getRendererByName(type)?.isFormItem
-              ) {
-                console.warn('name is required', this.props.$schema);
-              }
-
               return;
             }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e5fc461</samp>

This pull request improves the editor functionality for CRUD operations and form controls. It allows more customization and manipulation of the CRUD toolbar actions using `CRUDToolbarControl`. It also prevents the editor controls from being wrapped by the `wrapControl` function, which is meant for normal form controls.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e5fc461</samp>

> _`wrapControl` skips_
> _editor's special controls_
> _a winter pruning_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e5fc461</samp>

*  Add a condition to skip editor controls in `wrapControl` function ([link](https://github.com/baidu/amis/pull/8788/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aR185))
*  Import modules and functions for schema and toolbar manipulation in `CRUDToolbarControl` component ([link](https://github.com/baidu/amis/pull/8788/files?diff=unified&w=0#diff-109dd7a4e559ae1d94c4777ae52f7caca33f86ae38d5080ea73ce08dba77d92dL9-R19))
*  Add `reaction` property to listen to schema changes and update toolbar options in `CRUDToolbarControl` component ([link](https://github.com/baidu/amis/pull/8788/files?diff=unified&w=0#diff-109dd7a4e559ae1d94c4777ae52f7caca33f86ae38d5080ea73ce08dba77d92dR65-R66))
*  Replace `getActions` method with `getActionNodes` method to find all action nodes in schema in `CRUDToolbarControl` component ([link](https://github.com/baidu/amis/pull/8788/files?diff=unified&w=0#diff-109dd7a4e559ae1d94c4777ae52f7caca33f86ae38d5080ea73ce08dba77d92dL71-R112))
*  Use `addSchema2Toolbar` function to adapt action schema to toolbar data in `handleAddAction` method in `CRUDToolbarControl` component ([link](https://github.com/baidu/amis/pull/8788/files?diff=unified&w=0#diff-109dd7a4e559ae1d94c4777ae52f7caca33f86ae38d5080ea73ce08dba77d92dL233-R256))
*  Use `onChange` prop to notify parent component about toolbar data changes in `handleAddAction` and `handleDelete` methods in `CRUDToolbarControl` component ([link](https://github.com/baidu/amis/pull/8788/files?diff=unified&w=0#diff-109dd7a4e559ae1d94c4777ae52f7caca33f86ae38d5080ea73ce08dba77d92dL140-R160), [link](https://github.com/baidu/amis/pull/8788/files?diff=unified&w=0#diff-109dd7a4e559ae1d94c4777ae52f7caca33f86ae38d5080ea73ce08dba77d92dL246-R262), [link](https://github.com/baidu/amis/pull/8788/files?diff=unified&w=0#diff-109dd7a4e559ae1d94c4777ae52f7caca33f86ae38d5080ea73ce08dba77d92dL264-R280))
*  Use `onChange` prop to trigger schema update after deleting an action in `handleDelete` method in `CRUDToolbarControl` component ([link](https://github.com/baidu/amis/pull/8788/files?diff=unified&w=0#diff-109dd7a4e559ae1d94c4777ae52f7caca33f86ae38d5080ea73ce08dba77d92dL264-R280))
