### PR TITLE
fix: 修复style不支持css variable问题

### DIFF
--- a/packages/amis-core/src/utils/style.ts
+++ b/packages/amis-core/src/utils/style.ts
@@ -46,7 +46,7 @@ export function buildStyle(style: any, data: any) {
         styleVar.radius['bottom-left-border-radius'];
       delete styleVar['radius'];
     }
-    if (key.indexOf('-') !== -1) {
+    if (key.indexOf('-') > 0) {
       styleVar[camelCase(valueMap[key] || key)] = styleVar[key];
       delete styleVar[key];
     }

--- a/packages/amis-core/src/utils/style.ts
+++ b/packages/amis-core/src/utils/style.ts
@@ -46,6 +46,7 @@ export function buildStyle(style: any, data: any) {
         styleVar.radius['bottom-left-border-radius'];
       delete styleVar['radius'];
     }
+    // 将属性短横线命名转换为驼峰命名，如background-color => backgroundColor。但不处理css variable，如--colors-brand-5
     if (key.indexOf('-') > 0) {
       styleVar[camelCase(valueMap[key] || key)] = styleVar[key];
       delete styleVar[key];


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0e0e99e</samp>

Fixed a bug in `style.ts` that affected CSS property conversion. Prevented keys that start with a dash from being camel cased.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0e0e99e</samp>

> _`key.indexOf` changed_
> _No camel case for dash-prefixed_
> _CSS bug fixed in fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0e0e99e</samp>

* Fix a bug that caused some CSS properties to be ignored or overwritten by amis by changing the condition for converting keys to camel case in `style.ts` ([link](https://github.com/baidu/amis/pull/8827/files?diff=unified&w=0#diff-9e9ba3fea7a7eb2b1435c9839f14714b483805a2e06697c89cedfd85138eb34bL49-R49))
