### PR TITLE
chore: 优化默认字体列表 Closes #6768

### DIFF
--- a/packages/amis-ui/scss/themes/_ang-variables.scss
+++ b/packages/amis-ui/scss/themes/_ang-variables.scss
@@ -109,9 +109,11 @@ $ns: 'a-';
   --colors-neutral-line-9: #f3f2f5;
   --colors-neutral-line-10: #f8f7fa;
   --colors-neutral-line-11: #ffffff;
-  --fonts-base-family: -apple-system, BlinkMacSystemFont, SF Pro SC, SF Pro Text,
-    Helvetica Neue, Helvetica, PingFang SC, Segoe UI, Roboto, Hiragino Sans GB,
-    Arial, microsoft yahei ui, Microsoft YaHei, SimSun, sans-serif;
+  --fonts-base-family: -apple-system, 'Noto Sans', 'Helvetica Neue', Helvetica,
+    'Nimbus Sans L', Arial, 'Liberation Sans', 'PingFang SC', 'Hiragino Sans GB',
+    'Noto Sans CJK SC', 'Source Han Sans SC', 'Source Han Sans CN',
+    'Microsoft YaHei', 'Wenquanyi Micro Hei', 'WenQuanYi Zen Hei', 'ST Heiti',
+    SimHei, 'WenQuanYi Zen Hei Sharp', sans-serif;
   --fonts-size-1: 48px;
   --fonts-size-2: 40px;
   --fonts-size-3: 32px;

--- a/packages/amis-ui/scss/themes/_antd-variables.scss
+++ b/packages/amis-ui/scss/themes/_antd-variables.scss
@@ -109,9 +109,11 @@ $ns: 'antd-';
   --colors-neutral-line-9: #f2f4f5;
   --colors-neutral-line-10: #f7f9fa;
   --colors-neutral-line-11: #ffffff;
-  --fonts-base-family: -apple-system, BlinkMacSystemFont, SF Pro SC, SF Pro Text,
-    Helvetica Neue, Helvetica, PingFang SC, Segoe UI, Roboto, Hiragino Sans GB,
-    Arial, microsoft yahei ui, Microsoft YaHei, SimSun, sans-serif;
+  --fonts-base-family: -apple-system, 'Noto Sans', 'Helvetica Neue', Helvetica,
+    'Nimbus Sans L', Arial, 'Liberation Sans', 'PingFang SC', 'Hiragino Sans GB',
+    'Noto Sans CJK SC', 'Source Han Sans SC', 'Source Han Sans CN',
+    'Microsoft YaHei', 'Wenquanyi Micro Hei', 'WenQuanYi Zen Hei', 'ST Heiti',
+    SimHei, 'WenQuanYi Zen Hei Sharp', sans-serif;
   --fonts-size-1: 48px;
   --fonts-size-2: 40px;
   --fonts-size-3: 32px;

--- a/packages/amis-ui/scss/themes/_cxd-variables.scss
+++ b/packages/amis-ui/scss/themes/_cxd-variables.scss
@@ -106,9 +106,12 @@ $ns: 'cxd-';
   --colors-neutral-line-9: #f2f3f5;
   --colors-neutral-line-10: #f7f8fa;
   --colors-neutral-line-11: #ffffff;
-  --fonts-base-family: -apple-system, BlinkMacSystemFont, SF Pro SC, SF Pro Text,
-    Helvetica Neue, Helvetica, PingFang SC, Segoe UI, Roboto, Hiragino Sans GB,
-    Arial, microsoft yahei ui, Microsoft YaHei, SimSun, sans-serif;
+  // 参考 https://zenozeng.github.io/fonts.css/
+  --fonts-base-family: -apple-system, 'Noto Sans', 'Helvetica Neue', Helvetica,
+    'Nimbus Sans L', Arial, 'Liberation Sans', 'PingFang SC', 'Hiragino Sans GB',
+    'Noto Sans CJK SC', 'Source Han Sans SC', 'Source Han Sans CN',
+    'Microsoft YaHei', 'Wenquanyi Micro Hei', 'WenQuanYi Zen Hei', 'ST Heiti',
+    SimHei, 'WenQuanYi Zen Hei Sharp', sans-serif;
   --fonts-size-1: 48px;
   --fonts-size-2: 40px;
   --fonts-size-3: 32px;

--- a/packages/amis-ui/scss/themes/_dark-variables.scss
+++ b/packages/amis-ui/scss/themes/_dark-variables.scss
@@ -117,9 +117,11 @@ $ns: 'dark-';
   --colors-neutral-line-9: #f2f4f5;
   --colors-neutral-line-10: #f7f9fa;
   --colors-neutral-line-11: #ffffff;
-  --fonts-base-family: -apple-system, BlinkMacSystemFont, SF Pro SC, SF Pro Text,
-    Helvetica Neue, Helvetica, PingFang SC, Segoe UI, Roboto, Hiragino Sans GB,
-    Arial, microsoft yahei ui, Microsoft YaHei, SimSun, sans-serif;
+  --fonts-base-family: -apple-system, 'Noto Sans', 'Helvetica Neue', Helvetica,
+    'Nimbus Sans L', Arial, 'Liberation Sans', 'PingFang SC', 'Hiragino Sans GB',
+    'Noto Sans CJK SC', 'Source Han Sans SC', 'Source Han Sans CN',
+    'Microsoft YaHei', 'Wenquanyi Micro Hei', 'WenQuanYi Zen Hei', 'ST Heiti',
+    SimHei, 'WenQuanYi Zen Hei Sharp', sans-serif;
   --fonts-size-1: 48px;
   --fonts-size-2: 40px;
   --fonts-size-3: 32px;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1d05399</samp>

Updated the `--fonts-base-family` variable in four theme variables files (`_ang-variables.scss`, `_antd-variables.scss`, `_cxd-variables.scss`, and `_dark-variables.scss`) to use `Noto Sans` and more Chinese fonts. This improves the font compatibility and readability for the ANG, Ant Design, CXD, and dark mode UI frameworks.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1d05399</samp>

> _`--fonts-base-family`_
> _Updated for all UI themes_
> _A winter refresh_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1d05399</samp>

* Updated the base font family for four UI themes to use Noto Sans and more Chinese fonts ([link](https://github.com/baidu/amis/pull/8830/files?diff=unified&w=0#diff-e951c4b98ba0f51f942c7f496dfb35373826b35670ba40b15d32249be03cc97fL112-R116), [link](https://github.com/baidu/amis/pull/8830/files?diff=unified&w=0#diff-62541456ad28a061578226578ce09bdd6739a32e646c3d9ae2a045f85b4d2ca6L112-R116), [link](https://github.com/baidu/amis/pull/8830/files?diff=unified&w=0#diff-aee05f5a77c9c9de0cbae090127dc57df3d6612121966ee71afcf33117347196L109-R114), [link](https://github.com/baidu/amis/pull/8830/files?diff=unified&w=0#diff-d9d65ad257189990ca634f378e3815dc094d22f1ee341da7726cf339d5a1679cL120-R124))
