### PR TITLE
fix: table嵌套模式下selectedChange参数错误、table展示单选可多选问题修复

### DIFF
--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -1050,7 +1050,13 @@ export const TableStore = iRendererStore
         );
       }
 
-      config.multiple !== undefined && (self.multiple = config.multiple);
+      if (config.multiple !== undefined) {
+        self.multiple = config.multiple;
+      } else {
+        // 如果通过crud或picker，multiple始终设置了true或false
+        // 如果仅使用table，默认multiple为true，但props未设置multiple的情况下其实是展示单选
+        self.multiple = false;
+      }
       config.footable !== undefined && (self.footable = config.footable);
       config.expandConfig !== undefined &&
         (self.expandConfig = config.expandConfig);

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -967,54 +967,25 @@ export default class Table extends React.Component<TableProps, object> {
 
     value = value !== undefined ? value : !item.checked;
 
-    let rows = [item];
-    if (shift) {
-      rows = store.getToggleShiftRows(item);
-    }
-
-    const selectedItems = value
-      ? [
-          ...store.selectedRows.map((row: IRow) => row.data),
-          ...rows.map((row: IRow) => row.data)
-        ]
-      : store.selectedRows
-          .filter(
-            (row: IRow) =>
-              rows.findIndex((rowItem: IRow) => rowItem === row) === -1
-          )
-          .map((row: IRow) => row.data);
-    const unSelectedItems = value
-      ? store.unSelectedRows
-          .filter(
-            (row: IRow) =>
-              rows.findIndex((rowItem: IRow) => rowItem === row) === -1
-          )
-          .map((row: IRow) => row.data)
-      : [
-          ...store.unSelectedRows.map((row: IRow) => row.data),
-          ...rows.map((row: IRow) => row.data)
-        ];
-
-    const rendererEvent = await dispatchEvent(
-      'selectedChange',
-      createObject(data, {
-        selectedItems,
-        unSelectedItems
-      })
-    );
-
-    if (rendererEvent?.prevented) {
-      return;
-    }
-
     if (shift) {
       store.toggleShift(item, value);
     } else {
       // 如果picker的value是绑定的上层数量变量
       // 那么用户只能通过事件动作来更新上层变量来实现选中
-      // 但是注册了setValue动作后，会优先通过componentDidUpdate更新了selectedRows
-      // 那么这里直接toggle就判断出错了 需要明确是选中还是取消选中
       item.toggle(value);
+    }
+
+    const rendererEvent = await dispatchEvent(
+      'selectedChange',
+      createObject(data, {
+        selectedItems: store.selectedRows.map(row => row.data),
+        unSelectedItems: store.unSelectedRows.map(row => row.data),
+        item: item.data
+      })
+    );
+
+    if (rendererEvent?.prevented) {
+      return;
     }
 
     this.syncSelected();
@@ -1069,27 +1040,19 @@ export default class Table extends React.Component<TableProps, object> {
     const {store, data, dispatchEvent} = this.props;
     const items = store.rows.map((row: any) => row.data);
 
-    const allChecked = store.allChecked;
-    const selectedItems = store.getSelectedRows();
+    store.toggleAll();
 
     const rendererEvent = await dispatchEvent(
       'selectedChange',
       createObject(data, {
-        selectedItems: allChecked
-          ? selectedItems.filter(item => !item.checkable).map(item => item.data)
-          : selectedItems.map(item => item.data),
-        unSelectedItems: allChecked ? selectedItems.map(item => item.data) : [],
+        selectedItems: store.selectedRows.map(row => row.data),
+        unSelectedItems: store.unSelectedRows.map(row => row.data),
         items
       })
     );
+
     if (rendererEvent?.prevented) {
       return;
-    }
-
-    // selectedChange事件注册的动作里，有可能已经通过setValue把selectedRows的情况改了
-    // 没有改的情况下 才会去执行store.toogleAll()
-    if (allChecked === store.allChecked) {
-      store.toggleAll();
     }
 
     this.syncSelected();


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 19f15a1</samp>

This pull request refactors and fixes the table row selection feature in the `Table` renderer and the `TableStore` classes. It simplifies the code, moves the state to the store, and adds more information to the selection events. It also ensures the multiple prop is respected by the table component.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 19f15a1</samp>

> _The table component had a bug_
> _It ignored the multiple prop, so smug_
> _But now it's been fixed_
> _With an else branch and a mix_
> _Of comments to explain the logic snug_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 19f15a1</samp>

* Fix a bug where the table component would not respect the multiple prop if it was not explicitly set by the user ([link](https://github.com/baidu/amis/pull/8822/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1053-R1059))
* Refactor the logic of toggling the selection of a row or a group of rows with the shift key, moving it from the renderer component `Table/index.tsx` to the store `table.ts` and simplifying the calculation of the selected and unselected items ([link](https://github.com/baidu/amis/pull/8822/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL970-R983), [link](https://github.com/baidu/amis/pull/8822/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1010-L1019))
* Refactor the logic of toggling the selection of all rows, moving it before the event dispatching and simplifying the calculation of the selected and unselected items ([link](https://github.com/baidu/amis/pull/8822/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1072-R1057))
