### PR TITLE
fix: 修复下拉弹窗在某些情况点击外层不关闭的问题

### DIFF
--- a/packages/amis-core/src/components/PopOver.tsx
+++ b/packages/amis-core/src/components/PopOver.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import {findDOMNode} from 'react-dom';
 import {ClassNamesFn, themeable} from '../theme';
-import {camel, preventDefault} from '../utils';
+import {autobind, camel, preventDefault} from '../utils';
 
 export interface Offset {
   x: number;
@@ -54,6 +54,7 @@ export class PopOver extends React.PureComponent<PopOverProps, PopOverState> {
 
   parent: HTMLElement;
   wrapperRef: React.RefObject<HTMLDivElement> = React.createRef();
+  isRootClosed = false;
 
   componentDidMount() {
     this.mayUpdateOffset();
@@ -68,6 +69,23 @@ export class PopOver extends React.PureComponent<PopOverProps, PopOverState> {
         capture: false
       });
     }
+
+    // 从弹窗中处理复制过来的，如果要修改，请同步修改
+    // 因为 overlay 功能其实是用 postion: fixed 来实现的
+    // 目的是加一个蒙层监听蒙层点击然后关闭弹窗。意图就是 closeOnOutside
+    // 但是如果上层有个 translateZ 之类的样式就会影响 fixed 的定位，导致功能失效
+    // 所以这里兜底加了个 closeOnOutside 的功能
+    document.body.addEventListener(
+      'mousedown',
+      this.handleRootMouseDownCapture,
+      true
+    );
+    document.body.addEventListener(
+      'mouseup',
+      this.handleRootMouseUpCapture,
+      true
+    );
+    document.body.addEventListener('mouseup', this.handleRootMouseUp);
   }
 
   componentDidUpdate() {
@@ -79,6 +97,62 @@ export class PopOver extends React.PureComponent<PopOverProps, PopOverState> {
 
     if (this.wrapperRef && this.wrapperRef.current) {
       this.wrapperRef.current.removeEventListener('touchmove', preventDefault);
+    }
+
+    document.body.removeEventListener('mouseup', this.handleRootMouseUp);
+    document.body.removeEventListener(
+      'mousedown',
+      this.handleRootMouseDownCapture,
+      true
+    );
+    document.body.removeEventListener(
+      'mouseup',
+      this.handleRootMouseUpCapture,
+      true
+    );
+  }
+
+  @autobind
+  handleRootMouseDownCapture(e: MouseEvent) {
+    const target = e.target as HTMLElement;
+    const {overlay: closeOnOutside, classPrefix: ns} = this.props;
+    const isLeftButton =
+      (e.button === 1 && window.event !== null) || e.button === 0;
+
+    this.isRootClosed = !!(
+      isLeftButton &&
+      closeOnOutside &&
+      target &&
+      this.wrapperRef.current &&
+      ((!this.wrapperRef.current.contains(target) &&
+        !target.closest('[role=dialog]')) ||
+        (target.matches(`.${ns}Modal`) && target === this.wrapperRef.current))
+    ); // 干脆过滤掉来自弹框里面的点击
+  }
+
+  @autobind
+  handleRootMouseUpCapture(e: MouseEvent) {
+    // mousedown 的时候不在弹窗里面，则不需要判断了
+    if (!this.isRootClosed) {
+      return;
+    }
+
+    // 再判断 mouseup 的时候是不是在弹窗里面
+    this.handleRootMouseDownCapture(e);
+  }
+
+  @autobind
+  handleRootMouseUp(e: MouseEvent) {
+    const {onHide} = this.props;
+    if (this.isRootClosed && !e.defaultPrevented) {
+      // 因为原来 overlay 是不会让别的部分还有点击事件的，所以这里要阻止默认事件
+      // 参考：https://stackoverflow.com/questions/8643739/cancel-click-event-in-the-mouseup-event-handler
+      let captureClick = (e: Event) => {
+        e.stopPropagation();
+        window.removeEventListener('click', captureClick, true);
+      };
+      window.addEventListener('click', captureClick, true);
+      onHide?.();
     }
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4712b8b</samp>

Improved the `PopOver` component to close automatically when the user clicks outside of it. Reused the logic and code from the `Modal` component and added a new flag and event listeners.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4712b8b</samp>

> _Oh, the popover is a tricky thing, it likes to stay on screen_
> _But we don't want it to annoy the users, so we need a way to make it leave_
> _We'll use the code from the modal, and `autobind` our handlers_
> _And we'll set the `isRootClosed` flag, when we click outside the anchors_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4712b8b</samp>

*  Import `autobind` utility function and use it to decorate event handlers for closing popover on outside click ([link](https://github.com/baidu/amis/pull/8882/files?diff=unified&w=0#diff-fee0b8a1fae75987d696f747563baa845dd7fdd4136afffa791553a3fffa4fc8L10-R10), [link](https://github.com/baidu/amis/pull/8882/files?diff=unified&w=0#diff-fee0b8a1fae75987d696f747563baa845dd7fdd4136afffa791553a3fffa4fc8L83-R149))
* Add `isRootClosed` property to `PopOver` class and use it to track whether the user clicks outside of the popover or on the modal ([link](https://github.com/baidu/amis/pull/8882/files?diff=unified&w=0#diff-fee0b8a1fae75987d696f747563baa845dd7fdd4136afffa791553a3fffa4fc8R57), [link](https://github.com/baidu/amis/pull/8882/files?diff=unified&w=0#diff-fee0b8a1fae75987d696f747563baa845dd7fdd4136afffa791553a3fffa4fc8R72-R88), [link](https://github.com/baidu/amis/pull/8882/files?diff=unified&w=0#diff-fee0b8a1fae75987d696f747563baa845dd7fdd4136afffa791553a3fffa4fc8L83-R149))
* Add and remove event listeners for `mousedown`, `mouseup`, and `click` events on `document.body` in `componentDidMount` and `componentWillUnmount` lifecycle methods of `PopOver` class ([link](https://github.com/baidu/amis/pull/8882/files?diff=unified&w=0#diff-fee0b8a1fae75987d696f747563baa845dd7fdd4136afffa791553a3fffa4fc8R72-R88), [link](https://github.com/baidu/amis/pull/8882/files?diff=unified&w=0#diff-fee0b8a1fae75987d696f747563baa845dd7fdd4136afffa791553a3fffa4fc8L83-R149))
* Copy fallback mechanism for `closeOnOutside` prop from `Modal` component and explain the reason in a comment ([link](https://github.com/baidu/amis/pull/8882/files?diff=unified&w=0#diff-fee0b8a1fae75987d696f747563baa845dd7fdd4136afffa791553a3fffa4fc8R72-R88))
* Move `mayUpdateOffset` method to a different position in the file without modifying it ([link](https://github.com/baidu/amis/pull/8882/files?diff=unified&w=0#diff-fee0b8a1fae75987d696f747563baa845dd7fdd4136afffa791553a3fffa4fc8L83-R149))
