### PR TITLE
feat: Switch组件支持加载中状态

### DIFF
--- a/docs/zh-CN/components/form/switch.md
+++ b/docs/zh-CN/components/form/switch.md
@@ -25,6 +25,24 @@ order: 51
 }
 ```
 
+## 禁用状态
+
+```schema: scope="body"
+{
+    "type": "form",
+    "api": "/api/mock2/form/saveForm",
+    "body": [
+        {
+            "name": "switch",
+            "type": "switch",
+            "disabled": true,
+            "label": "开关",
+            "option": "开关说明"
+        }
+    ]
+}
+```
+
 ## 配置真假值
 
 默认情况：
@@ -105,7 +123,7 @@ order: 51
 
 ## 不同尺寸
 
-> 2.0.0 及以上版本
+> `2.0.0` 及以上版本
 
 ```schema: scope="body"
 {
@@ -127,18 +145,123 @@ order: 51
 }
 ```
 
+## 加载状态
+
+> `3.6.0` 及以上版本
+
+设置`"loading": true`, 标识开关操作的异步任务仍在执行中。另外`loadingOn`支持表达式
+
+```schema: scope="body"
+{
+    "type": "form",
+    "api": "/api/mock2/form/saveForm",
+    "data": {
+        "shouldLoading": true
+    },
+    "body": [
+        {
+            "type": "switch",
+            "name": "switch1",
+            "label": "",
+            "loading": true,
+            "value": true
+        },
+        {
+
+            "type": "switch",
+            "name": "switch2",
+            "label": "",
+            "size": "sm",
+            "disabled": true,
+            "loading": true
+        }
+    ]
+}
+```
+
+配合`ajax`动作，实现开关操作后台异步任务：
+
+```schema: scope="body"
+{
+  "type": "page",
+  "body": [
+    {
+      "type": "form",
+      "id": "demo-form",
+      "body": [
+        {
+            "type": "hidden",
+            "name": "isFetching",
+            "value": false
+        },
+        {
+          "type": "switch",
+          "name": "switch",
+          "label": "操作状态开关",
+          "mode": "horizontal",
+          "loadingOn": "${isFetching}",
+          "onEvent": {
+            "change": {
+              "actions": [
+                {
+                  "actionType": "toast",
+                  "args": {
+                    "msgType": "warning",
+                    "msg": "任务${switch === true ? '派发' : '取消'}成功，等待后台操作..."
+                  }
+                },
+                {
+                  "actionType": "setValue",
+                  "componentId": "demo-form",
+                  "args": {
+                    "value": {
+                      "isFetching": true
+                    }
+                  }
+                },
+                {
+                  "actionType": "ajax",
+                  "api": {
+                    "url": "/api/mock2/form/saveForm?waitSeconds=3",
+                    "method": "get",
+                    "messages": {
+                      "success": "操作成功",
+                      "failed": "操作失败"
+                    }
+                  }
+                },
+                {
+                  "actionType": "setValue",
+                  "componentId": "demo-form",
+                  "args": {
+                    "value": {
+                      "isFetching": false
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
 ## 属性表
 
 除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置
 
-| 属性名     | 类型                        | 默认值  | 说明                 |
-| ---------- | --------------------------- | ------- | -------------------- |
+| 属性名     | 类型                        | 默认值  | 说明                 | 版本 |
+| ---------- | --------------------------- | ------- | -------------------- | --- |
 | option     | `string`                    |         | 选项说明             |
 | onText     | `string / IconSchema`       |         | 开启时开关显示的内容 |
 | offText    | `string / IconSchema`       |         | 关闭时开关显示的内容 |
 | trueValue  | `boolean / string / number` | `true`  | 标识真值             |
 | falseValue | `boolean / string / number` | `false` | 标识假值             |
 | size       | `"sm" \| "md"`              | `"md"`  | 开关大小             |
+| loading    | `boolean`                   | `false`  | 是否处于加载状态     | `3.6.0` |
 
 IconSchema 配置
 | 属性名 | 类型 | 默认值 | 说明 |

--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -1972,6 +1972,9 @@
   --Switch-checked-bgColor: var(--switch-default-on-bg-color);
   --Switch-checked-onHover-bgColor: var(--switch-default-on-hover-bg-color);
   --Switch-checked-onActive-bgColor: var(--colors-brand-4);
+  --Switch-spinner-icon-width: var(--sizes-base-7);
+  --Switch-spinner-icon-width--sm: var(--sizes-base-5);
+  --switch-spinner-left--sm: var(--sizes-size-0);
 
   --collapse-default-top-border-color: var(--colors-neutral-line-8);
   --collapse-default-top-border-width: var(--borders-width-2);
@@ -3292,7 +3295,6 @@
   --spinner-size-size: var(--sizes-base-16);
   --spinner-lg-size: var(--sizes-base-24);
   --spinner-overlay-bg: var(--colors-neutral-fill-11);
-  --spinner-color: var(--colors-brand-5);
 
   --Spinner--lg-height: var(--spinner-lg-size);
   --Spinner--lg-width: var(--spinner-lg-size);
@@ -3304,6 +3306,7 @@
   --Spinner-overlay-bg: rgba(255, 255, 255, 0.4);
   --Spinner-width: var(--spinner-size-size);
   --Spinner-color: var(--spinner-base-color);
+  --Spinner-color--disabled: rgba(0, 0, 0, 0.65);
 
   // Image
   --image-image-normal-paddingTop: var(--sizes-size-3);

--- a/packages/amis-ui/scss/components/_spinner.scss
+++ b/packages/amis-ui/scss/components/_spinner.scss
@@ -77,6 +77,15 @@
       height: auto;
     }
 
+    &.#{$ns}Spinner-icon--disabled > svg.icon {
+      color: var(--Spinner-color--disabled);
+      fill: var(--Spinner-color--disabled);
+
+      & path {
+        fill: var(--Spinner-color--disabled);
+      }
+    }
+
     &--lg {
       width: var(--Spinner--lg-width);
       height: var(--Spinner--lg-height);

--- a/packages/amis-ui/scss/components/form/_switch.scss
+++ b/packages/amis-ui/scss/components/form/_switch.scss
@@ -153,6 +153,44 @@
       border-radius: 10px;
     }
   }
+
+  &-spinner {
+    position: absolute;
+    top: var(--Switch-slider-margin);
+    bottom: var(--Switch-slider-margin);
+    left: var(--Switch-slider-margin);
+
+    & > &-icon > svg.icon {
+      width: var(--Switch-spinner-icon-width);
+      height: var(--Switch-spinner-icon-width);
+    }
+
+    &--sm {
+      position: absolute;
+      top: var(--switch-size-sm-slider-margin);
+      bottom: var(--switch-size-sm-slider-margin);
+      left: var(--switch-spinner-left--sm);
+
+      & > .#{$ns}Switch-spinner-icon > svg.icon {
+        width: var(--Switch-spinner-icon-width--sm);
+        height: var(--Switch-spinner-icon-width--sm);
+      }
+    }
+
+    &.#{$ns}Switch-spinner--checked {
+      left: calc(
+        100% - var(--Switch-slider-width) - var(--Switch-slider-margin)
+      );
+      right: var(--Switch-slider-margin);
+
+      &.#{$ns}Switch-spinner--sm {
+        left: calc(
+          100% - var(--Switch-slider-width--sm) - var(--Switch-slider-margin)
+        );
+        right: var(--Switch-slider-margin);
+      }
+    }
+  }
 }
 
 .#{$ns}Switch-option {

--- a/packages/amis-ui/src/components/Spinner.tsx
+++ b/packages/amis-ui/src/components/Spinner.tsx
@@ -35,6 +35,8 @@ export interface SpinnerProps extends ThemeProps, SpinnerExtraProps {
   tipPlacement?: 'top' | 'right' | 'bottom' | 'left'; // spinner文案位置
   delay?: number; // 延迟显示
   overlay?: boolean; // 是否显示遮罩层，有children属性才生效
+  /** 是否处于禁用状态 */
+  disabled?: boolean;
 }
 
 export interface SpinnerExtraProps {
@@ -114,7 +116,8 @@ export class Spinner extends React.Component<
     tipPlacement: 'bottom' as 'bottom',
     delay: 0,
     overlay: false,
-    loadingConfig: {}
+    loadingConfig: {},
+    disabled: false
   };
 
   state = {
@@ -190,7 +193,8 @@ export class Spinner extends React.Component<
       icon: iconConfig,
       tip,
       tipPlacement = '',
-      loadingConfig
+      loadingConfig,
+      disabled
     } = this.props;
     // 定义了挂载位置时只能使用默认icon
     const icon = loadingConfig?.root ? undefined : iconConfig;
@@ -241,9 +245,10 @@ export class Spinner extends React.Component<
                       `Spinner-icon`,
                       {
                         [`Spinner-icon--${size}`]: ['lg', 'sm'].includes(size),
-                        [`Spinner-icon--default`]: !icon,
-                        [`Spinner-icon--simple`]: !isCustomIcon && icon,
-                        [`Spinner-icon--custom`]: isCustomIcon
+                        'Spinner-icon--default': !icon,
+                        'Spinner-icon--simple': !isCustomIcon && icon,
+                        'Spinner-icon--custom': isCustomIcon,
+                        'Spinner-icon--disabled': disabled
                       },
                       spinnerClassName
                     )}

--- a/packages/amis-ui/src/components/Switch.tsx
+++ b/packages/amis-ui/src/components/Switch.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import {ClassNamesFn, themeable} from 'amis-core';
-import {classPrefix, classnames} from '../themes/default';
+import {Spinner} from './Spinner';
 
 const sizeMap = {
   sm: 'Switch--sm',
@@ -39,6 +39,11 @@ interface SwitchProps {
   onText?: React.ReactNode;
   offText?: React.ReactNode;
   checked?: boolean;
+  loading?: boolean;
+  loadingConfig?: {
+    root?: string;
+    show?: boolean;
+  };
 }
 
 export class Switch extends React.PureComponent<SwitchProps, any> {
@@ -80,6 +85,8 @@ export class Switch extends React.PureComponent<SwitchProps, any> {
       readOnly,
       checked,
       classnames: cx,
+      loading,
+      loadingConfig,
       ...rest
     } = this.props;
 
@@ -94,27 +101,42 @@ export class Switch extends React.PureComponent<SwitchProps, any> {
         : typeof value === 'undefined'
         ? false
         : value == trueValue;
+    const isDisabled = disabled || loading;
 
     return (
       <label
-        className={cx(
-          `Switch`,
-          isChecked ? 'is-checked' : '',
-          disabled ? 'is-disabled' : '',
-          className
-        )}
+        className={cx(`Switch`, className, {
+          'is-checked': isChecked,
+          'is-disabled': isDisabled
+        })}
       >
         <input
           type="checkbox"
           checked={isChecked}
           onChange={this.hanldeCheck}
-          disabled={disabled}
+          disabled={isDisabled}
           readOnly={readOnly}
           {...rest}
         />
 
         <span className="text">{isChecked ? onText : offText}</span>
-        <span className="slider"></span>
+        <span className="slider">
+          {loading ? (
+            <Spinner
+              classnames={cx}
+              classPrefix={classPrefix}
+              className={cx('Switch-spinner', {
+                'Switch-spinner--sm': size === 'sm',
+                'Switch-spinner--checked': isChecked
+              })}
+              spinnerClassName={cx('Switch-spinner-icon')}
+              disabled={!isChecked}
+              size="sm"
+              icon="loading-outline"
+              loadingConfig={loadingConfig}
+            />
+          ) : null}
+        </span>
       </label>
     );
   }

--- a/packages/amis-ui/src/components/formula/Input.tsx
+++ b/packages/amis-ui/src/components/formula/Input.tsx
@@ -77,7 +77,7 @@ const FormulaInput: React.FC<FormulaInputProps> = props => {
   } = props;
   const schemaType = inputSettings.type;
   /** 自上层共享的属性 */
-  const sharedProps = pick(props, ['disabeld', 'clearable']);
+  const sharedProps = pick(props, ['disabled', 'clearable']);
   const pipInValue = useCallback(
     (value?: any) => {
       return value;

--- a/packages/amis/__tests__/renderers/Form/switch.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/switch.test.tsx
@@ -71,3 +71,42 @@ describe('Renderer:Switch', () => {
     expect(container).toMatchSnapshot();
   });
 });
+
+/**
+ * 默认状态为开启时
+ * 默认状态为关闭时
+ * 默认状态为禁用时
+ */
+test('Renderer:Switch with loading status', async () => {
+  const {container} = render(
+    amisRender(
+      {
+        type: 'form',
+        body: [
+          {
+            "type": "switch",
+            "name": "switch1",
+            "label": "",
+            "loading": true,
+            "value": true
+          },
+          {
+            "type": "switch",
+            "name": "switch2",
+            "label": "",
+            "disabled": true,
+            "loading": true,
+            "value": false
+          }
+        ],
+        actions: []
+      },
+      {},
+      makeEnv()
+    )
+  );
+
+  const loadingDom = container.querySelectorAll('.cxd-Switch-spinner');
+
+  expect(loadingDom?.length).toEqual(2);
+});

--- a/packages/amis/src/renderers/Form/Switch.tsx
+++ b/packages/amis/src/renderers/Form/Switch.tsx
@@ -6,10 +6,12 @@ import {
   resolveEventData
 } from 'amis-core';
 import {Icon, Switch} from 'amis-ui';
-import {createObject, autobind, isObject} from 'amis-core';
+import {autobind, isObject} from 'amis-core';
 import {IconSchema} from '../Icon';
 import {FormBaseControlSchema} from '../../Schema';
 import {supportStatic} from './StaticHoc';
+
+import type {SpinnerExtraProps} from 'amis-ui';
 
 /**
  * Switch
@@ -49,13 +51,17 @@ export interface SwitchControlSchema extends FormBaseControlSchema {
 
   /** 开关尺寸 */
   size?: 'sm' | 'md';
+
+  /** 是否处于加载状态 */
+  loading?: boolean;
 }
 
-export interface SwitchProps extends FormControlProps {
+export interface SwitchProps extends FormControlProps, SpinnerExtraProps {
   option?: string;
   trueValue?: any;
   falseValue?: any;
   size?: 'sm';
+  loading?: boolean;
 }
 
 export type SwitchRendererEvent = 'change';
@@ -129,7 +135,9 @@ export default class SwitchControl extends React.Component<SwitchProps, any> {
       trueValue,
       falseValue,
       onChange,
-      disabled
+      disabled,
+      loading,
+      loadingConfig
     } = this.props;
 
     const {on, off} = this.getResult();
@@ -147,6 +155,8 @@ export default class SwitchControl extends React.Component<SwitchProps, any> {
             disabled={disabled}
             onChange={this.handleChange}
             size={size as any}
+            loading={loading}
+            loadingConfig={loadingConfig}
           />
         )}
       </div>


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 29082dc</samp>

This pull request adds a loading feature to the switch component and updates the documentation and tests accordingly. It allows the switch to show a spinner icon and disable the input when the `loading` prop is true, and customize the spinner appearance with the `loadingConfig` prop. It also fixes a typo in the formula input component and modifies some CSS variables and selectors for the switch and spinner components. The affected files are `./docs/zh-CN/components/form/switch.md`, `./packages/amis-ui/scss/_components.scss`, `./packages/amis-ui/src/components/Spinner.tsx`, `./packages/amis-ui/src/components/Switch.tsx`, `./packages/amis/src/renderers/Form/Switch.tsx`, `./packages/amis-ui/scss/components/_spinner.scss`, `./packages/amis-ui/scss/components/form/_switch.scss`, `./packages/amis-ui/src/components/formula/Input.tsx`, and `./packages/amis/__tests__/renderers/Form/switch.test.tsx`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 29082dc</samp>

> _We're loading up the switch with a spinner on the side_
> _We're styling it with CSS and testing it with pride_
> _We're fixing all the typos and updating all the docs_
> _We're heaving on the `loading` prop, one, two, three, heave-ho!_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 29082dc</samp>

*  Add loading state and configuration to switch component ([link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-50dace4459a7f8aa17d8b9251b8d423125d62cb9c4120bc82eafe773376be598L130-R257), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-50dace4459a7f8aa17d8b9251b8d423125d62cb9c4120bc82eafe773376be598R264), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4R1975-R1977), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4R3309), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-c4191c785fcd30a1d499fd02cf2c3e93676c6d129f5522d6bfbf63675f75444cR80-R88), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-d131122856b2cd58e907802e36a46a487619f127a5a632595da468cad5c160e1R156-R193), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-93c59378c01b812a14f36a08b02bfb24a7439b92273cfa7f827f29588f45630bR38-R39), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-93c59378c01b812a14f36a08b02bfb24a7439b92273cfa7f827f29588f45630bL117-R120), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-93c59378c01b812a14f36a08b02bfb24a7439b92273cfa7f827f29588f45630bL193-R197), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-93c59378c01b812a14f36a08b02bfb24a7439b92273cfa7f827f29588f45630bL244-R251), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-4889c35e4ccb0a99ab7cc3bbb1744d42f9e076bc7493efc26e1e349ddee11de1L9-R9), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-4889c35e4ccb0a99ab7cc3bbb1744d42f9e076bc7493efc26e1e349ddee11de1R42-R46), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-4889c35e4ccb0a99ab7cc3bbb1744d42f9e076bc7493efc26e1e349ddee11de1R88-R89), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-4889c35e4ccb0a99ab7cc3bbb1744d42f9e076bc7493efc26e1e349ddee11de1L97-R111), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-4889c35e4ccb0a99ab7cc3bbb1744d42f9e076bc7493efc26e1e349ddee11de1L111-R117), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-4889c35e4ccb0a99ab7cc3bbb1744d42f9e076bc7493efc26e1e349ddee11de1L117-R139), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-480985fa635425e7fd1a7b850ab5ad24df78a7aa5076dc487592b0f4361737caL9-R15), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-480985fa635425e7fd1a7b850ab5ad24df78a7aa5076dc487592b0f4361737caL52-R64), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-480985fa635425e7fd1a7b850ab5ad24df78a7aa5076dc487592b0f4361737caL132-R140), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-480985fa635425e7fd1a7b850ab5ad24df78a7aa5076dc487592b0f4361737caR158-R159))
  * Extend `SwitchProps` interface with `SpinnerExtraProps` type to inherit loading-related properties ([link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-480985fa635425e7fd1a7b850ab5ad24df78a7aa5076dc487592b0f4361737caL52-R64))
  * Import `Spinner` component from `amis-ui` package and use it inside `Switch` component ([link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-4889c35e4ccb0a99ab7cc3bbb1744d42f9e076bc7493efc26e1e349ddee11de1L9-R9), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-4889c35e4ccb0a99ab7cc3bbb1744d42f9e076bc7493efc26e1e349ddee11de1L117-R139))
  * Add `disabled` property to `SpinnerProps` interface and `Spinner` component ([link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-93c59378c01b812a14f36a08b02bfb24a7439b92273cfa7f827f29588f45630bR38-R39), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-93c59378c01b812a14f36a08b02bfb24a7439b92273cfa7f827f29588f45630bL117-R120), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-93c59378c01b812a14f36a08b02bfb24a7439b92273cfa7f827f29588f45630bL193-R197), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-93c59378c01b812a14f36a08b02bfb24a7439b92273cfa7f827f29588f45630bL244-R251))
  * Style spinner element inside switch component with CSS variables and selectors ([link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4R1975-R1977), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4R3309), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-c4191c785fcd30a1d499fd02cf2c3e93676c6d129f5522d6bfbf63675f75444cR80-R88), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-d131122856b2cd58e907802e36a46a487619f127a5a632595da468cad5c160e1R156-R193))
  * Use `isDisabled` variable to combine `disabled` and `loading` properties and disable input element and switch component accordingly ([link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-4889c35e4ccb0a99ab7cc3bbb1744d42f9e076bc7493efc26e1e349ddee11de1L97-R111), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-4889c35e4ccb0a99ab7cc3bbb1744d42f9e076bc7493efc26e1e349ddee11de1L111-R117))
  * Add documentation and examples for loading state and configuration in `./docs/zh-CN/components/form/switch.md` ([link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-50dace4459a7f8aa17d8b9251b8d423125d62cb9c4120bc82eafe773376be598L130-R257), [link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-50dace4459a7f8aa17d8b9251b8d423125d62cb9c4120bc82eafe773376be598R264))
  * Add test case for rendering switch component with loading status in different scenarios in `./packages/amis/__tests__/renderers/Form/switch.test.tsx` ([link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-80a595322486ac69249f52a814ad31be888188d8e213dfdc2b8efd945b0b72cfR74-R112))
* Add example of using switch component with disabled property in `./docs/zh-CN/components/form/switch.md` ([link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-50dace4459a7f8aa17d8b9251b8d423125d62cb9c4120bc82eafe773376be598R28-R45))
* Fix typo of disabled property in `./packages/amis-ui/src/components/formula/Input.tsx` ([link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-6a3dacc1d80cbde4dcd1d597b6aeb6d24f7874c3c317bf98ed47721a48e10930L80-R80))
* Add backticks around version number in `./docs/zh-CN/components/form/switch.md` ([link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-50dace4459a7f8aa17d8b9251b8d423125d62cb9c4120bc82eafe773376be598L108-R126))
* Remove duplicated CSS variable and use existing one in `./packages/amis-ui/scss/_components.scss` ([link](https://github.com/baidu/amis/pull/8814/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4L3295))
