### PR TITLE
fix: 修复弹窗中 className 使用表达式无效的问题

### DIFF
--- a/packages/amis-core/src/utils/filter-schema.ts
+++ b/packages/amis-core/src/utils/filter-schema.ts
@@ -45,14 +45,14 @@ export function filterClassNameObject(
 export function getExprProperties(
   schema: PlainObject,
   data: object = {},
-  blackList: Array<string> = ['addOn', 'ref'],
+  ignoreList: Array<string> = ['addOn', 'ref'],
   props?: any
 ): PlainObject {
   const exprProps: PlainObject = {};
   let ctx: any = null;
 
   Object.getOwnPropertyNames(schema).forEach(key => {
-    if (blackList && ~blackList.indexOf(key)) {
+    if (ignoreList && ~ignoreList.indexOf(key)) {
       return;
     }
 
@@ -100,6 +100,20 @@ export function getExprProperties(
   });
 
   return exprProps;
+}
+
+export function hasExprPropertiesChanged(
+  schema: PlainObject,
+  prevSchema: PlainObject
+) {
+  return Object.getOwnPropertyNames(schema).some(key => {
+    let parts = /^(.*)(On|Expr|(?:c|C)lassName)(Raw)?$/.exec(key);
+    if (parts) {
+      return schema[key] !== prevSchema[key];
+    }
+
+    return false;
+  });
 }
 
 export default getExprProperties;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 85512d8</samp>

This pull request improves the performance and functionality of components that use dynamic expressions in their schema properties. It introduces a new utility function `hasExprPropertiesChanged` to filter schemas and avoid unnecessary rendering. It also simplifies and extends the expression handling logic in `WithStore.tsx`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 85512d8</samp>

> _To filter schemas with ease_
> _We added a function `hasExprPropertiesChanged`_
> _It checks if expressions are new or old_
> _And optimizes the rendering of components we behold_
> _This pull request also updates the terminology_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 85512d8</samp>

*  Rename `blackList` to `ignoreList` to avoid offensive terms ([link](https://github.com/baidu/amis/pull/8860/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3L48-R48), [link](https://github.com/baidu/amis/pull/8860/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3L55-R55))
*  Add `hasExprPropertiesChanged` function to `filter-schema.ts` to compare schemas for expression properties ([link](https://github.com/baidu/amis/pull/8860/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3R105-R118))
*  Import and use `hasExprPropertiesChanged` function in `WithStore.tsx` to handle schema updates in dialog scenarios ([link](https://github.com/baidu/amis/pull/8860/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL9-R11), [link](https://github.com/baidu/amis/pull/8860/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acR171-R191))
*  Simplify `getExprProperties` and `reaction` functions in `WithStore.tsx` to take only two arguments ([link](https://github.com/baidu/amis/pull/8860/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL130-R134), [link](https://github.com/baidu/amis/pull/8860/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL138-R144))
