### PR TITLE
perf: patch 逻辑改成批量处理提高性能

### DIFF
--- a/packages/amis-editor-core/src/manager.ts
+++ b/packages/amis-editor-core/src/manager.ts
@@ -1759,6 +1759,7 @@ export class EditorManager {
     }
     this.patching = true;
     this.patchingInvalid = false;
+    const batch: Array<{id: string; value: any}> = [];
     let patchList = (list: Array<EditorNodeType>) => {
       // 深度优先
       list.forEach((node: EditorNodeType) => {
@@ -1767,12 +1768,15 @@ export class EditorManager {
         }
 
         if (isAlive(node) && !node.isRegion) {
-          node.patch(this.store, force);
+          node.patch(this.store, force, (id, value) =>
+            batch.unshift({id, value})
+          );
         }
       });
     };
 
     patchList(this.store.root.children);
+    this.store.batchChangeValue(batch);
     this.patching = false;
     this.patchingInvalid && this.patchSchema(force);
   }

--- a/packages/amis-editor-core/src/store/node.ts
+++ b/packages/amis-editor-core/src/store/node.ts
@@ -629,7 +629,11 @@ export const EditorNode = types
         self.folded = !self.folded;
       },
 
-      patch(store: any, force = false) {
+      patch(
+        store: any,
+        force = false,
+        setPatchInfo?: (id: string, value: any) => void
+      ) {
         // 避免重复 patch
         if (self.patched && !force) {
           return;
@@ -675,13 +679,9 @@ export const EditorNode = types
           ) || patched;
 
         if (patched !== schema) {
-          root.changeValueById(
-            info.id,
-            JSONPipeIn(patched),
-            undefined,
-            true,
-            true
-          );
+          setPatchInfo
+            ? setPatchInfo(info.id, patched)
+            : root.changeValueById(info.id, patched, undefined, true, true);
         }
       },
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4651e65</samp>

This pull request enhances the editor functionality of `amis` by implementing a batch update mechanism for the editor nodes and the store schema. It modifies the `manager.ts`, `editor.ts`, and `node.ts` files in the `amis-editor-core` package to use a `batch` array, a `debounce` function, and a callback function to improve the performance and stability of the editor.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4651e65</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A batch update mechanism for the editor nodes,_
> _And stored the patch information in a `batch` array,_
> _To change the store schema with one swift stroke._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4651e65</samp>

*  Add a `batchChangeValue` method to the `MainStore` class to update the store schema in a batch with an array of objects with `id` and `value` properties ([link](https://github.com/baidu/amis/pull/8915/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8R1455-R1463))
* Modify the `EditorManager` class to use a `batch` array to collect the patch information of the editor nodes that need to be updated in the store schema ([link](https://github.com/baidu/amis/pull/8915/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fR1762))
* Modify the `patch` method of the `EditorNode` class to accept an optional callback function that receives the `id` and `value` of the patched node ([link](https://github.com/baidu/amis/pull/8915/files?diff=unified&w=0#diff-1a3d36eaf488e63b9e3aebc1811961232c7753524abb132e24d8ab51952e9fb6L632-R636))
* Modify the `node.patch` method call in the `EditorManager` class to pass a callback function that pushes the `id` and `value` of the patched node to the `batch` array ([link](https://github.com/baidu/amis/pull/8915/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fL1770-R1773))
* Call the `store.batchChangeValue` method with the `batch` array as an argument in the `EditorManager` class to apply the patch information of the nodes to the store schema in a batch ([link](https://github.com/baidu/amis/pull/8915/files?diff=unified&w=0#diff-28cf2319eba660f9dee469af69e873284c2d4591f12ebc24127d33219a43887fR1779))
* Import the `debounce` function from the `lodash` library and define a `lazyUpdateTargetName` method as a debounced version of the `updateTargetName` method in the `MainStore` class ([link](https://github.com/baidu/amis/pull/8915/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8R57), [link](https://github.com/baidu/amis/pull/8915/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8R1047-R1055))
* Replace the direct calls of the `updateTargetName` method with the `lazyUpdateTargetName` method in the `MainStore` class to delay the update of the target name when the schema is changed by the `reset`, `changeValueById`, `undo`, or `redo` methods ([link](https://github.com/baidu/amis/pull/8915/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8L1125-R1135), [link](https://github.com/baidu/amis/pull/8915/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8L1821-R1840), [link](https://github.com/baidu/amis/pull/8915/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8L1833-R1852), [link](https://github.com/baidu/amis/pull/8915/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8L1846-R1865))
* Add a `beforeDestroy` method to the `MainStore` class to cancel the `lazyUpdateTargetName` method if it is pending ([link](https://github.com/baidu/amis/pull/8915/files?diff=unified&w=0#diff-6e58da73b3bf4b51fa3b9e1ad11644fc35aa474ba939005c60bdc794bee5b5e8R1953-R1956))
