### PR TITLE
chore: ChangeLog命令支持按照commit类型排序, 执行完成后删除本地缓存

### DIFF
--- a/scripts/getChangeLog.ts
+++ b/scripts/getChangeLog.ts
@@ -2,20 +2,25 @@ import fs from 'fs';
 import path from 'path';
 import util from 'util';
 import {exec as nodeExec} from 'child_process';
-import {fileURLToPath} from 'url';
+
 const exec = util.promisify(nodeExec);
 
 const pkg = '@fex/amis';
 const folder = path.join(path.dirname(__filename), '../node_modules');
 
-export async function main(from: string, to: string) {
+export async function main(from: string, to: string, useMarkdown: boolean = false) {
+  const toBeClearedQueue = [];
   let {stdout: packFromStdout} = await exec(
     `npm pack ${pkg}@${from} --pack-destination="${folder}"`
   );
   const fromFilname = packFromStdout.trim();
   const fromFolder = `${folder}/amis_${from}`;
+  const fromTgz = path.join(folder, fromFilname);
+
   await exec(`mkdir -p ${fromFolder}`);
-  await exec(`tar -xzvf ${path.join(folder, fromFilname)} -C ${fromFolder}`);
+  await exec(`tar -xzvf ${fromTgz} -C ${fromFolder}`);
+
+  toBeClearedQueue.push(fromFolder, fromTgz);
 
   const fromRevision = JSON.parse(
     fs.readFileSync(fromFolder + '/package/revision.json', 'utf-8').trim()
@@ -26,8 +31,12 @@ export async function main(from: string, to: string) {
   );
   const toFilname = packToStdout.trim();
   const toFolder = `${folder}/amis_${to}`;
+  const toTgz = path.join(folder, toFilname);
+
   await exec(`mkdir -p ${toFolder}`);
-  await exec(`tar -xzvf ${path.join(folder, toFilname)} -C ${toFolder}`);
+  await exec(`tar -xzvf ${toTgz} -C ${toFolder}`);
+
+  toBeClearedQueue.push(toFolder, toTgz);
 
   const toRevision = JSON.parse(
     fs.readFileSync(toFolder + '/package/revision.json', 'utf-8').trim()
@@ -49,7 +58,43 @@ export async function main(from: string, to: string) {
       return msg;
     })
     .filter(item => item);
-  console.log(commits.join('\n'));
+
+  const prefixes = ['feat', 'feats', 'feat(amis)', 'feat(amis-editor)', 'fix', 'fix(amis)', 'fix(amis-editor)', 'chore', 'chore(amis)', 'chore(amis-editor)', 'styles', 'style', 'style(amis)', 'style(amis-editor)', 'docs', 'doc', 'docs(amis)', 'docs(amis-editor)', 'perf', 'refactor', 'revert',];
+
+  /** 按照commit类型排序 */
+  commits.sort((lhs, rhs) => {
+    let lhsPrefixIndex = prefixes.findIndex(p => p === lhs.split(/\s*[:：]+\s*/)[0]);
+    let rhsPrefixIndex = prefixes.findIndex(p => p === rhs.split(/\s*[:：]+\s*/)[0]);
+
+    /** 找不到对应的标签就排队尾 */
+    if (lhsPrefixIndex === -1) {
+      lhsPrefixIndex = prefixes.length + 1;
+    }
+
+    if (rhsPrefixIndex === -1) {
+      rhsPrefixIndex = prefixes.length + 1;
+    }
+
+    return lhsPrefixIndex - rhsPrefixIndex;
+  })
+
+  console.log(
+    '\x1b[32m%s\x1b[0m',
+    `✨ [@fex/amis] ${from} ===> ${to} change log：`
+  );
+
+  if (useMarkdown) {
+    console.log(commits.map(i => `* ${i}`).join('\n'));
+  } else {
+    console.log(commits.join('\n'));
+  }
+
+  /** 清除缓存的文件和文件夹 */
+  await exec(`npx rimraf ${toBeClearedQueue.join(' ')}`);
+  console.log(
+    '\x1b[32m%s\x1b[0m',
+    '✨ [@fex/amis] Temporarily cached files have been successfully cleared!'
+  );
 }
 
 main.apply(null, process.argv.slice(2)).catch((err: any) => {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2f8684d</samp>

Improved the `getChangeLog.ts` script to produce better change logs. The script can now output markdown, sort commits by type, and delete temporary files. This makes the change log more user-friendly and easier to maintain.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2f8684d</samp>

> _Sing, O Muse, of the skillful script `getChangeLog.ts`_
> _That can craft a splendid markdown of the package deeds_
> _Sorting by type the valiant commits of the developers_
> _Like the stars in the sky that Zeus himself decreed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2f8684d</samp>

* Remove unused import of `fileURLToPath` from `url` module ([link](https://github.com/baidu/amis/pull/8810/files?diff=unified&w=0#diff-53f8bfa4a4b86d53cb52443688cc0851b860e19b154b628840a0ea0ac930e432L5-R5))
* Add `useMarkdown` parameter to `main` function to control output format ([link](https://github.com/baidu/amis/pull/8810/files?diff=unified&w=0#diff-53f8bfa4a4b86d53cb52443688cc0851b860e19b154b628840a0ea0ac930e432L11-R12))
* Sort `commits` array by commit type using `prefixes` constant ([link](https://github.com/baidu/amis/pull/8810/files?diff=unified&w=0#diff-53f8bfa4a4b86d53cb52443688cc0851b860e19b154b628840a0ea0ac930e432L52-R97))
* Format output as markdown or plain text depending on `useMarkdown` value ([link](https://github.com/baidu/amis/pull/8810/files?diff=unified&w=0#diff-53f8bfa4a4b86d53cb52443688cc0851b860e19b154b628840a0ea0ac930e432L52-R97))
* Use `npx rimraf` to delete temporary files and folders from `node_modules` ([link](https://github.com/baidu/amis/pull/8810/files?diff=unified&w=0#diff-53f8bfa4a4b86d53cb52443688cc0851b860e19b154b628840a0ea0ac930e432L52-R97))
* Add or modify console messages with colors and emojis ([link](https://github.com/baidu/amis/pull/8810/files?diff=unified&w=0#diff-53f8bfa4a4b86d53cb52443688cc0851b860e19b154b628840a0ea0ac930e432L52-R97))
* Store tarball paths of `from` and `to` versions in `fromTgz` and `toTgz` variables ([link](https://github.com/baidu/amis/pull/8810/files?diff=unified&w=0#diff-53f8bfa4a4b86d53cb52443688cc0851b860e19b154b628840a0ea0ac930e432L17-R24), [link](https://github.com/baidu/amis/pull/8810/files?diff=unified&w=0#diff-53f8bfa4a4b86d53cb52443688cc0851b860e19b154b628840a0ea0ac930e432L29-R40))
* Push `fromTgz`, `toTgz`, `fromFolder`, and `toFolder` to `toBeClearedQueue` array ([link](https://github.com/baidu/amis/pull/8810/files?diff=unified&w=0#diff-53f8bfa4a4b86d53cb52443688cc0851b860e19b154b628840a0ea0ac930e432L17-R24), [link](https://github.com/baidu/amis/pull/8810/files?diff=unified&w=0#diff-53f8bfa4a4b86d53cb52443688cc0851b860e19b154b628840a0ea0ac930e432L29-R40))
