### PR TITLE
fix: crud编辑器提示导致报错问题修复

### DIFF
--- a/docs/zh-CN/components/table2.md
+++ b/docs/zh-CN/components/table2.md
@@ -16,70 +16,70 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "title": "表格标题 - ${rows.length}",
+      "source": "$rows",
+      "columns": [
         {
-            "type": "table2",
-            "title": "表格标题 - ${rows.length}",
-            "source": "$rows",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                    "width": 120
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "type": "property",
-                    "items": [
-                        {
-                            "label": "cpu",
-                            "content": "1 core"
-                        },
-                        {
-                            "label": "memory",
-                            "content": "4G"
-                        },
-                        {
-                            "label": "disk",
-                            "content": "80G"
-                        },
-                        {
-                            "label": "network",
-                            "content": "4M",
-                            "span": 2
-                        },
-                        {
-                            "label": "IDC",
-                            "content": "beijing"
-                        },
-                        {
-                            "label": "Note",
-                            "content": "其它说明",
-                            "span": 3
-                        }
-                    ]
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Operation",
-                    "name": "operation",
-                    "type": "button",
-                    "label": "删除",
-                    "size": "sm"
-                }
-            ],
-            "footer": {
-                "type": "tpl",
-                "tpl": "表格Footer"
+          "title": "Engine",
+          "name": "engine",
+          "width": 120
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "type": "property",
+          "items": [
+            {
+              "label": "cpu",
+              "content": "1 core"
+            },
+            {
+              "label": "memory",
+              "content": "4G"
+            },
+            {
+              "label": "disk",
+              "content": "80G"
+            },
+            {
+              "label": "network",
+              "content": "4M",
+              "span": 2
+            },
+            {
+              "label": "IDC",
+              "content": "beijing"
+            },
+            {
+              "label": "Note",
+              "content": "其它说明",
+              "span": 3
             }
+          ]
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Operation",
+          "name": "operation",
+          "type": "button",
+          "label": "删除",
+          "size": "sm"
         }
-    ]
+      ],
+      "footer": {
+        "type": "tpl",
+        "tpl": "表格Footer"
+      }
+    }
+  ]
 }
 ```
 
@@ -93,39 +93,39 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "rowSelection": {
+        "type": "checkbox",
+        "keyField": "id"
+      },
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "rowSelection": {
-                "type": "checkbox",
-                "keyField": "id"
-            },
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Operation",
-                    "name": "operation",
-                    "type": "button",
-                    "label": "删除",
-                    "size": "sm"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Operation",
+          "name": "operation",
+          "type": "button",
+          "label": "删除",
+          "size": "sm"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -135,40 +135,40 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "rowSelection": {
+        "type": "checkbox",
+        "keyField": "id",
+        "rowClick": true
+      },
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "rowSelection": {
-                "type": "checkbox",
-                "keyField": "id",
-                "rowClick": true
-            },
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Operation",
-                    "name": "operation",
-                    "type": "button",
-                    "label": "删除",
-                    "size": "sm"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Operation",
+          "name": "operation",
+          "type": "button",
+          "label": "删除",
+          "size": "sm"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -178,44 +178,44 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "rowSelection": {
+        "type": "checkbox",
+        "keyField": "id",
+        "selectedRowKeys": [1, 2]
+      },
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "rowSelection": {
-                "type": "checkbox",
-                "keyField": "id",
-                "selectedRowKeys": [1, 2]
-            },
-            "columns": [
-                {
-                    "title": "ID",
-                    "name": "id"
-                },
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Operation",
-                    "name": "operation",
-                    "type": "button",
-                    "label": "删除",
-                    "size": "sm"
-                }
-            ]
+          "title": "ID",
+          "name": "id"
+        },
+        {
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Operation",
+          "name": "operation",
+          "type": "button",
+          "label": "删除",
+          "size": "sm"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -225,44 +225,44 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "rowSelection": {
+        "type": "checkbox",
+        "keyField": "id",
+        "selectedRowKeysExpr": "data.record.id === 1"
+      },
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "rowSelection": {
-                "type": "checkbox",
-                "keyField": "id",
-                "selectedRowKeysExpr": "data.record.id === 1"
-            },
-            "columns": [
-                {
-                    "title": "ID",
-                    "name": "id"
-                },
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Operation",
-                    "name": "operation",
-                    "type": "button",
-                    "label": "删除",
-                    "size": "sm"
-                }
-            ]
+          "title": "ID",
+          "name": "id"
+        },
+        {
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Operation",
+          "name": "operation",
+          "type": "button",
+          "label": "删除",
+          "size": "sm"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -272,33 +272,33 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "rowSelection": {
+        "type": "radio",
+        "keyField": "id",
+        "disableOn": "this.record.id === 1"
+      },
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "rowSelection": {
-                "type": "radio",
-                "keyField": "id",
-                "disableOn": "this.record.id === 1"
-            },
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -308,61 +308,61 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "rowSelection": {
+        "type": "checkbox",
+        "keyField": "id",
+        "selections": [
+          {
+            "key": "all",
+            "text": "全选所有"
+          },
+          {
+            "key": "invert",
+            "text": "反选当页"
+          },
+          {
+            "key": "none",
+            "text": "清空所有"
+          },
+          {
+            "key": "odd",
+            "text": "选择奇数行"
+          },
+          {
+            "key": "even",
+            "text": "选择偶数行"
+          }
+        ]
+      },
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "rowSelection": {
-                "type": "checkbox",
-                "keyField": "id",
-                "selections": [
-                    {
-                        "key": "all",
-                        "text": "全选所有"
-                    },
-                    {
-                        "key": "invert",
-                        "text": "反选当页"
-                    },
-                    {
-                        "key": "none",
-                        "text": "清空所有"
-                    },
-                    {
-                        "key": "odd",
-                        "text": "选择奇数行"
-                    },
-                    {
-                        "key": "even",
-                        "text": "选择偶数行"
-                    }
-                ]
-            },
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Operation",
-                    "name": "operation",
-                    "type": "button",
-                    "label": "删除",
-                    "size": "sm"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Operation",
+          "name": "operation",
+          "type": "button",
+          "label": "删除",
+          "size": "sm"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -372,40 +372,40 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "maxKeepItemSelectionLength": 2,
+      "rowSelection": {
+        "type": "checkbox",
+        "keyField": "id"
+      },
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "maxKeepItemSelectionLength": 2,
-            "rowSelection": {
-                "type": "checkbox",
-                "keyField": "id"
-            },
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Operation",
-                    "name": "operation",
-                    "type": "button",
-                    "label": "删除",
-                    "size": "sm"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Operation",
+          "name": "operation",
+          "type": "button",
+          "label": "删除",
+          "size": "sm"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -415,52 +415,52 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                    "sorter": true,
-                    "filterMultiple": true,
-                    "filters": [
-                        {
-                            "text": "Joe",
-                            "value": "Joe"
-                        },
-                        {
-                            "text": "Jim",
-                            "value": "Jim"
-                        }
-                    ]
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "sorter": true,
-                    "width": 100
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser",
-                    "filters": [
-                        {
-                            "text": "Joe",
-                            "value": "Joe"
-                        },
-                        {
-                            "text": "Jim",
-                            "value": "Jim"
-                        }
-                    ]
-                }
-            ]
+          "title": "Engine",
+          "name": "engine",
+          "sorter": true,
+          "filterMultiple": true,
+          "filters": [
+            {
+              "text": "Joe",
+              "value": "Joe"
+            },
+            {
+              "text": "Jim",
+              "value": "Jim"
+            }
+          ]
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "sorter": true,
+          "width": 100
+        },
+        {
+          "title": "Browser",
+          "name": "browser",
+          "filters": [
+            {
+              "text": "Joe",
+              "value": "Joe"
+            },
+            {
+              "text": "Jim",
+              "value": "Jim"
+            }
+          ]
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -470,38 +470,38 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "bordered": true,
+      "title": "标题",
+      "footer": "Footer",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "bordered": true,
-            "title": "标题",
-            "footer": "Footer",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Operation",
-                    "name": "operation",
-                    "type": "button",
-                    "label": "删除",
-                    "size": "sm"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Operation",
+          "name": "operation",
+          "type": "button",
+          "label": "删除",
+          "size": "sm"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -515,48 +515,48 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Operation",
-                    "name": "operation",
-                    "type": "button",
-                    "label": "删除",
-                    "size": "sm"
-                }
-            ],
-            "expandable": {
-                "expandableOn": "this.record && (this.record.id === 1 || this.record.id === 3)",
-                "keyField": "id",
-                "expandedRowClassNameExpr": "<%= data.rowIndex === 2 ? 'bg-success' : '' %>",
-                "expandedRowKeys": ["3"],
-                "type": "container",
-                "body": [
-                    {
-                        "type": "tpl",
-                        "html": "<div class=\"test\">测试测试</div>"
-                    }
-                ]
-            }
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Operation",
+          "name": "operation",
+          "type": "button",
+          "label": "删除",
+          "size": "sm"
         }
-    ]
+      ],
+      "expandable": {
+        "expandableOn": "this.record && (this.record.id === 1 || this.record.id === 3)",
+        "keyField": "id",
+        "expandedRowClassNameExpr": "<%= data.rowIndex === 2 ? 'bg-success' : '' %>",
+        "expandedRowKeys": ["3"],
+        "type": "container",
+        "body": [
+          {
+            "type": "tpl",
+            "html": "<div class=\"test\">测试测试</div>"
+          }
+        ]
+      }
+    }
+  ]
 }
 ```
 
@@ -566,48 +566,48 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Operation",
-                    "name": "operation",
-                    "type": "button",
-                    "label": "删除",
-                    "size": "sm"
-                }
-            ],
-            "expandable": {
-                "expandableOn": "this.record && (this.record.id === 1 || this.record.id === 3)",
-                "keyField": "id",
-                "expandedRowClassNameExpr": "<%= data.rowIndex % 2 ? 'bg-success' : '' %>",
-                "expandedRowKeysExpr": "data.record.id == '3'",
-                "type": "container",
-                "body": [
-                    {
-                        "type": "tpl",
-                        "html": "<div class=\"test\">测试测试</div>"
-                    }
-                ]
-            }
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Operation",
+          "name": "operation",
+          "type": "button",
+          "label": "删除",
+          "size": "sm"
         }
-    ]
+      ],
+      "expandable": {
+        "expandableOn": "this.record && (this.record.id === 1 || this.record.id === 3)",
+        "keyField": "id",
+        "expandedRowClassNameExpr": "<%= data.rowIndex % 2 ? 'bg-success' : '' %>",
+        "expandedRowKeysExpr": "data.record.id == '3'",
+        "type": "container",
+        "body": [
+          {
+            "type": "tpl",
+            "html": "<div class=\"test\">测试测试</div>"
+          }
+        ]
+      }
+    }
+  ]
 }
 ```
 
@@ -617,64 +617,64 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Operation",
-                    "name": "operation",
-                    "type": "button",
-                    "label": "删除",
-                    "size": "sm"
-                }
-            ],
-            "expandable": {
-                "expandableOn": "this.record && (this.record.id === 1 || this.record.id === 3)",
-                "keyField": "id",
-                "expandedRowClassNameExpr": "<%= data.rowIndex % 2 ? 'bg-success' : '' %>",
-                "expandedRowKeys": ["3"],
-                "type": "container",
-                "position": "right",
-                "body": [
-                    {
-                        "type": "tpl",
-                        "html": "<div class=\"test\">测试测试</div>"
-                    }
-                ]
-            },
-            "footSummary": [
-                {
-                    "type": "text",
-                    "text": "总计"
-                },
-                {
-                    "type": "tpl",
-                    "tpl": "测试测试",
-                    "colSpan": 2
-                },
-                {
-                    "type": "tpl",
-                    "tpl": "最后一列"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Operation",
+          "name": "operation",
+          "type": "button",
+          "label": "删除",
+          "size": "sm"
         }
-    ]
+      ],
+      "expandable": {
+        "expandableOn": "this.record && (this.record.id === 1 || this.record.id === 3)",
+        "keyField": "id",
+        "expandedRowClassNameExpr": "<%= data.rowIndex % 2 ? 'bg-success' : '' %>",
+        "expandedRowKeys": ["3"],
+        "type": "container",
+        "position": "right",
+        "body": [
+          {
+            "type": "tpl",
+            "html": "<div class=\"test\">测试测试</div>"
+          }
+        ]
+      },
+      "footSummary": [
+        {
+          "type": "text",
+          "text": "总计"
+        },
+        {
+          "type": "tpl",
+          "tpl": "测试测试",
+          "colSpan": 2
+        },
+        {
+          "type": "tpl",
+          "tpl": "最后一列"
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -684,62 +684,62 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "id": "table-select",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "id": "table-select",
-            "columns": [
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Operation",
+          "name": "operation",
+          "type": "button",
+          "label": "展开",
+          "size": "sm",
+          "onEvent": {
+            "click": {
+              "actions": [
                 {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Operation",
-                    "name": "operation",
-                    "type": "button",
-                    "label": "展开",
-                    "size": "sm",
-                    "onEvent": {
-                        "click": {
-                            "actions": [
-                                {
-                                    "actionType": "expand",
-                                    "componentId": "table-select",
-                                    "description": "展开行",
-                                    "args": {
-                                        "value": "${id}"
-                                    }
-                                }
-                            ]
-                        }
-                    }
+                  "actionType": "expand",
+                  "componentId": "table-select",
+                  "description": "展开行",
+                  "args": {
+                    "value": "${id}"
+                  }
                 }
-            ],
-            "expandable": {
-                "keyField": "id",
-                "expandedRowClassNameExpr": "<%= data.rowIndex % 2 ? 'bg-success' : '' %>",
-                "type": "container",
-                "position": "none",
-                "body": [
-                    {
-                        "type": "tpl",
-                        "html": "<div class=\"test\">测试测试</div>"
-                    }
-                ]
+              ]
             }
+          }
         }
-    ]
+      ],
+      "expandable": {
+        "keyField": "id",
+        "expandedRowClassNameExpr": "<%= data.rowIndex % 2 ? 'bg-success' : '' %>",
+        "type": "container",
+        "position": "none",
+        "body": [
+          {
+            "type": "tpl",
+            "html": "<div class=\"test\">测试测试</div>"
+          }
+        ]
+      }
+    }
+  ]
 }
 ```
 
@@ -747,68 +747,68 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "container",
+      "style": {
+        "marginBottom": "5px"
+      },
+      "body": [
         {
-            "type": "container",
-            "style": {
-                "marginBottom": "5px"
-            },
-            "body": [
+          "type": "button",
+          "label": "展开",
+          "size": "sm",
+          "onEvent": {
+            "click": {
+              "actions": [
                 {
-                    "type": "button",
-                    "label": "展开",
-                    "size": "sm",
-                    "onEvent": {
-                        "click": {
-                            "actions": [
-                                {
-                                    "actionType": "expand",
-                                    "componentId": "table-select2",
-                                    "description": "展开行",
-                                    "args": {
-                                        "expandedRowsExpr": "data.record?.id === 1 || data.record?.id === 3"
-                                    }
-                                }
-                            ]
-                        }
-                    }
+                  "actionType": "expand",
+                  "componentId": "table-select2",
+                  "description": "展开行",
+                  "args": {
+                    "expandedRowsExpr": "data.record?.id === 1 || data.record?.id === 3"
+                  }
                 }
-            ]
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "type": "table2",
+      "source": "$rows",
+      "id": "table-select2",
+      "columns": [
+        {
+          "title": "Engine",
+          "name": "engine"
         },
         {
-            "type": "table2",
-            "source": "$rows",
-            "id": "table-select2",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                }
-            ],
-            "expandable": {
-                "keyField": "id",
-                "expandedRowClassNameExpr": "<%= data.rowIndex % 2 ? 'bg-success' : '' %>",
-                "type": "container",
-                "position": "none",
-                "body": [
-                    {
-                        "type": "tpl",
-                        "html": "<div class=\"test\">测试测试</div>"
-                    }
-                ]
-            }
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
         }
-    ]
+      ],
+      "expandable": {
+        "keyField": "id",
+        "expandedRowClassNameExpr": "<%= data.rowIndex % 2 ? 'bg-success' : '' %>",
+        "type": "container",
+        "position": "none",
+        "body": [
+          {
+            "type": "tpl",
+            "html": "<div class=\"test\">测试测试</div>"
+          }
+        ]
+      }
+    }
+  ]
 }
 ```
 
@@ -818,42 +818,42 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=10",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=10",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "rowSpanExpr": "<%= data.rowIndex === 2 ? 2 : 0 %>"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText",
-                    "colSpanExpr": "<%= data.rowIndex === 6 ? 3 : 0 %>"
-                },
-                {
-                    "title": "Grade",
-                    "name": "grade"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "rowSpanExpr": "<%= data.rowIndex === 2 ? 2 : 0 %>"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText",
+          "colSpanExpr": "<%= data.rowIndex === 6 ? 3 : 0 %>"
+        },
+        {
+          "title": "Grade",
+          "name": "grade"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -970,29 +970,29 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=10",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=10",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "scroll": {"y" : 200},
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "scroll": {"y" : 200},
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Grade",
-                    "name": "grade"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Grade",
+          "name": "grade"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -1002,46 +1002,46 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=6",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=6",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "scroll": {"x": 1000},
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "scroll": {"x": 1000},
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                    "fixed": "left",
-                    "width": 100
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "fixed": "left",
-                    "width": 100
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Grade",
-                    "name": "grade"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform",
-                    "fixed": "right"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine",
+          "fixed": "left",
+          "width": 100
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "fixed": "left",
+          "width": 100
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Grade",
+          "name": "grade"
+        },
+        {
+          "title": "Platform",
+          "name": "platform",
+          "fixed": "right"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -1051,74 +1051,74 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=10",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=10",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "scroll": {"x": 1000, "y": 200},
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "scroll": {"x": 1000, "y": 200},
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                    "fixed": "left",
-                    "width": 100
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "type": "property",
-                    "width": 400,
-                    "items": [
-                        {
-                            "label": "cpu",
-                            "content": "1 core"
-                        },
-                        {
-                            "label": "memory",
-                            "content": "4G"
-                        },
-                        {
-                            "label": "disk",
-                            "content": "80G"
-                        },
-                        {
-                            "label": "network",
-                            "content": "4M",
-                            "span": 2
-                        },
-                        {
-                            "label": "IDC",
-                            "content": "beijing"
-                        },
-                        {
-                            "label": "Note",
-                            "content": "其它说明",
-                            "span": 3
-                        }
-                    ]
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Grade",
-                    "name": "grade"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform",
-                    "fixed": "right"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine",
+          "fixed": "left",
+          "width": 100
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "type": "property",
+          "width": 400,
+          "items": [
+            {
+              "label": "cpu",
+              "content": "1 core"
+            },
+            {
+              "label": "memory",
+              "content": "4G"
+            },
+            {
+              "label": "disk",
+              "content": "80G"
+            },
+            {
+              "label": "network",
+              "content": "4M",
+              "span": 2
+            },
+            {
+              "label": "IDC",
+              "content": "beijing"
+            },
+            {
+              "label": "Note",
+              "content": "其它说明",
+              "span": 3
+            }
+          ]
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Grade",
+          "name": "grade"
+        },
+        {
+          "title": "Platform",
+          "name": "platform",
+          "fixed": "right"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -1128,53 +1128,53 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=10",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=10",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "scroll": {"y": 200},
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "scroll": {"y": 200},
-            "columns": [
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Grade",
+          "name": "grade"
+        },
+        {
+          "title": "Grade1",
+          "name": "grade1",
+          "children": [
+            {
+              "title": "Browser",
+              "name": "browser"
+            },
+            {
+              "title": "Badge",
+              "name": "badgeText",
+              "children": [
                 {
-                    "title": "Engine",
-                    "name": "engine",
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Grade",
-                    "name": "grade"
-                },
-                {
-                    "title": "Grade1",
-                    "name": "grade1",
-                    "children": [
-                        {
-                            "title": "Browser",
-                            "name": "browser"
-                        },
-                        {
-                            "title": "Badge",
-                            "name": "badgeText",
-                            "children": [
-                                {
-                                    "title": "ID",
-                                    "name": "id"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
+                  "title": "ID",
+                  "name": "id"
                 }
-            ]
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -1182,64 +1182,64 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=10",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=10",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "scroll": {"y": 200},
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "scroll": {"y": 200},
-            "columns": [
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Grade",
+          "name": "grade",
+          "colSpanExpr": "<%= data.rowIndex === 1 ? 3 : 0 %>"
+        },
+        {
+          "title": "Grade1",
+          "name": "grade1",
+          "children": [
+            {
+              "title": "Browser",
+              "name": "browser"
+            }
+          ]
+        },
+        {
+          "title": "Platform1",
+          "name": "platform1",
+          "children": [
+            {
+              "title": "Badge1",
+              "name": "badgeText1",
+              "children": [
                 {
-                    "title": "Engine",
-                    "name": "engine",
+                  "title": "ID",
+                  "name": "id"
                 },
                 {
-                    "title": "Version",
-                    "name": "version"
+                  "title": "Platform",
+                  "name": "platform"
                 },
                 {
-                    "title": "Grade",
-                    "name": "grade",
-                    "colSpanExpr": "<%= data.rowIndex === 1 ? 3 : 0 %>"
-                },
-                {
-                    "title": "Grade1",
-                    "name": "grade1",
-                    "children": [
-                        {
-                            "title": "Browser",
-                            "name": "browser"
-                        }
-                    ]
-                },
-                {
-                    "title": "Platform1",
-                    "name": "platform1",
-                    "children": [
-                        {
-                            "title": "Badge1",
-                            "name": "badgeText1",
-                            "children": [
-                                {
-                                    "title": "ID",
-                                    "name": "id"
-                                },
-                                {
-                                    "title": "Platform",
-                                    "name": "platform"
-                                },
-                                {
-                                    "title": "Badge",
-                                    "name": "badgeText"
-                                }
-                            ]
-                        }
-                    ]
+                  "title": "Badge",
+                  "name": "badgeText"
                 }
-            ]
+              ]
+            }
+          ]
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -1251,44 +1251,44 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "draggable": true,
+      "keyField": "id",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "draggable": true,
-            "keyField": "id",
-            "columns": [
-                {
-                    "title": "ID",
-                    "name": "id"
-                },
-                {
-                    "title": "Grade",
-                    "name": "grade"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText",
-                    "children": [
-                        {
-                            "title": "Engine",
-                            "name": "engine",
-                        }
-                    ]
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ]
+          "title": "ID",
+          "name": "id"
+        },
+        {
+          "title": "Grade",
+          "name": "grade"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText",
+          "children": [
+            {
+              "title": "Engine",
+              "name": "engine"
+            }
+          ]
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -1298,192 +1298,192 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "page",
-    "body": {
-        "type": "service",
-        "data": {
-            "rows": [
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 4.0",
-                    "platform": "Win 95+",
-                    "version": "4",
-                    "grade": "X",
-                    "id": 1,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 1001,
-                            "children": [
-                                {
-                                    "engine": "Trident",
-                                    "browser": "Internet Explorer 4.0",
-                                    "platform": "Win 95+",
-                                    "version": "4",
-                                    "grade": "X",
-                                    "id": 10001
-                                },
-                                {
-                                    "engine": "Trident",
-                                    "browser": "Internet Explorer 5.0",
-                                    "platform": "Win 95+",
-                                    "version": "5",
-                                    "grade": "C",
-                                    "id": 10002
-                                }
-                            ]
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 1002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 5.0",
-                    "platform": "Win 95+",
-                    "version": "5",
-                    "grade": "C",
-                    "id": 2,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 2001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 2002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 5.5",
-                    "platform": "Win 95+",
-                    "version": "5.5",
-                    "grade": "A",
-                    "id": 3,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 3001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 3002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 6",
-                    "platform": "Win 98+",
-                    "version": "6",
-                    "grade": "A",
-                    "id": 4,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 4001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 4002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 7",
-                    "platform": "Win XP SP2+",
-                    "version": "7",
-                    "grade": "A",
-                    "id": 5,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 5001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 5002
-                        }
-                    ]
-                }
-            ]
-        },
-        "body": [
+  "type": "page",
+  "body": {
+    "type": "service",
+    "data": {
+      "rows": [
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 4.0",
+          "platform": "Win 95+",
+          "version": "4",
+          "grade": "X",
+          "id": 1,
+          "children": [
             {
-                "type": "table2",
-                "source": "$rows",
-                "columns": [
-                    {
-                        "name": "engine",
-                        "title": "Engine"
-                    },
-                    {
-                        "name": "grade",
-                        "title": "Grade"
-                    },
-                    {
-                        "name": "browser",
-                        "title": "Browser"
-                    },
-                    {
-                        "name": "id",
-                        "title": "ID"
-                    },
-                    {
-                        "name": "platform",
-                        "title": "Platform"
-                    }
-                ],
-                "keyField": "id",
-                "draggable": true
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 1001,
+              "children": [
+                {
+                  "engine": "Trident",
+                  "browser": "Internet Explorer 4.0",
+                  "platform": "Win 95+",
+                  "version": "4",
+                  "grade": "X",
+                  "id": 10001
+                },
+                {
+                  "engine": "Trident",
+                  "browser": "Internet Explorer 5.0",
+                  "platform": "Win 95+",
+                  "version": "5",
+                  "grade": "C",
+                  "id": 10002
+                }
+              ]
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 1002
             }
-        ]
-    }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 5.0",
+          "platform": "Win 95+",
+          "version": "5",
+          "grade": "C",
+          "id": 2,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 2001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 2002
+            }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 5.5",
+          "platform": "Win 95+",
+          "version": "5.5",
+          "grade": "A",
+          "id": 3,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 3001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 3002
+            }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 6",
+          "platform": "Win 98+",
+          "version": "6",
+          "grade": "A",
+          "id": 4,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 4001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 4002
+            }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 7",
+          "platform": "Win XP SP2+",
+          "version": "7",
+          "grade": "A",
+          "id": 5,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 5001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 5002
+            }
+          ]
+        }
+      ]
+    },
+    "body": [
+      {
+        "type": "table2",
+        "source": "$rows",
+        "columns": [
+          {
+            "name": "engine",
+            "title": "Engine"
+          },
+          {
+            "name": "grade",
+            "title": "Grade"
+          },
+          {
+            "name": "browser",
+            "title": "Browser"
+          },
+          {
+            "name": "id",
+            "title": "ID"
+          },
+          {
+            "name": "platform",
+            "title": "Platform"
+          }
+        ],
+        "keyField": "id",
+        "draggable": true
+      }
+    ]
+  }
 }
 ```
 
@@ -1497,56 +1497,56 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=10",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=10",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "scroll": {"y": 200},
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "scroll": {"y": 200},
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Grade",
-                    "name": "grade"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ],
-            "headSummary": [
-                {
-                    "type": "text",
-                    "text": "总计"
-                },
-                {
-                    "type": "tpl",
-                    "tpl": "测试测试",
-                    "colSpan": 5
-                }
-            ],
-            "rowSelection": {
-                "type": "checkbox",
-                "keyField": "id"
-            }
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Grade",
+          "name": "grade"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ],
+      "headSummary": [
+        {
+          "type": "text",
+          "text": "总计"
+        },
+        {
+          "type": "tpl",
+          "tpl": "测试测试",
+          "colSpan": 5
+        }
+      ],
+      "rowSelection": {
+        "type": "checkbox",
+        "keyField": "id"
+      }
+    }
+  ]
 }
 ```
 
@@ -1556,65 +1556,65 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=10",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=10",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "scroll": {"y": 200},
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "scroll": {"y": 200},
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Grade",
-                    "name": "grade"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ],
-            "headSummary": [
-                [
-                    {
-                        "type": "text",
-                        "text": "总计"
-                    },
-                    {
-                        "type": "tpl",
-                        "tpl": "测试测试",
-                        "colSpan": 5
-                    }
-                ],
-                [
-                    {
-                        "type": "text",
-                        "text": "总结",
-                        "colSpan": 6
-                    }
-                ]
-            ],
-            "rowSelection": {
-                "type": "checkbox",
-                "keyField": "id"
-            }
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Grade",
+          "name": "grade"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ],
+      "headSummary": [
+        [
+          {
+            "type": "text",
+            "text": "总计"
+          },
+          {
+            "type": "tpl",
+            "tpl": "测试测试",
+            "colSpan": 5
+          }
+        ],
+        [
+          {
+            "type": "text",
+            "text": "总结",
+            "colSpan": 6
+          }
+        ]
+      ],
+      "rowSelection": {
+        "type": "checkbox",
+        "keyField": "id"
+      }
+    }
+  ]
 }
 ```
 
@@ -1624,55 +1624,55 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=10",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=10",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "bordered": true,
+      "scroll": {"y": 200, "x": 1000},
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "bordered": true,
-            "scroll": {"y": 200, "x": 1000},
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                    "fixed": "left"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Grade",
-                    "name": "grade"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ],
-            "footSummary": [
-                {
-                    "type": "text",
-                    "text": "总计",
-                    "fixed": 'left'
-                },
-                {
-                    "type": "tpl",
-                    "tpl": "测试测试",
-                    "colSpan": 5
-                }
-            ]
+          "title": "Engine",
+          "name": "engine",
+          "fixed": "left"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Grade",
+          "name": "grade"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ],
+      "footSummary": [
+        {
+          "type": "text",
+          "text": "总计",
+          "fixed": 'left'
+        },
+        {
+          "type": "tpl",
+          "tpl": "测试测试",
+          "colSpan": 5
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -1682,62 +1682,62 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=10",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=10",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "bordered": true,
+      "scroll": {"y": 200, "x": 1000},
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "bordered": true,
-            "scroll": {"y": 200, "x": 1000},
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                    "fixed": "left"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Grade",
-                    "name": "grade"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ],
-            "footSummary": [
-                {
-                    "type": "text",
-                    "text": "总计",
-                    "colSpan": 6
-                },
-                [
-                    {
-                        "type": "tpl",
-                        "tpl": "测试测试",
-                        "colSpan": 5
-                    },
-                    {
-                        "type": "text",
-                        "text": "总结",
-                        "colSpan": 1
-                    }
-                ]
-            ]
+          "title": "Engine",
+          "name": "engine",
+          "fixed": "left"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Grade",
+          "name": "grade"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ],
+      "footSummary": [
+        {
+          "type": "text",
+          "text": "总计",
+          "colSpan": 6
+        },
+        [
+          {
+            "type": "tpl",
+            "tpl": "测试测试",
+            "colSpan": 5
+          },
+          {
+            "type": "text",
+            "text": "总结",
+            "colSpan": 1
+          }
+        ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -1747,48 +1747,48 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=6",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=6",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "scroll": {"x": 1000},
+      "resizable": true,
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "scroll": {"x": 1000},
-            "resizable": true,
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                    "width": 200,
-                    "align": "center"
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "width": 200,
-                    "align": "right"
-                },
-                {
-                    "title": "Grade",
-                    "name": "grade",
-                    "width": 200
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser",
-                    "width": 200
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine",
+          "width": 200,
+          "align": "center"
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "width": 200,
+          "align": "right"
+        },
+        {
+          "title": "Grade",
+          "name": "grade",
+          "width": 200
+        },
+        {
+          "title": "Browser",
+          "name": "browser",
+          "width": 200
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -1800,48 +1800,48 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=6",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=6",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "columnsTogglable": true,
+      "title": "表格的标题",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "columnsTogglable": true,
-            "title": "表格的标题",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                    "width": 200
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "width": 200
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser",
-                    "width": 200,
-                    "children": [
-                        {
-                            "title": "Grade",
-                            "name": "grade",
-                            "width": 200
-                        }
-                    ]
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine",
+          "width": 200
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "width": 200
+        },
+        {
+          "title": "Browser",
+          "name": "browser",
+          "width": 200,
+          "children": [
+            {
+              "title": "Grade",
+              "name": "grade",
+              "width": 200
+            }
+          ]
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -1851,50 +1851,50 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=6",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=6",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "columnsTogglable": {
+        "icon": "fa fa-user"
+      },
+      "title": "表格的标题",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "columnsTogglable": {
-                "icon": "fa fa-user"
-            },
-            "title": "表格的标题",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                    "width": 200
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "width": 200
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser",
-                    "width": 200,
-                    "children": [
-                        {
-                            "title": "Grade",
-                            "name": "grade",
-                            "width": 200
-                        }
-                    ]
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine",
+          "width": 200
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "width": 200
+        },
+        {
+          "title": "Browser",
+          "name": "browser",
+          "width": 200,
+          "children": [
+            {
+              "title": "Grade",
+              "name": "grade",
+              "width": 200
+            }
+          ]
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -1904,45 +1904,45 @@ order: 67
 
 ```schema
 {
-    "type": "table2",
-    "data": {
-        "items": []
+  "type": "table2",
+  "data": {
+    "items": []
+  },
+  "columns": [
+    {
+      "title": "Engine",
+      "name": "engine",
+      "width": 200
     },
-    "columns": [
+    {
+      "title": "Version",
+      "name": "version",
+      "width": 200
+    },
+    {
+      "title": "Browser",
+      "name": "browser",
+      "width": 200,
+      "children": [
         {
-            "title": "Engine",
-            "name": "engine",
-            "width": 200
-        },
-        {
-            "title": "Version",
-            "name": "version",
-            "width": 200
-        },
-        {
-            "title": "Browser",
-            "name": "browser",
-            "width": 200,
-            "children": [
-                {
-                    "title": "Grade",
-                    "name": "grade",
-                    "width": 200
-                }
-            ]
-        },
-        {
-            "title": "Platform",
-            "name": "platform",
-            "children": [
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                }
-            ]
+          "title": "Grade",
+          "name": "grade",
+          "width": 200
         }
-    ],
-    "placeholder": "暂无数据"
+      ]
+    },
+    {
+      "title": "Platform",
+      "name": "platform",
+      "children": [
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        }
+      ]
+    }
+  ],
+  "placeholder": "暂无数据"
 }
 ```
 
@@ -1952,45 +1952,45 @@ order: 67
 
 ```schema
 {
-    "type": "table2",
-    "data": {
-        "items": []
+  "type": "table2",
+  "data": {
+    "items": []
+  },
+  "columns": [
+    {
+      "title": "Engine",
+      "name": "engine",
+      "width": 200
     },
-    "columns": [
+    {
+      "title": "Version",
+      "name": "version",
+      "width": 200
+    },
+    {
+      "title": "Browser",
+      "name": "browser",
+      "width": 200,
+      "children": [
         {
-            "title": "Engine",
-            "name": "engine",
-            "width": 200
+          "title": "Grade",
+          "name": "grade",
+          "width": 200
         },
         {
-            "title": "Version",
-            "name": "version",
-            "width": 200
-        },
-        {
-            "title": "Browser",
-            "name": "browser",
-            "width": 200,
-            "children": [
-                {
-                    "title": "Grade",
-                    "name": "grade",
-                    "width": 200
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText",
-                    "children": [
-                        {
-                            "title": "Platform",
-                            "name": "platform"
-                        }
-                    ]
-                }
-            ]
+          "title": "Badge",
+          "name": "badgeText",
+          "children": [
+            {
+              "title": "Platform",
+              "name": "platform"
+            }
+          ]
         }
-    ],
-    "loading": true
+      ]
+    }
+  ],
+  "loading": true
 }
 ```
 
@@ -2002,199 +2002,199 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "page",
-    "body": {
-        "type": "service",
-        "data": {
-            "rows": [
-                {
-                    "engine": "Trident1",
-                    "browser": "Internet Explorer 4.0",
-                    "platform": "Win 95+",
-                    "version": "4",
-                    "grade": "X",
-                    "id": 1,
-                    "children": [
-                        {
-                            "engine": "Trident1-1",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 1001,
-                            "children": [
-                                {
-                                    "engine": "Trident1-1-1",
-                                    "browser": "Internet Explorer 4.0",
-                                    "platform": "Win 95+",
-                                    "version": "4",
-                                    "grade": "X",
-                                    "id": 10001
-                                },
-                                {
-                                    "engine": "Trident1-1-2",
-                                    "browser": "Internet Explorer 5.0",
-                                    "platform": "Win 95+",
-                                    "version": "5",
-                                    "grade": "C",
-                                    "id": 10002
-                                }
-                            ]
-                        },
-                        {
-                            "engine": "Trident1-2",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 1002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident2",
-                    "browser": "Internet Explorer 5.0",
-                    "platform": "Win 95+",
-                    "version": "5",
-                    "grade": "C",
-                    "id": 2,
-                    "children": [
-                        {
-                            "engine": "Trident2-1",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 2001
-                        },
-                        {
-                            "engine": "Trident2-2",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 2002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 5.5",
-                    "platform": "Win 95+",
-                    "version": "5.5",
-                    "grade": "A",
-                    "id": 3,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 3001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 3002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 6",
-                    "platform": "Win 98+",
-                    "version": "6",
-                    "grade": "A",
-                    "id": 4,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 4001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 4002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 7",
-                    "platform": "Win XP SP2+",
-                    "version": "7",
-                    "grade": "A",
-                    "id": 5,
-                    "children":[
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 5001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 5002
-                        }
-                    ]
-                }
-            ]
-        },
-        "body": [
+  "type": "page",
+  "body": {
+    "type": "service",
+    "data": {
+      "rows": [
+        {
+          "engine": "Trident1",
+          "browser": "Internet Explorer 4.0",
+          "platform": "Win 95+",
+          "version": "4",
+          "grade": "X",
+          "id": 1,
+          "children": [
             {
-                "type": "table2",
-                "source": "$rows",
-                "columns": [
-                    {
-                        "name": "id",
-                        "title": "ID"
-                    },
-                    {
-                        "name": "engine",
-                        "title": "Engine"
-                    },
-                    {
-                        "name": "grade",
-                        "title": "Grade"
-                    },
-                    {
-                        "name": "version",
-                        "title": "Version"
-                    },
-                    {
-                        "name": "browser",
-                        "title": "Browser"
-                    },
-                    {
-                        "name": "id",
-                        "title": "ID"
-                    },
-                    {
-                        "name": "platform",
-                        "title": "Platform"
-                    }
-                ],
-                "keyField": "id"
+              "engine": "Trident1-1",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 1001,
+              "children": [
+                {
+                  "engine": "Trident1-1-1",
+                  "browser": "Internet Explorer 4.0",
+                  "platform": "Win 95+",
+                  "version": "4",
+                  "grade": "X",
+                  "id": 10001
+                },
+                {
+                  "engine": "Trident1-1-2",
+                  "browser": "Internet Explorer 5.0",
+                  "platform": "Win 95+",
+                  "version": "5",
+                  "grade": "C",
+                  "id": 10002
+                }
+              ]
+            },
+            {
+              "engine": "Trident1-2",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 1002
             }
-        ]
-    }
+          ]
+        },
+        {
+          "engine": "Trident2",
+          "browser": "Internet Explorer 5.0",
+          "platform": "Win 95+",
+          "version": "5",
+          "grade": "C",
+          "id": 2,
+          "children": [
+            {
+              "engine": "Trident2-1",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 2001
+            },
+            {
+              "engine": "Trident2-2",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 2002
+            }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 5.5",
+          "platform": "Win 95+",
+          "version": "5.5",
+          "grade": "A",
+          "id": 3,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 3001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 3002
+            }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 6",
+          "platform": "Win 98+",
+          "version": "6",
+          "grade": "A",
+          "id": 4,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 4001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 4002
+            }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 7",
+          "platform": "Win XP SP2+",
+          "version": "7",
+          "grade": "A",
+          "id": 5,
+          "children":[
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 5001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 5002
+            }
+          ]
+        }
+      ]
+    },
+    "body": [
+      {
+        "type": "table2",
+        "source": "$rows",
+        "columns": [
+          {
+            "name": "id",
+            "title": "ID"
+          },
+          {
+            "name": "engine",
+            "title": "Engine"
+          },
+          {
+            "name": "grade",
+            "title": "Grade"
+          },
+          {
+            "name": "version",
+            "title": "Version"
+          },
+          {
+            "name": "browser",
+            "title": "Browser"
+          },
+          {
+            "name": "id",
+            "title": "ID"
+          },
+          {
+            "name": "platform",
+            "title": "Platform"
+          }
+        ],
+        "keyField": "id"
+      }
+    ]
+  }
 }
 ```
 
@@ -2204,203 +2204,203 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "page",
-    "body": {
-        "type": "service",
-        "data": {
-            "rows": [
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 4.0",
-                    "platform": "Win 95+",
-                    "version": "4",
-                    "grade": "X",
-                    "id": 1,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 1001,
-                            "children": [
-                                {
-                                    "engine": "Trident",
-                                    "browser": "Internet Explorer 4.0",
-                                    "platform": "Win 95+",
-                                    "version": "4",
-                                    "grade": "X",
-                                    "id": 10001
-                                },
-                                {
-                                    "engine": "Trident",
-                                    "browser": "Internet Explorer 5.0",
-                                    "platform": "Win 95+",
-                                    "version": "5",
-                                    "grade": "C",
-                                    "id": 10002
-                                }
-                            ]
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 1002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 5.0",
-                    "platform": "Win 95+",
-                    "version": "5",
-                    "grade": "C",
-                    "id": 2,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 2001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 2002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 5.5",
-                    "platform": "Win 95+",
-                    "version": "5.5",
-                    "grade": "A",
-                    "id": 3,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 3001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 3002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 6",
-                    "platform": "Win 98+",
-                    "version": "6",
-                    "grade": "A",
-                    "id": 4,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 4001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 4002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 7",
-                    "platform": "Win XP SP2+",
-                    "version": "7",
-                    "grade": "A",
-                    "id": 5,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 5001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 5002
-                        }
-                    ]
-                }
-            ]
-        },
-        "body": [
+  "type": "page",
+  "body": {
+    "type": "service",
+    "data": {
+      "rows": [
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 4.0",
+          "platform": "Win 95+",
+          "version": "4",
+          "grade": "X",
+          "id": 1,
+          "children": [
             {
-                "type": "table2",
-                "source": "$rows",
-                "columns": [
-                    {
-                        "name": "id",
-                        "title": "ID"
-                    },
-                    {
-                        "name": "engine",
-                        "title": "Engine"
-                    },
-                    {
-                        "name": "grade",
-                        "title": "Grade"
-                    },
-                    {
-                        "name": "version",
-                        "title": "Version"
-                    },
-                    {
-                        "name": "browser",
-                        "title": "Browser"
-                    },
-                    {
-                        "name": "id",
-                        "title": "ID"
-                    },
-                    {
-                        "name": "platform",
-                        "title": "Platform"
-                    }
-                ],
-                "keyField": "id",
-                "rowSelection": {
-                    "type": "checkbox",
-                    "keyField": "id"
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 1001,
+              "children": [
+                {
+                  "engine": "Trident",
+                  "browser": "Internet Explorer 4.0",
+                  "platform": "Win 95+",
+                  "version": "4",
+                  "grade": "X",
+                  "id": 10001
+                },
+                {
+                  "engine": "Trident",
+                  "browser": "Internet Explorer 5.0",
+                  "platform": "Win 95+",
+                  "version": "5",
+                  "grade": "C",
+                  "id": 10002
                 }
+              ]
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 1002
             }
-        ]
-    }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 5.0",
+          "platform": "Win 95+",
+          "version": "5",
+          "grade": "C",
+          "id": 2,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 2001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 2002
+            }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 5.5",
+          "platform": "Win 95+",
+          "version": "5.5",
+          "grade": "A",
+          "id": 3,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 3001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 3002
+            }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 6",
+          "platform": "Win 98+",
+          "version": "6",
+          "grade": "A",
+          "id": 4,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 4001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 4002
+            }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 7",
+          "platform": "Win XP SP2+",
+          "version": "7",
+          "grade": "A",
+          "id": 5,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 5001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 5002
+            }
+          ]
+        }
+      ]
+    },
+    "body": [
+      {
+        "type": "table2",
+        "source": "$rows",
+        "columns": [
+          {
+            "name": "id",
+            "title": "ID"
+          },
+          {
+            "name": "engine",
+            "title": "Engine"
+          },
+          {
+            "name": "grade",
+            "title": "Grade"
+          },
+          {
+            "name": "version",
+            "title": "Version"
+          },
+          {
+            "name": "browser",
+            "title": "Browser"
+          },
+          {
+            "name": "id",
+            "title": "ID"
+          },
+          {
+            "name": "platform",
+            "title": "Platform"
+          }
+        ],
+        "keyField": "id",
+        "rowSelection": {
+          "type": "checkbox",
+          "keyField": "id"
+        }
+      }
+    ]
+  }
 }
 ```
 
@@ -2410,199 +2410,199 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "page",
-    "body": {
-        "type": "service",
-        "data": {
-            "rows": [
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 4.0",
-                    "platform":  "Win 95+",
-                    "version": "4",
-                    "grade": "X",
-                    "id": 1,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 1001,
-                            "children": [
-                                {
-                                    "engine": "Trident",
-                                    "browser": "Internet Explorer 4.0",
-                                    "platform": "Win 95+",
-                                    "version": "4",
-                                    "grade": "X",
-                                    "id": 10001
-                                },
-                                {
-                                    "engine": "Trident",
-                                    "browser": "Internet Explorer 5.0",
-                                    "platform": "Win 95+",
-                                    "version": "5",
-                                    "grade": "C",
-                                    "id": 10002
-                                }
-                            ]
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 1002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 5.0",
-                    "platform": "Win 95+",
-                    "version": "5",
-                    "grade": "C",
-                    "id": 2,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 2001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 2002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 5.5",
-                    "platform": "Win 95+",
-                    "version": "5.5",
-                    "grade": "A",
-                    "id": 3,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 3001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 3002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 6",
-                    "platform": "Win 98+",
-                    "version": "6",
-                    "grade": "A",
-                    "id": 4,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 4001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 4002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 7",
-                    "platform": "Win XP SP2+",
-                    "version": "7",
-                    "grade": "A",
-                    "id": 5,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 5001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 5002
-                        }
-                    ]
-                }
-            ]
-        },
-        "body": [
+  "type": "page",
+  "body": {
+    "type": "service",
+    "data": {
+      "rows": [
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 4.0",
+          "platform":  "Win 95+",
+          "version": "4",
+          "grade": "X",
+          "id": 1,
+          "children": [
             {
-                "type": "table2",
-                "source": "$rows",
-                "columns": [
-                    {
-                        "name": "engine",
-                        "title": "Engine"
-                    },
-                    {
-                        "name": "grade",
-                        "title": "Grade"
-                    },
-                    {
-                        "name": "version",
-                        "title": "Version"
-                    },
-                    {
-                        "name": "browser",
-                        "title": "Browser"
-                    },
-                    {
-                        "name": "id",
-                        "title": "ID"
-                    },
-                    {
-                        "name": "platform",
-                        "title": "Platform"
-                    }
-                ],
-                "keyField": "id",
-                "rowSelection": {
-                    "type": "radio",
-                    "keyField": "id"
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 1001,
+              "children": [
+                {
+                  "engine": "Trident",
+                  "browser": "Internet Explorer 4.0",
+                  "platform": "Win 95+",
+                  "version": "4",
+                  "grade": "X",
+                  "id": 10001
+                },
+                {
+                  "engine": "Trident",
+                  "browser": "Internet Explorer 5.0",
+                  "platform": "Win 95+",
+                  "version": "5",
+                  "grade": "C",
+                  "id": 10002
                 }
+              ]
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 1002
             }
-        ]
-    }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 5.0",
+          "platform": "Win 95+",
+          "version": "5",
+          "grade": "C",
+          "id": 2,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 2001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 2002
+            }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 5.5",
+          "platform": "Win 95+",
+          "version": "5.5",
+          "grade": "A",
+          "id": 3,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 3001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 3002
+            }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 6",
+          "platform": "Win 98+",
+          "version": "6",
+          "grade": "A",
+          "id": 4,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 4001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 4002
+            }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 7",
+          "platform": "Win XP SP2+",
+          "version": "7",
+          "grade": "A",
+          "id": 5,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 5001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 5002
+            }
+          ]
+        }
+      ]
+    },
+    "body": [
+      {
+        "type": "table2",
+        "source": "$rows",
+        "columns": [
+          {
+            "name": "engine",
+            "title": "Engine"
+          },
+          {
+            "name": "grade",
+            "title": "Grade"
+          },
+          {
+            "name": "version",
+            "title": "Version"
+          },
+          {
+            "name": "browser",
+            "title": "Browser"
+          },
+          {
+            "name": "id",
+            "title": "ID"
+          },
+          {
+            "name": "platform",
+            "title": "Platform"
+          }
+        ],
+        "keyField": "id",
+        "rowSelection": {
+          "type": "radio",
+          "keyField": "id"
+        }
+      }
+    ]
+  }
 }
 ```
 
@@ -2612,200 +2612,200 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "page",
-    "body": {
-        "type": "service",
-        "data":{
-            "rows": [
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 4.0",
-                    "platform": "Win 95+",
-                    "version": "4",
-                    "grade": "X",
-                    "id": 1,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 1001,
-                            "children": [
-                                {
-                                    "engine": "Trident",
-                                    "browser": "Internet Explorer 4.0",
-                                    "platform": "Win 95+",
-                                    "version": "4",
-                                    "grade": "X",
-                                    "id": 10001
-                                },
-                                {
-                                    "engine": "Trident",
-                                    "browser": "Internet Explorer 5.0",
-                                    "platform": "Win 95+",
-                                    "version": "5",
-                                    "grade": "C",
-                                    "id": 10002
-                                }
-                            ]
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 1002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 5.0",
-                    "platform": "Win 95+",
-                    "version": "5",
-                    "grade": "C",
-                    "id": 2,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 2001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 2002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 5.5",
-                    "platform": "Win 95+",
-                    "version": "5.5",
-                    "grade": "A",
-                    "id": 3,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 3001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 3002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 6",
-                    "platform": "Win 98+",
-                    "version": "6",
-                    "grade": "A",
-                    "id": 4,
-                    "children": [
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id": 4001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id": 4002
-                        }
-                    ]
-                },
-                {
-                    "engine": "Trident",
-                    "browser": "Internet Explorer 7",
-                    "platform": "Win XP SP2+",
-                    "version": "7",
-                    "grade": "A",
-                    "id":5,
-                    "children":[
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 4.0",
-                            "platform": "Win 95+",
-                            "version": "4",
-                            "grade": "X",
-                            "id":5001
-                        },
-                        {
-                            "engine": "Trident",
-                            "browser": "Internet Explorer 5.0",
-                            "platform": "Win 95+",
-                            "version": "5",
-                            "grade": "C",
-                            "id":5002
-                        }
-                    ]
-                }
-            ]
-        },
-        "body":[
+  "type": "page",
+  "body": {
+    "type": "service",
+    "data":{
+      "rows": [
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 4.0",
+          "platform": "Win 95+",
+          "version": "4",
+          "grade": "X",
+          "id": 1,
+          "children": [
             {
-                "type": "table2",
-                "source": "$rows",
-                "columns":[
-                    {
-                        "name": "engine",
-                        "title": "Engine"
-                    },
-                    {
-                        "name": "grade",
-                        "title": "Grade"
-                    },
-                    {
-                        "name": "version",
-                        "title": "Version"
-                    },
-                    {
-                        "name": "browser",
-                        "title": "Browser"
-                    },
-                    {
-                        "name": "id",
-                        "title": "ID"
-                    },
-                    {
-                        "name": "platform",
-                        "title": "Platform"
-                    }
-                ],
-                "keyField": "id",
-                "rowSelection":{
-                    "type": "checkbox",
-                    "keyField": "id"
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 1001,
+              "children": [
+                {
+                  "engine": "Trident",
+                  "browser": "Internet Explorer 4.0",
+                  "platform": "Win 95+",
+                  "version": "4",
+                  "grade": "X",
+                  "id": 10001
                 },
-                "indentSize": 20
+                {
+                  "engine": "Trident",
+                  "browser": "Internet Explorer 5.0",
+                  "platform": "Win 95+",
+                  "version": "5",
+                  "grade": "C",
+                  "id": 10002
+                }
+              ]
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 1002
             }
-        ]
-    }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 5.0",
+          "platform": "Win 95+",
+          "version": "5",
+          "grade": "C",
+          "id": 2,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 2001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 2002
+            }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 5.5",
+          "platform": "Win 95+",
+          "version": "5.5",
+          "grade": "A",
+          "id": 3,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 3001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 3002
+            }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 6",
+          "platform": "Win 98+",
+          "version": "6",
+          "grade": "A",
+          "id": 4,
+          "children": [
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id": 4001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id": 4002
+            }
+          ]
+        },
+        {
+          "engine": "Trident",
+          "browser": "Internet Explorer 7",
+          "platform": "Win XP SP2+",
+          "version": "7",
+          "grade": "A",
+          "id":5,
+          "children":[
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 4.0",
+              "platform": "Win 95+",
+              "version": "4",
+              "grade": "X",
+              "id":5001
+            },
+            {
+              "engine": "Trident",
+              "browser": "Internet Explorer 5.0",
+              "platform": "Win 95+",
+              "version": "5",
+              "grade": "C",
+              "id":5002
+            }
+          ]
+        }
+      ]
+    },
+    "body":[
+      {
+        "type": "table2",
+        "source": "$rows",
+        "columns":[
+          {
+            "name": "engine",
+            "title": "Engine"
+          },
+          {
+            "name": "grade",
+            "title": "Grade"
+          },
+          {
+            "name": "version",
+            "title": "Version"
+          },
+          {
+            "name": "browser",
+            "title": "Browser"
+          },
+          {
+            "name": "id",
+            "title": "ID"
+          },
+          {
+            "name": "platform",
+            "title": "Platform"
+          }
+        ],
+        "keyField": "id",
+        "rowSelection":{
+          "type": "checkbox",
+          "keyField": "id"
+        },
+        "indentSize": 20
+      }
+    ]
+  }
 }
 ```
 
@@ -2815,47 +2815,47 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=6",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=6",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                    "width": 200
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "width": 200,
-                    "searchable": true
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser",
-                    "width": 200,
-                    "children": [
-                        {
-                            "title": "Grade",
-                            "name": "grade",
-                            "width": 200
-                        }
-                    ]
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine",
+          "width": 200
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "width": 200,
+          "searchable": true
+        },
+        {
+          "title": "Browser",
+          "name": "browser",
+          "width": 200,
+          "children": [
+            {
+              "title": "Grade",
+              "name": "grade",
+              "width": 200
+            }
+          ]
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -2865,48 +2865,48 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=6",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=6",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "title": "表格的标题",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "title": "表格的标题",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                    "width": 200
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "width": 200
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser",
-                    "width": 200,
-                    "children": [
-                        {
-                            "title": "Grade",
-                            "name": "grade",
-                            "width": 200
-                        }
-                    ]
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ],
-            "sticky": true
+          "title": "Engine",
+          "name": "engine",
+          "width": 200
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "width": 200
+        },
+        {
+          "title": "Browser",
+          "name": "browser",
+          "width": 200,
+          "children": [
+            {
+              "title": "Grade",
+              "name": "grade",
+              "width": 200
+            }
+          ]
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ],
+      "sticky": true
+    }
+  ]
 }
 ```
 
@@ -2920,70 +2920,70 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=6",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=6",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "size": "large",
+      "rowSelection": {
+        "type": "checkbox",
+        "keyField": "id"
+      },
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "size": "large",
-            "rowSelection": {
-                "type": "checkbox",
-                "keyField": "id"
+          "title": "Engine",
+          "name": "engine",
+          "sorter": true,
+          "tpl": "${engine|truncate:5}"
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "sorter": true,
+          "filterMultiple": true,
+          "filters": [
+            {
+              "text": "Joe",
+              "value": "Joe"
             },
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                    "sorter": true,
-                    "tpl": "${engine|truncate:5}"
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "sorter": true,
-                    "filterMultiple": true,
-                    "filters": [
-                        {
-                            "text": "Joe",
-                            "value": "Joe"
-                        },
-                        {
-                            "text": "Jim",
-                            "value": "Jim"
-                        }
-                    ]
-                },
-                {
-                    "type": "tpl",
-                    "title": "Browser",
-                    "name": "browser",
-                    "tpl": "${browser|truncate:5}",
-                    "searchable": true
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ],
-            "footSummary": [
-                {
-                    "type": "text",
-                    "text": "总计",
-                    "fixed": "left"
-                },
-                {
-                    "type": "tpl",
-                    "tpl": "测试测试",
-                    "colSpan": 5
-                }
-            ]
+            {
+              "text": "Jim",
+              "value": "Jim"
+            }
+          ]
+        },
+        {
+          "type": "tpl",
+          "title": "Browser",
+          "name": "browser",
+          "tpl": "${browser|truncate:5}",
+          "searchable": true
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ],
+      "footSummary": [
+        {
+          "type": "text",
+          "text": "总计",
+          "fixed": "left"
+        },
+        {
+          "type": "tpl",
+          "tpl": "测试测试",
+          "colSpan": 5
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -2993,69 +2993,69 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=6",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=6",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "rowSelection": {
+        "type": "checkbox",
+        "keyField": "id"
+      },
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "rowSelection": {
-                "type": "checkbox",
-                "keyField": "id"
+          "title": "Engine",
+          "name": "engine",
+          "sorter": true,
+          "tpl": "${engine|truncate:5}"
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "sorter": true,
+          "filterMultiple": true,
+          "filters": [
+            {
+              "text": "Joe",
+              "value": "Joe"
             },
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                    "sorter": true,
-                    "tpl": "${engine|truncate:5}"
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "sorter": true,
-                    "filterMultiple": true,
-                    "filters": [
-                        {
-                            "text": "Joe",
-                            "value": "Joe"
-                        },
-                        {
-                            "text": "Jim",
-                            "value": "Jim"
-                        }
-                    ]
-                },
-                {
-                    "type": "tpl",
-                    "title": "Browser",
-                    "name": "browser",
-                    "tpl": "${engine|truncate:5}",
-                    "searchable": true
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ],
-            "footSummary": [
-                {
-                    "type": "text",
-                    "text": "总计",
-                    "fixed": "left"
-                },
-                {
-                    "type": "tpl",
-                    "tpl": "测试测试",
-                    "colSpan": 5
-                }
-            ]
+            {
+              "text": "Jim",
+              "value": "Jim"
+            }
+          ]
+        },
+        {
+          "type": "tpl",
+          "title": "Browser",
+          "name": "browser",
+          "tpl": "${engine|truncate:5}",
+          "searchable": true
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ],
+      "footSummary": [
+        {
+          "type": "text",
+          "text": "总计",
+          "fixed": "left"
+        },
+        {
+          "type": "tpl",
+          "tpl": "测试测试",
+          "colSpan": 5
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -3065,70 +3065,70 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=6",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=6",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "size": "small",
+      "rowSelection": {
+        "type": "checkbox",
+        "keyField": "id"
+      },
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "size": "small",
-            "rowSelection": {
-                "type": "checkbox",
-                "keyField": "id"
+          "title": "Engine",
+          "name": "engine",
+          "sorter": true,
+          "tpl": "${engine|truncate:5}"
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "sorter": true,
+          "filterMultiple": true,
+          "filters": [
+            {
+              "text": "Joe",
+              "value": "Joe"
             },
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                    "sorter": true,
-                    "tpl": "${engine|truncate:5}"
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "sorter": true,
-                    "filterMultiple": true,
-                    "filters": [
-                        {
-                            "text": "Joe",
-                            "value": "Joe"
-                        },
-                        {
-                            "text": "Jim",
-                            "value": "Jim"
-                        }
-                    ]
-                },
-                {
-                    "type": "tpl",
-                    "title": "Browser",
-                    "name": "browser",
-                    "tpl": "${engine|truncate:5}",
-                    "searchable": true
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ],
-            "footSummary": [
-                {
-                    "type": "text",
-                    "text": "总计",
-                    "fixed": "left"
-                },
-                {
-                    "type": "tpl",
-                    "tpl": "测试测试",
-                    "colSpan": 5
-                }
-            ]
+            {
+              "text": "Jim",
+              "value": "Jim"
+            }
+          ]
+        },
+        {
+          "type": "tpl",
+          "title": "Browser",
+          "name": "browser",
+          "tpl": "${engine|truncate:5}",
+          "searchable": true
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ],
+      "footSummary": [
+        {
+          "type": "text",
+          "text": "总计",
+          "fixed": "left"
+        },
+        {
+          "type": "tpl",
+          "tpl": "测试测试",
+          "colSpan": 5
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -3138,40 +3138,40 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=6",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=6",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "title": "表格的标题",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "title": "表格的标题",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine",
-                    "width": 200
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "copyable": true
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser",
-                    "width": 200
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine",
+          "width": 200
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "copyable": true
+        },
+        {
+          "title": "Browser",
+          "name": "browser",
+          "width": 200
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -3181,43 +3181,43 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=6",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=6",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser",
-                    "copyable": true,
-                    "popOver": {
-                        "body": {
-                            "type": "tpl",
-                            "tpl": "详细信息：${browser}"
-                        }
-                    }
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Browser",
+          "name": "browser",
+          "copyable": true,
+          "popOver": {
+            "body": {
+              "type": "tpl",
+              "tpl": "详细信息：${browser}"
+            }
+          }
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -3225,47 +3225,47 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=6",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=6",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "type": "tpl",
-                    "title": "Browser",
-                    "name": "browser",
-                    "tpl": "${engine|truncate:5}",
-                    "popOver": {
-                        "trigger": "hover",
-                        "position": "left-top",
-                        "showIcon": false,
-                        "body": {
-                            "type": "tpl",
-                            "tpl": "${browser}"
-                        }
-                    }
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "type": "tpl",
+          "title": "Browser",
+          "name": "browser",
+          "tpl": "${engine|truncate:5}",
+          "popOver": {
+            "trigger": "hover",
+            "position": "left-top",
+            "showIcon": false,
+            "body": {
+              "type": "tpl",
+              "tpl": "${browser}"
+            }
+          }
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -3273,53 +3273,53 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=6",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=6",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "columns": [
-                {
-                    "title": "ID",
-                    "name": "id",
-                    "popOver": {
-                        "body": {
-                            "type": "tpl",
-                            "tpl": "${id}"
-                        }
-                    },
-                    "popOverEnableOn": "this.id == 1"
-                },
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser",
-                    "popOver": {
-                        "body": {
-                            "type": "tpl",
-                            "tpl": "${browser}"
-                        }
-                    }
-                },
-                {
-                    "title": "Badge",
-                    "name": "badgeText"
-                },
-                {
-                    "title": "Platform",
-                    "name": "platform"
-                }
-            ]
+          "title": "ID",
+          "name": "id",
+          "popOver": {
+            "body": {
+              "type": "tpl",
+              "tpl": "${id}"
+            }
+          },
+          "popOverEnableOn": "this.id == 1"
+        },
+        {
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        },
+        {
+          "title": "Browser",
+          "name": "browser",
+          "popOver": {
+            "body": {
+              "type": "tpl",
+              "tpl": "${browser}"
+            }
+          }
+        },
+        {
+          "title": "Badge",
+          "name": "badgeText"
+        },
+        {
+          "title": "Platform",
+          "name": "platform"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -3343,66 +3343,66 @@ order: 67
       "visibleOn": "this.badgeText"
     },
     "columns": [
-        {
-            "name": "id",
-            "title": "ID",
-            "searchable": {
-              "type": "input-text",
-              "name": "id",
-              "label": "主键",
-              "placeholder": "输入id",
-              "size": "sm",
-            }
-        },
-        {
-            "name": "engine",
-            "title": "Rendering engine"
-        },
-        {
-            "name": "browser",
-            "title": "Browser",
-            "searchable": {
-              "type": "select",
-              "name": "browser",
-              "label": "浏览器",
-              "placeholder": "选择浏览器",
-              "size": "sm",
-              "options": [
-                {
-                  "label": "Internet Explorer ",
-                  "value": "ie"
-                },
-                {
-                  "label": "AOL browser",
-                  "value": "aol"
-                },
-                {
-                  "label": "Firefox",
-                  "value": "firefox"
-                }
-              ]
-            }
-        },
-        {
-            "name": "platform",
-            "title": "Platform(s)"
-        },
-        {
-            "name": "version",
-            "title": "Engine version",
-            "searchable": {
-              "type": "input-number",
-              "name": "version",
-              "label": "版本号",
-              "placeholder": "输入版本号",
-              "size": "sm",
-              "mode": "horizontal"
-            }
-        },
-        {
-            "name": "grade",
-            "title": "CSS grade"
+      {
+        "name": "id",
+        "title": "ID",
+        "searchable": {
+          "type": "input-text",
+          "name": "id",
+          "label": "主键",
+          "placeholder": "输入id",
+          "size": "sm",
         }
+      },
+      {
+        "name": "engine",
+        "title": "Rendering engine"
+      },
+      {
+        "name": "browser",
+        "title": "Browser",
+        "searchable": {
+          "type": "select",
+          "name": "browser",
+          "label": "浏览器",
+          "placeholder": "选择浏览器",
+          "size": "sm",
+          "options": [
+            {
+              "label": "Internet Explorer ",
+              "value": "ie"
+            },
+            {
+              "label": "AOL browser",
+              "value": "aol"
+            },
+            {
+              "label": "Firefox",
+              "value": "firefox"
+            }
+          ]
+        }
+      },
+      {
+        "name": "platform",
+        "title": "Platform(s)"
+      },
+      {
+        "name": "version",
+        "title": "Engine version",
+        "searchable": {
+          "type": "input-number",
+          "name": "version",
+          "label": "版本号",
+          "placeholder": "输入版本号",
+          "size": "sm",
+          "mode": "horizontal"
+        }
+      },
+      {
+        "name": "grade",
+        "title": "CSS grade"
+      }
     ]
   },
   data: {
@@ -3518,8 +3518,8 @@ order: 67
         "type": "table2",
         "source": "$rows",
         "quickSaveApi": {
-            "url": "/api/mock2/sample/bulkUpdate",
-            "method": "put"
+          "url": "/api/mock2/sample/bulkUpdate",
+          "method": "put"
         },
         "columns": [
           {
@@ -3554,39 +3554,39 @@ order: 67
 {
   "type": "page",
   "body": {
-        "type": "service",
-        "api": "/api/sample?perPage=5",
-        "body": [
-            {
-                "type": "table2",
-                "source": "$rows",
-                "quickSaveApi": {
-                    "url": "/api/mock2/sample/bulkUpdate",
-                    "method": "put"
-                },
-                "columns": [
-                    {
-                        "name": "id",
-                        "title": "ID"
-                    },
-                    {
-                        "name": "grade",
-                        "title": "CSS grade",
-                        "quickEdit": {
-                            "type": "select",
-                            "options": [
-                                "A",
-                                "B",
-                                "C",
-                                "D",
-                                "X"
-                            ]
-                        }
-                    }
-                ]
+    "type": "service",
+    "api": "/api/sample?perPage=5",
+    "body": [
+      {
+        "type": "table2",
+        "source": "$rows",
+        "quickSaveApi": {
+          "url": "/api/mock2/sample/bulkUpdate",
+          "method": "put"
+        },
+        "columns": [
+          {
+            "name": "id",
+            "title": "ID"
+          },
+          {
+            "name": "grade",
+            "title": "CSS grade",
+            "quickEdit": {
+              "type": "select",
+              "options": [
+                "A",
+                "B",
+                "C",
+                "D",
+                "X"
+              ]
             }
+          }
         ]
-    }
+      }
+    ]
+  }
 }
 ```
 
@@ -3596,50 +3596,49 @@ order: 67
 {
   "type": "page",
   "body": {
-        "type": "service",
-        "api": "/api/sample?perPage=5",
-        "body": [
-            {
-                "type": "table2",
-                "source": "$rows",
-                "quickSaveApi": {
-                    "url": "/api/mock2/sample/bulkUpdate",
-                    "method": "put"
+    "type": "service",
+    "api": "/api/sample?perPage=5",
+    "body": [
+      {
+        "type": "table2",
+        "source": "$rows",
+        "quickSaveApi": {
+          "url": "/api/mock2/sample/bulkUpdate",
+          "method": "put"
+        },
+        "columns": [
+          {
+            "name": "id",
+            "title": "ID"
+          },
+          {
+            "name": "grade",
+            "title": "CSS grade",
+            "quickEdit": {
+              "body": [
+                {
+                  "type": "select",
+                  "name": "grade",
+                  "options": [
+                    "A",
+                    "B",
+                    "C",
+                    "D",
+                    "X"
+                  ]
                 },
-                "columns": [
-                    {
-                        "name": "id",
-                        "title": "ID"
-                    },
-                    {
-                        "name": "grade",
-                        "title": "CSS grade",
-                        "quickEdit": {
-                            "body": [
-                                {
-                                    "type": "select",
-                                    "name": "grade",
-                                    "options": [
-                                        "A",
-                                        "B",
-                                        "C",
-                                        "D",
-                                        "X"
-                                    ]
-                                },
-
-                                {
-                                    "label": "id",
-                                    "type": "input-text",
-                                    "name": "id"
-                                }
-                            ]
-                        }
-                    }
-                ]
+                {
+                  "label": "id",
+                  "type": "input-text",
+                  "name": "id"
+                }
+              ]
             }
+          }
         ]
-    }
+      }
+    ]
+  }
 }
 ```
 
@@ -3651,51 +3650,51 @@ order: 67
 {
   "type": "page",
   "body": {
-        "type": "service",
-        "api": "/api/sample?perPage=5",
-        "body": [
-            {
-                "type": "table2",
-                "source": "$rows",
-                "quickSaveApi": {
-                    "url": "/api/mock2/sample/bulkUpdate",
-                    "method": "put"
-                },
-                "columns": [
-                    {
-                        "name": "id",
-                        "title": "ID"
-                    },
-                    {
-                        "name": "grade",
-                        "title": "CSS grade",
-                        "quickEdit": {
-                            "mode": "inline",
-                            "type": "select",
-                            "size": "xs",
-                            "options": [
-                                "A",
-                                "B",
-                                "C",
-                                "D",
-                                "X"
-                            ]
-                        }
-                    },
-                    {
-                        "name": "switch",
-                        "title": "switch",
-                        "quickEdit": {
-                            "mode": "inline",
-                            "type": "switch",
-                            "onText": "开启",
-                            "offText": "关闭"
-                        }
-                    }
-                ]
+    "type": "service",
+    "api": "/api/sample?perPage=5",
+    "body": [
+      {
+        "type": "table2",
+        "source": "$rows",
+        "quickSaveApi": {
+          "url": "/api/mock2/sample/bulkUpdate",
+          "method": "put"
+        },
+        "columns": [
+          {
+            "name": "id",
+            "title": "ID"
+          },
+          {
+            "name": "grade",
+            "title": "CSS grade",
+            "quickEdit": {
+              "mode": "inline",
+              "type": "select",
+              "size": "xs",
+              "options": [
+                "A",
+                "B",
+                "C",
+                "D",
+                "X"
+              ]
             }
+          },
+          {
+            "name": "switch",
+            "title": "switch",
+            "quickEdit": {
+              "mode": "inline",
+              "type": "switch",
+              "onText": "开启",
+              "offText": "关闭"
+            }
+          }
         ]
-    }
+      }
+    ]
+  }
 }
 ```
 
@@ -3707,53 +3706,53 @@ order: 67
 {
   "type": "page",
   "body": {
-        "type": "service",
-        "api": "/api/sample?perPage=5",
-        "body": [
-            {
-                "type": "table2",
-                "source": "$rows",
-                "quickSaveItemApi": {
-                    "url": "/api/mock2/sample/$id",
-                    "method": "put"
-                },
-                "columns": [
-                    {
-                        "name": "id",
-                        "title": "ID"
-                    },
-                    {
-                        "name": "grade",
-                        "title": "CSS grade",
-                        "quickEdit": {
-                            "mode": "inline",
-                            "type": "select",
-                            "size": "xs",
-                            "options": [
-                                "A",
-                                "B",
-                                "C",
-                                "D",
-                                "X"
-                            ],
-                            "saveImmediately": true
-                        }
-                    },
-                    {
-                        "name": "switch",
-                        "title": "switch",
-                        "quickEdit": {
-                            "mode": "inline",
-                            "type": "switch",
-                            "onText": "开启",
-                            "offText": "关闭",
-                            "saveImmediately": true
-                        }
-                    }
-                ]
+    "type": "service",
+    "api": "/api/sample?perPage=5",
+    "body": [
+      {
+        "type": "table2",
+        "source": "$rows",
+        "quickSaveItemApi": {
+          "url": "/api/mock2/sample/$id",
+          "method": "put"
+        },
+        "columns": [
+          {
+            "name": "id",
+            "title": "ID"
+          },
+          {
+            "name": "grade",
+            "title": "CSS grade",
+            "quickEdit": {
+              "mode": "inline",
+              "type": "select",
+              "size": "xs",
+              "options": [
+                "A",
+                "B",
+                "C",
+                "D",
+                "X"
+              ],
+              "saveImmediately": true
             }
+          },
+          {
+            "name": "switch",
+            "title": "switch",
+            "quickEdit": {
+              "mode": "inline",
+              "type": "switch",
+              "onText": "开启",
+              "offText": "关闭",
+              "saveImmediately": true
+            }
+          }
         ]
-    }
+      }
+    ]
+  }
 }
 ```
 
@@ -3763,53 +3762,53 @@ order: 67
 {
   "type": "page",
   "body": {
-        "type": "service",
-        "api": "/api/sample?perPage=5",
-        "body": [
-            {
-                "type": "table2",
-                "source": "$rows",
-                "columns": [
-                    {
-                        "name": "id",
-                        "title": "ID"
-                    },
-                    {
-                        "name": "grade",
-                        "title": "CSS grade",
-                        "quickEdit": {
-                            "mode": "inline",
-                            "type": "select",
-                            "size": "xs",
-                            "options": [
-                                "A",
-                                "B",
-                                "C",
-                                "D",
-                                "X"
-                            ],
-                            "saveImmediately": {
-                                "api": "/api/mock2/sample/$id"
-                            }
-                        }
-                    },
-                    {
-                        "name": "switch",
-                        "title": "switch",
-                        "quickEdit": {
-                            "mode": "inline",
-                            "type": "switch",
-                            "onText": "开启",
-                            "offText": "关闭",
-                            "saveImmediately": {
-                                "api": "/api/mock2/sample/$id"
-                            }
-                        }
-                    }
-                ]
+    "type": "service",
+    "api": "/api/sample?perPage=5",
+    "body": [
+      {
+        "type": "table2",
+        "source": "$rows",
+        "columns": [
+          {
+            "name": "id",
+            "title": "ID"
+          },
+          {
+            "name": "grade",
+            "title": "CSS grade",
+            "quickEdit": {
+              "mode": "inline",
+              "type": "select",
+              "size": "xs",
+              "options": [
+                "A",
+                "B",
+                "C",
+                "D",
+                "X"
+              ],
+              "saveImmediately": {
+                "api": "/api/mock2/sample/$id"
+              }
             }
+          },
+          {
+            "name": "switch",
+            "title": "switch",
+            "quickEdit": {
+              "mode": "inline",
+              "type": "switch",
+              "onText": "开启",
+              "offText": "关闭",
+              "saveImmediately": {
+                "api": "/api/mock2/sample/$id"
+              }
+            }
+          }
         ]
-    }
+      }
+    ]
+  }
 }
 ```
 
@@ -3819,36 +3818,36 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "className": "text-primary"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Operation",
-                    "name": "operation",
-                    "type": "button",
-                    "label": "删除",
-                    "size": "sm"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "className": "text-primary"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Operation",
+          "name": "operation",
+          "type": "button",
+          "label": "删除",
+          "size": "sm"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -3856,37 +3855,37 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "className": "text-primary",
-                    "titleClassName": "font-bold"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Operation",
-                    "name": "operation",
-                    "type": "button",
-                    "label": "删除",
-                    "size": "sm"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "className": "text-primary",
+          "titleClassName": "font-bold"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Operation",
+          "name": "operation",
+          "type": "button",
+          "label": "删除",
+          "size": "sm"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -3896,36 +3895,36 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "columns": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version",
-                    "classNameExpr": "<%= data.version > 5 ? 'text-danger' : '' %>"
-                },
-                {
-                    "title": "Browser",
-                    "name": "browser"
-                },
-                {
-                    "title": "Operation",
-                    "name": "operation",
-                    "type": "button",
-                    "label": "删除",
-                    "size": "sm"
-                }
-            ]
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version",
+          "classNameExpr": "<%= data.version > 5 ? 'text-danger' : '' %>"
+        },
+        {
+          "title": "Browser",
+          "name": "browser"
+        },
+        {
+          "title": "Operation",
+          "name": "operation",
+          "type": "button",
+          "label": "删除",
+          "size": "sm"
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 
@@ -3935,42 +3934,42 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=5",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=5",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "itemActions": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "itemActions": [
-                {
-                    "label": "编辑",
-                    "type": "button",
-                    "actionType": "dialog",
-                    "dialog": {
-                        "title": "编辑",
-                        "body": "这是个简单的编辑弹框"
-                    }
-                },
-                {
-                    "label": "删除",
-                    "type": "button",
-                    "actionType": "ajax",
-                    "confirmText": "确认要删除？",
-                    "api": "/api/mock2/form/saveForm"
-                }
-            ],
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                }
-            ]
+          "label": "编辑",
+          "type": "button",
+          "actionType": "dialog",
+          "dialog": {
+            "title": "编辑",
+            "body": "这是个简单的编辑弹框"
+          }
+        },
+        {
+          "label": "删除",
+          "type": "button",
+          "actionType": "ajax",
+          "confirmText": "确认要删除？",
+          "api": "/api/mock2/form/saveForm"
         }
-    ]
+      ],
+      "columns": [
+        {
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -3978,45 +3977,45 @@ order: 67
 
 ```schema: scope="body"
 {
-    "type": "service",
-    "api": "/api/sample?perPage=20",
-    "body": [
+  "type": "service",
+  "api": "/api/sample?perPage=20",
+  "body": [
+    {
+      "type": "table2",
+      "source": "$rows",
+      "itemActions": [
         {
-            "type": "table2",
-            "source": "$rows",
-            "itemActions": [
-                {
-                    "label": "编辑",
-                    "type": "button",
-                    "actionType": "dialog",
-                    "dialog": {
-                        "title": "编辑",
-                        "body": "这是个简单的编辑弹框"
-                    }
-                },
-                {
-                    "label": "删除",
-                    "type": "button",
-                    "actionType": "ajax",
-                    "confirmText": "确认要删除？",
-                    "api": "/api/mock2/form/saveForm"
-                }
-            ],
-            "scroll": {
-                "y": 100
-            },
-            "columns": [
-                {
-                    "title": "Engine",
-                    "name": "engine"
-                },
-                {
-                    "title": "Version",
-                    "name": "version"
-                }
-            ]
+          "label": "编辑",
+          "type": "button",
+          "actionType": "dialog",
+          "dialog": {
+            "title": "编辑",
+            "body": "这是个简单的编辑弹框"
+          }
+        },
+        {
+          "label": "删除",
+          "type": "button",
+          "actionType": "ajax",
+          "confirmText": "确认要删除？",
+          "api": "/api/mock2/form/saveForm"
         }
-    ]
+      ],
+      "scroll": {
+        "y": 100
+      },
+      "columns": [
+        {
+          "title": "Engine",
+          "name": "engine"
+        },
+        {
+          "title": "Version",
+          "name": "version"
+        }
+      ]
+    }
+  ]
 }
 ```
 

--- a/packages/amis-core/src/store/crud.ts
+++ b/packages/amis-core/src/store/crud.ts
@@ -704,10 +704,13 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
 
       const data = {
         ...self.pristine,
-        items: items.slice(
-          (self.page - 1) * self.perPage,
-          self.page * self.perPage
-        ),
+        items:
+          items.length > self.perPage
+            ? items.slice(
+                (self.page - 1) * self.perPage,
+                self.page * self.perPage
+              )
+            : items,
         count: items.length,
         total: items.length
       };

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -686,7 +686,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     } else if (!props.api && isPureVariable(props.source)) {
       const next = resolveVariableAndFilter(props.source, props.data, '| raw');
 
-      if (!this.lastData || !isEqual(this.lastData, next)) {
+      if (!this.lastData || this.lastData !== next) {
         store.initFromScope(props.data, props.source, {
           columns: store.columns ?? props.columns
         });

--- a/packages/amis/src/renderers/CRUD2.tsx
+++ b/packages/amis/src/renderers/CRUD2.tsx
@@ -21,7 +21,6 @@ import {findDOMNode} from 'react-dom';
 import {evalExpression, filter} from 'amis-core';
 import {isEffectiveApi, isApiOutdated} from 'amis-core';
 import findIndex from 'lodash/findIndex';
-import isEqual from 'lodash/isEqual';
 import {Html, SpinnerExtraProps} from 'amis-ui';
 import {
   BaseSchema,
@@ -395,7 +394,7 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
     } else if (!props.api && isPureVariable(props.source)) {
       const next = resolveVariableAndFilter(props.source, props.data, '| raw');
 
-      if (!this.lastData || !isEqual(this.lastData, next)) {
+      if (!this.lastData || this.lastData !== next) {
         store.initFromScope(props.data, props.source, {
           columns: store.columns ?? props.columns
         });


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 59526d5</samp>

This pull request improves the performance and functionality of the CRUD and CRUD2 renderers in `amis`. It fixes a pagination bug in the CRUDStore, removes redundant imports, and uses faster equality checks to avoid unnecessary re-rendering.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 59526d5</samp>

> _Oh we're the jolly coders of the `CRUD2` renderer_
> _We slice and dice the data with a flick of our finger_
> _We don't need no deep equality to slow us down_
> _We use the strictest checks to make our app run sound_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 59526d5</samp>

* Fix pagination bug in CRUDStore by checking items length before slicing ([link](https://github.com/baidu/amis/pull/8806/files?diff=unified&w=0#diff-19289b8da9cdbd60b8351ae09cb4ab5548ecb4ea18d2085a39a6cf66c59dd7cdL707-R713))
* Optimize performance of CRUD and CRUD2 renderers by using strict equality check for data comparison ([link](https://github.com/baidu/amis/pull/8806/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L689-R689), [link](https://github.com/baidu/amis/pull/8806/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL398-R397))
* Remove unused import of isEqual from `CRUD2.tsx` ([link](https://github.com/baidu/amis/pull/8806/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL24))
