### PR TITLE
fix(amis): 搜索组件功能失效问题修复

### DIFF
--- a/packages/amis/src/renderers/SearchBox.tsx
+++ b/packages/amis/src/renderers/SearchBox.tsx
@@ -188,6 +188,7 @@ export class SearchBoxRenderer extends React.Component<
     const {
       data,
       name,
+      disabled,
       onQuery: onQuery,
       mini,
       enhance,
@@ -208,7 +209,8 @@ export class SearchBoxRenderer extends React.Component<
         className={className}
         style={style}
         name={name}
-        disabled={!onQuery}
+        // disabled={!onQuery}
+        disabled={disabled}
         defaultActive={!!value}
         defaultValue={onChange ? undefined : value}
         value={value}

--- a/packages/amis/src/renderers/SearchBox.tsx
+++ b/packages/amis/src/renderers/SearchBox.tsx
@@ -180,7 +180,7 @@ export class SearchBoxRenderer extends React.Component<
   }
   setData(value: any) {
     if (typeof value === 'string') {
-      this.setState({value});
+      this.handleChange(value);
     }
   }
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7b3994b</samp>

Add `disabled` prop for `SearchBoxRenderer` component. This allows the user to control the search box's availability without affecting the query logic.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7b3994b</samp>

> _No escape from the doom of the `SearchBoxRenderer`_
> _You can't hide your query from its dark power_
> _Only the `disabled` prop can save you from its wrath_
> _But beware, it may unleash a new horror_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7b3994b</samp>

* Add a new prop `disabled` to the `SearchBoxRenderer` class to control the search box state ([link](https://github.com/baidu/amis/pull/8927/files?diff=unified&w=0#diff-31f99d01c6fce6b476f0823ef31ddbb20eebd2f4d78e5680f4fa9b2449a87afaR191))
* Use the `disabled` prop instead of the `onQuery` prop to disable the search box in the `SearchBox` component ([link](https://github.com/baidu/amis/pull/8927/files?diff=unified&w=0#diff-31f99d01c6fce6b476f0823ef31ddbb20eebd2f4d78e5680f4fa9b2449a87afaL211-R213))
