### PR TITLE
feat:ConditionBuilder字段配置支持defaultOp Close #2468

### DIFF
--- a/docs/zh-CN/components/form/condition-builder.md
+++ b/docs/zh-CN/components/form/condition-builder.md
@@ -328,7 +328,7 @@ type Value = ValueGroup;
 - `label` 字段名称。
 - `placeholder` 占位符
 - `operators` 默认为 `[ 'select_equals', 'select_not_equals', 'select_any_in', 'select_not_any_in' ]` 如果不要那么多，可以配置覆盖。
-- `defaultOp`
+- `defaultOp` 默认为 `"select_equals"`
 - `options` 选项列表，`Array<{label: string, value: any}>`
 - `source` 动态选项，请配置 api。
 - `searchable` 是否可以搜索
@@ -392,7 +392,9 @@ type Value = ValueGroup;
 - `label` 字段名称
 - `placeholder` 占位符
 - `operators` 默认为空，需配置自定义判断条件，支持字符串或 key-value 格式
+- `defaultOp` 默认操作符
 - `value` 字段配置右边值需要渲染的组件，支持 amis 输入类组件或自定义输入类组件
+- `defaultValue` 右边值的默认值
 
 ```schema: scope="body"
 {
@@ -412,6 +414,8 @@ type Value = ValueGroup;
               "value": {
                 "type": "input-color"
               },
+              "defaultOp": "equal",
+              "defaultValue": "#ff0000",
               "operators": [
                 "equal",
                 {

--- a/packages/amis-ui/src/components/condition-builder/Item.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Item.tsx
@@ -80,10 +80,13 @@ export class ConditionItem extends React.Component<ConditionItemProps> {
 
   @autobind
   handleLeftChange(leftValue: any) {
+    const {fields, config} = this.props;
+    // 获取默认Op
+    const field: any = findTree(fields, (f: any) => f.name === leftValue.field);
     const value = {
       ...this.props.value,
       left: leftValue,
-      op: undefined,
+      op: field?.defaultOp || config.types[field?.type]?.defaultOp || undefined,
       right: undefined
     };
     const onChange = this.props.onChange;

--- a/packages/amis-ui/src/components/condition-builder/config.ts
+++ b/packages/amis-ui/src/components/condition-builder/config.ts
@@ -61,6 +61,7 @@ const defaultConfig: ConditionBuilderConfig = {
       ]
     },
     number: {
+      defaultOp: 'equal',
       operators: [
         'equal',
         'not_equal',
@@ -75,6 +76,7 @@ const defaultConfig: ConditionBuilderConfig = {
       ]
     },
     date: {
+      defaultOp: 'equal',
       operators: [
         'equal',
         'not_equal',
@@ -90,6 +92,7 @@ const defaultConfig: ConditionBuilderConfig = {
     },
 
     time: {
+      defaultOp: 'equal',
       operators: [
         'equal',
         'not_equal',
@@ -105,6 +108,7 @@ const defaultConfig: ConditionBuilderConfig = {
     },
 
     datetime: {
+      defaultOp: 'equal',
       operators: [
         'equal',
         'not_equal',
@@ -120,6 +124,7 @@ const defaultConfig: ConditionBuilderConfig = {
     },
 
     select: {
+      defaultOp: 'select_equals',
       operators: [
         'select_equals',
         'select_not_equals',
@@ -130,6 +135,7 @@ const defaultConfig: ConditionBuilderConfig = {
     },
 
     boolean: {
+      defaultOp: 'equal',
       operators: ['equal', 'not_equal']
     }
   }

--- a/packages/amis/__tests__/renderers/Form/conditionBuilder.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/conditionBuilder.test.tsx
@@ -140,14 +140,6 @@ test('Renderer:condition-builder add', async () => {
 
   fireEvent.click(textType);
 
-  const textOpType = await findByText('请选择操作');
-
-  fireEvent.click(textOpType);
-
-  const qualOpType = await findByText('等于');
-
-  fireEvent.click(qualOpType);
-
   const textRightInput = await findByPlaceholderText('请输入文本');
 
   fireEvent.change(textRightInput, {target: {value: 'amis'}});
@@ -251,8 +243,6 @@ test('Renderer:condition-builder with number type', async () => {
   fireEvent.click(await findByText('添加条件'));
   fireEvent.click(await findByText('请选择字段'));
   fireEvent.click(await findByText('数字'));
-  fireEvent.click(await findByText('请选择操作'));
-  fireEvent.click(await findByText('等于'));
 
   fireEvent.change(await findByPlaceholderText('请输入数字'), {
     target: {value: 81192}
@@ -396,8 +386,6 @@ test('Renderer:condition-builder with select type & source & searchable', async 
   fireEvent.click(await findByText('添加条件'));
   fireEvent.click(await findByText('请选择字段'));
   fireEvent.click(await findByText('动态选项'));
-  fireEvent.click(await findByText('请选择操作'));
-  fireEvent.click(await findByText('等于'));
 
   await wait(200);
   expect(fetcher).toHaveBeenCalled();
@@ -573,8 +561,6 @@ test('Renderer:condition-builder with source fields', async () => {
   fireEvent.click(await findByText('添加条件'));
   fireEvent.click(await findByText('请选择字段'));
   fireEvent.click(await findByText('布尔'));
-  fireEvent.click(await findByText('请选择操作'));
-  fireEvent.click(await findByText('等于'));
   fireEvent.click(container.querySelector('.cxd-Switch')!);
 
   await wait(200);
@@ -706,8 +692,6 @@ test('Renderer:condition-builder with builderMode & showANDOR & showNot', async 
 
   fireEvent.click(await findByText('请选择字段'));
   fireEvent.click(await findByText('布尔'));
-  fireEvent.click(await findByText('请选择操作'));
-  fireEvent.click(await findByText('等于'));
   fireEvent.click(container.querySelector('.cxd-Switch')!);
 
   await wait(200);
@@ -810,7 +794,7 @@ test('Renderer:condition-builder with not embed', async () => {
   fireEvent.click(await findByText('添加条件'));
   fireEvent.click(await findByText('请选择字段'));
   fireEvent.click(await findByText('日期测试'));
-  fireEvent.click(await findByText('请选择操作'));
+  fireEvent.click(await findByText('等于'));
   fireEvent.click(await findByText('不属于范围'));
 
   expect(


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b2f5916</samp>

This pull request adds a feature to the condition builder component that automatically selects a default operator for each field type when creating a condition. It introduces a `defaultOp` property to the field and type configurations in `config.ts` and uses it in the `handleLeftChange` method of `Item.tsx`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b2f5916</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever way to update the condition builder's logic,_
> _And made the operator match the field and type selected,_
> _As easily as Zeus wields his thunderbolts in battle._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b2f5916</samp>

*  Add `defaultOp` property to various field type configurations in `defaultConfig` object, which specifies the operator to use by default for each type ([link](https://github.com/baidu/amis/pull/8914/files?diff=unified&w=0#diff-812ea7249a25ef1a0230a90bfb013a246853b76c6da88b6de11ccebefb38c683R64), [link](https://github.com/baidu/amis/pull/8914/files?diff=unified&w=0#diff-812ea7249a25ef1a0230a90bfb013a246853b76c6da88b6de11ccebefb38c683R79), [link](https://github.com/baidu/amis/pull/8914/files?diff=unified&w=0#diff-812ea7249a25ef1a0230a90bfb013a246853b76c6da88b6de11ccebefb38c683R95), [link](https://github.com/baidu/amis/pull/8914/files?diff=unified&w=0#diff-812ea7249a25ef1a0230a90bfb013a246853b76c6da88b6de11ccebefb38c683R111), [link](https://github.com/baidu/amis/pull/8914/files?diff=unified&w=0#diff-812ea7249a25ef1a0230a90bfb013a246853b76c6da88b6de11ccebefb38c683R127), [link](https://github.com/baidu/amis/pull/8914/files?diff=unified&w=0#diff-812ea7249a25ef1a0230a90bfb013a246853b76c6da88b6de11ccebefb38c683R138))
*  Update `handleLeftChange` method of `ConditionItem` component to get the default operator based on the selected field and its type, and set it as the value of `op` state ([link](https://github.com/baidu/amis/pull/8914/files?diff=unified&w=0#diff-bd3cef1dd1adf5cbac8db6825eccda213b5450966cc365712f22a32093048fc6L83-R92))
