### PR TITLE
fix: 修复由#8822引入的crud多选问题

### DIFF
--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -1050,13 +1050,7 @@ export const TableStore = iRendererStore
         );
       }
 
-      if (config.multiple !== undefined) {
-        self.multiple = config.multiple;
-      } else {
-        // 如果通过crud或picker，multiple始终设置了true或false
-        // 如果仅使用table，默认multiple为true，但props未设置multiple的情况下其实是展示单选
-        self.multiple = false;
-      }
+      config.multiple !== undefined && (self.multiple = config.multiple);
       config.footable !== undefined && (self.footable = config.footable);
       config.expandConfig !== undefined &&
         (self.expandConfig = config.expandConfig);

--- a/packages/amis/__tests__/renderers/Table.test.tsx
+++ b/packages/amis/__tests__/renderers/Table.test.tsx
@@ -958,19 +958,7 @@ describe('Renderer:table selectable & itemCheckableOn', () => {
     ]
   };
 
-  test('radio style', async () => {
-    const {container} = render(amisRender(schema, {}, makeEnv({})));
-    await waitFor(() => {
-      expect(container.querySelector('[type=radio]')).toBeInTheDocument();
-    });
-
-    expect(
-      container.querySelector('[data-id="1"] [type=radio][disabled=""]')!
-    ).toBeInTheDocument();
-  });
-
   test('checkbox style', async () => {
-    schema.multiple = true;
     const {container} = render(amisRender(schema, {}, makeEnv({})));
     await waitFor(() => {
       expect(container.querySelector('[type=checkbox]')).toBeInTheDocument();
@@ -978,6 +966,18 @@ describe('Renderer:table selectable & itemCheckableOn', () => {
 
     expect(
       container.querySelector('[data-id="1"] [type=checkbox][disabled=""]')!
+    ).toBeInTheDocument();
+  });
+
+  test('radio style', async () => {
+    schema.multiple = false;
+    const {container} = render(amisRender(schema, {}, makeEnv({})));
+    await waitFor(() => {
+      expect(container.querySelector('[type=radio]')).toBeInTheDocument();
+    });
+
+    expect(
+      container.querySelector('[data-id="1"] [type=radio][disabled=""]')!
     ).toBeInTheDocument();
   });
 });

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -1760,8 +1760,6 @@ export default class Table extends React.Component<TableProps, object> {
       store,
       query,
       onQuery,
-      multiple,
-      env,
       render,
       classPrefix: ns,
       resizable,
@@ -1805,7 +1803,7 @@ export default class Table extends React.Component<TableProps, object> {
           style={style}
           className={cx(column.pristine.className, stickyClassName)}
         >
-          {store.rows.length && multiple ? (
+          {store.rows.length && store.multiple ? (
             <Checkbox
               classPrefix={ns}
               partial={store.someChecked && !store.allChecked}
@@ -2038,11 +2036,8 @@ export default class Table extends React.Component<TableProps, object> {
     const {
       render,
       store,
-      multiple,
       classPrefix: ns,
       classnames: cx,
-      checkOnItemClick,
-      popOverContainer,
       canAccessSuperData,
       itemBadge,
       translate
@@ -2058,7 +2053,7 @@ export default class Table extends React.Component<TableProps, object> {
         ignoreDrag={ignoreDrag}
         render={render}
         store={store}
-        multiple={multiple}
+        multiple={store.multiple}
         canAccessSuperData={canAccessSuperData}
         classnames={cx}
         classPrefix={ns}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3c95177</samp>

This pull request simplifies the code and rendering logic of the `Table` component and its related store. It removes unnecessary props and uses a consistent way of setting the `multiple` property from the `config` object.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3c95177</samp>

> _To set `multiple` for the table_
> _The logic was not very stable_
> _But now it's concise_
> _With a short-circuit device_
> _And the props are no longer a babble_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3c95177</samp>

*  Simplify the logic of setting the `multiple` property of the `TableStore` instance using short-circuit evaluation ([link](https://github.com/baidu/amis/pull/8852/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1053-R1053))
*  Remove unused props from the `Table` and `TableBody` components ([link](https://github.com/baidu/amis/pull/8852/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1763-L1764), [link](https://github.com/baidu/amis/pull/8852/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2041-R2040))
*  Use the `store.multiple` property instead of the `multiple` prop in the `Table` and `TableBody` components to render the checkboxes and rows correctly ([link](https://github.com/baidu/amis/pull/8852/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1808-R1806), [link](https://github.com/baidu/amis/pull/8852/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2061-R2056))
