### PR TITLE
feat: 同步pagemaker分支一些editor的提交

### DIFF
--- a/packages/amis-editor-core/src/component/SubEditor.tsx
+++ b/packages/amis-editor-core/src/component/SubEditor.tsx
@@ -181,9 +181,10 @@ export class SubEditor extends React.Component<SubEditorProps> {
                       }
                       return;
                     }}
-                    getHostNodeDataSchema={() =>
-                      manager.getContextSchemas(manager.store.activeId)
-                    }
+                    getHostNodeDataSchema={async () => {
+                      await manager.getContextSchemas(manager.store.activeId);
+                      return manager.dataSchema;
+                    }}
                   />
                 )
               }

--- a/packages/amis-editor/src/plugin/Form/ListSelect.tsx
+++ b/packages/amis-editor/src/plugin/Form/ListSelect.tsx
@@ -55,6 +55,8 @@ export class ListControlPlugin extends BasePlugin {
 
   panelTitle = '列表选择';
 
+  panelJustify = true;
+
   // 事件定义
   events: RendererPluginEvent[] = [
     {
@@ -119,8 +121,11 @@ export class ListControlPlugin extends BasePlugin {
             getSchemaTpl('multiple'),
             getSchemaTpl('extractValue'),
             getSchemaTpl('valueFormula', {
-              rendererSchema: (schema: Schema) => schema,
-              mode: 'vertical',
+              // 边栏渲染不渲染自定义样式，会干扰css生成
+              rendererSchema: (schema: Schema) => ({
+                ...(schema || {}),
+                itemSchema: null
+              }),
               useSelectMode: true, // 改用 Select 设置模式
               visibleOn: 'this.options && this.options.length > 0'
             })

--- a/packages/amis-editor/src/renderer/ExpressionFormulaControl.tsx
+++ b/packages/amis-editor/src/renderer/ExpressionFormulaControl.tsx
@@ -113,7 +113,7 @@ export default class ExpressionFormulaControl extends React.Component<
   handleClearExpression(e: React.MouseEvent<HTMLElement>) {
     e.stopPropagation();
     e.preventDefault();
-    this.props?.onChange?.('');
+    this.props?.onChange?.(undefined);
   }
 
   @autobind

--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -168,6 +168,7 @@ setSchemaTpl('formItemInline', {
   label: '表单项内联',
   name: 'inline',
   visibleOn: 'data.mode != "inline"',
+  inputClassName: 'is-inline',
   pipeIn: defaultValue(false)
   // onChange: (value:any, origin:any, item:any, form:any) => form.getValueByName('size') === "full" && form.setValueByName('')
 });

--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -7,7 +7,7 @@ import {
   EditorManager
 } from 'amis-editor-core';
 import type {DSField} from 'amis-editor-core';
-import type {SchemaObject} from 'amis';
+import type {SchemaObject, Schema} from 'amis';
 import flatten from 'lodash/flatten';
 import {InputComponentName} from '../component/InputComponentName';
 import {FormulaDateType} from '../renderer/FormulaControl';
@@ -450,11 +450,18 @@ setSchemaTpl(
     } = config || {};
     let curRendererSchema = rendererSchema;
 
-    if (useSelectMode && curRendererSchema && curRendererSchema.options) {
-      curRendererSchema = {
-        ...curRendererSchema,
-        type: 'select'
-      };
+    if (useSelectMode && curRendererSchema) {
+      if (typeof curRendererSchema === 'function') {
+        curRendererSchema = (schema: Schema) => ({
+          ...rendererSchema(schema),
+          type: 'select'
+        });
+      } else if (curRendererSchema.options) {
+        curRendererSchema = {
+          ...curRendererSchema,
+          type: 'select'
+        };
+      }
     }
 
     return {

--- a/packages/amis-ui/scss/components/form/_select.scss
+++ b/packages/amis-ui/scss/components/form/_select.scss
@@ -664,3 +664,27 @@
     }
   }
 }
+
+// 下拉框在弹框中的的时候没有select层，所以把这部分单独提出来
+.#{$ns}PopOver.#{$ns}Select-popover {
+  &.#{$ns}PopOver--v-top {
+    margin-top: px2rem(4px);
+  }
+  &.#{$ns}PopOver--v-bottom {
+    margin-bottom: px2rem(4px);
+  }
+  .#{$ns}Select-menu {
+    .#{$ns}Checkbox span {
+      line-height: var(--select-base-default-option-line-height);
+      height: var(--select-base-default-option-line-height);
+    }
+    .#{$ns}Select-option {
+      line-height: var(--select-base-default-option-line-height);
+      height: var(--select-base-default-option-line-height);
+    }
+    .#{$ns}Select-addBtn {
+      line-height: var(--select-base-default-option-line-height);
+      height: var(--select-base-default-option-line-height);
+    }
+  }
+}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c4f72a9</samp>

This pull request enhances the list select component in the amis-editor plugin by adding a panel layout option, fixing some bugs, and improving the schema templates and the variable selection. It also improves the UI design of the select popover in a dialog. It modifies the files `ListSelect.tsx`, `common.tsx`, `SubEditor.tsx`, `util.ts`, `ExpressionFormulaControl.tsx`, and `_select.scss`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c4f72a9</samp>

> _We are the masters of the list select_
> _We control the schema and the context_
> _We fix the bugs and enhance the style_
> _We unleash the power of the amis-editor_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c4f72a9</samp>

* Fix a bug where the sub editor does not get the correct data schema from the host node when editing a list select component ([link](https://github.com/baidu/amis/pull/8926/files?diff=unified&w=0#diff-6d734e24dd983184fd036bb62cec9ac5cf70a17ffd14cd375cb0d98c494b7008L184-R187))
  - Handling the case where the manager is in sub editor mode and needs to get the host node variables and the parent editor context variables ([link](https://github.com/baidu/amis/pull/8926/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL1152-R1196))
  - Filtering out the item schema from the renderer schema to avoid rendering custom styles in the sidebar ([link](https://github.com/baidu/amis/pull/8926/files?diff=unified&w=0#diff-f14e68bb630f7a038ec628fe3d5ad444f30cafde6423fd4b66fec57d1026787aL1152-R1196), [link](https://github.com/baidu/amis/pull/8926/files?diff=unified&w=0#diff-235237c89adc972d4bf87380300ca947a5a5de87d01b59c1bff98b4c95fa6f27L122-R128), [link](https://github.com/baidu/amis/pull/8926/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05L453-R465))
  - Using the `rendererSchema` function to remove the item schema from the schema object in the `valueFormula` schema template ([link](https://github.com/baidu/amis/pull/8926/files?diff=unified&w=0#diff-235237c89adc972d4bf87380300ca947a5a5de87d01b59c1bff98b4c95fa6f27L122-R128), [link](https://github.com/baidu/amis/pull/8926/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05L453-R465))
  - Passing `undefined` instead of `''` to the `onChange` prop when clearing the value formula ([link](https://github.com/baidu/amis/pull/8926/files?diff=unified&w=0#diff-e7b608c2a49667045406924c258ea5ef7330193663db19e986a8669dd2bebe06L116-R116))
* Make the list select component use the panel layout for the options instead of the inline layout by adding a `panelJustify` property to the `ListControlPlugin` class and setting it to true ([link](https://github.com/baidu/amis/pull/8926/files?diff=unified&w=0#diff-235237c89adc972d4bf87380300ca947a5a5de87d01b59c1bff98b4c95fa6f27R58-R59))
* Style the select popover when it is used in a dialog by adding some CSS rules to the `_select.scss` file ([link](https://github.com/baidu/amis/pull/8926/files?diff=unified&w=0#diff-76523bcea8a2970bd9ef0d5aad600399861a30059dd8da81137c0923f5eb6d07R667-R690))
* Make the name input field in the sidebar use the inline style instead of the default style by adding an `inputClassName` property to the `name` schema template and setting it to `is-inline` ([link](https://github.com/baidu/amis/pull/8926/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05R171))
* Add the `Schema` type to the import statement in `common.tsx` to use it as a parameter for the `rendererSchema` function ([link](https://github.com/baidu/amis/pull/8926/files?diff=unified&w=0#diff-a4359e1efbe3c320ab402ee14a9fa73386e3da07b3f27049dcbc13a91c314c05L10-R10))
