### PR TITLE
feat(amis-editor): tree-select支持reload动作

### DIFF
--- a/packages/amis-editor/src/plugin/Form/TreeSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/TreeSelect.tsx
@@ -249,6 +249,11 @@ export class TreeSelectControlPlugin extends BasePlugin {
       actionType: 'setValue',
       actionLabel: '赋值',
       description: '触发组件数据更新'
+    },
+    {
+      actionType: 'reload',
+      actionLabel: '重新加载',
+      description: '触发组件数据刷新并重新渲染'
     }
   ];
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1cbef5d</samp>

Add reload action and label for TreeSelect component. This enables dynamic data sources for `TreeSelect` in `amis-editor`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1cbef5d</samp>

> _`TreeSelect` changes_
> _Dynamic data sources now_
> _Refresh with new action_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1cbef5d</samp>

* Add a new action type and label for the TreeSelect component to support dynamic data sources ([link](https://github.com/baidu/amis/pull/8813/files?diff=unified&w=0#diff-90baebf200b81ed14dd4240db28e6f322004b03cd30f304d5757560f6b7b65ecR252-R256))
