### PR TITLE
style: 页面设计器 配置面板弹窗字体调整

### DIFF
--- a/packages/amis-editor-core/scss/control/_api-control.scss
+++ b/packages/amis-editor-core/scss/control/_api-control.scss
@@ -88,9 +88,6 @@
 
       .ae-ApiControl-form {
         @include panel-sm-content();
-        --Tabs--line-fontSize: #{$Editor-right-panel-font-size};
-        --Tabs--line-active-fontSize: #{$Editor-right-panel-font-size};
-        --Tabs--line-hover-fontSize: #{$Editor-right-panel-font-size};
         .ae-ApiControl-tabContent {
           max-height: 560px;
           overflow-x: hidden;

--- a/packages/amis-editor-core/scss/control/_event-action.scss
+++ b/packages/amis-editor-core/scss/control/_event-action.scss
@@ -230,7 +230,6 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    font-size: 12px;
     color: #84868c;
     line-height: #{px2rem(24px)};
 
@@ -254,10 +253,6 @@
 }
 
 .action-config-dialog {
-  *:not(svg) {
-    font-size: 12px;
-  }
-
   .action-config-panel {
     background: #ffffff;
     border: 1px solid #e8e9eb;
@@ -270,7 +265,6 @@
     .action-panel-title {
       margin: 16px 16px 12px;
       line-height: 18px;
-      font-size: 12px;
       font-weight: 500;
     }
 
@@ -302,7 +296,6 @@
           height: 100%;
           max-height: 100%;
           padding: 0;
-          font-size: 12px;
           & > div > div {
             margin-top: 82px;
             height: 64px;
@@ -314,7 +307,6 @@
         .action-tree-control {
           ul {
             li {
-              font-size: 12px;
               & > div {
                 flex-direction: row-reverse;
                 padding-left: 16px;
@@ -367,10 +359,8 @@
       padding: 0 8px 0 0;
       .event-action-radio {
         padding-top: 5px;
-        font-size: 12px;
       }
       .action-desc {
-        font-size: 12px;
         margin-left: 16px;
         color: var(--Form-item-fontColor);
       }
@@ -394,9 +384,6 @@
 
         label {
           text-align: left;
-        }
-        span {
-          font-size: 12px;
         }
       }
       .ae-BaseRemark {

--- a/packages/amis-editor-core/scss/editor.scss
+++ b/packages/amis-editor-core/scss/editor.scss
@@ -1783,17 +1783,9 @@ div.ae-DragImage {
   width: px2rem(700px);
   @include panel-sm-content();
 
-  --Form-item-fontSize: #{$Editor-right-panel-font-size};
-  --select-base-default-fontSize: #{$Editor-right-panel-font-size};
-  --select-base-default-option-fontSize: #{$Editor-right-panel-font-size};
-  --Table-thead-fontSize: #{$Editor-right-panel-font-size};
-  --button-size-default-fontSize: #{$Editor-right-panel-font-size};
-  --checkbox-checkbox-default-fontSize: #{$Editor-right-panel-font-size};
-  --radio-default-default-fontSize: #{$Editor-right-panel-font-size};
-  --radio-default-default-lineHeight: #{$Editor-right-panel-radios-line-height};
-  --Tabs--vertical-fontSize: #{$Editor-right-panel-font-size};
-  --Tabs--vertical-active-fontSize: #{$Editor-right-panel-font-size};
-  --Tabs--vertical-hover-fontSize: #{$Editor-right-panel-font-size};
+  &-title {
+    font-size: px2rem(14px);
+  }
 
   &--CRUD {
     width: px2rem(800px);

--- a/packages/amis-editor-core/src/component/ScaffoldModal.tsx
+++ b/packages/amis-editor-core/src/component/ScaffoldModal.tsx
@@ -213,7 +213,7 @@ export class ScaffoldModal extends React.Component<SubEditorProps> {
         contentClassName={scaffoldFormContext?.className}
         show={!!scaffoldFormContext}
         onHide={this.handleCancelClick}
-        className="ae-scaffoldForm-Modal AMISCSSWrapper"
+        className="ae-scaffoldForm-Modal :AMISCSSWrapper"
         closeOnEsc={!store.scaffoldFormBuzy}
       >
         <div className={cx('Modal-header')}>

--- a/packages/amis-editor/src/component/BaseControl.ts
+++ b/packages/amis-editor/src/component/BaseControl.ts
@@ -430,7 +430,7 @@ export function remarkTpl(config: {
       },
       body: {
         type: 'grid',
-        className: 'pt-4 right-panel-pop AMISCSSWrapper',
+        className: 'pt-4 right-panel-pop :AMISCSSWrapper',
         gap: 'lg',
         columns: [
           {
@@ -480,17 +480,16 @@ export function remarkTpl(config: {
               getSchemaTpl('icon'),
               {
                 name: 'className',
-                label: 'CSS 类名',
-                type: 'input-text',
-                labelRemark: BaseLabelMark(
+                label: tipedLabel(
+                  'CSS 类名',
                   '有哪些辅助类 CSS 类名？请前往 <a href="https://baidu.gitee.io/amis/zh-CN/style/index" target="_blank">样式说明</a>，除此之外你可以添加自定义类名，然后在系统配置中添加自定义样式。'
-                )
+                ),
+                type: 'input-text'
               },
               {
                 name: 'trigger',
                 type: 'select',
-                label: '触发方式',
-                labelRemark: BaseLabelMark('浮层触发方式默认值为鼠标悬停'),
+                label: tipedLabel('触发方式', '浮层触发方式默认值为鼠标悬停'),
                 multiple: true,
                 pipeIn: (value: any) =>
                   Array.isArray(value) ? value.join(',') : [],

--- a/packages/amis-editor/src/plugin/CRUD2/BaseCRUD.tsx
+++ b/packages/amis-editor/src/plugin/CRUD2/BaseCRUD.tsx
@@ -164,7 +164,7 @@ export class BaseCRUDPlugin extends BasePlugin {
         }
       },
       className:
-        'ae-Scaffold-Modal ae-Scaffold-Modal--CRUD ae-Scaffold-Modal-content AMISCSSWrapper', //  ae-formItemControl
+        'ae-Scaffold-Modal ae-Scaffold-Modal--CRUD ae-Scaffold-Modal-content :AMISCSSWrapper', //  ae-formItemControl
       stepsBody: true,
       canSkip: true,
       canRebuild: true,

--- a/packages/amis-editor/src/plugin/Form/Form.tsx
+++ b/packages/amis-editor/src/plugin/Form/Form.tsx
@@ -395,7 +395,7 @@ export class FormPlugin extends BasePlugin {
         }
       },
       canRebuild: true,
-      className: 'ae-Scaffold-Modal ae-Scaffold-Modal-content AMISCSSWrapper',
+      className: 'ae-Scaffold-Modal ae-Scaffold-Modal-content :AMISCSSWrapper',
       body: [
         {
           type: 'radios',

--- a/packages/amis-editor/src/renderer/APIControl.tsx
+++ b/packages/amis-editor/src/renderer/APIControl.tsx
@@ -522,7 +522,7 @@ export default class APIControl extends React.Component<
 
     return {
       type: 'form',
-      className: 'ae-ApiControl-form AMISCSSWrapper',
+      className: 'ae-ApiControl-form :AMISCSSWrapper',
       mode: 'horizontal',
       submitOnChange,
       wrapWithPanel: false,

--- a/packages/amis-editor/src/renderer/ActionApiControl.tsx
+++ b/packages/amis-editor/src/renderer/ActionApiControl.tsx
@@ -360,7 +360,7 @@ export default class APIControl extends React.Component<
   renderApiConfigTabs(messageDesc?: string, submitOnChange: boolean = false) {
     return {
       type: 'form',
-      className: 'ae-ApiControl-form AMISCSSWrapper',
+      className: 'ae-ApiControl-form :AMISCSSWrapper',
       mode: 'horizontal',
       submitOnChange,
       wrapWithPanel: false,

--- a/packages/amis-editor/src/renderer/StatusControl.tsx
+++ b/packages/amis-editor/src/renderer/StatusControl.tsx
@@ -7,7 +7,6 @@ import cx from 'classnames';
 import {FormItem, Switch, Option} from 'amis';
 
 import {autobind, getSchemaTpl} from 'amis-editor-core';
-import {BaseLabelMark} from '../component/BaseControl';
 
 import type {FormControlProps} from 'amis-core';
 import type {SchemaCollection} from 'amis';

--- a/packages/amis-editor/src/renderer/crud2-control/AddColumnModal.tsx
+++ b/packages/amis-editor/src/renderer/crud2-control/AddColumnModal.tsx
@@ -150,10 +150,10 @@ const AddColumnModal: React.FC<AddColumnModalProps> = props => {
         show={visible}
         onHide={onClose}
         closeOnEsc={false}
-        contentClassName="ae-Scaffold-Modal AMISCSSWrapper"
+        contentClassName="ae-Scaffold-Modal :AMISCSSWrapper"
       >
         <Modal.Header showCloseButton onClose={onClose}>
-          <Modal.Title>添加列</Modal.Title>
+          <Modal.Title className="ae-Scaffold-Modal-title">添加列</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           {render(

--- a/packages/amis-editor/src/renderer/event-control/action-config-dialog.tsx
+++ b/packages/amis-editor/src/renderer/event-control/action-config-dialog.tsx
@@ -363,7 +363,7 @@ export default class ActionDialog extends React.Component<ActionDialogProp> {
             style: {
               borderStyle: 'solid'
             },
-            className: 'action-config-panel AMISCSSWrapper'
+            className: 'action-config-panel :AMISCSSWrapper'
           }
         ],
         onClose


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4682698</samp>

This pull request refactors and simplifies some scss styles and class names for various components in the amis-editor and amis-editor-core packages. It also fixes some minor issues with the remark template function and the label components.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4682698</samp>

> _The event action component's style_
> _Was redundant and messy a while_
> _But with some refactoring_
> _And `AMISCSSWrapper` fixing_
> _It now looks much better and agile_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4682698</samp>

*  Remove font size declarations for event action component and use global variable instead ([link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-331aefd0b2e89136c09ca5ead48336a5c2d449bda68b87e65f01c007b4eec5e7L233), [link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-331aefd0b2e89136c09ca5ead48336a5c2d449bda68b87e65f01c007b4eec5e7L257-L260), [link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-331aefd0b2e89136c09ca5ead48336a5c2d449bda68b87e65f01c007b4eec5e7L273), [link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-331aefd0b2e89136c09ca5ead48336a5c2d449bda68b87e65f01c007b4eec5e7L305), [link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-331aefd0b2e89136c09ca5ead48336a5c2d449bda68b87e65f01c007b4eec5e7L317), [link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-331aefd0b2e89136c09ca5ead48336a5c2d449bda68b87e65f01c007b4eec5e7L398-L400))
*  Remove font size variables for tabs line in API control component and editor right panel and use global variable instead ([link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-fef64af12fa407ae97c872fcbeeebe6b60bd0aa6e4976827ad5f04bef9accf60L91-L93), [link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-a655efcb1bba154f0bdcbcff35544de6ac126ba2ace65f57c008e0d1eb4c1fc9L1786-R1788))
*  Move event action radio and action desc styles from `event-action.scss` to `api-control.scss` as they are only used in API control component ([link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-331aefd0b2e89136c09ca5ead48336a5c2d449bda68b87e65f01c007b4eec5e7L370-R363))
*  Add colon before `AMISCSSWrapper` class name in various components as it is a modifier class that should be applied after the base class name ([link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-85faab9f8c432f5b71f49bdb3e107d8f36edae4199b8cc13dd9b6a2b391b613dL216-R216), [link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-851dba93506fd34484adaa1d720285d572d18ca4392a0c4893fca27c4159fa92L433-R433), [link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-84800995b352e55dac9d39fc260b3288d628b48ce9ed6a2d34b7338b0e74fa68L167-R167), [link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-d3f19aa7a438fceeebff55a461ae3e989b9416fde9078db4ed19893f5e75335dL398-R398), [link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-e65abd8ed33a9d63bc29309ed26eb057b2d1f780106822c5eabeeaa220f8c91fL525-R525), [link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-0e3971a496f3279ae50c1ec88e123bcb7043d0e93e188e25070de55d56367a4aL363-R363), [link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-bca893b099ca937943ac72a5ef0208df221f47d9846dba048ff0782f87289317L153-R156), [link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-3d7b0c5e5c5515b4c22895cf1ee4f3be874c4fd89fa5b5445bfcf8e55523e919L366-R366))
*  Replace `BaseLabelMark` function with `tipedLabel` function in remark template function for consistency and conciseness ([link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-851dba93506fd34484adaa1d720285d572d18ca4392a0c4893fca27c4159fa92L483-R492))
*  Add font size declaration for scaffold modal title in `editor.scss` ([link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-a655efcb1bba154f0bdcbcff35544de6ac126ba2ace65f57c008e0d1eb4c1fc9L1786-R1788))
*  Add class name for add column modal title in `AddColumnModal.tsx` for consistent styling ([link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-bca893b099ca937943ac72a5ef0208df221f47d9846dba048ff0782f87289317L153-R156))
*  Remove unused import of `BaseLabelMark` function in `StatusControl.tsx` ([link](https://github.com/baidu/amis/pull/8906/files?diff=unified&w=0#diff-04709e53c43bdedbb92ed32bd99c2d62584ca89aec4243a5fef10598148bae02L10))
