### PR TITLE
chore: 弹窗中校验表单错误 3s 后自动消失以免误会 Close: #1636

### DIFF
--- a/packages/amis/src/renderers/Drawer.tsx
+++ b/packages/amis/src/renderers/Drawer.tsx
@@ -5,7 +5,8 @@ import {
   filterTarget,
   isPureVariable,
   resolveVariableAndFilter,
-  setThemeClassName
+  setThemeClassName,
+  ValidateError
 } from 'amis-core';
 import {Renderer, RendererProps} from 'amis-core';
 import {SchemaNode, Schema, ActionObject} from 'amis-core';
@@ -214,6 +215,7 @@ export default class Drawer extends React.Component<DrawerProps> {
   reaction: any;
   $$id: string = guid();
   drawer: any;
+  clearErrorTimer: ReturnType<typeof setTimeout> | undefined;
   constructor(props: DrawerProps) {
     super(props);
 
@@ -251,6 +253,7 @@ export default class Drawer extends React.Component<DrawerProps> {
 
   componentWillUnmount() {
     this.reaction && this.reaction();
+    clearTimeout(this.clearErrorTimer);
   }
 
   buildActions(): Array<ActionSchema> {
@@ -850,6 +853,13 @@ export class DrawerRenderer extends Drawer {
         .catch(reason => {
           store.updateMessage(reason.message, true);
           store.markBusying(false);
+
+          if (reason.constructor?.name === ValidateError.name) {
+            clearTimeout(this.clearErrorTimer);
+            this.clearErrorTimer = setTimeout(() => {
+              store.updateMessage('');
+            }, 3000);
+          }
         });
 
       return true;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4e2efe7</samp>

Improved the user experience and functionality of the `dialog` and `drawer` renderers in `amis`. Fixed some bugs and added features to handle validation errors and closing events.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4e2efe7</samp>

> _Sing, O Muse, of the skillful coder who refined the dialog renderer_
> _And made it show the errors of amis-core, the source of many woes_
> _But not for long, for with a clearErrorTimer, the swift and clever tool_
> _He cleared the screen of blemishes, like Zeus dispersing stormy clouds_

### Why

Close: #1636

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4e2efe7</samp>

* Import `ValidateError` type from `amis-core` to handle validation errors in dialog and drawer renderers ([link](https://github.com/baidu/amis/pull/8849/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bL9-R10), [link](https://github.com/baidu/amis/pull/8849/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8L8-R9))
* Add `clearErrorTimer` property to `Dialog` and `Drawer` classes to store a timeout function that clears the error message after a delay ([link](https://github.com/baidu/amis/pull/8849/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bR809), [link](https://github.com/baidu/amis/pull/8849/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8R218))
* Clear `clearErrorTimer` in `componentWillUnmount` lifecycle method to avoid memory leaks and unnecessary updates ([link](https://github.com/baidu/amis/pull/8849/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bR822), [link](https://github.com/baidu/amis/pull/8849/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8R256))
* Update `catch` block of `submit` method in `Dialog` and `Drawer` to check if the rejected reason is a `ValidateError` instance, and if so, set `clearErrorTimer` to clear the error message after 3 seconds ([link](https://github.com/baidu/amis/pull/8849/files?diff=unified&w=0#diff-9b104c3af578d57bf829a819f5b4d655e0f4673162a6de39d85026597cddcc1bR903-R912), [link](https://github.com/baidu/amis/pull/8849/files?diff=unified&w=0#diff-d1276fe8ec87430c75553ea95a8447201eacab262f6873f2fc7e00b31a83d1e8R856-R862))
