### PR TITLE
fix(amis):input-number 小数光标偏移问题

### DIFF
--- a/packages/amis-core/__tests__/utils/math.test.ts
+++ b/packages/amis-core/__tests__/utils/math.test.ts
@@ -16,6 +16,8 @@ test(`math safeSub:test`, () => {
 
 test('numberFormatter:test', () => {
   expect(numberFormatter(0)).toEqual('0');
+  expect(numberFormatter(0.123)).toEqual('0.123');
+  expect(numberFormatter(0.123, 0)).toEqual('0');
   expect(numberFormatter(0, 2)).toEqual('0.00');
   expect(numberFormatter(0, 8)).toEqual('0.00000000');
   expect(numberFormatter(123456)).toEqual('123,456');

--- a/packages/amis-core/src/utils/math.ts
+++ b/packages/amis-core/src/utils/math.ts
@@ -31,14 +31,18 @@ export function safeSub(arg1: number, arg2: number) {
   return (arg1 * maxDigits - arg2 * maxDigits) / maxDigits;
 }
 
-export function numberFormatter(num: number | string, precision: number = 0) {
+export function numberFormatter(num: number | string, precision?: number) {
   const ZERO = 0;
   const number = +num;
+  const finalP =
+    typeof precision === 'number'
+      ? precision
+      : number.toString().split('.')[1]?.length || 0;
   if (typeof number === 'number' && !isNaN(number)) {
-    const regexp = precision ? /(\d)(?=(\d{3})+\.)/g : /(\d)(?=(\d{3})+$)/g;
-    return number.toFixed(precision).replace(regexp, '$1,');
+    const regexp = finalP ? /(\d)(?=(\d{3})+\.)/g : /(\d)(?=(\d{3})+$)/g;
+    return number.toFixed(finalP).replace(regexp, '$1,');
   }
-  return ZERO.toFixed(precision);
+  return ZERO.toFixed(finalP);
 }
 
 /**

--- a/packages/amis/src/renderers/Form/InputNumber.tsx
+++ b/packages/amis/src/renderers/Form/InputNumber.tsx
@@ -330,6 +330,7 @@ export default class NumberControl extends React.Component<
       return;
     }
     const {kilobitSeparator, prefix} = this.props;
+    const integer = value > 0 ? Math.floor(value) : Math.ceil(value);
     let pos = `${value}`.length;
 
     if (prefix) {
@@ -338,13 +339,13 @@ export default class NumberControl extends React.Component<
 
     if (kilobitSeparator) {
       // 处理有千分符的情况 123,456,789
-      const ksLen = Math.floor((`${Math.abs(value)}`.length - 1) / 3);
+      const ksLen = Math.floor((`${Math.abs(integer)}`.length - 1) / 3);
       if (ksLen > 0) {
         pos += ksLen;
       }
     }
 
-    if (this.input) {
+    if (this.input && (kilobitSeparator || prefix)) {
       this.input.setSelectionRange?.(pos, pos);
     }
   }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9dd5dd4</samp>

Fixed cursor and formatting issues in `InputNumber` component and `numberFormatter` function. Enhanced the precision handling of `numberFormatter` to avoid truncating or padding decimals.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9dd5dd4</samp>

> _Sing, O Muse, of the cunning code review_
> _That fixed the bugs of `numberFormatter` and `InputNumber`_
> _And made the digits shine with proper precision_
> _Like the stars that Hermes guides with his golden wand._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9dd5dd4</samp>

* Fix a bug in the `numberFormatter` function that would truncate decimals or add unnecessary zeros when the input number had a different precision than the specified one ([link](https://github.com/baidu/amis/pull/8799/files?diff=unified&w=0#diff-e4301860018921c04669278018d4efd9880f97b910816dee541b1135b0927b1dL34-R42))
* Improve the user experience of the `InputNumber` component by using the `integer` variable to calculate the cursor position when the input has a kilobit separator or a prefix ([link](https://github.com/baidu/amis/pull/8799/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685R333), [link](https://github.com/baidu/amis/pull/8799/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685L341-R342), [link](https://github.com/baidu/amis/pull/8799/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685L347-R348))
* Modify the `handleBlur` method of the `InputNumber` component in `packages/amis/src/renderers/Form/InputNumber.tsx` to only set the cursor position if the input has a kilobit separator or a prefix, and to use the actual decimal length of the input number as the default precision ([link](https://github.com/baidu/amis/pull/8799/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685R333), [link](https://github.com/baidu/amis/pull/8799/files?diff=unified&w=0#diff-daae26cdbc910321ac03b9e1e11300556f4a6c5d683738f93b6d828e9fcc9685L347-R348))
