### PR TITLE
styles: 选择器组件left & right padding调整为16px

### DIFF
--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -897,8 +897,8 @@
   --input-default-default-lineHeight: var(--fonts-lineHeight-2);
   --input-default-default-paddingTop: var(--sizes-size-3);
   --input-default-default-paddingBottom: var(--sizes-size-3);
-  --input-default-default-paddingLeft: var(--sizes-size-6);
-  --input-default-default-paddingRight: var(--sizes-size-6);
+  --input-default-default-paddingLeft: var(--sizes-size-9);
+  --input-default-default-paddingRight: var(--sizes-size-9);
   --input-default-default-bg-color: var(--colors-neutral-fill-11);
   --input-default-hover-top-border-color: var(--colors-brand-5);
   --input-default-hover-top-border-width: var(--borders-width-2);
@@ -918,8 +918,8 @@
   --input-default-hover-bottom-left-border-radius: var(--borders-radius-3);
   --input-default-hover-paddingTop: var(--sizes-size-3);
   --input-default-hover-paddingBottom: var(--sizes-size-3);
-  --input-default-hover-paddingLeft: var(--sizes-size-6);
-  --input-default-hover-paddingRight: var(--sizes-size-6);
+  --input-default-hover-paddingLeft: var(--sizes-size-9);
+  --input-default-hover-paddingRight: var(--sizes-size-9);
   --input-default-hover-bg-color: var(--colors-neutral-fill-11);
   --input-default-active-top-border-color: var(--colors-brand-5);
   --input-default-active-top-border-width: var(--borders-width-2);
@@ -939,8 +939,8 @@
   --input-default-active-bottom-left-border-radius: var(--borders-radius-3);
   --input-default-active-paddingTop: var(--sizes-size-3);
   --input-default-active-paddingBottom: var(--sizes-size-3);
-  --input-default-active-paddingLeft: var(--sizes-size-6);
-  --input-default-active-paddingRight: var(--sizes-size-6);
+  --input-default-active-paddingLeft: var(--sizes-size-9);
+  --input-default-active-paddingRight: var(--sizes-size-9);
   --input-default-active-shadow: var(--shadows-shadow-none);
   --input-default-active-bg-color: var(--colors-neutral-fill-11);
   --input-default-disabled-top-border-color: var(--colors-neutral-line-8);
@@ -1028,8 +1028,8 @@
   --inputNumber-base-default-bottom-left-border-radius: var(--borders-radius-3);
   --inputNumber-base-default-paddingTop: var(--sizes-size-3);
   --inputNumber-base-default-paddingBottom: var(--sizes-size-3);
-  --inputNumber-base-default-paddingLeft: var(--sizes-size-6);
-  --inputNumber-base-default-paddingRight: var(--sizes-size-6);
+  --inputNumber-base-default-paddingLeft: var(--sizes-size-9);
+  --inputNumber-base-default-paddingRight: var(--sizes-size-9);
   --inputNumber-base-default-bg-color: var(--colors-neutral-fill-11);
   --inputNumber-base-hover-top-border-color: var(--colors-brand-5);
   --inputNumber-base-hover-top-border-width: var(--borders-width-2);
@@ -2736,16 +2736,17 @@
   --select-base-default-bottom-left-border-radius: var(--borders-radius-3);
   --select-base-default-paddingTop: var(--sizes-size-3);
   --select-base-default-paddingBottom: var(--sizes-size-3);
-  --select-base-default-paddingLeft: var(--sizes-size-6);
-  --select-base-default-paddingRight: var(--sizes-size-6);
+  --select-base-default-paddingLeft: var(--sizes-size-9);
+  --select-base-default-paddingRight: var(--sizes-size-9);
   --select-base-default-color: var(--colors-neutral-text-2);
   --select-base-default-fontSize: var(--fonts-size-7);
   --select-base-default-fontWeight: var(--fonts-weight-6);
   --select-base-default-bg-color: var(--colors-neutral-fill-11);
   --select-base-default-option-paddingTop: var(--sizes-size-0);
   --select-base-default-option-paddingBottom: var(--sizes-size-0);
-  --select-base-default-option-paddingLeft: var(--sizes-size-6);
-  --select-base-default-option-paddingRight: var(--sizes-size-6);
+  --select-base-default-option-paddingLeft: var(--sizes-size-9);
+  --select-base-default-option-paddingRight: var(--sizes-size-9);
+
   --select-base-default-option-color: var(--colors-neutral-text-2);
   --select-base-default-option-fontSize: var(--fonts-size-7);
   --select-base-default-option-fontWeight: var(--fonts-weight-6);
@@ -2958,8 +2959,8 @@
   --inputDate-default-bottom-left-border-radius: var(--borders-radius-3);
   --inputDate-default-paddingTop: var(--sizes-size-3);
   --inputDate-default-paddingBottom: var(--sizes-size-3);
-  --inputDate-default-paddingLeft: var(--sizes-size-6);
-  --inputDate-default-paddingRight: var(--sizes-size-6);
+  --inputDate-default-paddingLeft: var(--sizes-size-9);
+  --inputDate-default-paddingRight: var(--sizes-size-9);
   --inputDate-default-fontSize: var(--fonts-size-7);
   --inputDate-default-fontWeight: var(--fonts-weight-6);
   --inputDate-default-height: var(--sizes-base-16);

--- a/packages/amis-ui/scss/_properties.scss
+++ b/packages/amis-ui/scss/_properties.scss
@@ -255,7 +255,7 @@ $Table-strip-bg: transparent;
   --ColorPicker-onFocused-borderColor: var(--Form-input-onFocused-borderColor);
   --ColorPicker-onHover-bg: var(--colors-neutral-fill-11);
   --ColorPicker-onHover-borderColor: var(--colors-brand-5);
-  --ColorPicker-paddingX: var(--sizes-size-6);
+  --ColorPicker-paddingX: var(--sizes-size-9);
   --ColorPicker-paddingY: var(--sizes-size-3);
   --ColorPicker-placeholderColor: var(--colors-neutral-text-6);
   --ColorPicker-boxShadow: var(--shadows-shadow-normal);


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8531d48</samp>

This pull request introduces a theme editing tool and makes some UI improvements to the input-related components and the ColorPicker component in the `amis-ui` package. The changes aim to enhance the development and customization of amis themes and the user experience of the components.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8531d48</samp>

> _Sing, O Muse, of the skillful developers who refined_
> _The splendid amis themes with careful changes sublime_
> _They added generous padding to the ColorPicker bright_
> _Like the golden chariot of Helios that fills the sky with light_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8531d48</samp>

*  Add `amis-theme-editor-helper` dependency to enable theme editing and variable generation ([link](https://github.com/baidu/amis/pull/8898/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R44))
*  Increase horizontal padding of input, inputNumber, select, select option, inputDate, and ColorPicker components to improve UI spacing and alignment ([link](https://github.com/baidu/amis/pull/8898/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4L900-R901), [link](https://github.com/baidu/amis/pull/8898/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4L921-R922), [link](https://github.com/baidu/amis/pull/8898/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4L942-R943), [link](https://github.com/baidu/amis/pull/8898/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4L1031-R1032), [link](https://github.com/baidu/amis/pull/8898/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4L2739-R2740), [link](https://github.com/baidu/amis/pull/8898/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4L2747-R2749), [link](https://github.com/baidu/amis/pull/8898/files?diff=unified&w=0#diff-efce95a42e95608f1e72013e3faefd54ae9a004f4ff27fe045949745a05607a4L2961-R2963), [link](https://github.com/baidu/amis/pull/8898/files?diff=unified&w=0#diff-11e33167cf3700a03b633f75ed54c24b2e57771a316f2e113cf09c791919c795L258-R258))
*  Sort devDependencies alphabetically for readability and consistency in `package.json` ([link](https://github.com/baidu/amis/pull/8898/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L49-R54))
*  Remove extra newline at the end of `package.json` to follow common convention ([link](https://github.com/baidu/amis/pull/8898/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L146-R147))
