### PR TITLE
style: 「设计器」配置面板居中必填项*样式调整

### DIFF
--- a/packages/amis-editor-core/scss/control/_formItem-control.scss
+++ b/packages/amis-editor-core/scss/control/_formItem-control.scss
@@ -15,6 +15,10 @@
       line-height: 32px;
       margin: 0;
       padding-top: 0;
+
+      > span {
+        display: inline;
+      }
     }
   }
 


### PR DESCRIPTION
### What

底层amis 必填*的样式进行了调整，设计器中由于对label配置了line-height，导致*的位置有所偏移，这里在editor中对*的样式进行修正

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 12c6ebb</samp>

* Fix form label and input alignment by setting span elements inside `.form-item-control-label` to display as inline ([link](https://github.com/baidu/amis/pull/8866/files?diff=unified&w=0#diff-cf5d81915ddfe41869a60d2bb90a8e8d542686d0e6ce7504a8666a1c6a42e931R18-R21))
