### PR TITLE
feat: radios选项label支持schema渲染

### DIFF
--- a/packages/amis/__tests__/renderers/Form/radios.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/radios.test.tsx
@@ -4,6 +4,8 @@ import '../../../src';
 import {render as amisRender} from '../../../src';
 import {makeEnv, wait} from '../../helper';
 import {clearStoresCache} from '../../../src';
+import * as amisCore from 'amis-core';
+import RadiosControl from '../../../src/renderers/Form/Radios';
 
 afterEach(() => {
   cleanup();
@@ -191,4 +193,33 @@ test('Renderer:radios with boolean value', async () => {
     expect(onSubmit).toBeCalledTimes(2);
   });
   expect(onSubmit.mock.calls[1][0].radios).toEqual(false);
+});
+
+describe('renderLabel', () => {
+  test('传入的字符串,使用filter函数处理,以支持数据解析', () => {
+    const spyFilter = jest.spyOn(amisCore, 'filter');
+
+    const radioComponent = new RadiosControl({data: {num: 1}} as any);
+
+    radioComponent.renderLabel(
+      {label: 'options${num}', value: 1},
+      {labelField: 'label'}
+    );
+
+    expect(spyFilter).toBeCalledTimes(1);
+    expect(spyFilter).toBeCalledWith('options${num}', {num: 1});
+  });
+
+  test('传入的对象,使用render函数处理,以支持schema渲染', () => {
+    const mockRender = jest.fn();
+    const radioComponent = new RadiosControl({render: mockRender} as any);
+
+    radioComponent.renderLabel(
+      {label: {type: 'tpl', tpl: 'option1'} as any, value: 1},
+      {labelField: 'label'}
+    );
+
+    expect(mockRender).toBeCalledTimes(1);
+    expect(mockRender).toBeCalledWith('label', {type: 'tpl', tpl: 'option1'});
+  });
 });

--- a/packages/amis/src/renderers/Form/Radios.tsx
+++ b/packages/amis/src/renderers/Form/Radios.tsx
@@ -95,9 +95,15 @@ export default class RadiosControl extends React.Component<RadiosProps, any> {
 
   @autobind
   renderLabel(option: Option, {labelField}: any) {
-    const {data} = this.props;
+    const {data, render} = this.props;
     const label = option[labelField || 'label'];
-    return <>{typeof label === 'string' ? filter(label, data) : `${label}`}</>;
+    return (
+      <>
+        {typeof label === 'string'
+          ? filter(label, data)
+          : render('label', label)}
+      </>
+    );
   }
 
   @supportStatic()


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2c97600</samp>

Added schema-based rendering for radio labels in `Radios` component. Changed the `label` type in `Option` interface and updated the `renderLabel` method and the tests accordingly.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2c97600</samp>

> _Oh we're the coders of the `Radios` component_
> _We make the labels render as we want_
> _With `Schema` objects or with strings_
> _We use the `render` function and we sing_

### Why

<!-- author to complete -->

form表单项的label可以支持schema渲染,但是radios的选项却不支持,字符串作为选项显示值,无法满足一些复杂的场景需要.比如下图,想要将选项显示为图标

<img width="355" alt="image" src="https://github.com/baidu/amis/assets/30344590/c0dd658a-f7a6-4514-ad48-540d17c6c343">


### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2c97600</samp>

*  Allow schema-based rendering for radio option labels ([link](https://github.com/baidu/amis/pull/8924/files?diff=unified&w=0#diff-9795a06699f88c4c144fccb14b9ddca83b8d9639d2062c27b01495b6b80e7d7dL10-R10), [link](https://github.com/baidu/amis/pull/8924/files?diff=unified&w=0#diff-7af4a50302b318914d60e122239cc961e42f402e8829480a99caf6f54bfcd9e6L98-R106))
  - Change the `label` property of the `Option` interface to accept either a string or a `Schema` object ([link](https://github.com/baidu/amis/pull/8924/files?diff=unified&w=0#diff-9795a06699f88c4c144fccb14b9ddca83b8d9639d2062c27b01495b6b80e7d7dL10-R10))
  - Modify the `renderLabel` method of the `RadiosControl` component to use the `render` function from the props when the label is a schema object ([link](https://github.com/baidu/amis/pull/8924/files?diff=unified&w=0#diff-7af4a50302b318914d60e122239cc961e42f402e8829480a99caf6f54bfcd9e6L98-R106))
* Add test cases for the `renderLabel` method of the `RadiosControl` component ([link](https://github.com/baidu/amis/pull/8924/files?diff=unified&w=0#diff-fd31da61b3ca73aa7c275c57c4f58390da5ef90df0d3abd806f4e9c1642ce090R7-R8), [link](https://github.com/baidu/amis/pull/8924/files?diff=unified&w=0#diff-fd31da61b3ca73aa7c275c57c4f58390da5ef90df0d3abd806f4e9c1642ce090R197-R225))
  - Import the `amis-core` module and the `RadiosControl` component in the test file `radios.test.tsx` ([link](https://github.com/baidu/amis/pull/8924/files?diff=unified&w=0#diff-fd31da61b3ca73aa7c275c57c4f58390da5ef90df0d3abd806f4e9c1642ce090R7-R8))
  - Check that the `filter` function is called with the correct arguments when the label is a string with data interpolation ([link](https://github.com/baidu/amis/pull/8924/files?diff=unified&w=0#diff-fd31da61b3ca73aa7c275c57c4f58390da5ef90df0d3abd806f4e9c1642ce090R197-R225))
  - Check that the `render` function is called with the correct arguments when the label is a schema object ([link](https://github.com/baidu/amis/pull/8924/files?diff=unified&w=0#diff-fd31da61b3ca73aa7c275c57c4f58390da5ef90df0d3abd806f4e9c1642ce090R197-R225))
