### PR TITLE
fix: 修复 quickEdit 通信找不到的问题(由 #8206 引发优先级乱了)

### DIFF
--- a/packages/amis/__tests__/renderers/Table.test.tsx
+++ b/packages/amis/__tests__/renderers/Table.test.tsx
@@ -1197,8 +1197,7 @@ test('Renderer:table-column-quickEdit-inline', async () => {
             type: 'switch',
             quickEdit: {
               type: 'switch',
-              mode: 'inline',
-              id: 'u:4201a414cde3'
+              mode: 'inline'
             }
           },
           {

--- a/packages/amis/src/renderers/QuickEdit.tsx
+++ b/packages/amis/src/renderers/QuickEdit.tsx
@@ -448,8 +448,8 @@ export const HocQuickEdit =
                 {
                   type: quickEdit.type || 'input-text',
                   name: quickEdit.name || name,
-                  ...quickEdit,
                   ...(isline ? {id: id} : {}),
+                  ...quickEdit,
                   mode: undefined
                 }
               ]


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 928be46</samp>

Fixed a bug in `QuickEdit.tsx` that prevented the `quickEdit` props from overriding the `isline` props. This improves the usability and configurability of the quick edit component.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 928be46</samp>

> _`quickEdit` props_
> _override `isline` props now_
> _flexible winter_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 928be46</samp>

*  Swap the order of spreading the `quickEdit` and the `isline` props in the `QuickEdit` component to allow overriding ([link](https://github.com/baidu/amis/pull/8859/files?diff=unified&w=0#diff-1c381ecd0fed6b7bf54010799670b19f2726fd86ec024687047445a2ba7637d1L451-R452))
