### PR TITLE
fix: RootRenderer的runtime error被隐藏问题

### DIFF
--- a/packages/amis-core/src/RootRenderer.tsx
+++ b/packages/amis-core/src/RootRenderer.tsx
@@ -474,7 +474,7 @@ export class RootRenderer extends React.Component<RootRendererProps> {
     const store = this.store;
 
     if (store.runtimeError) {
-      this.renderRuntimeError();
+      return this.renderRuntimeError();
     }
 
     return (


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cb0fc3b</samp>

Fixed a rendering bug in `RootRenderer.tsx` that caused error messages to be obscured. Added a `return` statement to stop rendering on runtime error.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cb0fc3b</samp>

> _`return` stops render_
> _when runtime error occurs_
> _no more overlap - spring_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cb0fc3b</samp>

*  Prevent further rendering on runtime error by adding `return` statement ([link](https://github.com/baidu/amis/pull/8839/files?diff=unified&w=0#diff-4cba0119d1b827598fb03c9a62c9380b173776edc7267f0eb7577a50b3d7bb22L477-R477))
