### PR TITLE
fix(amis-editor): 阻止inputTable的在editor中预览时的change事件,避免特殊case时死循环

### DIFF
--- a/packages/amis-editor-core/src/mocker.ts
+++ b/packages/amis-editor-core/src/mocker.ts
@@ -17,11 +17,6 @@ export function mockValue(schema: any) {
     schema.type === 'input-month'
   ) {
     return moment().format('X');
-  } else if (schema.type === 'number' || schema.type === 'input-number') {
-    const precision = schema.precision || 0;
-    return precision
-      ? (Math.random() * 10000).toFixed(precision)
-      : Math.random() * 10000;
   } else if (schema.type === 'image' || schema.type === 'static-image') {
     return placeholderImage;
   } else if (schema.type === 'images' || schema.type === 'static-images') {

--- a/packages/amis-editor/src/plugin/Form/InputTable.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputTable.tsx
@@ -1268,7 +1268,11 @@ export class TableControlPlugin extends BasePlugin {
       props.value = arr.slice(0, 10);
     }
 
-    return props;
+    return {
+      ...props,
+      // 阻止编辑器预览态的 change 事件，避免特殊case引发change后导致的死循环
+      onChange: () => true
+    };
   }
 
   // 自动插入 label


### PR DESCRIPTION
当editor中使用以下case时，会导致死循环
原因是：
- editor 实时预览时，input-table plugin 会在filterProps mock 假数据
- 初始化时， input-number假数据值是 【随机数】，input-text等一般组件的值是 【假数据】
- 当后者根据表达式渲染时，触发inputTable 的emitValue，props.onChange....然后重新渲染
- 重新渲染时 filterProps 会mock的新的数据（因为是随机数）
- 从而导致死循环
```
{
    "type": "input-table",
    "name": "work",
    "columns": [
        {
            "type": "input-number",
            "name": "column1"
        },
        {
            "type": "input-text",
            "name": "column2",
            "value": "${column1}"
        }
    ]
}
```

解决办法：
- 在 editor plugin 中 props 传入 onChange: ()=> true, 来阻断change
- 预览态也根本不需要 onChange

另一个mocker的改动是因为关于 input-number 的 mocker逻辑写重复了