### PR TITLE
feat: input-date & input-date-range 事件动作 setValue 支持相对时间 Close: #8845

### DIFF
--- a/packages/amis/__tests__/renderers/Form/inputDate.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/inputDate.test.tsx
@@ -521,3 +521,42 @@ test('Renderer:inputDate disabledDate', async () => {
   expect(mondayCell).toHaveClass('rdtDisabled');
   expect(tuesdayCell).not.toHaveClass('rdtDisabled');
 });
+
+test('Renderer:inputDate setValue actions with special words', async () => {
+  const {container, submitBtn, onSubmit, getByText} = await setup([
+    {
+      type: 'input-date',
+      name: 'date',
+      id: 'date',
+      label: '日期',
+      format: 'YYYY-MM-DD'
+    },
+
+    {
+      type: 'button',
+      label: '设置值',
+      onEvent: {
+        click: {
+          actions: [
+            {
+              actionType: 'setValue',
+              componentId: 'date',
+              args: {
+                value: 'today'
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]);
+
+  // 打开弹框
+  fireEvent.click(getByText('设置值'));
+  await wait(200);
+  const today = moment();
+  const inputDate = container.querySelector('.cxd-DatePicker-input');
+
+  expect(inputDate).toBeInTheDocument();
+  expect((inputDate as any)?.value).toEqual(today.format('YYYY-MM-DD'));
+});

--- a/packages/amis/__tests__/renderers/Form/inputDateRange.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/inputDateRange.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * 组件名称：InputDateRange 日期
+ *
+ */
+
+import React from 'react';
+import PageRenderer from '../../../../amis-core/src/renderers/Form';
+import * as renderer from 'react-test-renderer';
+import {
+  render,
+  fireEvent,
+  cleanup,
+  getByText,
+  waitFor,
+  screen
+} from '@testing-library/react';
+import '../../../src';
+import {render as amisRender} from '../../../src';
+import {makeEnv, wait} from '../../helper';
+import moment from 'moment';
+
+const setup = async (items: any[] = []) => {
+  const onSubmit = jest.fn();
+  const utils = render(
+    amisRender(
+      {
+        type: 'page',
+        body: {
+          type: 'form',
+          submitText: 'Submit',
+          api: '/api/mock/saveForm?waitSeconds=1',
+          mode: 'horizontal',
+          body: items
+        }
+      },
+      {onSubmit},
+      makeEnv()
+    )
+  );
+
+  const submitBtn = utils.container.querySelector(
+    'button[type="submit"]'
+  ) as HTMLElement;
+
+  return {
+    onSubmit,
+    submitBtn,
+    ...utils
+  };
+};
+
+test('1.Renderer:inputDateRange setValue actions with special words', async () => {
+  const {container, submitBtn, onSubmit, getByText} = await setup([
+    {
+      type: 'input-date-range',
+      name: 'date',
+      id: 'date',
+      label: '日期',
+      format: 'YYYY-MM-DD'
+    },
+
+    {
+      type: 'button',
+      label: '设置值',
+      onEvent: {
+        click: {
+          actions: [
+            {
+              actionType: 'setValue',
+              componentId: 'date',
+              args: {
+                value: 'today,+2days'
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]);
+
+  // 打开弹框
+  fireEvent.click(getByText('设置值'));
+  await wait(200);
+  const today = moment();
+  const inputDates = container.querySelectorAll('.cxd-DateRangePicker-input');
+  expect(inputDates.length).toBe(2);
+
+  expect((inputDates[0] as any)?.value).toEqual(today.format('YYYY-MM-DD'));
+  expect((inputDates[1] as any)?.value).toEqual(
+    moment(today).add(2, 'days').format('YYYY-MM-DD')
+  );
+});

--- a/packages/amis/src/renderers/Form/InputDate.tsx
+++ b/packages/amis/src/renderers/Form/InputDate.tsx
@@ -558,6 +558,21 @@ export default class DateControl extends React.PureComponent<
     }
   }
 
+  setData(value: any) {
+    const {data, valueFormat, format, utc, onChange} = this.props;
+
+    if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      value instanceof Date
+    ) {
+      const date = filterDate(value as any, data, valueFormat || format);
+      value = (utc ? moment.utc(date) : date).format(valueFormat || format);
+    }
+
+    onChange(value);
+  }
+
   // 值的变化
   @autobind
   async handleChange(nextValue: any) {

--- a/packages/amis/src/renderers/Form/InputDateRange.tsx
+++ b/packages/amis/src/renderers/Form/InputDateRange.tsx
@@ -245,6 +245,27 @@ export default class DateRangeControl extends React.Component<DateRangeProps> {
     }
   }
 
+  setData(value: any) {
+    const {data, delimiter, valueFormat, format, joinValues, utc, onChange} =
+      this.props;
+
+    if (typeof value === 'string') {
+      let arr = typeof value === 'string' ? value.split(delimiter) : value;
+      value = DateRangePicker.formatValue(
+        {
+          startDate: filterDate(arr[0], data, valueFormat || format),
+          endDate: filterDate(arr[1], data, valueFormat || format)
+        },
+        valueFormat || format,
+        joinValues,
+        delimiter,
+        utc
+      );
+    }
+
+    onChange(value);
+  }
+
   // 值的变化
   @autobind
   async handleChange(nextValue: any) {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 63a2fd6</samp>

This pull request adds support for dynamic date values in the `input-date` and `input-date-range` components, using special words like 'today' or '+2days'. It also adds test cases for these components and refactors the value setting and formatting logic into separate methods.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 63a2fd6</samp>

> _`InputDate` tests_
> _Adding `setData` method_
> _Autumn of moments_

### Why

Close: #8845

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 63a2fd6</samp>

*  Add a setData method to handle the value setting logic for input-date and input-date-range components ([link](https://github.com/baidu/amis/pull/8848/files?diff=unified&w=0#diff-56835df54b63fc25653bc9cb41f895a4e75843bbbf719028fbcc740ae394a94fR561-R575), [link](https://github.com/baidu/amis/pull/8848/files?diff=unified&w=0#diff-6a9d63c3962b312f04344a4c28956690724f3f476fe6b8f2802501fc10b28ce2R248-R268))
*  Support special words like 'today' or '+2days' to set the date value dynamically using the setValue action ([link](https://github.com/baidu/amis/pull/8848/files?diff=unified&w=0#diff-65f7d11dabbec5a48f48840d26fad5a8e2618d4641a532bb2ee54ea5bcb49d95R524-R562), [link](https://github.com/baidu/amis/pull/8848/files?diff=unified&w=0#diff-e0420ed2cde97527e2599c47d47d8f0436fb319104c4cde25169fb65826d7244R1-R92))
*  Add test cases for input-date and input-date-range components in `inputDate.test.tsx` and `inputDateRange.test.tsx` to verify the new features ([link](https://github.com/baidu/amis/pull/8848/files?diff=unified&w=0#diff-65f7d11dabbec5a48f48840d26fad5a8e2618d4641a532bb2ee54ea5bcb49d95R524-R562), [link](https://github.com/baidu/amis/pull/8848/files?diff=unified&w=0#diff-e0420ed2cde97527e2599c47d47d8f0436fb319104c4cde25169fb65826d7244R1-R92))
