### PR TITLE
feat: table支持行点击时不勾选 Close #8220

### DIFF
--- a/docs/zh-CN/components/table.md
+++ b/docs/zh-CN/components/table.md
@@ -2272,6 +2272,7 @@ popOver 的其它配置请参考 [popover](./popover)
         {
             "type": "table",
             "source": "$rows",
+            "selectable": true,
             "onEvent": {
                 "rowClick": {
                     "actions": [

--- a/packages/amis/src/renderers/Table/TableRow.tsx
+++ b/packages/amis/src/renderers/Table/TableRow.tsx
@@ -92,8 +92,15 @@ export class TableRow extends React.PureComponent<
     e.preventDefault();
     e.stopPropagation();
 
-    const {itemAction, onAction, item, itemIndex, onCheck, onRowClick} =
-      this.props;
+    const {
+      itemAction,
+      onAction,
+      item,
+      itemIndex,
+      onCheck,
+      onRowClick,
+      checkOnItemClick
+    } = this.props;
 
     const rendererEvent = await onRowClick?.(item?.data, itemIndex);
 
@@ -105,7 +112,7 @@ export class TableRow extends React.PureComponent<
       onAction && onAction(e, itemAction, item?.locals);
       // item.toggle();
     } else {
-      if (item.checkable && item.isCheckAvaiableOnClick) {
+      if (item.checkable && item.isCheckAvaiableOnClick && checkOnItemClick) {
         onCheck?.(item, !item.checked, shiftKey);
       }
     }


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9a787d2</samp>

This pull request adds a new feature to the `Table` component and its schema that allows the user to select rows by clicking on them or using the checkbox column. It also adds a new property `checkOnItemClick` that controls whether clicking on a row also toggles its checkbox state. The changes affect the files `TableRow.tsx`, `table.md`, and `index.tsx`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9a787d2</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A new feature for the `Table` component, that wise_
> _And versatile tool for displaying data rows_
> _With various options for selection and action flows._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9a787d2</samp>

*  Add new properties to table schema for row selection and checkbox toggling ([link](https://github.com/baidu/amis/pull/8916/files?diff=unified&w=0#diff-8a30381c7717a1ae36bd67d653324e6d01991200c0a2f1a0124f1e753d0cf380R2275-R2276))
*  Set default value of `checkOnItemClick` to `true` in `Table` component ([link](https://github.com/baidu/amis/pull/8916/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2580-R2580))
*  Pass `checkOnItemClick` prop from `Table` to `TableRow` components ([link](https://github.com/baidu/amis/pull/8916/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2580-R2580), [link](https://github.com/baidu/amis/pull/8916/files?diff=unified&w=0#diff-43b60bad2b0604663fde07452d82b7576c0d07c3fea6c0a0d6d24a1dd3b82f49L95-R103))
*  Check `checkOnItemClick` prop before calling `onCheck` callback in `TableRow` component ([link](https://github.com/baidu/amis/pull/8916/files?diff=unified&w=0#diff-43b60bad2b0604663fde07452d82b7576c0d07c3fea6c0a0d6d24a1dd3b82f49L108-R115))
