### PR TITLE
fix(amis-editor): 修改input-date 最大最小值定义schema

### DIFF
--- a/packages/amis-editor/src/plugin/Form/InputDate.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputDate.tsx
@@ -358,11 +358,7 @@ export class DateControlPlugin extends BasePlugin {
                   name: 'minDate',
                   header: '表达式或相对值',
                   DateTimeType: FormulaDateType.IsDate,
-                  rendererSchema: () => {
-                    const schema = this.manager.store.getSchema(
-                      context.schema?.id,
-                      'id'
-                    );
+                  rendererSchema: (schema: Schema) => {
                     return {
                       ...schema,
                       value: context?.schema.minDate
@@ -376,11 +372,7 @@ export class DateControlPlugin extends BasePlugin {
                   name: 'maxDate',
                   header: '表达式或相对值',
                   DateTimeType: FormulaDateType.IsDate,
-                  rendererSchema: () => {
-                    const schema = this.manager.store.getSchema(
-                      context.schema?.id,
-                      'id'
-                    );
+                  rendererSchema: (schema: Schema) => {
                     return {
                       ...schema,
                       value: context?.schema.maxDate


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 835c1d1</samp>

Improved the date input plugin by refactoring the `Formula` component. Used the schema parameter instead of the store to avoid unnecessary requests and ensure schema validity.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 835c1d1</samp>

> _To make the date input more speedy_
> _The `Formula` component was needy_
> _It used the schema param_
> _Instead of the store's mayhem_
> _And now the plugin is more steady_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 835c1d1</samp>

*  Changed the `rendererSchema` property of the `Formula` component to accept a `schema` parameter instead of fetching the schema from the store ([link](https://github.com/baidu/amis/pull/8819/files?diff=unified&w=0#diff-b2fbf87e05b744e08c1257bc524b94cce8950b94797e28818f063fa9d887f7ecL361-R361), [link](https://github.com/baidu/amis/pull/8819/files?diff=unified&w=0#diff-b2fbf87e05b744e08c1257bc524b94cce8950b94797e28818f063fa9d887f7ecL379-R375)) in `Form/InputDate.tsx`. This improves the performance and consistency of the date input component.
