### PR TITLE
docs: 增加 searchImediately 的示例 Closes #8828

### DIFF
--- a/docs/zh-CN/components/search-box.md
+++ b/docs/zh-CN/components/search-box.md
@@ -188,6 +188,33 @@ icon:
 }
 ```
 
+## 立刻搜索模式
+
+设置 `"searchImediately": true` 实现输入时即搜索
+
+```schema
+{
+    "type": "page",
+    "body": [
+      {
+        "type": "service",
+        "api": "/api/mock2/page/initData?keywords=${keywords}",
+        "body": [
+          {
+            "type": "search-box",
+            "name": "keywords",
+            "searchImediately": true
+          },
+          {
+            "type": "tpl",
+            "tpl": "<p>关键字：${keywords}</p><p>返回结果：${&|json}</p>"
+          }
+        ]
+      }
+    ]
+}
+```
+
 ## 属性表
 
 | 属性名           | 类型      | 默认值 | 说明                         | 版本    |


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b3a8589</samp>

This change improves the documentation of the `search-box` component by adding a section on how to use the `searchImediately` option for instant search. It also includes a schema example to illustrate the option.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b3a8589</samp>

> _`searchImediately`_
> _Instant results in springtime_
> _New docs for search-box_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b3a8589</samp>

* Add a new option `searchImediately` to the search-box component, which allows the user to trigger the search action as they type in the input field. ([link](https://github.com/baidu/amis/pull/8912/files?diff=unified&w=0#diff-af256e55b304ba172a6afe7fe51e2623bd205b7c5c474d828c3db5dda7b51262R191-R217),                          F0L475
