### PR TITLE
fix(amis): StaticHoc改用componentDidCatch拦截渲染异常

### DIFF
--- a/packages/amis-core/src/components/ErrorBoundary.tsx
+++ b/packages/amis-core/src/components/ErrorBoundary.tsx
@@ -47,7 +47,7 @@ export default class ErrorBoundary extends React.Component<
 
       // 默认渲染错误信息
       return (
-        <div className="ae-Editor-renderer-error">
+        <div className="renderer-error-boundary">
           渲染发生错误，详细错误信息请查看控制台输出。
         </div>
       );

--- a/packages/amis-core/src/components/ErrorBoundary.tsx
+++ b/packages/amis-core/src/components/ErrorBoundary.tsx
@@ -6,7 +6,8 @@
 import React from 'react';
 
 interface ErrorBoundaryProps {
-  curErrorSchema?: any;
+  // 自定义错误信息，控制台输出
+  customErrorMsg?: string;
   fallback?: () => void;
   children: any;
 }
@@ -25,12 +26,9 @@ export default class ErrorBoundary extends React.Component<
   }
 
   componentDidCatch(error: any, errorInfo: any) {
-    const {curErrorSchema} = this.props;
-    if (curErrorSchema) {
-      console.warn(
-        `拦截到${curErrorSchema.type}渲染错误，当前组件schema:`,
-        curErrorSchema
-      );
+    const {customErrorMsg} = this.props;
+    if (customErrorMsg) {
+      console.warn(customErrorMsg);
     }
 
     console.warn('错误对象：', error);
@@ -41,7 +39,7 @@ export default class ErrorBoundary extends React.Component<
   }
 
   render() {
-    const {curErrorSchema, fallback} = this.props;
+    const {fallback} = this.props;
     if (this.state.hasError) {
       if (fallback) {
         return fallback();
@@ -50,7 +48,7 @@ export default class ErrorBoundary extends React.Component<
       // 默认渲染错误信息
       return (
         <div className="ae-Editor-renderer-error">
-          {curErrorSchema.type} 渲染发生错误，详细错误信息请查看控制台输出。
+          渲染发生错误，详细错误信息请查看控制台输出。
         </div>
       );
     }

--- a/packages/amis-core/src/components/ErrorBoundary.tsx
+++ b/packages/amis-core/src/components/ErrorBoundary.tsx
@@ -1,0 +1,54 @@
+/**
+ * @file ErrorBoundary
+ * @description 捕获发生在其子组件树任何位置的 JavaScript 错误，并打印这些错误
+ * @author wibetter
+ */
+import React from 'react';
+
+interface ErrorBoundaryProps {
+  curSchema?: any;
+  children: any;
+}
+
+interface ErrorBoundaryStates {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryStates
+> {
+  constructor(props: any) {
+    super(props);
+    this.state = {hasError: false};
+  }
+
+  componentDidCatch(error: any, errorInfo: any) {
+    const {curSchema} = this.props;
+    if (curSchema) {
+      console.warn(
+        `拦截到${curSchema.type}渲染错误，当前组件schema:`,
+        curSchema
+      );
+    }
+
+    console.warn('错误对象：', error);
+    console.warn('错误信息：', errorInfo);
+    this.setState({
+      hasError: true
+    });
+  }
+
+  render() {
+    const {curSchema} = this.props;
+    if (this.state.hasError) {
+      return (
+        <div className="ae-Editor-renderer-error">
+          {curSchema.type} 渲染发生错误，详细错误信息请查看控制台输出。
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/amis-core/src/components/ErrorBoundary.tsx
+++ b/packages/amis-core/src/components/ErrorBoundary.tsx
@@ -6,7 +6,8 @@
 import React from 'react';
 
 interface ErrorBoundaryProps {
-  curSchema?: any;
+  curErrorSchema?: any;
+  fallback?: () => void;
   children: any;
 }
 
@@ -24,11 +25,11 @@ export default class ErrorBoundary extends React.Component<
   }
 
   componentDidCatch(error: any, errorInfo: any) {
-    const {curSchema} = this.props;
-    if (curSchema) {
+    const {curErrorSchema} = this.props;
+    if (curErrorSchema) {
       console.warn(
-        `拦截到${curSchema.type}渲染错误，当前组件schema:`,
-        curSchema
+        `拦截到${curErrorSchema.type}渲染错误，当前组件schema:`,
+        curErrorSchema
       );
     }
 
@@ -40,11 +41,16 @@ export default class ErrorBoundary extends React.Component<
   }
 
   render() {
-    const {curSchema} = this.props;
+    const {curErrorSchema, fallback} = this.props;
     if (this.state.hasError) {
+      if (fallback) {
+        return fallback();
+      }
+
+      // 默认渲染错误信息
       return (
         <div className="ae-Editor-renderer-error">
-          {curSchema.type} 渲染发生错误，详细错误信息请查看控制台输出。
+          {curErrorSchema.type} 渲染发生错误，详细错误信息请查看控制台输出。
         </div>
       );
     }

--- a/packages/amis-core/src/index.tsx
+++ b/packages/amis-core/src/index.tsx
@@ -96,6 +96,7 @@ import type {FilterContext} from 'amis-formula';
 import LazyComponent from './components/LazyComponent';
 import Overlay from './components/Overlay';
 import PopOver from './components/PopOver';
+import ErrorBoundary from './components/ErrorBoundary';
 import {FormRenderer} from './renderers/Form';
 import type {FormHorizontal, FormSchemaBase} from './renderers/Form';
 import {
@@ -182,6 +183,7 @@ export {
   LazyComponent,
   Overlay,
   PopOver,
+  ErrorBoundary,
   addSchemaFilter,
   OptionsControlProps,
   FormOptionsControl,

--- a/packages/amis-editor-core/scss/editor.scss
+++ b/packages/amis-editor-core/scss/editor.scss
@@ -801,14 +801,6 @@
   }
 }
 
-.ae-Editor-renderer-error {
-  padding: 5px;
-  font-family: PingFangSC-Medium;
-  font-size: 14px;
-  color: #cf1322;
-  border: 1px dashed #cf1322;
-}
-
 .ae-Editor-tip {
   user-select: none;
   max-width: 100px;

--- a/packages/amis-editor-core/src/component/factory.tsx
+++ b/packages/amis-editor-core/src/component/factory.tsx
@@ -23,7 +23,8 @@ import {
   JSONUpdate,
   getFixDialogType
 } from '../util';
-import {createObject, createObjectFromChain} from 'amis-core';
+import {createObjectFromChain} from 'amis-core';
+import {ErrorBoundary} from 'amis-core';
 import {CommonConfigWrapper} from './CommonConfigWrapper';
 import type {Schema} from 'amis';
 import type {DataScope} from 'amis-core';
@@ -40,14 +41,11 @@ export function makeWrapper(
   type Props = RendererProps & {
     $$id: string;
   };
-  type States = {
-    hasError: boolean;
-  };
   const store = manager.store;
   const renderer = rendererConfig.component;
 
   @observer
-  class Wrapper extends React.Component<Props, States> {
+  class Wrapper extends React.Component<Props> {
     static displayName = renderer.displayName;
     static propsList = ((renderer && renderer.propsList) || []).concat([
       '$$id'
@@ -56,11 +54,6 @@ export function makeWrapper(
     static contextType = EditorNodeContext;
     editorNode?: EditorNodeType;
     scopeId?: string;
-
-    constructor(props: Props) {
-      super(props);
-      this.state = {hasError: false};
-    }
 
     UNSAFE_componentWillMount() {
       const parent: EditorNodeType = (this.context as any) || store.root;
@@ -133,16 +126,6 @@ export function makeWrapper(
       }
     }
 
-    componentDidCatch(error: any, errorInfo: any) {
-      console.warn(`${info.name}(${info.id})渲染发生错误：`);
-      console.warn('当前渲染器信息：', info);
-      console.warn('错误对象：', error);
-      console.warn('错误信息：', errorInfo);
-      this.setState({
-        hasError: true
-      });
-    }
-
     componentWillUnmount() {
       if (this.editorNode && isAlive(this.editorNode)) {
         const parent: EditorNodeType = (this.context as any) || store.root;
@@ -186,14 +169,6 @@ export function makeWrapper(
     render() {
       const {$$id, ...rest} = this.props;
 
-      if (this.state.hasError) {
-        return (
-          <div className="ae-Editor-renderer-error">
-            {info.name}({info.id})渲染发生错误，详细错误信息请查看控制台输出。
-          </div>
-        );
-      }
-
       /*
        * 根据渲染器信息决定时 NodeWrapper 包裹还是 ContainerWrapper 包裹。
        * NodeWrapper 主要完成 dom 节点的标记（即：添加 data-editor-id 属性）。
@@ -207,18 +182,31 @@ export function makeWrapper(
         : info.regions
         ? ContainerWrapper
         : NodeWrapper; /*)*/
-
       return (
         <EditorNodeContext.Provider
           value={this.editorNode || (this.context as any)}
         >
-          <Wrapper
-            {...rest}
-            render={this.renderChild}
-            $$editor={info}
-            $$node={this.editorNode}
-            ref={this.wrapperRef}
-          />
+          <ErrorBoundary
+            customErrorMsg={`拦截到${
+              info.type
+            }渲染错误，当前组件信息: ${JSON.stringify(this.props.$schema)}`}
+            fallback={() => {
+              return (
+                <div className="ae-Editor-renderer-error">
+                  {info?.type}
+                  渲染发生错误，详细错误信息请查看控制台输出。
+                </div>
+              );
+            }}
+          >
+            <Wrapper
+              {...rest}
+              render={this.renderChild}
+              $$editor={info}
+              $$node={this.editorNode}
+              ref={this.wrapperRef}
+            />
+          </ErrorBoundary>
         </EditorNodeContext.Provider>
       );
     }

--- a/packages/amis-editor-core/src/component/factory.tsx
+++ b/packages/amis-editor-core/src/component/factory.tsx
@@ -192,7 +192,7 @@ export function makeWrapper(
             }渲染错误，当前组件信息: ${JSON.stringify(this.props.$schema)}`}
             fallback={() => {
               return (
-                <div className="ae-Editor-renderer-error">
+                <div className="renderer-error-boundary">
                   {info?.type}
                   渲染发生错误，详细错误信息请查看控制台输出。
                 </div>

--- a/packages/amis-ui/scss/base/_common.scss
+++ b/packages/amis-ui/scss/base/_common.scss
@@ -9,3 +9,11 @@
 .visibility-sensor {
   min-height: 5px;
 }
+
+.renderer-error-boundary {
+  padding: 5px;
+  font-family: PingFangSC-Medium;
+  font-size: 14px;
+  color: #cf1322;
+  border: 1px dashed #cf1322;
+}

--- a/packages/amis/package.json
+++ b/packages/amis/package.json
@@ -67,7 +67,6 @@
     "qrcode.react": "^3.1.0",
     "react-cropper": "^2.1.8",
     "react-dropzone": "^11.4.2",
-    "react-error-boundary": "^4.0.11",
     "react-intersection-observer": "9.5.2",
     "react-json-view": "1.21.3",
     "react-transition-group": "4.4.2",

--- a/packages/amis/src/renderers/Form/StaticHoc.tsx
+++ b/packages/amis/src/renderers/Form/StaticHoc.tsx
@@ -138,7 +138,7 @@ export function supportStatic<T extends FormControlProps>() {
             customErrorMsg={`拦截到${props.$schema.type}渲染错误，当前组件schema: ${props.$schema}`}
             fallback={() => {
               return (
-                <div className="ae-Editor-renderer-error">
+                <div className="renderer-error-boundary">
                   {props.$schema?.type}
                   渲染发生错误，详细错误信息请查看控制台输出。
                 </div>

--- a/packages/amis/src/renderers/Form/StaticHoc.tsx
+++ b/packages/amis/src/renderers/Form/StaticHoc.tsx
@@ -134,7 +134,17 @@ export function supportStatic<T extends FormControlProps>() {
         }
 
         return (
-          <ErrorBoundary curSchema={props.$schema}>
+          <ErrorBoundary
+            curErrorSchema={props.$schema}
+            fallback={() => {
+              return (
+                <div className="ae-Editor-renderer-error">
+                  {props.$schema?.type}
+                  渲染发生错误，详细错误信息请查看控制台输出。
+                </div>
+              );
+            }}
+          >
             <div className={cx(`${ns}Form-static`, className)}>{body}</div>
           </ErrorBoundary>
         );

--- a/packages/amis/src/renderers/Form/StaticHoc.tsx
+++ b/packages/amis/src/renderers/Form/StaticHoc.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import toString from 'lodash/toString';
 import {getPropValue, FormControlProps} from 'amis-core';
-import {ErrorBoundary} from 'react-error-boundary';
+import {ErrorBoundary} from 'amis-core';
 
 function renderCommonStatic(props: any, defaultValue: string) {
   const {type, render, staticSchema} = props;
@@ -135,11 +134,9 @@ export function supportStatic<T extends FormControlProps>() {
         }
 
         return (
-          <div className={cx(`${ns}Form-static`, className)}>
-            <ErrorBoundary fallback={<>{toString(body)}</>}>
-              {body}
-            </ErrorBoundary>
-          </div>
+          <ErrorBoundary curSchema={props.$schema}>
+            <div className={cx(`${ns}Form-static`, className)}>{body}</div>
+          </ErrorBoundary>
         );
       }
 

--- a/packages/amis/src/renderers/Form/StaticHoc.tsx
+++ b/packages/amis/src/renderers/Form/StaticHoc.tsx
@@ -135,7 +135,7 @@ export function supportStatic<T extends FormControlProps>() {
 
         return (
           <ErrorBoundary
-            curErrorSchema={props.$schema}
+            customErrorMsg={`拦截到${props.$schema.type}渲染错误，当前组件schema: ${props.$schema}`}
             fallback={() => {
               return (
                 <div className="ae-Editor-renderer-error">


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 24a02f8</samp>

Added a custom `ErrorBoundary` component to `amis-core` package and used it in `amis` package to handle errors in static form controls. Removed the `react-error-boundary` dependency from `amis` package.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 24a02f8</samp>

> _To catch errors in `amis-core`_
> _A component was added and more_
> _It logged the schema_
> _Of the faulty idea_
> _And replaced `react-error-boundary` store_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 24a02f8</samp>

*  Add `ErrorBoundary` component to catch and log errors in child components ([link](https://github.com/baidu/amis/pull/8844/files?diff=unified&w=0#diff-ce631b8e900f67636f4c3d32845a9fd7723097d180bdfef4fbd8f7f56ec9ccf0R1-R54), [link](https://github.com/baidu/amis/pull/8844/files?diff=unified&w=0#diff-ed2759a19afd843ed555f6c368bef12e2d0dab8b1b113f0ff059a4575bad00c2R99), [link](https://github.com/baidu/amis/pull/8844/files?diff=unified&w=0#diff-ed2759a19afd843ed555f6c368bef12e2d0dab8b1b113f0ff059a4575bad00c2R186))
*  Replace `react-error-boundary` dependency with `ErrorBoundary` component in `amis` package ([link](https://github.com/baidu/amis/pull/8844/files?diff=unified&w=0#diff-b49028542a3bb14de6e47e46a9f09f23ffeff3afea2a17d5ddace75726a33e12L70), [link](https://github.com/baidu/amis/pull/8844/files?diff=unified&w=0#diff-6743296e062555d6d5ef1ffa806450e07b74989e2b2bcc829517a34a8560e918L2-R3))
*  Wrap `ErrorBoundary` component around `body` element in `supportStatic` function and pass `curSchema` prop ([link](https://github.com/baidu/amis/pull/8844/files?diff=unified&w=0#diff-6743296e062555d6d5ef1ffa806450e07b74989e2b2bcc829517a34a8560e918L138-R139))
