### PR TITLE
fix(amis-editor): 渲染错误拦截不展示schema

### DIFF
--- a/packages/amis-editor-core/src/component/factory.tsx
+++ b/packages/amis-editor-core/src/component/factory.tsx
@@ -187,9 +187,7 @@ export function makeWrapper(
           value={this.editorNode || (this.context as any)}
         >
           <ErrorBoundary
-            customErrorMsg={`拦截到${
-              info.type
-            }渲染错误，当前组件信息: ${JSON.stringify(this.props.$schema)}`}
+            customErrorMsg={`拦截到${info.type}渲染错误`}
             fallback={() => {
               return (
                 <div className="renderer-error-boundary">

--- a/packages/amis/src/renderers/Form/StaticHoc.tsx
+++ b/packages/amis/src/renderers/Form/StaticHoc.tsx
@@ -135,7 +135,7 @@ export function supportStatic<T extends FormControlProps>() {
 
         return (
           <ErrorBoundary
-            customErrorMsg={`拦截到${props.$schema.type}渲染错误，当前组件schema: ${props.$schema}`}
+            customErrorMsg={`拦截到${props.$schema.type}渲染错误`}
             fallback={() => {
               return (
                 <div className="renderer-error-boundary">


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f037851</samp>

Simplified the `customErrorMsg` prop of the `ErrorBoundary` component in `packages/amis-editor-core/src/component/factory.tsx` to show only the error type. This improved the readability and usability of the rendering error message.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f037851</samp>

> _`ErrorBoundary`_
> _Simpler message for users_
> _Autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f037851</samp>

*  Simplify the error message of the `ErrorBoundary` component to only show the type of the rendering error ([link](https://github.com/baidu/amis/pull/8891/files?diff=unified&w=0#diff-5bcb2370bda7a8f3b1b692f3d568f62e4fd6aadd951424c0b7340c1ef5f40fe1L190-R190))
