### PR TITLE
docs: 修复文档中的 word 文件链接报错

### DIFF
--- a/fis-conf.js
+++ b/fis-conf.js
@@ -688,7 +688,10 @@ if (fis.project.currentMedia() === 'publish-sdk') {
     postprocessor: convertSCSSIE11
   });
   const ghPages = fis.media('gh-pages');
-  ghPages.set('project.files', ['examples/index.html']);
+  ghPages.set('project.files', [
+    'examples/index.html',
+    '/examples/static/*.docx'
+  ]);
 
   ghPages.match('*.scss', {
     parser: fis.plugin('sass', {
@@ -1006,6 +1009,10 @@ if (fis.project.currentMedia() === 'publish-sdk') {
 
   ghPages.match('::image', {
     useHash: true
+  });
+
+  ghPages.match('*.docx', {
+    useHash: false
   });
 
   ghPages.match('*.{js,ts,tsx,jsx}', {


### PR DESCRIPTION
ord 文件链接报错

### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at baab163</samp>

Added support for deploying documentation files to GitHub Pages. Modified `fis-conf.js` to include and preserve `*.docx` files in the `gh-pages` branch.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at baab163</samp>

> _Oh we are the coders of the `gh-pages` branch_
> _We push our docs to the web with a wrench_
> _We don't need no hash renaming for our `*.docx`_
> _We heave away and haul away and sing this catchy song_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at baab163</samp>

*  Include documentation files in GitHub Pages deployment ([link](https://github.com/baidu/amis/pull/8835/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedL691-R694), [link](https://github.com/baidu/amis/pull/8835/files?diff=unified&w=0#diff-9f1bf19d427f0a24a43d82a0e50feb43cefc495e2775bb695bd1dcb085bb8fedR1014-R1017))
