### PR TITLE
fix: 修复 jssdk 模式通过 embed 返回的 scoped 获取组件失败的问题 Close: #8864

### DIFF
--- a/examples/embed.tsx
+++ b/examples/embed.tsx
@@ -259,7 +259,13 @@ export function embed(
       ...props,
       scopeRef: (ref: any) => {
         if (ref) {
-          Object.assign(scoped, ref);
+          Object.keys(ref).forEach(key => {
+            let value = ref[key];
+            if (typeof value === 'function') {
+              value = value.bind(ref);
+            }
+            (scoped as any)[key] = value;
+          });
           callback?.();
         }
       }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1e180df</samp>

Fix scope object binding bug in `embed` function. Allow embedding React components in AMIS schemas.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1e180df</samp>

> _`embed` function_
> _fixes scope binding bug_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1e180df</samp>

* Fix scope binding bug for embed function ([link](https://github.com/baidu/amis/pull/8868/files?diff=unified&w=0#diff-87941d3a37b91c5deb23aa31d74dd4260118b71257f89262cce39dcac1d5dd2aL262-R268))
