### PR TITLE
fix: 修复 combo 同步父级数据可能存在展示值和实际值不一致的问题 Close: #8773

### DIFF
--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -522,6 +522,18 @@ export default class Form extends React.Component<FormProps, object> {
         )
       );
     }
+
+    // withStore 里面与上层数据会做同步
+    // 这个时候变更的数据没有同步 onChange 出去，出现数据不一致的问题。
+    // https://github.com/baidu/amis/issues/8773
+    this.toDispose.push(
+      reaction(
+        () => store.initedAt,
+        () => {
+          store.inited && this.emitChange(!!this.props.submitOnChange);
+        }
+      )
+    );
   }
 
   componentDidMount() {

--- a/packages/amis/__tests__/renderers/Form/combo.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/combo.test.tsx
@@ -659,6 +659,17 @@ test('Renderer:combo with canAccessSuperData & strictMode & syncFields', async (
   expect(comboInputs[0]!.value).toBe('');
   expect(comboInputs[1]!.value).toBe('123');
   expect(comboInputs[2]!.value).toBe('123456');
+
+  fireEvent.click(submitBtn);
+  await wait(300);
+  expect(onSubmit).toHaveBeenCalled();
+
+  expect(onSubmit.mock.calls[0][0]).toMatchObject({
+    super_text: '123456',
+    combo1: [{}],
+    combo2: [{super_text: '123'}],
+    combo3: [{super_text: '123456'}]
+  });
 });
 
 // 9. tabsMode

--- a/packages/amis/__tests__/renderers/Form/inputArray.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/inputArray.test.tsx
@@ -194,6 +194,7 @@ test('Renderer:inputArray with minLength & maxLength', async () => {
   expect(container.querySelector('.cxd-Combo-addBtn')).toBeInTheDocument();
   // 最大值
   fireEvent.click(container.querySelector('.cxd-Combo-addBtn')!);
+  await wait(300);
   await waitFor(() => {
     expect(container.querySelector('a.cxd-Combo-delBtn')).toBeInTheDocument();
     expect(

--- a/packages/amis/src/renderers/Form/Combo.tsx
+++ b/packages/amis/src/renderers/Form/Combo.tsx
@@ -541,8 +541,10 @@ export default class ComboControl extends React.Component<ComboProps> {
   }
 
   getValueAsArray(props = this.props) {
-    const {flat, joinValues, delimiter, type} = props;
-    let value = props.value;
+    const {flat, joinValues, delimiter, type, formItem} = props;
+    // 因为 combo 多个子表单可能同时发生变化。
+    // onChagne 触发多次，上次变更还没应用到 props.value 上来，这次触发变更就会包含历史数据，把上次触发的数据给重置成旧的了。
+    let value = formItem?.tmpValue || props.value;
 
     if (joinValues && flat && typeof value === 'string') {
       value = value.split(delimiter || ',');


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8134303</samp>

This pull request fixes two data synchronization issues in the `Form` and `Combo` renderers, which caused data inconsistency and overwriting problems. It uses the `initedAt` property and the `tmpValue` property to ensure the data changes are properly reflected and emitted.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8134303</samp>

> _`initedAt` reacts_
> _syncing data with changes_
> _autumn bug is fixed_

### Why

Close: #8773

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8134303</samp>

* Fix data inconsistency bug in Form renderer by reacting to store initialization ([link](https://github.com/baidu/amis/pull/8831/files?diff=unified&w=0#diff-74ef3e735568303c05308159e59fd316cca5f1fba7b0b805b50c43be1ca55cf3R525-R536))
* Prevent value overwrite in Combo component by using tmpValue instead of props.value ([link](https://github.com/baidu/amis/pull/8831/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L544-R547))
