### PR TITLE
fix: table2行数据同步上层数据域、前端排序等问题修复

### DIFF
--- a/docs/zh-CN/components/table2.md
+++ b/docs/zh-CN/components/table2.md
@@ -16,68 +16,114 @@ order: 67
 
 ```schema: scope="body"
 {
-  "type": "service",
-  "api": "/api/sample?perPage=5",
+  "type": "page",
+  "id": "page_001",
+  "data": {
+    "flag": true
+  },
   "body": [
     {
-      "type": "table2",
-      "title": "表格标题 - ${rows.length}",
-      "source": "$rows",
-      "columns": [
-        {
-          "title": "Engine",
-          "name": "engine",
-          "width": 120
-        },
-        {
-          "title": "Version",
-          "name": "version",
-          "type": "property",
-          "items": [
+      "type": "button",
+      "label": "启用行删除",
+      "className": "m-r",
+      "onEvent": {
+        "click": {
+          "actions": [
             {
-              "label": "cpu",
-              "content": "1 core"
-            },
-            {
-              "label": "memory",
-              "content": "4G"
-            },
-            {
-              "label": "disk",
-              "content": "80G"
-            },
-            {
-              "label": "network",
-              "content": "4M",
-              "span": 2
-            },
-            {
-              "label": "IDC",
-              "content": "beijing"
-            },
-            {
-              "label": "Note",
-              "content": "其它说明",
-              "span": 3
+              "actionType": "setValue",
+              "componentId": "page_001",
+              "args": {
+                "value": {"flag": false}
+              }
             }
           ]
-        },
-        {
-          "title": "Browser",
-          "name": "browser"
-        },
-        {
-          "title": "Operation",
-          "name": "operation",
-          "type": "button",
-          "label": "删除",
-          "size": "sm"
         }
-      ],
-      "footer": {
-        "type": "tpl",
-        "tpl": "表格Footer"
       }
+    },
+    {
+      "type": "button",
+      "label": "禁用行删除",
+      "onEvent": {
+        "click": {
+          "actions": [
+            {
+              "actionType": "setValue",
+              "componentId": "page_001",
+              "args": {
+                "value": {"flag": true}
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "service",
+      "api": "/api/sample?perPage=5",
+      "body": [
+        {
+          "type": "table2",
+          "title": "表格标题 - ${rows.length}",
+          "source": "$rows",
+          "canAccessSuperData": true,
+          "columns": [
+            {
+              "title": "Engine",
+              "name": "engine",
+              "width": 120
+            },
+            {
+              "title": "Version",
+              "name": "version",
+              "type": "property",
+              "items": [
+                {
+                  "label": "cpu",
+                  "content": "1 core"
+                },
+                {
+                  "label": "memory",
+                  "content": "4G"
+                },
+                {
+                  "label": "disk",
+                  "content": "80G"
+                },
+                {
+                  "label": "network",
+                  "content": "4M",
+                  "span": 2
+                },
+                {
+                  "label": "IDC",
+                  "content": "beijing"
+                },
+                {
+                  "label": "Note",
+                  "content": "其它说明",
+                  "span": 3
+                }
+              ]
+            },
+            {
+              "title": "Browser",
+              "name": "browser"
+            },
+            {
+              "title": "Operation",
+              "name": "operation",
+              "type": "button",
+              "label": "删除",
+              "size": "sm",
+              "disabledOn": "${flag}"
+            }
+          ],
+          "footer": {
+            "type": "tpl",
+            "tpl": "表格Footer"
+          }
+        }
+      ]
     }
   ]
 }

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -28,7 +28,8 @@ import {
   IRow2,
   ClassNamesFn,
   isArrayChildrenModified,
-  filterTarget
+  filterTarget,
+  changedEffect
 } from 'amis-core';
 import {Icon, Table, BadgeObject, SpinnerExtraProps} from 'amis-ui';
 import type {
@@ -158,6 +159,11 @@ export interface ColumnSchema {
   quickEdit?: SchemaQuickEdit;
 
   width?: string | number;
+
+  /**
+   * 表格列单元格是否可以获取父级数据域值，默认为true，该配置对当前列内单元格生效
+   */
+  canAccessSuperData?: boolean;
 }
 
 export interface RowSelectionOptionsSchema {
@@ -398,6 +404,11 @@ export interface TableSchema2 extends BaseSchema {
    * 表格自动计算高度
    */
   autoFillHeight?: boolean | AutoFillHeightObject;
+
+  /**
+   * 表格是否可以获取父级数据域值，默认为false
+   */
+  canAccessSuperData?: boolean;
 }
 
 // 事件调整 对应CRUD2里的事件配置也需要同步修改
@@ -443,6 +454,7 @@ export interface Table2Props extends RendererProps, SpinnerExtraProps {
   headingClassName?: string;
   keepItemSelectionOnPageChange?: boolean;
   maxKeepItemSelectionLength?: number;
+  canAccessSuperData?: boolean;
 }
 
 export default class Table2 extends React.Component<Table2Props, object> {
@@ -489,7 +501,8 @@ export default class Table2 extends React.Component<Table2Props, object> {
   reactions: Array<any> = [];
 
   static defaultProps: Partial<Table2Props> = {
-    keyField: 'id'
+    keyField: 'id',
+    canAccessSuperData: false
   };
 
   constructor(props: Table2Props, context: IScopedContext) {
@@ -504,12 +517,14 @@ export default class Table2 extends React.Component<Table2Props, object> {
       columns,
       rowSelection,
       keyField,
-      primaryField
+      primaryField,
+      canAccessSuperData
     } = props;
 
     store.update({
       columnsTogglable,
       columns,
+      canAccessSuperData,
       rowSelectionKeyField: primaryField || rowSelection?.keyField || keyField
     });
     Table2.syncRows(store, props, undefined) && this.syncSelected();
@@ -657,11 +672,19 @@ export default class Table2 extends React.Component<Table2Props, object> {
     const props = this.props;
     const store = props.store;
 
-    if (anyChanged(['columnsTogglable'], prevProps, props)) {
-      store.update({
-        columnsTogglable: props.columnsTogglable
-      });
-    }
+    changedEffect(
+      ['orderBy', 'columnsTogglable', 'canAccessSuperData'],
+      prevProps,
+      props,
+      changes => {
+        if (changes.orderBy && !props.onQuery) {
+          delete changes.orderBy;
+        }
+        store.update(changes as any, {
+          resolveDefinitions: props.resolveDefinitions
+        });
+      }
+    );
 
     if (
       anyChanged(['source', 'value', 'items'], prevProps, props) ||
@@ -816,7 +839,6 @@ export default class Table2 extends React.Component<Table2Props, object> {
       render,
       store,
       popOverContainer,
-      canAccessSuperData,
       showBadge,
       itemBadge,
       classnames: cx
@@ -887,17 +909,12 @@ export default class Table2 extends React.Component<Table2Props, object> {
               levels?: Array<number>
             ) => {
               const props: RenderProps = {};
-              const item =
-                store.getRowByIndex(rowIndex, [...(levels || [])]) || {};
 
               const obj = {
                 children: this.renderCellSchema(column, {
                   data: record,
                   value: column.name
-                    ? resolveVariable(
-                        column.name,
-                        canAccessSuperData ? item.locals : item.data
-                      )
+                    ? resolveVariable(column.name, record)
                     : column.name,
                   popOverContainer:
                     popOverContainer || this.getPopOverContainer,
@@ -912,14 +929,14 @@ export default class Table2 extends React.Component<Table2Props, object> {
                     }
                   ) => {
                     this.handleQuickChange(
-                      item,
+                      record,
                       values,
                       saveImmediately,
                       savePristine,
                       options
                     );
                   },
-                  row: item,
+                  row: record,
                   showBadge,
                   itemBadge
                 }),


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4f058c9</samp>

This pull request adds a new feature to the `TableStore2` class and the `Table2` renderer that allows them to access the parent data scope, and improves the performance and readability of the table component and its utilities. It also updates the documentation and the example code to demonstrate the new feature and the row deletion operation.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4f058c9</samp>

> _We are the masters of the table, we can access the super data_
> _We sort and filter the tree, we resolve the definitions_
> _We optimize the performance, we refactor the code_
> _We are the masters of the table, we unleash the power of `TableStore2`_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4f058c9</samp>

*  Add a new feature to allow the table to access the parent data scope by passing a `canAccessSuperData` prop ([link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-e8b85e81bbe5cff7411adaeb4a91921da046554867928fe7598fb18cd94c6b42L19-R126), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292L217-R218), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292L349-R352), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292L427-R456), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R407-R411), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R457), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L492-R505), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L507-R521), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58R527), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L660-R687), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L819), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L890-L891), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L897-R917), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L915-R932), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L922-R939))
*  Refactor the table component to use the `dataSource` prop directly instead of the `state.dataSource` and remove the redundant state and condition ([link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L182), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L221), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L321-R324), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L957-R935), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1144-R1130), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1159-R1145), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1210-R1196), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L1225-R1209))
*  Add a new function `getSortData` to sort the tree data by the given columns and order using the `sorter` function of the column ([link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-ce137907834f60da0ad81ca3403b2c6f584d32b41081c4937daf045fc2b232c4R302-R347), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R1097-R1104))
*  Change the type of the `sorter` property of the column to accept a function that takes an additional parameter `order` to customize the sorting logic based on the order direction ([link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L51-R54))
*  Rename the `getSelectedRows` function to `getRowsByKeys`, which is more generic and can be used for both selected rows and expanded rows, and use it in the table component ([link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-ce137907834f60da0ad81ca3403b2c6f584d32b41081c4937daf045fc2b232c4L77-R80), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-ce137907834f60da0ad81ca3403b2c6f584d32b41081c4937daf045fc2b232c4L86-R86), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-ce137907834f60da0ad81ca3403b2c6f584d32b41081c4937daf045fc2b232c4L92-R99), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L341-R335), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L387-R392), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L965-R944))
*  Use the `filterTree` function instead of the `filter` function to handle the tree data and filter the nodes by the predicate function ([link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7R28-R29), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L695-R692))
*  Remove the else branch of the condition to check if the `onSort` prop is defined, which is redundant as the `sorter` function is only called when the `onSort` prop is undefined ([link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L730-R723))
*  Add a new parameter `options` to the `updateColumns` function of the store, which can be used to pass a `resolveDefinitions` function to resolve the column definitions that use `$ref` ([link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292L408-R440), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-0f4049c8d6544aed86df4f5b031f99fd496681ded272fe4eed8fc61cb3a60292L443-R470), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L660-R687))
*  Use the `changedEffect` function instead of the `anyChanged` function to compare the props and execute a callback function with the changed props, and add the `orderBy` and `canAccessSuperData` props to the comparison list ([link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L31-R32), [link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-3bc5e2ed0ca1bd67c009ac1d3a0f2a3ea8dea46ebef912b948ccf3fc5d76aa58L660-R687))
*  Split the levels string to an array using the `levelsSplit` function and import the `getRowsByKeys` function from `./util` ([link](https://github.com/baidu/amis/pull/8905/files?diff=unified&w=0#diff-046664b9cd666345104f4b1014f9188b7b7c0dcac8ed71151bfb048ff2e5baa7L39-R43))
