### PR TITLE
fix: 修复inputDate 配置 valueFormat + 表达式初始值时值不匹配 valueFormat Close: #8652

### DIFF
--- a/packages/amis/__tests__/renderers/Form/inputDate.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/inputDate.test.tsx
@@ -521,3 +521,23 @@ test('Renderer:inputDate disabledDate', async () => {
   expect(mondayCell).toHaveClass('rdtDisabled');
   expect(tuesdayCell).not.toHaveClass('rdtDisabled');
 });
+
+test('Renderer:inputDate defaultValue with formula', async () => {
+  const {container} = await setup([
+    {
+      type: 'input-date',
+      name: 'date',
+      label: '日期',
+      valueFormat: 'YYYY-MM-DD',
+      value: '${ DATE("2021-12-06 08:20:00") }'
+    }
+  ]);
+
+  await wait(300);
+  const input = container.querySelector(
+    '.cxd-DatePicker-input'
+  )! as HTMLInputElement;
+
+  expect(input).toBeInTheDocument();
+  expect(input.value).toBe('2021-12-06');
+});

--- a/packages/amis/src/renderers/Form/InputDate.tsx
+++ b/packages/amis/src/renderers/Form/InputDate.tsx
@@ -4,7 +4,8 @@ import {
   FormControlProps,
   FormBaseControl,
   resolveEventData,
-  str2function
+  str2function,
+  normalizeDate
 } from 'amis-core';
 import cx from 'classnames';
 import {filterDate, isPureVariable, resolveVariableAndFilter} from 'amis-core';
@@ -404,7 +405,8 @@ export default class DateControl extends React.PureComponent<
       data,
       format,
       valueFormat,
-      utc
+      utc,
+      changeMotivation
     } = props;
 
     if (defaultValue && value === defaultValue) {
@@ -412,6 +414,11 @@ export default class DateControl extends React.PureComponent<
       setPrinstineValue(
         (utc ? moment.utc(date) : date).format(valueFormat || format)
       );
+    } else if (changeMotivation === 'formulaChanged' && defaultValue && value) {
+      const date = normalizeDate(value, valueFormat || format);
+      if (date && date.format(valueFormat || format) !== value) {
+        setPrinstineValue(date.format(valueFormat || format));
+      }
     }
 
     let schedulesData = props.schedules;

--- a/packages/amis/src/renderers/Form/InputDateRange.tsx
+++ b/packages/amis/src/renderers/Form/InputDateRange.tsx
@@ -179,6 +179,7 @@ export default class DateRangeControl extends React.Component<DateRangeProps> {
         )
       );
     }
+    // todo 支持值格式的自动纠正
   }
 
   componentDidUpdate(prevProps: DateRangeProps) {


### PR DESCRIPTION
### What

copilot:summary

copilot:poem

### Why

Close: #8652

### How

copilot:walkthrough
