### PR TITLE
feat: Select组件reload期间展示禁用状态 Close: #8818

### DIFF
--- a/docs/zh-CN/components/form/select.md
+++ b/docs/zh-CN/components/form/select.md
@@ -1261,3 +1261,70 @@ leftOptions 动态加载，默认 source 接口是返回 options 部分，而 le
 | reset    | -                                      | 将值重置为`resetValue`，若没有配置`resetValue`，则清空                                  |
 | reload   | -                                      | 重新加载，调用 `source`，刷新数据域数据刷新（重新加载）                                 |
 | setValue | `value: string` \| `string[]` 更新的值 | 更新数据，开启`multiple`支持设置多项，开启`joinValues`时，多值用`,`分隔，否则多值用数组 |
+
+
+### 刷新数据源 reload
+
+```schema: scope="body"
+{
+    "type": "form",
+    "body": [
+        {
+          "type": "control",
+          "label": "点击刷新",
+          "mode": "horizontal",
+          "body": [
+            {
+              "type": "action",
+              "label": "点击刷新Select数据源",
+              "level": "primary",
+              "className": "mb-2",
+              "onEvent": {
+                "click": {
+                  "actions": [
+                    {
+                      "componentId": "select_reload",
+                      "actionType": "reload",
+                    }
+                  ],
+                  "debounce": {
+                    "wait": 200
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+            "name": "watchField",
+            "type": "input-text",
+            "label": "监听字段刷新",
+            "mode": "horizontal",
+            "placeholder": "输入内容刷新Select数据源",
+            "onEvent": {
+            "change": {
+              "actions": [
+                {
+                  "componentId": "select_reload",
+                  "actionType": "reload",
+                }
+              ],
+              "debounce": {
+                "wait": 250
+              }
+            }
+          }
+        },
+        {
+            "label": "Select",
+            "type": "select",
+            "name": "select",
+            "id": "select_reload",
+            "mode": "horizontal",
+            "source": "/api/mock2/form/getOptions?waitSeconds=3",
+            "multiple": true,
+            "clearable": true
+        }
+    ]
+}
+```

--- a/packages/amis-ui/src/components/Select.tsx
+++ b/packages/amis-ui/src/components/Select.tsx
@@ -477,14 +477,19 @@ export class Select extends React.Component<SelectProps, SelectState> {
 
   @autobind
   open() {
-    this.props.disabled ||
-      this.setState(
-        {
-          isOpen: true,
-          highlightedIndex: -1
-        },
-        () => setTimeout(this.focus, 500)
-      );
+    const {disabled, loading} = this.props;
+
+    if (disabled || loading) {
+      return;
+    }
+
+    this.setState(
+      {
+        isOpen: true,
+        highlightedIndex: -1
+      },
+      () => setTimeout(this.focus, 500)
+    );
   }
 
   @autobind
@@ -505,38 +510,36 @@ export class Select extends React.Component<SelectProps, SelectState> {
 
   @autobind
   toggle(e?: React.MouseEvent<HTMLDivElement>) {
+    const {disabled, loading} = this.props;
+
     if (
-      e &&
-      this.menu.current &&
-      this.menu.current.contains(e.target as HTMLElement)
+      (e &&
+        this.menu.current &&
+        this.menu.current.contains(e.target as HTMLElement)) ||
+      disabled ||
+      loading
     ) {
       return;
     }
 
-    this.props.disabled ||
-      this.setState(
-        {
-          isOpen: !this.state.isOpen,
-          highlightedIndex: -1
-        },
-        this.state.isOpen ? undefined : () => setTimeout(this.focus, 500)
-      );
+    this.setState(
+      {
+        isOpen: !this.state.isOpen,
+        highlightedIndex: -1
+      },
+      this.state.isOpen ? undefined : () => setTimeout(this.focus, 500)
+    );
   }
 
   @autobind
   onFocus(e: any) {
-    const {simpleValue} = this.props;
-    const {selection} = this.state;
+    const {simpleValue, disabled, loading} = this.props;
+    const {selection, isOpen} = this.state;
     const value = simpleValue ? selection.map(item => item.value) : selection;
 
-    this.props.disabled ||
-      this.state.isOpen ||
-      this.setState(
-        {
-          isFocused: true
-        },
-        this.focus
-      );
+    if (!disabled && !loading && !isOpen) {
+      this.setState({isFocused: true}, this.focus);
+    }
 
     this.props.onFocus &&
       this.props.onFocus({
@@ -1345,7 +1348,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
                   [`Select--searchable`]: searchable,
                   'is-opened': isOpen,
                   'is-focused': this.state.isFocused,
-                  'is-disabled': disabled,
+                  'is-disabled': disabled || loading,
                   'is-mobile': mobileUI,
                   'is-error': hasError,
                   [`Select--border${ucFirst(borderMode)}`]: borderMode


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b5472f7</samp>

This pull request enhances the Select component and its documentation. It adds a loading state and style to the component when its data source is loading asynchronously, and it provides a new example of how to use the reload action to refresh the data source based on user interactions. The example also illustrates the use of the debounce option to optimize the performance of the reload action.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b5472f7</samp>

> _If you want to refresh your `Select`_
> _With a button or input effect_
> _Use the reload action_
> _With debounce satisfaction_
> _And the docs have a new example set_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b5472f7</samp>

*  Prevent opening or interacting with Select component while data is loading ([link](https://github.com/baidu/amis/pull/8902/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL480-R492), [link](https://github.com/baidu/amis/pull/8902/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL508-R542), [link](https://github.com/baidu/amis/pull/8902/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL1348-R1351))
* Add new example of using reload action to refresh Select data source based on user interactions ([link](https://github.com/baidu/amis/pull/8902/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2R1264-R1330))
