### PR TITLE
pick fix: 修复弹窗中 className 使用表达式无效的问题、 fix: 修复下拉弹窗在某些情况点击外层不关闭的问题、style: 调整 table 固顶模式的样式兼容 safari 

### DIFF
--- a/packages/amis-core/src/components/PopOver.tsx
+++ b/packages/amis-core/src/components/PopOver.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import {findDOMNode} from 'react-dom';
 import {ClassNamesFn, themeable} from '../theme';
-import {camel, preventDefault} from '../utils';
+import {autobind, camel, preventDefault} from '../utils';
 
 export interface Offset {
   x: number;
@@ -54,6 +54,7 @@ export class PopOver extends React.PureComponent<PopOverProps, PopOverState> {
 
   parent: HTMLElement;
   wrapperRef: React.RefObject<HTMLDivElement> = React.createRef();
+  isRootClosed = false;
 
   componentDidMount() {
     this.mayUpdateOffset();
@@ -68,6 +69,23 @@ export class PopOver extends React.PureComponent<PopOverProps, PopOverState> {
         capture: false
       });
     }
+
+    // 从弹窗中处理复制过来的，如果要修改，请同步修改
+    // 因为 overlay 功能其实是用 postion: fixed 来实现的
+    // 目的是加一个蒙层监听蒙层点击然后关闭弹窗。意图就是 closeOnOutside
+    // 但是如果上层有个 translateZ 之类的样式就会影响 fixed 的定位，导致功能失效
+    // 所以这里兜底加了个 closeOnOutside 的功能
+    document.body.addEventListener(
+      'mousedown',
+      this.handleRootMouseDownCapture,
+      true
+    );
+    document.body.addEventListener(
+      'mouseup',
+      this.handleRootMouseUpCapture,
+      true
+    );
+    document.body.addEventListener('mouseup', this.handleRootMouseUp);
   }
 
   componentDidUpdate() {
@@ -79,6 +97,62 @@ export class PopOver extends React.PureComponent<PopOverProps, PopOverState> {
 
     if (this.wrapperRef && this.wrapperRef.current) {
       this.wrapperRef.current.removeEventListener('touchmove', preventDefault);
+    }
+
+    document.body.removeEventListener('mouseup', this.handleRootMouseUp);
+    document.body.removeEventListener(
+      'mousedown',
+      this.handleRootMouseDownCapture,
+      true
+    );
+    document.body.removeEventListener(
+      'mouseup',
+      this.handleRootMouseUpCapture,
+      true
+    );
+  }
+
+  @autobind
+  handleRootMouseDownCapture(e: MouseEvent) {
+    const target = e.target as HTMLElement;
+    const {overlay: closeOnOutside, classPrefix: ns} = this.props;
+    const isLeftButton =
+      (e.button === 1 && window.event !== null) || e.button === 0;
+
+    this.isRootClosed = !!(
+      isLeftButton &&
+      closeOnOutside &&
+      target &&
+      this.wrapperRef.current &&
+      ((!this.wrapperRef.current.contains(target) &&
+        !target.closest('[role=dialog]')) ||
+        (target.matches(`.${ns}Modal`) && target === this.wrapperRef.current))
+    ); // 干脆过滤掉来自弹框里面的点击
+  }
+
+  @autobind
+  handleRootMouseUpCapture(e: MouseEvent) {
+    // mousedown 的时候不在弹窗里面，则不需要判断了
+    if (!this.isRootClosed) {
+      return;
+    }
+
+    // 再判断 mouseup 的时候是不是在弹窗里面
+    this.handleRootMouseDownCapture(e);
+  }
+
+  @autobind
+  handleRootMouseUp(e: MouseEvent) {
+    const {onHide} = this.props;
+    if (this.isRootClosed && !e.defaultPrevented) {
+      // 因为原来 overlay 是不会让别的部分还有点击事件的，所以这里要阻止默认事件
+      // 参考：https://stackoverflow.com/questions/8643739/cancel-click-event-in-the-mouseup-event-handler
+      let captureClick = (e: Event) => {
+        e.stopPropagation();
+        window.removeEventListener('click', captureClick, true);
+      };
+      window.addEventListener('click', captureClick, true);
+      onHide?.();
     }
   }
 

--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -528,7 +528,8 @@ export const TableStore = iRendererStore
     exportExcelLoading: false,
     searchFormExpanded: false, // 用来控制搜索框是否展开了，那个自动根据 searchable 生成的表单 autoGenerateFilter
     lazyRenderAfter: 100,
-    tableLayout: 'auto'
+    tableLayout: 'auto',
+    theadHeight: 0
   })
   .views(self => {
     function getColumnsExceptBuiltinTypes() {
@@ -1001,7 +1002,7 @@ export const TableStore = iRendererStore
       },
 
       buildStyles(style: any) {
-        style = {...style};
+        style = {...style, '--Table-thead-height': self.theadHeight + 'px'};
 
         getFilteredColumns().forEach(column => {
           style[`--Table-column-${column.index}-width`] =
@@ -1301,9 +1302,9 @@ export const TableStore = iRendererStore
       if (!table) {
         return;
       }
-      const cols = [].slice.call(
-        table.querySelectorAll(':scope>thead>tr>th[data-index]')
-      );
+      const thead = table.querySelector(':scope>thead') as HTMLElement;
+      const cols = [].slice.call(thead.querySelectorAll('tr>th[data-index]'));
+      self.theadHeight = thead.offsetHeight;
       cols.forEach((col: HTMLElement) => {
         const index = parseInt(col.getAttribute('data-index')!, 10);
         const column = self.columns[index];

--- a/packages/amis-core/src/utils/filter-schema.ts
+++ b/packages/amis-core/src/utils/filter-schema.ts
@@ -45,14 +45,14 @@ export function filterClassNameObject(
 export function getExprProperties(
   schema: PlainObject,
   data: object = {},
-  blackList: Array<string> = ['addOn', 'ref'],
+  ignoreList: Array<string> = ['addOn', 'ref'],
   props?: any
 ): PlainObject {
   const exprProps: PlainObject = {};
   let ctx: any = null;
 
   Object.getOwnPropertyNames(schema).forEach(key => {
-    if (blackList && ~blackList.indexOf(key)) {
+    if (ignoreList && ~ignoreList.indexOf(key)) {
       return;
     }
 
@@ -100,6 +100,20 @@ export function getExprProperties(
   });
 
   return exprProps;
+}
+
+export function hasExprPropertiesChanged(
+  schema: PlainObject,
+  prevSchema: PlainObject
+) {
+  return Object.getOwnPropertyNames(schema).some(key => {
+    let parts = /^(.*)(On|Expr|(?:c|C)lassName)(Raw)?$/.exec(key);
+    if (parts) {
+      return schema[key] !== prevSchema[key];
+    }
+
+    return false;
+  });
 }
 
 export default getExprProperties;

--- a/packages/amis-ui/scss/components/_table.scss
+++ b/packages/amis-ui/scss/components/_table.scss
@@ -273,8 +273,12 @@
       padding-top: 0;
     }
 
-    &--affixHeader > thead {
-      visibility: collapse;
+    &--affixHeader {
+      margin-top: calc(var(--Table-thead-height) * -1);
+
+      > thead {
+        visibility: hidden;
+      }
     }
 
     &--withCombine {

--- a/packages/amis/__tests__/event-action/renderers/__snapshots__/crud.test.tsx.snap
+++ b/packages/amis/__tests__/event-action/renderers/__snapshots__/crud.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`doAction:crud reload 1`] = `
           >
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -335,7 +335,7 @@ exports[`doAction:crud reload with data1 1`] = `
           >
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -642,7 +642,7 @@ exports[`doAction:crud reload with data2 1`] = `
           >
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`Renderer:input table 1`] = `
                   >
                     <div
                       class="cxd-Table"
-                      style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
+                      style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
                     >
                       <div
                         class="cxd-Table-contentWrap"
@@ -378,7 +378,7 @@ exports[`Renderer:input table add 1`] = `
           >
             <div
               class="cxd-Table"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-contentWrap"
@@ -690,7 +690,7 @@ exports[`Renderer:input-table cell selects delete 1`] = `
           >
             <div
               class="cxd-Table"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-contentWrap"
@@ -1029,7 +1029,7 @@ exports[`Renderer:input-table init display 1`] = `
           >
             <div
               class="cxd-Table"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-contentWrap"
@@ -1716,7 +1716,7 @@ exports[`Renderer:input-table with combo column 1`] = `
           >
             <div
               class="cxd-Table"
-              style="--Table-column-3-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-contentWrap"

--- a/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/CRUD.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`1. Renderer:crud basic interval headerToolbar footerToolbar 1`] = `
           >
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -2157,7 +2157,7 @@ exports[`6. Renderer:crud source & alwaysShowPagination 1`] = `
           >
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -2799,7 +2799,7 @@ exports[`13. enderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionL
             </div>
             <div
               class="cxd-Table cxd-Crud-body"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative; --Table-column-1-width: 0px;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative; --Table-column-1-width: 0px;"
             >
               <div
                 class="cxd-Table-fixedTop"

--- a/packages/amis/__tests__/renderers/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Pagination.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`Renderer:Pagination 1`] = `
       </div>
       <div
         class="cxd-Table"
-        style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
+        style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
       >
         <div
           class="cxd-Table-fixedTop"

--- a/packages/amis/__tests__/renderers/__snapshots__/Table.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Table.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Renderer:table 1`] = `
 <div>
   <div
     class="cxd-Table"
-    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
+    style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -370,7 +370,7 @@ exports[`Renderer:table align 1`] = `
 <div>
   <div
     class="cxd-Table"
-    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
+    style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -775,7 +775,7 @@ exports[`Renderer:table children 1`] = `
           >
             <div
               class="cxd-Table m-b-none"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -1355,7 +1355,7 @@ exports[`Renderer:table classNameExpr 1`] = `
 <div>
   <div
     class="cxd-Table"
-    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
+    style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -1721,7 +1721,7 @@ exports[`Renderer:table column head style className 1`] = `
 <div>
   <div
     class="cxd-Table className"
-    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
+    style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -2114,7 +2114,7 @@ exports[`Renderer:table combine Renderer:table combineNum only 1`] = `
           >
             <div
               class="cxd-Table"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -2689,7 +2689,7 @@ exports[`Renderer:table combine Renderer:table combineNum with fromIndex 1`] = `
           >
             <div
               class="cxd-Table"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -3334,7 +3334,7 @@ exports[`Renderer:table groupName-default 1`] = `
           >
             <div
               class="cxd-Table m-b-none"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -4113,7 +4113,7 @@ exports[`Renderer:table groupName-middleNoGroupName 1`] = `
           >
             <div
               class="cxd-Table m-b-none"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -4896,7 +4896,7 @@ exports[`Renderer:table groupName-startNoGroupName 1`] = `
           >
             <div
               class="cxd-Table m-b-none"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -5667,7 +5667,7 @@ exports[`Renderer:table groupName-withTpl 1`] = `
           >
             <div
               class="cxd-Table m-b-none"
-              style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
+              style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-8-width: 0px; position: relative;"
             >
               <div
                 class="cxd-Table-fixedTop"
@@ -6430,7 +6430,7 @@ exports[`Renderer:table isHead fixed 1`] = `
 <div>
   <div
     class="cxd-Table"
-    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
+    style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-fixedTop"
@@ -6807,7 +6807,7 @@ exports[`Renderer:table list 1`] = `
 <div>
   <div
     class="cxd-Table"
-    style="--Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; --Table-column-10-width: 0px; --Table-column-11-width: 0px; position: relative;"
+    style="--Table-thead-height: 0px; --Table-column-3-width: 0px; --Table-column-4-width: 0px; --Table-column-5-width: 0px; --Table-column-6-width: 0px; --Table-column-7-width: 0px; --Table-column-8-width: 0px; --Table-column-9-width: 0px; --Table-column-10-width: 0px; --Table-column-11-width: 0px; position: relative;"
   >
     <div
       class="cxd-Table-toolbar cxd-Table-headToolbar"

--- a/packages/amis/src/renderers/Table/ItemActionsWrapper.tsx
+++ b/packages/amis/src/renderers/Table/ItemActionsWrapper.tsx
@@ -30,7 +30,10 @@ function ItemActionsWrapper(props: ItemActionsProps) {
     }
     const rect = dom.getBoundingClientRect();
     const height = rect.height;
-    const top = rect.top - frame.getBoundingClientRect().top;
+    const top =
+      rect.top -
+      frame.getBoundingClientRect().top +
+      parseInt(getComputedStyle(frame)['marginTop'], 10);
     divRef.current!.style.cssText += `top: ${top}px;height: ${height}px;`;
   }, [store.hoverRow?.id]);
 

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -1591,6 +1591,10 @@ export default class Table extends React.Component<TableProps, object> {
 
     document.addEventListener('mousemove', this.handleColResizeMouseMove);
     document.addEventListener('mouseup', this.handleColResizeMouseUp);
+
+    // 防止选中文本
+    e.preventDefault();
+    e.stopPropagation();
   }
 
   // 垂直线拖拽移动


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2d1f018</samp>

This pull request adds two new features and several bug fixes to the table and popover components in `amis-core` and `amis-ui`. The new features are: closing the popover when clicking outside and fixing the table header at the top when scrolling. The bug fixes include: preventing text selection when resizing table columns, aligning item actions with table rows, handling schema expressions in dialogs, and using more inclusive terminology in the code.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2d1f018</samp>

> _Sing, O Muse, of the skillful coder who enhanced the table component_
> _With many a clever change and fix, to please the users and the client_
> _He made the header fixed and firm, like the throne of Zeus the thunderer_
> _And hid the mouse events and text, like Hermes the trickster and wanderer_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2d1f018</samp>

*  Add `autobind` decorator to `PopOver` class methods and handle `closeOnOutside` prop with document event listeners ([link](https://github.com/baidu/amis/pull/8884/files?diff=unified&w=0#diff-fee0b8a1fae75987d696f747563baa845dd7fdd4136afffa791553a3fffa4fc8L10-R10), [link](https://github.com/baidu/amis/pull/8884/files?diff=unified&w=0#diff-fee0b8a1fae75987d696f747563baa845dd7fdd4136afffa791553a3fffa4fc8R57), [link](https://github.com/baidu/amis/pull/8884/files?diff=unified&w=0#diff-fee0b8a1fae75987d696f747563baa845dd7fdd4136afffa791553a3fffa4fc8R72-R88), [link](https://github.com/baidu/amis/pull/8884/files?diff=unified&w=0#diff-fee0b8a1fae75987d696f747563baa845dd7fdd4136afffa791553a3fffa4fc8L83-R158)) in `PopOver.tsx`
*  Rename `blackList` parameter and variable to `ignoreList` and add `hasExprPropertiesChanged` function to `filter-schema.ts` ([link](https://github.com/baidu/amis/pull/8884/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3L48-R48), [link](https://github.com/baidu/amis/pull/8884/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3L55-R55), [link](https://github.com/baidu/amis/pull/8884/files?diff=unified&w=0#diff-67569df3ac2a44ea07ed4fd9bdefa902a1c4581dc1b13ff4c3153557f802fef3R105-R118))
*  Use `hasExprPropertiesChanged` function to detect schema changes that affect expressions and remove unnecessary arguments from `getExprProperties` calls in `WithStore.tsx` ([link](https://github.com/baidu/amis/pull/8884/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL9-R11), [link](https://github.com/baidu/amis/pull/8884/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL130-R134), [link](https://github.com/baidu/amis/pull/8884/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL138-R144), [link](https://github.com/baidu/amis/pull/8884/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acR171-R191))
*  Update table style to hide table header and set margin-top to negative header height when affix header is enabled in `_table.scss` ([link](https://github.com/baidu/amis/pull/8884/files?diff=unified&w=0#diff-86a8277e8494106d5e5c532d4d8710b1e5b8c84234089da23e1a35e366e6686dL276-R281))
*  Prevent default and propagation of mouse down event in table component to avoid text selection when resizing columns in `index.tsx` ([link](https://github.com/baidu/amis/pull/8884/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aR1594-R1597))
*  Fix item actions wrapper position in table component by adding table frame margin-top to row offset in `ItemActionsWrapper.tsx` ([link](https://github.com/baidu/amis/pull/8884/files?diff=unified&w=0#diff-bda67a6633404089c137bb1ee42f18f7375f41f00ee22b7e636b7174acd0e4f8L33-R36))
