### PR TITLE
feat:scoped支持调用amis动作

### DIFF
--- a/docs/zh-CN/start/getting-started.md
+++ b/docs/zh-CN/start/getting-started.md
@@ -230,6 +230,59 @@ let amisScoped = amis.embed(
 
 还可以通过 `amisScoped.getComponentByName('page1.form1').setValues({'name1': 'othername'})` 来修改表单中的值。
 
+### 调用 amis 动作
+
+可以通过`amisScoped.doAction(actions, ctx)`来调用 amis 中的通用动作和目标组件的动作。了解事件动作机制可以查看[事件动作](../../docs/concepts/event-action)。参数说明如下：
+
+- `actions`：动作列表，支持执行单个或多个动作
+- `ctx`：上下文，它可以为动作配置补充上下文数据，例如下面`toast`动作中`msg`配置中的`${myName}`就来自于补充上下文`ctx`
+
+下面的例子中依次执行了`toast提示`、`ajax请求`、`dialog弹窗`、`给目标组件赋值`动作。
+
+```js
+amisScoped.doAction(
+  [
+    {
+      actionType: 'toast',
+      args: {
+        msg: '${amisUser.name}, ${myName}'
+      }
+    },
+    {
+      actionType: 'ajax',
+      api: {
+        url: 'https://3xsw4ap8wah59.cfc-execute.bj.baidubce.com/api/amis-mock/mock2/form/saveForm',
+        method: 'post'
+      }
+    },
+    {
+      actionType: 'dialog',
+      dialog: {
+        type: 'dialog',
+        title: '弹窗',
+        body: [
+          {
+            type: 'tpl',
+            tpl: '<p>对，你打开了弹窗</p>',
+            inline: false
+          }
+        ]
+      }
+    },
+    {
+      actionType: 'setValue',
+      componentId: 'name',
+      args: {
+        value: '${myName}'
+      }
+    }
+  ],
+  {
+    myName: 'amis'
+  }
+);
+```
+
 ### 更新属性
 
 可以通过 amisScoped 对象的 updateProps 方法来更新下发到 amis 的属性。

--- a/packages/amis-core/src/Scoped.tsx
+++ b/packages/amis-core/src/Scoped.tsx
@@ -21,7 +21,8 @@ import {
 } from './utils/helper';
 import {RendererData, ActionObject} from './types';
 import {isPureVariable} from './utils/isPureVariable';
-import {filter} from './utils';
+import {createObject, createRendererEvent, filter} from './utils';
+import {ListenerAction, runActions} from './actions';
 
 /**
  * target 里面可能包含 ?xxx=xxx，这种情况下，需要把 ?xxx=xxx 保留下来，然后对前面的部分进行 filter
@@ -75,6 +76,7 @@ export interface IScopedContext {
     session: string,
     path: string
   ) => ScopedComponentType[];
+  doAction: (actions: ListenerAction | ListenerAction[], ctx: any) => void;
 }
 type AliasIScopedContext = IScopedContext;
 
@@ -354,6 +356,22 @@ function createScopedTools(
       const component: any = scoped.getComponentById(id);
       if (component && component.props.show) {
         closeDialog(component);
+      }
+    },
+
+    async doAction(actions: ListenerAction | ListenerAction[], ctx: any) {
+      const renderer = this.getComponents()[0]; // 直接拿最顶层
+      const rendererEvent = createRendererEvent('embed', {
+        env,
+        nativeEvent: undefined,
+        data: createObject(renderer.props.data, ctx),
+        scoped: this
+      });
+
+      await runActions(actions, renderer, rendererEvent);
+
+      if (rendererEvent.prevented) {
+        return;
       }
     }
   };

--- a/packages/amis-core/src/actions/AjaxAction.ts
+++ b/packages/amis-core/src/actions/AjaxAction.ts
@@ -39,7 +39,7 @@ export class AjaxAction implements RendererAction {
     renderer: ListenerContext,
     event: RendererEvent<any>
   ) {
-    if (!renderer.props.env?.fetcher) {
+    if (!event.context.env?.fetcher) {
       throw new Error('env.fetcher is required!');
     }
 

--- a/packages/amis-core/src/actions/CmptAction.ts
+++ b/packages/amis-core/src/actions/CmptAction.ts
@@ -40,7 +40,7 @@ export class CmptAction implements RendererAction {
 
     /** 如果args中携带path参数, 则认为是全局变量赋值, 否则认为是组件变量赋值 */
     if (action.actionType === 'setValue' && path && typeof path === 'string') {
-      const beforeSetData = renderer?.props?.env?.beforeSetData;
+      const beforeSetData = event?.context?.env?.beforeSetData;
       if (beforeSetData && typeof beforeSetData === 'function') {
         const res = await beforeSetData(renderer, action, event);
 

--- a/packages/amis-core/src/actions/CopyAction.ts
+++ b/packages/amis-core/src/actions/CopyAction.ts
@@ -28,12 +28,12 @@ export class CopyAction implements RendererAction {
     renderer: ListenerContext,
     event: RendererEvent<any>
   ) {
-    if (!renderer.props.env?.copy) {
+    if (!event.context.env?.copy) {
       throw new Error('env.copy is required!');
     }
 
     if (action.args?.content) {
-      renderer.props.env.copy?.(action.args.content, {
+      event.context.env?.copy?.(action.args.content, {
         format: action.args?.copyFormat ?? 'text/html'
       });
     }

--- a/packages/amis-core/src/actions/LinkAction.ts
+++ b/packages/amis-core/src/actions/LinkAction.ts
@@ -34,7 +34,7 @@ export class LinkAction implements RendererAction {
     renderer: ListenerContext,
     event: RendererEvent<any>
   ) {
-    if (!renderer.props.env?.jumpTo) {
+    if (!event.context.env?.jumpTo) {
       throw new Error('env.jumpTo is required!');
     }
 
@@ -53,7 +53,7 @@ export class LinkAction implements RendererAction {
       }
     );
 
-    renderer.props.env.jumpTo(
+    event.context.env?.jumpTo(
       urlObj.url,
       {
         actionType: action.actionType,

--- a/packages/amis-core/src/actions/ToastAction.ts
+++ b/packages/amis-core/src/actions/ToastAction.ts
@@ -34,11 +34,11 @@ export class ToastAction implements RendererAction {
     renderer: ListenerContext,
     event: RendererEvent<any>
   ) {
-    if (!renderer.props.env?.notify) {
+    if (!event.context.env?.notify) {
       throw new Error('env.notify is required!');
     }
 
-    event.context.env.notify?.(
+    event.context.env?.notify?.(
       action.args?.msgType || 'info',
       String(action.args?.msg),
       action.args


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at aa280f8</samp>

This pull request fixes several bugs in different action classes that used the wrong `env` object for calling utility functions. It also adds a new feature to the `Scoped` component, which allows executing amis actions in the renderer scope, and updates the documentation accordingly.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at aa280f8</samp>

> _`doAction` added_
> _Invoke amis actions from code_
> _Autumn bug fixes_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at aa280f8</samp>

*  Add a new section to the documentation of amis that explains how to use the `doAction` method to invoke amis actions from external code ([link](https://github.com/baidu/amis/pull/8875/files?diff=unified&w=0#diff-cecdf20aaa84e6464093def72aee232955ad9649b13e7187284dfb7176b3cdacR233-R285))
*  Fix a bug in several action classes that were using the wrong `env` property from the renderer props instead of the event context, which could cause errors when calling various utility functions ([link](https://github.com/baidu/amis/pull/8875/files?diff=unified&w=0#diff-c85a51364485b453adba3a7d4d6cfc4ed76d74ffadc05dd7daf7b386e120c8b6L42-R42), [link](https://github.com/baidu/amis/pull/8875/files?diff=unified&w=0#diff-9fcca25fc37554994f4168d09ade3ba52487964b8f897e0a9de38442dc6b1ceaL43-R43), [link](https://github.com/baidu/amis/pull/8875/files?diff=unified&w=0#diff-7f3708c1922f1fed348fef3cbdf077a0c67f917b3ad4164d01b2fb35a02fa248L31-R36), [link](https://github.com/baidu/amis/pull/8875/files?diff=unified&w=0#diff-9ee01812295197c85b01b74e12fe82f66047a468ca69a7d21787691619379cffL37-R37), [link](https://github.com/baidu/amis/pull/8875/files?diff=unified&w=0#diff-9ee01812295197c85b01b74e12fe82f66047a468ca69a7d21787691619379cffL56-R56), [link](https://github.com/baidu/amis/pull/8875/files?diff=unified&w=0#diff-da81880799b793c68e4885039c07cd1003160e2c596442b3c5fe6a5a538e553dL37-R41))
*  Import two more utility functions from `./utils` in `Scoped.tsx` that are used to create objects and renderer events ([link](https://github.com/baidu/amis/pull/8875/files?diff=unified&w=0#diff-b2a2713e66ce0dcac88d294eb3a363249f0364d755ce255cf7b3ead775bfbf36L24-R25))
*  Add a new property to the `IScopedContext` interface that defines the type signature of the `doAction` method ([link](https://github.com/baidu/amis/pull/8875/files?diff=unified&w=0#diff-b2a2713e66ce0dcac88d294eb3a363249f0364d755ce255cf7b3ead775bfbf36R79))
*  Implement the `doAction` method in the `createScopedTools` function that executes the given actions in the scope of the amis renderer ([link](https://github.com/baidu/amis/pull/8875/files?diff=unified&w=0#diff-b2a2713e66ce0dcac88d294eb3a363249f0364d755ce255cf7b3ead775bfbf36R360-R376))
