### PR TITLE
feat(amis&amis-editor): 地理位置选择器功能完善和强化 close #8802

### DIFF
--- a/docs/zh-CN/components/form/location-picker.md
+++ b/docs/zh-CN/components/form/location-picker.md
@@ -60,5 +60,7 @@ order: 30
 | vendor          | 'baidu'   | 'baidu' \| 'gaode' | 地图厂商，目前只实现了百度地图和高德地图                   |
 | ak              | `string`  | 无                 | 百度/高德地图的 ak                                         |
 | clearable       | `boolean` | false              | 输入框是否可清空                                           |
-| placeholder     | `string`  | '请选择位置'       | 默认提示                                                   |
-| coordinatesType | `string`  | 'bd09'             | 默为百度/高德坐标，可设置为'gcj02', 高德地图不支持坐标转换 |
+| placeholder     | `string`  | '请选择位置'         | 默认提示                                                   |
+| autoSelectCurrentLoc     | `boolean`  | false    | 是否自动选中当前地理位置                                 |
+| onlySelectCurrentLoc     | `boolean`  | false    | 是否限制只能选中当前地理位置，设置为true后，可用于充当定位组件 |
+| coordinatesType | `string`  | 'bd09'             | 默为百度/高德坐标，可设置为'gcj02', 高德地图不支持坐标转换   |

--- a/packages/amis-editor/src/plugin/Form/LocationPicker.tsx
+++ b/packages/amis-editor/src/plugin/Form/LocationPicker.tsx
@@ -1,4 +1,4 @@
-import {EditorNodeType, getSchemaTpl} from 'amis-editor-core';
+import {EditorNodeType, getSchemaTpl, tipedLabel} from 'amis-editor-core';
 import {registerEditorPlugin} from 'amis-editor-core';
 import {BasePlugin, BaseEventContext} from 'amis-editor-core';
 import {ValidatorTag} from '../../validator';
@@ -82,7 +82,20 @@ export class LocationControlPlugin extends BasePlugin {
                     {label: '国测局坐标', value: 'gcj02'}
                   ]
                 },
-
+                getSchemaTpl('switch', {
+                  name: 'autoSelectCurrentLoc',
+                  label: tipedLabel(
+                    '自动选择',
+                    '开启后，自动选中用户当前的地理位置'
+                  )
+                }),
+                getSchemaTpl('switch', {
+                  name: 'onlySelectCurrentLoc',
+                  label: tipedLabel(
+                    '只读模式',
+                    '开启后，只能使用当前地理位置，不可选择其他地理位置'
+                  )
+                }),
                 getSchemaTpl('clearable'),
                 getSchemaTpl('labelRemark'),
                 getSchemaTpl('remark'),

--- a/packages/amis-editor/src/plugin/Form/LocationPicker.tsx
+++ b/packages/amis-editor/src/plugin/Form/LocationPicker.tsx
@@ -99,7 +99,13 @@ export class LocationControlPlugin extends BasePlugin {
                 getSchemaTpl('clearable'),
                 getSchemaTpl('labelRemark'),
                 getSchemaTpl('remark'),
-                getSchemaTpl('placeholder'),
+                getSchemaTpl('placeholder', {
+                  visibleOn: '!onlySelectCurrentLoc'
+                }),
+                getSchemaTpl('placeholder', {
+                  name: 'getLocationPlaceholder',
+                  visibleOn: 'onlySelectCurrentLoc'
+                }),
                 getSchemaTpl('description')
               ]
             },

--- a/packages/amis-ui/src/components/BaiduMapPicker.tsx
+++ b/packages/amis-ui/src/components/BaiduMapPicker.tsx
@@ -137,7 +137,7 @@ export class BaiduMapPicker extends React.Component<
 
     const geolocationControl = new BMap.GeolocationControl();
     geolocationControl.addEventListener('locationSuccess', (e: any) => {
-      this.getLocations(e.point);
+      this.getLocations(e.point, true);
     });
     map.addControl(geolocationControl);
 
@@ -187,7 +187,7 @@ export class BaiduMapPicker extends React.Component<
     value ? this.getLocations(point) : geolocationControl.location();
   }
 
-  getLocations(point: any, select?: boolean) {
+  getLocations(point: any, selectCurrentLoc?: boolean) {
     const map = this.map;
 
     map.clearOverlays();
@@ -231,7 +231,7 @@ export class BaiduMapPicker extends React.Component<
           locs
         },
         () => {
-          if (!select) {
+          if (!selectCurrentLoc) {
             return;
           }
 
@@ -308,6 +308,7 @@ export class BaiduMapPicker extends React.Component<
           city: loc.city
         });
     }
+    console.log('this.props:', this.props);
   }
 
   @autobind

--- a/packages/amis-ui/src/components/BaiduMapPicker.tsx
+++ b/packages/amis-ui/src/components/BaiduMapPicker.tsx
@@ -38,6 +38,8 @@ interface MapPickerProps {
     city?: string;
   };
   onChange?: (value: any) => void;
+  autoSelectCurrentLoc?: boolean;
+  onlySelectCurrentLoc?: boolean;
 }
 
 interface LocationItem {
@@ -109,6 +111,7 @@ export class BaiduMapPicker extends React.Component<
 
   @autobind
   async initMap() {
+    const autoSelectCurrentLoc = this.props.autoSelectCurrentLoc ?? false;
     const map = new BMap.Map(this.mapRef.current, {
       enableMapClick: false
     });
@@ -137,11 +140,14 @@ export class BaiduMapPicker extends React.Component<
 
     const geolocationControl = new BMap.GeolocationControl();
     geolocationControl.addEventListener('locationSuccess', (e: any) => {
-      this.getLocations(e.point, true);
+      this.getLocations(e.point, autoSelectCurrentLoc);
     });
     map.addControl(geolocationControl);
 
     map.addEventListener('click', (e: any) => {
+      if (this.props.onlySelectCurrentLoc) {
+        return;
+      }
       this.getLocations(e.point, true);
     });
 
@@ -187,6 +193,7 @@ export class BaiduMapPicker extends React.Component<
     value ? this.getLocations(point) : geolocationControl.location();
   }
 
+  @autobind
   getLocations(point: any, selectCurrentLoc?: boolean) {
     const map = this.map;
 
@@ -308,7 +315,6 @@ export class BaiduMapPicker extends React.Component<
           city: loc.city
         });
     }
-    console.log('this.props:', this.props);
   }
 
   @autobind
@@ -319,7 +325,7 @@ export class BaiduMapPicker extends React.Component<
     });
 
     var local = new BMap.LocalSearch(this.map, {
-      //智能搜索
+      // 智能搜索
       onSearchComplete: () => {
         const results = local.getResults();
         const poi = results.getPoi(0);
@@ -335,20 +341,23 @@ export class BaiduMapPicker extends React.Component<
 
   render() {
     const {classnames: cx} = this.props;
+    const onlySelectCurrentLoc = this.props.onlySelectCurrentLoc ?? false;
     const {locIndex, locs, inputValue, sugs} = this.state;
     const hasSug = Array.isArray(sugs) && sugs.length;
 
     return (
       <div className={cx('MapPicker')}>
-        <div className={cx('MapPicker-search TextControl-control')}>
-          <div className={cx('TextControl-input')}>
-            <input
-              onChange={this.handleChange}
-              value={inputValue}
-              placeholder="搜索地点"
-            />
+        {!onlySelectCurrentLoc && (
+          <div className={cx('MapPicker-search TextControl-control')}>
+            <div className={cx('TextControl-input')}>
+              <input
+                onChange={this.handleChange}
+                value={inputValue}
+                placeholder="搜索地点"
+              />
+            </div>
           </div>
-        </div>
+        )}
 
         <div
           ref={this.mapRef}
@@ -362,23 +371,36 @@ export class BaiduMapPicker extends React.Component<
             invisible: hasSug
           })}
         >
-          {locs.map((item, index) => (
+          {!onlySelectCurrentLoc &&
+            locs.map((item, index) => (
+              <div
+                onClick={this.handleSelect}
+                key={index}
+                data-index={index}
+                className={cx('MapPicker-item')}
+              >
+                <div className={cx('MapPicker-itemTitle')}>{item.title}</div>
+                <div className={cx('MapPicker-itemDesc')}>{item.address}</div>
+                {locIndex === index ? (
+                  <Icon icon="success" className="icon" />
+                ) : null}
+              </div>
+            ))}
+          {onlySelectCurrentLoc && locs.length > 0 && (
             <div
               onClick={this.handleSelect}
-              key={index}
-              data-index={index}
+              key="locs-current"
+              data-index={0}
               className={cx('MapPicker-item')}
             >
-              <div className={cx('MapPicker-itemTitle')}>{item.title}</div>
-              <div className={cx('MapPicker-itemDesc')}>{item.address}</div>
-              {locIndex === index ? (
-                <Icon icon="success" className="icon" />
-              ) : null}
+              <div className={cx('MapPicker-itemTitle')}>{locs[0].title}</div>
+              <div className={cx('MapPicker-itemDesc')}>{locs[0].address}</div>
+              {locIndex === 0 ? <Icon icon="success" className="icon" /> : null}
             </div>
-          ))}
+          )}
         </div>
 
-        {hasSug ? (
+        {hasSug && !onlySelectCurrentLoc ? (
           <div className={cx('MapPicker-sug')}>
             {sugs.map(item => (
               <div

--- a/packages/amis-ui/src/components/LocationPicker.tsx
+++ b/packages/amis-ui/src/components/LocationPicker.tsx
@@ -14,6 +14,7 @@ export interface LocationProps extends ThemeProps, LocaleProps {
   vendor: 'baidu' | 'gaode' | 'tenxun';
   coordinatesType: 'bd09' | 'gcj02';
   placeholder: string;
+  getLocationPlaceholder: string;
   clearable: boolean;
   ak: string;
   value?: {
@@ -27,6 +28,8 @@ export interface LocationProps extends ThemeProps, LocaleProps {
   popoverClassName?: string;
   onChange: (value: any) => void;
   popOverContainer?: any;
+  autoSelectCurrentLoc?: boolean;
+  onlySelectCurrentLoc?: boolean;
 }
 
 export interface LocationState {
@@ -40,6 +43,7 @@ export class LocationPicker extends React.Component<
 > {
   static defaultProps = {
     placeholder: 'LocationPicker.placeholder',
+    getLocationPlaceholder: 'LocationPicker.getLocation',
     clearable: false
   };
   domRef: React.RefObject<HTMLDivElement> = React.createRef();
@@ -155,12 +159,15 @@ export class LocationPicker extends React.Component<
       popoverClassName,
       disabled,
       placeholder,
+      getLocationPlaceholder,
       clearable,
       popOverContainer,
       vendor,
       coordinatesType,
       ak,
-      mobileUI
+      mobileUI,
+      autoSelectCurrentLoc,
+      onlySelectCurrentLoc
     } = this.props;
     const __ = this.props.translate;
     const {isFocused, isOpened} = this.state;
@@ -173,6 +180,8 @@ export class LocationPicker extends React.Component<
               ak={ak}
               value={value}
               coordinatesType={coordinatesType}
+              autoSelectCurrentLoc={autoSelectCurrentLoc}
+              onlySelectCurrentLoc={onlySelectCurrentLoc}
               onChange={this.handleChange}
             />
           );
@@ -213,7 +222,7 @@ export class LocationPicker extends React.Component<
           <span className={cx('LocationPicker-value')}>{value.address}</span>
         ) : (
           <span className={cx('LocationPicker-placeholder')}>
-            {__(placeholder)}
+            {__(onlySelectCurrentLoc ? getLocationPlaceholder : placeholder)}
           </span>
         )}
 
@@ -242,6 +251,8 @@ export class LocationPicker extends React.Component<
                   ak={ak}
                   value={value}
                   coordinatesType={coordinatesType}
+                  autoSelectCurrentLoc={autoSelectCurrentLoc}
+                  onlySelectCurrentLoc={onlySelectCurrentLoc}
                   onChange={this.handleTempChange}
                 />
               ) : (
@@ -268,6 +279,8 @@ export class LocationPicker extends React.Component<
                   ak={ak}
                   value={value}
                   coordinatesType={coordinatesType}
+                  autoSelectCurrentLoc={autoSelectCurrentLoc}
+                  onlySelectCurrentLoc={onlySelectCurrentLoc}
                   onChange={this.handleChange}
                 />
               ) : (

--- a/packages/amis-ui/src/locale/de-DE.ts
+++ b/packages/amis-ui/src/locale/de-DE.ts
@@ -188,6 +188,8 @@ register('de-DE', {
   'loading': 'Wird geladen...',
   'loadingFailed': 'Das Laden ist fehlgeschlagen',
   'LocationPicker.placeholder': 'Wählen Sie einen Ort',
+  'LocationPicker.getLocation':
+    'Klicken Sie hier, um Standortinformationen zu erhalten',
   'Month.placeholder': 'Wählen Sie einen Monat',
   'Nav.sourceError': 'Fehler beim Abrufen des Links',
   'networkError':

--- a/packages/amis-ui/src/locale/en-US.ts
+++ b/packages/amis-ui/src/locale/en-US.ts
@@ -180,6 +180,7 @@ register('en-US', {
   'loading': 'Loading',
   'loadingFailed': 'Loading failed',
   'LocationPicker.placeholder': 'Pick location',
+  'LocationPicker.getLocation': 'Click to obtain location information',
   'Month.placeholder': 'Select a month',
   'Nav.sourceError': 'Fetch link error',
   'networkError': 'Network error or missing CORS configuration',

--- a/packages/amis-ui/src/locale/zh-CN.ts
+++ b/packages/amis-ui/src/locale/zh-CN.ts
@@ -185,6 +185,7 @@ register('zh-CN', {
   'loading': '加载中',
   'loadingFailed': '加载失败',
   'LocationPicker.placeholder': '请选择位置',
+  'LocationPicker.getLocation': '点击获取位置信息',
   'Month.placeholder': '请选择月份',
   'Nav.sourceError': '获取链接错误',
   'networkError': '网络错误，可能是未配置跨域 CORS',

--- a/packages/amis/src/renderers/Form/LocationPicker.tsx
+++ b/packages/amis/src/renderers/Form/LocationPicker.tsx
@@ -51,33 +51,6 @@ export class LocationControl extends React.Component<LocationControlProps> {
     coordinatesType: 'bd09'
   };
   domRef: React.RefObject<HTMLDivElement> = React.createRef();
-  state = {
-    isOpened: false
-  };
-
-  @autobind
-  close() {
-    this.setState({
-      isOpened: false
-    });
-  }
-
-  @autobind
-  open() {
-    this.setState({
-      isOpened: true
-    });
-  }
-
-  @autobind
-  handleClick() {
-    this.state.isOpened ? this.close() : this.open();
-  }
-
-  @autobind
-  getParent() {
-    return this.domRef.current?.parentElement;
-  }
 
   @autobind
   getTarget() {
@@ -85,14 +58,7 @@ export class LocationControl extends React.Component<LocationControlProps> {
   }
 
   renderStatic(displayValue = '-') {
-    const {
-      classnames: cx,
-      value,
-      vendor,
-      ak,
-      coordinatesType,
-      popOverContainer
-    } = this.props;
+    const {classnames: cx, value} = this.props;
     const __ = this.props.translate;
 
     if (!value) {
@@ -107,35 +73,6 @@ export class LocationControl extends React.Component<LocationControlProps> {
         ref={this.domRef}
       >
         <span>{value.address}</span>
-        <a
-          className={cx('LocationPicker-toggler', 'ml-1')}
-          onClick={this.handleClick}
-        >
-          <Icon icon="location" className="icon" />
-        </a>
-        <Overlay
-          target={this.getTarget}
-          container={popOverContainer || this.getParent}
-          rootClose={false}
-          show={this.state.isOpened}
-        >
-          <PopOver
-            className={cx('LocationPicker-popover')}
-            onHide={this.close}
-            overlay
-            style={{width: this.getTarget()?.offsetWidth}}
-          >
-            {vendor === 'baidu' ? (
-              <BaiduMapPicker
-                ak={ak}
-                value={value}
-                coordinatesType={coordinatesType}
-              />
-            ) : (
-              <Alert2>{__('{{vendor}} 地图控件不支持', {vendor})}</Alert2>
-            )}
-          </PopOver>
-        </Overlay>
       </div>
     );
   }

--- a/packages/amis/src/renderers/Form/LocationPicker.tsx
+++ b/packages/amis/src/renderers/Form/LocationPicker.tsx
@@ -29,6 +29,17 @@ export interface LocationControlSchema extends FormBaseControlSchema {
    * 有的地图需要设置 ak 信息
    */
   ak?: string;
+
+  /**
+   * 是否自动选中当前地理位置
+   */
+  autoSelectCurrentLoc?: boolean;
+
+  /**
+   * 是否只能选中当前地理位置
+   * 备注：可用于充当定位组件，只允许选择当前位置
+   */
+  onlySelectCurrentLoc?: boolean;
 }
 
 export interface LocationControlProps

--- a/packages/amis/src/renderers/Form/LocationPicker.tsx
+++ b/packages/amis/src/renderers/Form/LocationPicker.tsx
@@ -40,6 +40,12 @@ export interface LocationControlSchema extends FormBaseControlSchema {
    * 备注：可用于充当定位组件，只允许选择当前位置
    */
   onlySelectCurrentLoc?: boolean;
+
+  /**
+   * 开启只读模式后的占位提示，默认为“点击获取位置信息”
+   * 备注：区分下现有的placeholder（“请选择位置”）
+   */
+  getLocationPlaceholder?: string;
 }
 
 export interface LocationControlProps

--- a/packages/amis/src/renderers/Form/LocationPicker.tsx
+++ b/packages/amis/src/renderers/Form/LocationPicker.tsx
@@ -36,7 +36,7 @@ export interface LocationControlSchema extends FormBaseControlSchema {
   autoSelectCurrentLoc?: boolean;
 
   /**
-   * 是否只能选中当前地理位置
+   * 是否限制只能选中当前地理位置
    * 备注：可用于充当定位组件，只允许选择当前位置
    */
   onlySelectCurrentLoc?: boolean;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 66e96b7</samp>

This pull request enhances the `LocationPicker` component and its editor plugin by adding new props, tooltips, and translations. It also simplifies the rendering logic of the component and updates the documentation accordingly. The main files affected are `LocationPicker.tsx`, `BaiduMapPicker.tsx`, `LocationPicker.md`, and the locale files. The goal is to improve the usability and functionality of the component and the plugin.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 66e96b7</samp>

> _`LocationPicker` is the master of your fate_
> _Choose your props and seal your destiny_
> _`autoSelectCurrentLoc` or `onlySelectCurrentLoc`_
> _The map is yours, unleash your creativity_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 66e96b7</samp>

*  Add and document new props for the LocationPicker component and its editor plugin ([link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-5859eeefef7594395097f021a0fb2b8236ffddf25af8b27b270fc60e8f6104f5L63-R66), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-8534104c6d1ba261956979c0bdcf04ba4594d8487198264313dbcfe933cefa7eL1-R1), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-8534104c6d1ba261956979c0bdcf04ba4594d8487198264313dbcfe933cefa7eL85-R108), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-85efc1f678e69a57f117ffb6c0ae6bcc47e765d05f55fd7838c181afde7e7df5R41-R42), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-a4b48c526ba606d1228e7746830b46b6950bff6f3feea67e611871f10405ac63R17), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-a4b48c526ba606d1228e7746830b46b6950bff6f3feea67e611871f10405ac63R31-R32), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-a4b48c526ba606d1228e7746830b46b6950bff6f3feea67e611871f10405ac63R46), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-abe7dd7b5853e6adb8d5618af04b6e2bd1e9d6d4d8b70f3e79ed840766c97099R32-R48))
*  Implement the logic of the new props in the BaiduMapPicker component and pass them from the LocationPicker component ([link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-85efc1f678e69a57f117ffb6c0ae6bcc47e765d05f55fd7838c181afde7e7df5R114), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-85efc1f678e69a57f117ffb6c0ae6bcc47e765d05f55fd7838c181afde7e7df5L140-R150), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-85efc1f678e69a57f117ffb6c0ae6bcc47e765d05f55fd7838c181afde7e7df5L190-R197), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-85efc1f678e69a57f117ffb6c0ae6bcc47e765d05f55fd7838c181afde7e7df5L234-R241), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-85efc1f678e69a57f117ffb6c0ae6bcc47e765d05f55fd7838c181afde7e7df5R344), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-85efc1f678e69a57f117ffb6c0ae6bcc47e765d05f55fd7838c181afde7e7df5L342-R360), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-85efc1f678e69a57f117ffb6c0ae6bcc47e765d05f55fd7838c181afde7e7df5L364-R403), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-a4b48c526ba606d1228e7746830b46b6950bff6f3feea67e611871f10405ac63R162), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-a4b48c526ba606d1228e7746830b46b6950bff6f3feea67e611871f10405ac63L163-R170), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-a4b48c526ba606d1228e7746830b46b6950bff6f3feea67e611871f10405ac63R183-R184), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-a4b48c526ba606d1228e7746830b46b6950bff6f3feea67e611871f10405ac63L216-R225), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-a4b48c526ba606d1228e7746830b46b6950bff6f3feea67e611871f10405ac63R254-R255), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-a4b48c526ba606d1228e7746830b46b6950bff6f3feea67e611871f10405ac63R282-R283))
*  Remove the overlay and popover logic from the LocationPicker component and render a static map instead ([link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-abe7dd7b5853e6adb8d5618af04b6e2bd1e9d6d4d8b70f3e79ed840766c97099L54-R72), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-abe7dd7b5853e6adb8d5618af04b6e2bd1e9d6d4d8b70f3e79ed840766c97099L88-R78), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-abe7dd7b5853e6adb8d5618af04b6e2bd1e9d6d4d8b70f3e79ed840766c97099L110-L138))
*  Add translation entries for the default value of the `getLocationPlaceholder` prop in different languages ([link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-7c7473c7eeac8c306a9c1dbf7f116bf87b1bcd4c31e9e0f8c619febc67faf8a5R191-R192), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-fb22f243566a7ed671bc6279e3cc6f0a1eddc2fe4259d84b4cb8a7f596987e49R183), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-2fd35dabf975bb2b4ad936c4efcf03b6ce58a0954eba2964acffa8e557091e64R188))
*  Add the `autobind` decorator and a space after the comment symbol in the `BaiduMapPicker` component ([link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-85efc1f678e69a57f117ffb6c0ae6bcc47e765d05f55fd7838c181afde7e7df5L190-R197), [link](https://github.com/baidu/amis/pull/8834/files?diff=unified&w=0#diff-85efc1f678e69a57f117ffb6c0ae6bcc47e765d05f55fd7838c181afde7e7df5L321-R328))
