### PR TITLE
fix: 表单项 validateApi 捕获接口异常 Close: #8850

### DIFF
--- a/packages/amis-core/src/store/formItem.ts
+++ b/packages/amis-core/src/store/formItem.ts
@@ -500,23 +500,28 @@ export const FormItemStore = StoreNode.named('FormItemStore')
           validateCancel = null;
         }
 
-        const json: Payload = yield getEnv(self).fetcher(
-          self.validateApi,
-          /** 如果配置validateApi，需要将用户最新输入同步到数据域内 */
-          createObject(data, {[self.name]: self.tmpValue}),
-          {
-            cancelExecutor: (executor: Function) => (validateCancel = executor)
-          }
-        );
-        validateCancel = null;
-
-        if (!json.ok && json.status === 422 && json.errors) {
-          addError(
-            String(
-              (self.validateApi as ApiObject)?.messages?.failed ??
-                (json.errors || json.msg || `表单项「${self.name}」校验失败`)
-            )
+        try {
+          const json: Payload = yield getEnv(self).fetcher(
+            self.validateApi,
+            /** 如果配置validateApi，需要将用户最新输入同步到数据域内 */
+            createObject(data, {[self.name]: self.tmpValue}),
+            {
+              cancelExecutor: (executor: Function) =>
+                (validateCancel = executor)
+            }
           );
+          validateCancel = null;
+
+          if (!json.ok && json.status === 422 && json.errors) {
+            addError(
+              String(
+                (self.validateApi as ApiObject)?.messages?.failed ??
+                  (json.errors || json.msg || `表单项「${self.name}」校验失败`)
+              )
+            );
+          }
+        } catch (err) {
+          addError(String(err));
         }
       }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ac34b0c</samp>

Improved error handling for form item validation. Added a try-catch block around the `fetcher` call in `formItem.ts` to catch and display any errors from the `validateApi` feature.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ac34b0c</samp>

> _`validateApi` call_
> _may fail in any season_
> _catch errors with `try`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ac34b0c</samp>

*  Add error handling for validateApi feature of form item ([link](https://github.com/baidu/amis/pull/8899/files?diff=unified&w=0#diff-973ce837479894e3956dfb7e37c94af0609e07fc8106874d2f7e49004757a2c9L503-R524))
