### PR TITLE
fix: Select组件设置labelField和maxTagCount时剩余标签数量不显示问题 Close: #8893

### DIFF
--- a/docs/zh-CN/components/form/select.md
+++ b/docs/zh-CN/components/form/select.md
@@ -1187,6 +1187,38 @@ leftOptions 动态加载，默认 source 接口是返回 options 部分，而 le
 }
 ```
 
+## 自动补全 autoComplete
+
+可以在`autoComplete`配置中，用数据映射，获取变量`term`，为当前输入的关键字。
+
+```schema: scope="body"
+{
+    "type": "form",
+    "body": [
+        {
+            "name": "select1",
+            "type": "select",
+            "label": "选项自动补全（单选）",
+            "autoComplete": "/api/mock2/options/autoComplete?term=${term}",
+            "placeholder": "请输入",
+            "clearable": true
+        },
+        {
+            "name": "select2",
+            "type": "select",
+            "label": "选项自动补全（多选）",
+            "autoComplete": "/api/mock2/options/autoComplete?labelField=name&valueField=id&term=${term}",
+            "placeholder": "请输入",
+            "labelField": "name",
+            "valueField": "id",
+            "clearable": true,
+            "multiple": true,
+            "maxTagCount": 2
+        }
+    ]
+}
+```
+
 ## 属性表
 
 除了支持 [普通表单项属性表](./formitem#%E5%B1%9E%E6%80%A7%E8%A1%A8) 中的配置以外，还支持下面一些配置

--- a/mock/cfc/mock/options/autoComplete.js
+++ b/mock/cfc/mock/options/autoComplete.js
@@ -31,15 +31,18 @@ const db = [
 ];
 
 module.exports = function (req, res) {
+  const labelField = req.query.labelField || 'label';
+  const valueField = req.query.valueField || 'value';
   const term = req.query.term || '';
+  const list = db.map(item => ({[labelField]: item.label, [valueField]: item.value}))
 
   res.json({
     status: 0,
     msg: '',
     data: term
-      ? db.filter(function (item) {
+      ? list.filter(function (item) {
           return term ? ~item.label.indexOf(term) : false;
         })
-      : db
+      : list
   });
 };

--- a/packages/amis-ui/src/components/Select.tsx
+++ b/packages/amis-ui/src/components/Select.tsx
@@ -657,10 +657,18 @@ export class Select extends React.Component<SelectProps, SelectState> {
     }
   }
 
+  /**
+   * DownShift中ESC按键动作会触发change事件，此时selectItem为null，需要单独处理，参考：
+   * {@link https://github.com/downshift-js/downshift/issues/719 GitHub Issue #719}
+   */
   @autobind
   handleChange(selectItem: any) {
     const {onChange, multiple, simpleValue, valueField} = this.props;
     let {selection} = this.state;
+
+    if (selectItem == null) {
+      return;
+    }
 
     if (multiple) {
       const selectionValues = selection.map(item => item[valueField]);
@@ -785,6 +793,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
       translate: __
     } = this.props;
     const selection = this.state.selection;
+    const labelKey = labelField || 'label';
 
     if (!selection.length) {
       return (
@@ -815,7 +824,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
       };
       return [
         ...selection.slice(0, maxVisibleCount),
-        {label: `+ ${selection.length - maxVisibleCount} ...`}
+        {[labelKey]: `+ ${selection.length - maxVisibleCount} ...`}
       ].map((item, index) => {
         if (index === maxVisibleCount) {
           return (
@@ -843,7 +852,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
                             <span className={cx('Select-valueLabel')}>
                               {renderValueLabel
                                 ? renderValueLabel(item)
-                                : item[labelField || 'label']}
+                                : item[labelKey]}
                             </span>
                             <span
                               className={cx('Select-valueIcon', {
@@ -870,9 +879,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
                 } /** 避免点击查看浮窗时呼出下拉菜单 */
               >
                 <span className={cx('Select-valueLabel')}>
-                  {renderValueLabel
-                    ? renderValueLabel(item)
-                    : item[labelField || 'label']}
+                  {renderValueLabel ? renderValueLabel(item) : item[labelKey]}
                 </span>
               </div>
             </TooltipWrapper>
@@ -883,7 +890,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
           <TooltipWrapper
             container={popOverContainer}
             placement={'top'}
-            tooltip={item[labelField || 'label']}
+            tooltip={item[labelKey]}
             trigger={'hover'}
             key={index}
           >
@@ -894,9 +901,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
               })}
             >
               <span className={cx('Select-valueLabel')}>
-                {renderValueLabel
-                  ? renderValueLabel(item)
-                  : item[labelField || 'label']}
+                {renderValueLabel ? renderValueLabel(item) : item[labelKey]}
               </span>
               <span
                 className={cx('Select-valueIcon', {
@@ -922,22 +927,18 @@ export class Select extends React.Component<SelectProps, SelectState> {
             })}
             key={index}
           >
-            {renderValueLabel
-              ? renderValueLabel(item)
-              : item[labelField || 'label']}
+            {renderValueLabel ? renderValueLabel(item) : item[labelKey]}
           </div>
         );
       }
 
       return valuesNoWrap ? (
-        `${item[labelField || 'label']}${
-          index === selection.length - 1 ? '' : ' + '
-        }`
+        `${item[labelKey]}${index === selection.length - 1 ? '' : ' + '}`
       ) : (
         <TooltipWrapper
           container={popOverContainer}
           placement={'top'}
-          tooltip={item[labelField || 'label']}
+          tooltip={item[labelKey]}
           trigger={'hover'}
           key={index}
         >
@@ -948,9 +949,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
             })}
           >
             <span className={cx('Select-valueLabel')}>
-              {renderValueLabel
-                ? renderValueLabel(item)
-                : item[labelField || 'label']}
+              {renderValueLabel ? renderValueLabel(item) : item[labelKey]}
             </span>
             <span
               className={cx('Select-valueIcon', {
@@ -978,7 +977,6 @@ export class Select extends React.Component<SelectProps, SelectState> {
     const {
       popOverContainer,
       options,
-      value,
       valueField,
       labelField,
       noResultsText,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 81136c9</samp>

This pull request enhances the `Select` component and its documentation by adding an `autoComplete` feature that supports fetching options from an API and customizing the label and value fields. It also fixes a bug with the ESC key and removes an unused prop.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 81136c9</samp>

> _If you want to use `Select` with ease_
> _And fetch options from APIs as you please_
> _You can set `autoComplete`_
> _And customize label and value fields_
> _And avoid the bug with the ESC key squeeze_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 81136c9</samp>

*  Add `autoComplete` configuration to select component, allowing fetching options from an API based on input term ([link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2R1190-R1221))
*  Modify mock API for `autoComplete` feature, adding parameters to customize label and value fields of options, and filtering options by input term ([link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-5a93466f7399cc2b8d61b669ca17faa6ddb9118e1848ce5d4cc9a55ac692af13L34-R37), [link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-5a93466f7399cc2b8d61b669ca17faa6ddb9118e1848ce5d4cc9a55ac692af13L40-R46))
*  Add `labelField` prop to `Select` component class, enabling access to customized label field of options ([link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecR796))
*  Replace hardcoded 'label' field with `labelKey` variable in `render` method of `Select` component class, using `labelField` prop or default value ([link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL818-R827), [link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL846-R855), [link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL873-R882), [link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL886-R893), [link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL897-R904), [link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL925-R930), [link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL933-R941), [link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL951-R952))
*  Add `renderValueLabel` prop to `Select` component class, allowing custom rendering of selected option labels ([link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL846-R855), [link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL873-R882), [link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL897-R904), [link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL925-R930), [link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL933-R941), [link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL951-R952))
*  Fix issue of ESC key triggering change event with null value in DownShift library, by adding early return in `handleChange` method of `Select` component class ([link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecR660-R663), [link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecR669-R672))
*  Remove unused `value` prop from `Select` component class, avoiding confusion or conflicts with `value` state ([link](https://github.com/baidu/amis/pull/8913/files?diff=unified&w=0#diff-6b3d1e3be25b7cef556981d8517cd53b6a22adcbea5a0e2da34bbe4f0d5fa7ecL981))
