### PR TITLE
fix(amis-editor): 修复公式编辑器self标记功能不生效问题

### DIFF
--- a/packages/amis-editor/src/renderer/textarea-formula/FormulaPicker.tsx
+++ b/packages/amis-editor/src/renderer/textarea-formula/FormulaPicker.tsx
@@ -1,9 +1,10 @@
 import React, {useEffect} from 'react';
 import {Modal, Button} from 'amis';
+import {FormControlProps} from 'amis-core';
 import cx from 'classnames';
 import FormulaEditor from 'amis-ui/lib/components/formula/Editor';
 
-export interface FormulaPickerProps {
+export interface FormulaPickerProps extends FormControlProps {
   onConfirm: (data: string | undefined) => void;
   onClose: () => void;
   variables: any[];
@@ -43,6 +44,9 @@ const FormulaPicker: React.FC<FormulaPickerProps> = props => {
     props.onConfirm && props.onConfirm(formula);
   };
 
+  // 自身字段
+  const selfName = props?.data?.name;
+
   return (
     <Modal
       className={cx('FormulaPicker-Modal')}
@@ -60,6 +64,7 @@ const FormulaPicker: React.FC<FormulaPickerProps> = props => {
           value={formula}
           evalMode={evalMode}
           onChange={handleChange}
+          selfVariableName={selfName}
         />
       </Modal.Body>
       <Modal.Footer>

--- a/packages/amis-ui/scss/components/form/_selection.scss
+++ b/packages/amis-ui/scss/components/form/_selection.scss
@@ -217,6 +217,7 @@
 
   &-item {
     position: relative;
+    margin-bottom: 2px;
   }
   &-item.is-expanded > &-sublist {
     display: block;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6a42670</samp>

This pull request enhances the formula editor feature in `amis-editor` by allowing access to form values and preventing circular references. It also improves the UI of the selected variables by adding some margin.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6a42670</samp>

> _`FormulaPicker`_
> _Accesses form values now_
> _Avoids self-reference_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6a42670</samp>

*  Extend `FormulaPickerProps` interface to inherit from `FormControlProps` and access form values ([link](https://github.com/baidu/amis/pull/8910/files?diff=unified&w=0#diff-81d403d78e98e70e6b31027c9eccbe5b094e521ec35bf88ef32825da3467dca8L3-R7))
*  Declare `selfName` variable to store the name of the current form field from `data` prop ([link](https://github.com/baidu/amis/pull/8910/files?diff=unified&w=0#diff-81d403d78e98e70e6b31027c9eccbe5b094e521ec35bf88ef32825da3467dca8R47-R49))
*  Pass `selfName` variable to `FormulaEditor` component as `selfVariableName` prop to avoid circular references in formulas ([link](https://github.com/baidu/amis/pull/8910/files?diff=unified&w=0#diff-81d403d78e98e70e6b31027c9eccbe5b094e521ec35bf88ef32825da3467dca8R67))
*  Add `margin-bottom` style to `.selection-item` class in `packages/amis-ui/scss/components/form/_selection.scss` to improve spacing between selected variables in formula editor ([link](https://github.com/baidu/amis/pull/8910/files?diff=unified&w=0#diff-0f0487287579e1a13ea4e8643e44936d1aaf6c272bc335585eddb6fc06126402R220))
