### PR TITLE
docs: 修正CRUD2不同形态的文档链接

### DIFF
--- a/packages/amis-editor/src/plugin/CRUD2/CRUDCards.tsx
+++ b/packages/amis-editor/src/plugin/CRUD2/CRUDCards.tsx
@@ -45,7 +45,7 @@ export class CRUDCardsPlugin extends BaseCRUDPlugin {
 
   $schema = '/schemas/CRUD2CardsSchema.json';
 
-  docLink = '/amis/zh-CN/components/crud2';
+  docLink = '/amis/zh-CN/components/cards';
 
   previewSchema: Record<string, any> = this.generatePreviewSchema('cards');
 

--- a/packages/amis-editor/src/plugin/CRUD2/CRUDList.tsx
+++ b/packages/amis-editor/src/plugin/CRUD2/CRUDList.tsx
@@ -45,7 +45,7 @@ export class CRUDListPlugin extends BaseCRUDPlugin {
 
   $schema = '/schemas/CRUD2ListSchema.json';
 
-  docLink = '/amis/zh-CN/components/crud2';
+  docLink = '/amis/zh-CN/components/list';
 
   previewSchema: Record<string, any> = this.generatePreviewSchema('list');
 

--- a/packages/amis-editor/src/plugin/CRUD2/CRUDTable.tsx
+++ b/packages/amis-editor/src/plugin/CRUD2/CRUDTable.tsx
@@ -38,7 +38,7 @@ export class CRUDTablePlugin extends BaseCRUDPlugin {
 
   $schema = '/schemas/CRUD2TableSchema.json';
 
-  docLink = '/amis/zh-CN/components/crud2';
+  docLink = '/amis/zh-CN/components/table2';
 
   previewSchema: Record<string, any> = this.generatePreviewSchema('table2');
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 135f07d</samp>

Updated the `docLink` properties of the CRUD2 plugins in `packages/amis-editor/src/plugin/CRUD2` to point to the correct documentation pages for each CRUD view type. This improves the usability and consistency of the editor.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 135f07d</samp>

> _`docLink` updated_
> _pointing to specific docs_
> _autumn of crud2_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 135f07d</samp>

*  Update `docLink` properties of CRUD2 plugins to point to specific documentation pages for each component ([link](https://github.com/baidu/amis/pull/8855/files?diff=unified&w=0#diff-ba3b9098813bc83e24acec0f5319056e775580b7f07b19600e26f60b1f55b713L48-R48), [link](https://github.com/baidu/amis/pull/8855/files?diff=unified&w=0#diff-b36ef72e1bf41b6d450f40f9d81f442bcd8287692403c6810c5cf6010f9916abL48-R48), [link](https://github.com/baidu/amis/pull/8855/files?diff=unified&w=0#diff-95dba16fd4207333baa3b6eb1a47e43d1f2c7b02fc66dde9c82e635698367d6aL41-R41))
