### PR TITLE
fix: table嵌套在form以及affixHeader模式下自适应问题修复 (#8741)

### DIFF
--- a/packages/amis-ui/scss/components/form/_form.scss
+++ b/packages/amis-ui/scss/components/form/_form.scss
@@ -630,6 +630,7 @@
       flex: 1;
       flex-wrap: wrap;
       font-size: var(--fontSizeLg);
+      min-width: 0;
 
       .#{$ns}ColorPicker {
         > input {

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -1233,6 +1233,7 @@ export default class Table extends React.Component<TableProps, object> {
     if (this.resizeLine) {
       return;
     }
+    this.props.store.syncTableWidth();
     this.props.store.initTableWidth();
     this.handleOutterScroll();
     callback && setTimeout(callback, 20);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ff534b0</samp>

This pull request fixes a table layout bug and improves the table responsiveness. It adds a `min-width: 0` rule to the table header cells in `packages/amis-ui/scss/components/form/_form.scss` and calls the `syncTableWidth` method of the table store in `packages/amis/src/renderers/Table/index.tsx`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ff534b0</samp>

> _`syncTableWidth` runs_
> _when table component updates_
> _autumn leaves adjust_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ff534b0</samp>

* Fix table header overflow bug by setting `min-width: 0` for flex items ([link](https://github.com/baidu/amis/pull/8815/files?diff=unified&w=0#diff-f325489c306f0106cb368664288efa079f007a051f746e29ad32d88cde2abb4dR633))
* Update table column widths on component update by calling `syncTableWidth` method of table store ([link](https://github.com/baidu/amis/pull/8815/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR1236))
