### PR TITLE
fix: 修复 patch 逻辑新拖入节点可能不会执行的问题

### DIFF
--- a/packages/amis-editor-core/src/manager.ts
+++ b/packages/amis-editor-core/src/manager.ts
@@ -1751,11 +1751,14 @@ export class EditorManager {
   });
 
   patching = false;
+  patchingInvalid = false;
   patchSchema(force = false) {
     if (this.patching) {
+      this.patchingInvalid = true;
       return;
     }
     this.patching = true;
+    this.patchingInvalid = false;
     let patchList = (list: Array<EditorNodeType>) => {
       // 深度优先
       list.forEach((node: EditorNodeType) => {
@@ -1771,6 +1774,7 @@ export class EditorManager {
 
     patchList(this.store.root.children);
     this.patching = false;
+    this.patchingInvalid && this.patchSchema(force);
   }
 
   /**

--- a/packages/amis-editor-core/src/store/editor.ts
+++ b/packages/amis-editor-core/src/store/editor.ts
@@ -642,8 +642,8 @@ export const MainStore = types
           return list.some(node => {
             if (!node.patched && !node.isRegion) {
               return true;
-            } else if (node.children.length) {
-              return hasUnPatched(node.children);
+            } else if (node.uniqueChildren.length) {
+              return hasUnPatched(node.uniqueChildren);
             }
 
             return false;

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -141,7 +141,8 @@ export function JSONPipeIn(
       /** 脚手架构建的Schema提前构建好了组件 ID，此时无需生成 ID，避免破坏事件动作 */
       if (
         (!obj.__origin || obj.__origin !== 'scaffold') &&
-        (typeof obj.id !== 'string' || !obj.id || obj.id.startsWith('u:'))
+        typeof obj.id === 'string' &&
+        obj.id.startsWith('u:')
       ) {
         const newId = generateNodeId();
         obj.id && (idMap[obj.id] = newId);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 55607f7</samp>

This pull request improves the schema patching logic and fixes a bug in the node id generation. It adds flags to `EditorManager` to handle concurrent patching, uses `uniqueChildren` to avoid counting duplicated nodes as unpatched, and modifies the condition in `JSONPipeIn` to preserve valid node ids.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 55607f7</samp>

> _Sing, O Muse, of the skillful coder who modified the editor_
> _To improve its function and to fix the errors that plagued it_
> _He changed the `hasUnPatched` method to use `uniqueChildren`_
> _And thus he counted rightly the nodes that needed patching_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 55607f7</samp>

*  Add properties and logic to handle schema patching invalidation and concurrency in `EditorManager` class (`packages/amis-editor-core/src/manager.ts`, [link](https://github.com/baidu/amis/pull/8793/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fL1754-R1761), [link](https://github.com/baidu/amis/pull/8793/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fR1777))
*  Fix bug that overwrites node id in `JSONPipeIn` function (`packages/amis-editor-core/src/util.ts`, [link](https://github.com/baidu/amis/pull/8793/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL144-R145))
*  Improve performance and accuracy of `hasUnPatched` function by using `uniqueChildren` property (`packages/amis-editor-core/src/store/editor.ts`, [link](https://github.com/baidu/amis/pull/8793/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8L645-R646))
