### PR TITLE
fix(amis-editor): Combo可视化配置兼容schema为空的情况

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Combo.tsx
+++ b/packages/amis-editor/src/plugin/Form/Combo.tsx
@@ -703,8 +703,7 @@ export class ComboControlPlugin extends BasePlugin {
     while (pool.length) {
       const current = pool.shift() as EditorNodeType;
       const schema = current.schema;
-
-      if (schema.name) {
+      if (schema?.name) {
         itemsSchema.properties[schema.name] =
           await current.info.plugin.buildDataSchemas?.(
             current,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5efa097</samp>

Fix TypeScript errors and warnings in `amis-editor` package. Add optional chaining operator to `schema?.name` in `Form/Combo.tsx`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5efa097</samp>

> _`schema` may be null_
> _avoid error with `?.`_
> _a winter bug fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5efa097</samp>

*  Add optional chaining operator to prevent error when accessing `schema.name` ([link](https://github.com/baidu/amis/pull/8889/files?diff=unified&w=0#diff-785d17e956a3abfd5fcf93db4ac2b50aed00bb5bf2eb2a3f9c3776e81774d097L706-R706))
