### PR TITLE
feat: 事件动作支持上报埋点

### DIFF
--- a/packages/amis-core/src/types.ts
+++ b/packages/amis-core/src/types.ts
@@ -1,7 +1,7 @@
 // https://json-schema.org/draft-07/json-schema-release-notes.html
 import type {JSONSchema7} from 'json-schema';
 import {ListenerAction} from './actions/Action';
-import {debounceConfig} from './utils/renderer-event';
+import {debounceConfig, trackConfig} from './utils/renderer-event';
 
 export interface Option {
   /**
@@ -619,6 +619,7 @@ export interface BaseSchemaWithoutType {
       weight?: number; // 权重
       actions: ListenerAction[]; // 执行的动作集
       debounce?: debounceConfig;
+      track?: trackConfig;
     };
   };
   /**

--- a/packages/amis-core/src/types.ts
+++ b/packages/amis-core/src/types.ts
@@ -458,7 +458,8 @@ export interface EventTrack {
     | 'tabChange'
     | 'pageLoaded'
     | 'pageHidden'
-    | 'pageVisible';
+    | 'pageVisible'
+    | string;
 
   /**
    * 事件数据

--- a/packages/amis-core/src/utils/renderer-event.ts
+++ b/packages/amis-core/src/utils/renderer-event.ts
@@ -10,10 +10,16 @@ export interface debounceConfig {
   leading?: boolean;
   trailing?: boolean;
 }
+
+export interface trackConfig {
+  id: string;
+  name: string;
+}
 // 事件监听器
 export interface EventListeners {
   [propName: string]: {
     debounce?: debounceConfig;
+    track?: trackConfig;
     weight?: number; // 权重
     actions: ListenerAction[]; // 执行的动作集
   };
@@ -26,6 +32,7 @@ export interface OnEventProps {
       weight?: number; // 权重
       actions: ListenerAction[]; // 执行的动作集,
       debounce?: debounceConfig;
+      track?: trackConfig;
     };
   };
 }
@@ -36,6 +43,7 @@ export interface RendererEventListener {
   type: string;
   weight: number;
   debounce: debounceConfig | null;
+  track: trackConfig | null;
   actions: ListenerAction[];
   executing?: boolean;
   debounceInstance?: any;
@@ -118,6 +126,7 @@ export const bindEvent = (renderer: any) => {
             renderer,
             type: key,
             debounce: listener.debounce || null,
+            track: listeners[key].track || null,
             weight: listener.weight || 0,
             actions: listener.actions
           });
@@ -127,6 +136,7 @@ export const bindEvent = (renderer: any) => {
           renderer,
           type: key,
           debounce: listeners[key].debounce || null,
+          track: listeners[key].track || null,
           weight: listeners[key].weight || 0,
           actions: listeners[key].actions
         });
@@ -243,6 +253,17 @@ export async function dispatchEvent(
     } else {
       await runActions(listener.actions, listener.renderer, rendererEvent);
       checkExecuted();
+    }
+
+    if (listener?.track) {
+      const {id: trackId, name: trackName} = listener.track;
+      renderer?.props?.env?.tracker({
+        eventType: listener.type,
+        eventData: {
+          trackId,
+          trackName
+        }
+      });
     }
 
     // 停止后续监听器执行

--- a/packages/amis-editor/src/renderer/event-control/index.tsx
+++ b/packages/amis-editor/src/renderer/event-control/index.tsx
@@ -241,10 +241,8 @@ export class EventControl extends React.Component<
       };
     }
     if (!eventInfo.track) {
-      // 防抖配置的默认值
       eventInfo.track = {
-        open: false,
-        wait: 100
+        open: false
       };
     } else {
       eventInfo.track = {

--- a/packages/amis-editor/src/renderer/event-control/index.tsx
+++ b/packages/amis-editor/src/renderer/event-control/index.tsx
@@ -78,6 +78,11 @@ interface EventDialogData {
     open: boolean;
     wait?: number;
   };
+  trackConfig?: {
+    open: boolean;
+    id: string;
+    name: string;
+  };
   [propName: string]: any;
 }
 
@@ -235,6 +240,18 @@ export class EventControl extends React.Component<
         ...eventInfo.debounce
       };
     }
+    if (!eventInfo.track) {
+      // 防抖配置的默认值
+      eventInfo.track = {
+        open: false,
+        wait: 100
+      };
+    } else {
+      eventInfo.track = {
+        open: true,
+        ...eventInfo.track
+      };
+    }
     this.setState({
       eventDialogData: eventInfo,
       showEventDialog: true
@@ -243,11 +260,11 @@ export class EventControl extends React.Component<
 
   eventDialogSubmit(formData: any) {
     const {onChange} = this.props;
-    const {eventName, debounce = {}} = formData;
+    const {eventName, debounce = {}, track = {}} = formData;
     let onEvent = {
       ...this.state.onEvent
     };
-    let eventConfig = onEvent[`${eventName}`];
+    let eventConfig = {...onEvent[`${eventName}`]};
     if (!debounce.open) {
       delete eventConfig.debounce;
     } else {
@@ -258,6 +275,18 @@ export class EventControl extends React.Component<
         }
       };
     }
+    if (!track.open) {
+      delete eventConfig.track;
+    } else {
+      eventConfig = {
+        ...eventConfig,
+        track: {
+          id: track.id,
+          name: track.name
+        }
+      };
+    }
+
     onEvent[`${eventName}`] = {
       ...eventConfig
     };
@@ -1256,6 +1285,27 @@ export class EventControl extends React.Component<
                         max: 10000,
                         min: 0,
                         type: 'input-number'
+                      },
+                      {
+                        label: '事件埋点',
+                        type: 'switch',
+                        name: 'track.open',
+                        description:
+                          '开启事件埋点后，每次事件触发都会发送埋点数据到后台'
+                      },
+                      {
+                        label: 'track-id',
+                        required: true,
+                        hiddenOn: '!track.open',
+                        name: 'track.id',
+                        type: 'input-text'
+                      },
+                      {
+                        label: 'track-name',
+                        required: true,
+                        hiddenOn: '!track.open',
+                        name: 'track.name',
+                        type: 'input-text'
                       }
                     ],
                     onSubmit: this.eventDialogSubmit.bind(this)

--- a/packages/amis-editor/src/renderer/event-control/types.ts
+++ b/packages/amis-editor/src/renderer/event-control/types.ts
@@ -13,6 +13,10 @@ export interface ActionEventConfig {
     debounce?: {
       wait: number;
     };
+    track?: {
+      id: string;
+      name: string;
+    };
   };
 }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7485084</samp>

This pull request adds a feature to enable custom event tracking in the renderer event system. It defines a `track` property for event listeners and a `trackConfig` interface for the tracking configuration. It also modifies the `EventControl` component in the editor to allow users to configure event tracking with an `id` and a `name`. It updates the relevant types and schemas to support the new feature.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7485084</samp>

> _Sing, O Muse, of the cunning code that changed the `EventTrack` interface_
> _And made it accept any string as a type, not only the predefined ones_
> _So that the wise developers could track custom events for analytics_
> _And measure the impact of their actions on the users and the business_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7485084</samp>

*  Add support for custom event tracking for analytics purposes ([link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-9795a06699f88c4c144fccb14b9ddca83b8d9639d2062c27b01495b6b80e7d7dL461-R462), [link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6L13-R22), [link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6R35), [link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6R46), [link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6R129), [link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6R139), [link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6R258-R268), [link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754R81-R85), [link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754R243-R254), [link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754L246-R267), [link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754R278-R289), [link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754R1288-R1308), [link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-fc8454e971e7a7c27fed9ca49c6f8f2d640e3780449ddeabfbec61105738d386R16-R19))
  *  Allow any string as a possible event type in the `EventTrack` interface in `types.ts` ([link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-9795a06699f88c4c144fccb14b9ddca83b8d9639d2062c27b01495b6b80e7d7dL461-R462))
  *  Define a new interface `trackConfig` that specifies the id and name of a custom event in `renderer-event.ts` ([link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6L13-R22))
  *  Add a `track` property to the `EventListeners`, `OnEventProps`, and `RendererEventListener` interfaces in `renderer-event.ts` ([link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6R35), [link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6R46))
  *  Assign the `track` property of the `RendererEventListener` object to the `track` property of the `EventListeners` object, if it exists, or null otherwise, in the `bindEvent` function in `renderer-event.ts` ([link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6R129), [link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6R139))
  *  Check if the `listener` object has a `track` property that is not null, and if so, call the `tracker` function from the `env` prop of the `renderer` object, in the `dispatchEvent` function in `renderer-event.ts` ([link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-747212650e6ec93d9ee13fe53e5bdf0f621f1dd6318fd3d29f834e6147524bb6R258-R268))
  *  Add a `trackConfig` property to the `EventDialogData` interface in `event-control/index.tsx` ([link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754R81-R85))
  *  Initialize the `track` property of the `eventInfo` object to an object with an `open` flag and a default `wait` value, or spread the existing `track` object, in the `EventControl` component ([link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754R243-R254))
  *  Destructure the `track` object from the `formData` object, and spread the `onEvent` object from the state, in the `EventControl` component ([link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754L246-R267))
  *  Delete the `track` property from the `eventConfig` object if the `open` flag is false, or assign it to a new object with the `id` and `name` properties from the `track` object, in the `EventControl` component ([link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754R278-R289))
  *  Add four new form items to the event dialog schema in the `EventControl` component, for enabling or disabling the event tracking, and entering the `track-id` and `track-name` values ([link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-e4ada75982559fe0f42d3040e30e806945e0e0e1b81cf201d79a9e4dab6db754R1288-R1308))
  *  Add a `track` property to the `ActionEventConfig` interface in `event-control/types.ts` ([link](https://github.com/baidu/amis/pull/8832/files?diff=unified&w=0#diff-fc8454e971e7a7c27fed9ca49c6f8f2d640e3780449ddeabfbec61105738d386R16-R19))
