### PR TITLE
fix: Select组件开启autoComplete后请求竞态问题 Close: #8817

### DIFF
--- a/docs/zh-CN/components/form/select.md
+++ b/docs/zh-CN/components/form/select.md
@@ -1199,7 +1199,7 @@ leftOptions 动态加载，默认 source 接口是返回 options 部分，而 le
             "name": "select1",
             "type": "select",
             "label": "选项自动补全（单选）",
-            "autoComplete": "/api/mock2/options/autoComplete?term=${term}",
+            "autoComplete": "/api/mock2/options/autoComplete3?delay=true&term=${term}",
             "placeholder": "请输入",
             "clearable": true
         },

--- a/mock/cfc/mock/options/autoComplete3.js
+++ b/mock/cfc/mock/options/autoComplete3.js
@@ -1,0 +1,60 @@
+/**
+ * @file 请求随机延迟的模拟接口
+ */
+
+function generateRandomNames(num) {
+  const candidate = ['Alice', 'Bob', 'Charlie', 'David', 'Eve', 'Frank', 'Grace', 'Heidi', 'Ivan', 'Judy', 'Mike', 'Nina', 'Oliver', 'Polly', 'Queenie', 'Randy', 'Sybil', 'Trudy', 'Victor', 'Wendy', 'Xander', 'Yvonne', 'Zoe'];
+  const randomNames = [];
+
+  for (let i = 0; i < num; i++) {
+      const randomIndex = Math.floor(Math.random() * candidate.length);
+      randomNames.push(candidate[randomIndex]);
+  }
+
+  return [...new Set(randomNames)].map(i => ({ value: i, label: i }));
+}
+
+function generateRandomDelay() {
+  const timeout = [0, 200, 500, 700, 1000, 2000];
+
+  const randomDelay = [];
+  for (let i = 0; i < timeout.length; i++) {
+      const randomIndex = Math.floor(Math.random() * timeout.length);
+      randomDelay.push(timeout[randomIndex]);
+  }
+
+  return randomDelay[0];
+}
+
+function isPositiveInteger(input) {
+  var pattern = /^\d+$/;
+  return pattern.test(input);
+}
+
+module.exports = function (req, res) {
+  const labelField = req.query.labelField || 'label';
+  const valueField = req.query.valueField || 'value';
+  const term = req.query.term || '';
+  const useDelay = req.query.delay || false;
+  const total = isPositiveInteger(Number(req.query.total)) ? Number(req.query.total) : 20;
+  const list = generateRandomNames(total).map(item => ({[labelField]: item.label, [valueField]: item.value}));
+  const delay = generateRandomDelay();
+
+  const responseWrapper = () => {
+    res.json({
+      status: 0,
+      msg: '',
+      data: term
+        ? list.filter(function (item) {
+            return term ? ~item.label.toLowerCase().indexOf(term.toLowerCase()) : false;
+          })
+        : list
+    });
+  }
+
+  if (useDelay) {
+    return setTimeout(responseWrapper, delay);
+  }
+
+  return responseWrapper();
+};

--- a/packages/amis/src/renderers/Form/NestedSelect.tsx
+++ b/packages/amis/src/renderers/Form/NestedSelect.tsx
@@ -931,7 +931,6 @@ export default class NestedSelectControl extends React.Component<
       translate: __,
       inline,
       searchable,
-      autoComplete,
       selectedOptions,
       clearable,
       loading,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4c16138</samp>

This pull request adds a feature to the `Select` component that allows it to cancel outdated `autoComplete` requests and show a loading spinner when fetching options. It also improves the performance and reliability of the `WithRemoteConfig` component by canceling previous requests when loading remote configuration. The documentation and the mock api are updated accordingly. The `autoComplete` prop is removed from the `NestedSelect` component as it is not used and causes conflicts.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4c16138</samp>

> _Sing, O Muse, of the skillful coder who enhanced the Select component_
> _With the power to cancel outdated requests, like swift-footed Achilles_
> _Who chased the Trojans back to their walls, leaving behind his enemies_
> _And showing a spinner to the user, as bright as the shield of Athena._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4c16138</samp>

*  Implement canceling outdated requests and showing loading spinner for `autoComplete` prop in `Select` component ([link](https://github.com/baidu/amis/pull/8931/files?diff=unified&w=0#diff-c7760ca9aa73a2f50ab38d37db37be041410cbe37e16009b875be388d452ca31L3-R25),[link](https://github.com/baidu/amis/pull/8931/files?diff=unified&w=0#diff-c7760ca9aa73a2f50ab38d37db37be041410cbe37e16009b875be388d452ca31L194-R193),[link](https://github.com/baidu/amis/pull/8931/files?diff=unified&w=0#diff-c7760ca9aa73a2f50ab38d37db37be041410cbe37e16009b875be388d452ca31R218),[link](https://github.com/baidu/amis/pull/8931/files?diff=unified&w=0#diff-c7760ca9aa73a2f50ab38d37db37be041410cbe37e16009b875be388d452ca31R327-R328),[link](https://github.com/baidu/amis/pull/8931/files?diff=unified&w=0#diff-c7760ca9aa73a2f50ab38d37db37be041410cbe37e16009b875be388d452ca31L359-R376))
*  Apply the same feature to `WithRemoteConfig` component by adding `fetchCancel` variable and logic to `Store` model ([link](https://github.com/baidu/amis/pull/8931/files?diff=unified&w=0#diff-602aa42ab34a4a248db44b9b79423e2b319cf4a1b6c8de867a96b4fee67546c1R35),[link](https://github.com/baidu/amis/pull/8931/files?diff=unified&w=0#diff-602aa42ab34a4a248db44b9b79423e2b319cf4a1b6c8de867a96b4fee67546c1L43-R59))
*  Remove unused and conflicting `autoComplete` prop from `NestedSelect` component ([link](https://github.com/baidu/amis/pull/8931/files?diff=unified&w=0#diff-f309d4145f48da794e456b3afef7d6b0828cd1e0eade591d3ab27ae896bb5565L934))
*  Fix typo in `debounce` function name ([link](https://github.com/baidu/amis/pull/8931/files?diff=unified&w=0#diff-c7760ca9aa73a2f50ab38d37db37be041410cbe37e16009b875be388d452ca31L194-R193))
*  Reorder and group import statements by source in `Select` component ([link](https://github.com/baidu/amis/pull/8931/files?diff=unified&w=0#diff-c7760ca9aa73a2f50ab38d37db37be041410cbe37e16009b875be388d452ca31L3-R25))
*  Remove empty line in `WithRemoteConfig` component ([link](https://github.com/baidu/amis/pull/8931/files?diff=unified&w=0#diff-602aa42ab34a4a248db44b9b79423e2b319cf4a1b6c8de867a96b4fee67546c1L205))
*  Add mock api for `autoComplete3` that simulates random delay and names ([link](https://github.com/baidu/amis/pull/8931/files?diff=unified&w=0#diff-a03013f8dd985246f9e6b645d61f176f5550ba0f7157ad93736f49f0a67f26ffR1-R60))
*  Change `autoComplete` api in example code of `select.md` to use the mock api ([link](https://github.com/baidu/amis/pull/8931/files?diff=unified&w=0#diff-94a1188a68526a3776f51b22744fd58d5e0fcfd01a9508579388cb1368c941e2L1202-R1202))
