### PR TITLE
style: 调整 table 固顶模式的样式兼容 safari Close: #8708

### DIFF
--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -528,7 +528,8 @@ export const TableStore = iRendererStore
     exportExcelLoading: false,
     searchFormExpanded: false, // 用来控制搜索框是否展开了，那个自动根据 searchable 生成的表单 autoGenerateFilter
     lazyRenderAfter: 100,
-    tableLayout: 'auto'
+    tableLayout: 'auto',
+    theadHeight: 0
   })
   .views(self => {
     function getColumnsExceptBuiltinTypes() {
@@ -1001,7 +1002,7 @@ export const TableStore = iRendererStore
       },
 
       buildStyles(style: any) {
-        style = {...style};
+        style = {...style, '--Table-thead-height': self.theadHeight + 'px'};
 
         getFilteredColumns().forEach(column => {
           style[`--Table-column-${column.index}-width`] =
@@ -1301,9 +1302,9 @@ export const TableStore = iRendererStore
       if (!table) {
         return;
       }
-      const cols = [].slice.call(
-        table.querySelectorAll(':scope>thead>tr>th[data-index]')
-      );
+      const thead = table.querySelector(':scope>thead') as HTMLElement;
+      const cols = [].slice.call(thead.querySelectorAll('tr>th[data-index]'));
+      self.theadHeight = thead.offsetHeight;
       cols.forEach((col: HTMLElement) => {
         const index = parseInt(col.getAttribute('data-index')!, 10);
         const column = self.columns[index];

--- a/packages/amis-ui/scss/components/_table.scss
+++ b/packages/amis-ui/scss/components/_table.scss
@@ -273,8 +273,12 @@
       padding-top: 0;
     }
 
-    &--affixHeader > thead {
-      visibility: collapse;
+    &--affixHeader {
+      margin-top: calc(var(--Table-thead-height) * -1);
+
+      > thead {
+        visibility: hidden;
+      }
     }
 
     &--withCombine {

--- a/packages/amis/__tests__/event-action/renderers/__snapshots__/crud.test.tsx.snap
+++ b/packages/amis/__tests__/event-action/renderers/__snapshots__/crud.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`doAction:crud reload 1`] = `
           >
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -335,7 +335,7 @@ exports[`doAction:crud reload with data1 1`] = `
           >
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -642,7 +642,7 @@ exports[`doAction:crud reload with data2 1`] = `
           >
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`Renderer:input table 1`] = `
                   >
                     <div
                       class="cxd-Table"
-                      style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
+                      style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
                     >
                       <div
                         class="cxd-Table-contentWrap"
@@ -378,7 +378,7 @@ exports[`Renderer:input table add 1`] = `
           >
             <div
               class="cxd-Table"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-contentWrap"
@@ -690,7 +690,7 @@ exports[`Renderer:input-table cell selects delete 1`] = `
           >
             <div
               class="cxd-Table"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-contentWrap"
@@ -1029,7 +1029,7 @@ exports[`Renderer:input-table init display 1`] = `
           >
             <div
               class="cxd-Table"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-contentWrap"
@@ -1716,7 +1716,7 @@ exports[`Renderer:input-table with combo column 1`] = `
           >
             <div
               class="cxd-Table"
-              style="--Table-column-3-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-contentWrap"

--- a/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`1. Renderer:crud basic interval headerToolbar footerToolbar 1`] = `
           >
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -2157,7 +2157,7 @@ exports[`6. Renderer:crud source & alwaysShowPagination 1`] = `
           >
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -2799,7 +2799,7 @@ exports[`13. enderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionL
             </div>
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative; --Table-column-1-width: 0px;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative; --Table-column-1-width: 0px;"
             >
               <div
                 class="cxd-Table-fixedTop"

--- a/packages/amis/__tests__/renderers/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Pagination.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`Renderer:Pagination 1`] = `
       </div>
       <div
         class="cxd-Table"
-        style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
+        style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
       >
         <div
           class="cxd-Table-fixedTop"

--- a/packages/amis/__tests__/renderers/__snapshots__/Table.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Table.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Renderer:table 1`] = `
 <div>
   <div
     class="cxd-Table"
-    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
+    style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -370,7 +370,7 @@ exports[`Renderer:table align 1`] = `
 <div>
   <div
     class="cxd-Table"
-    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
+    style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -775,7 +775,7 @@ exports[`Renderer:table children 1`] = `
           >
             <div
               class="cxd-Table m-b-none"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -1355,7 +1355,7 @@ exports[`Renderer:table classNameExpr 1`] = `
 <div>
   <div
     class="cxd-Table"
-    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
+    style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -1721,7 +1721,7 @@ exports[`Renderer:table column head style className 1`] = `
 <div>
   <div
     class="cxd-Table className"
-    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
+    style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -2114,7 +2114,7 @@ exports[`Renderer:table combine Renderer:table combineNum only 1`] = `
           >
             <div
               class="cxd-Table"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -2689,7 +2689,7 @@ exports[`Renderer:table combine Renderer:table combineNum with fromIndex 1`] = `
           >
             <div
               class="cxd-Table"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -3334,7 +3334,7 @@ exports[`Renderer:table groupName-default 1`] = `
           >
             <div
               class="cxd-Table m-b-none"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -4113,7 +4113,7 @@ exports[`Renderer:table groupName-middleNoGroupName 1`] = `
           >
             <div
               class="cxd-Table m-b-none"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -4896,7 +4896,7 @@ exports[`Renderer:table groupName-startNoGroupName 1`] = `
           >
             <div
               class="cxd-Table m-b-none"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -5667,7 +5667,7 @@ exports[`Renderer:table groupName-withTpl 1`] = `
           >
             <div
               class="cxd-Table m-b-none"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -6430,7 +6430,7 @@ exports[`Renderer:table isHead fixed 1`] = `
 <div>
   <div
     class="cxd-Table"
-    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
+    style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -6807,7 +6807,7 @@ exports[`Renderer:table list 1`] = `
 <div>
   <div
     class="cxd-Table"
-    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; --Table-column-10-width: 0px; --Table-column-11-width: 0px; position: relative;"
+    style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; --Table-column-10-width: 0px; --Table-column-11-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-toolbar cxd-Table-headToolbar"

--- a/packages/amis/src/renderers/Table/ItemActionsWrapper.tsx
+++ b/packages/amis/src/renderers/Table/ItemActionsWrapper.tsx
@@ -30,7 +30,10 @@ function ItemActionsWrapper(props: ItemActionsProps) {
     }
     const rect = dom.getBoundingClientRect();
     const height = rect.height;
-    const top = rect.top - frame.getBoundingClientRect().top;
+    const top =
+      rect.top -
+      frame.getBoundingClientRect().top +
+      parseInt(getComputedStyle(frame)['marginTop'], 10);
     divRef.current!.style.cssText += `top: ${top}px;height: ${height}px;`;
   }, [store.hoverRow?.id]);
 

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -1591,6 +1591,10 @@ export default class Table extends React.Component<TableProps, object> {
 
     document.addEventListener('mousemove', this.handleColResizeMouseMove);
     document.addEventListener('mouseup', this.handleColResizeMouseUp);
+
+    // 防止选中文本
+    e.preventDefault();
+    e.stopPropagation();
   }
 
   // 垂直线拖拽移动


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7cbeb60</samp>

This pull request enhances the table component with a dynamic header height feature and fixes some style and interaction issues. It updates the `TableStore` model, the `table.scss` style, and the `Table` and `ItemActionsWrapper` components.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7cbeb60</samp>

> _`Table` component_
> _Adjusts header and columns_
> _Autumn leaves falling_

### Why

Close: #8708

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7cbeb60</samp>

*  Add a new state variable `theadHeight` to store the table header height and set a CSS custom property for styling ([link](https://github.com/baidu/amis/pull/8863/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL531-R532), [link](https://github.com/baidu/amis/pull/8863/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1004-R1005))
*  Modify the `syncTableWidth` method to query and assign the table header height and use it as the scope for column selectors ([link](https://github.com/baidu/amis/pull/8863/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1304-R1307))
*  Adjust the margin-top and visibility of the table element when the table header is affixed to prevent overlapping ([link](https://github.com/baidu/amis/pull/8863/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dL276-R281))
*  Prevent the default behavior and propagation of the mousemove event when resizing the table columns to avoid text selection ([link](https://github.com/baidu/amis/pull/8863/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR1594-R1597))
*  Adjust the top position of the `ItemActionsWrapper` element by adding the margin-top of the table frame element to align with the table row ([link](https://github.com/baidu/amis/pull/8863/files?diff=unified&w=0#diff-bda67a6633404089c137bb1ee42f18f7375f41f00ee22b7e636b7174acd0e4f8L33-R36))
