### PR TITLE
fix: 本地旧版 node_modules 可能导致 fontawesome-free 打包 sdk 时被使用 Closes #8837

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "qs": "6.9.7"
   },
   "devDependencies": {
+    "@fortawesome/fontawesome-free": "^6.1.1",
     "@babel/generator": "^7.22.9",
     "@babel/parser": "^7.22.7",
     "@babel/traverse": "^7.22.8",

--- a/packages/amis-editor-core/package.json
+++ b/packages/amis-editor-core/package.json
@@ -59,7 +59,7 @@
     "sortablejs": "^1.14.0"
   },
   "devDependencies": {
-    "@fortawesome/fontawesome-free": "^5.15.3",
+    "@fortawesome/fontawesome-free": "^6.1.1",
     "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.3.0",

--- a/packages/amis-editor/package.json
+++ b/packages/amis-editor/package.json
@@ -49,7 +49,7 @@
     "mobx-state-tree": "^3.17.3"
   },
   "devDependencies": {
-    "@fortawesome/fontawesome-free": "^5.15.3",
+    "@fortawesome/fontawesome-free": "^6.1.1",
     "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.3.0",


### PR DESCRIPTION
### What

copilot:summary

copilot:poem

### Why

<!-- author to complete -->

### How

copilot:walkthrough
