### PR TITLE
fix: 修复 tinymce 粘贴出现死循环的问题

### DIFF
--- a/packages/amis-ui/src/components/Tinymce.tsx
+++ b/packages/amis-ui/src/components/Tinymce.tsx
@@ -80,7 +80,8 @@ export default class TinymceEditor extends React.Component<TinymceEditorProps> {
       props.model !== prevProps.model &&
       props.model !== this.currentContent
     ) {
-      this.editorInitialized && this.editor?.setContent(props.model || '');
+      this.editorInitialized &&
+        this.editor?.setContent((this.currentContent = props.model || ''));
     }
 
     if (this.props.config !== prevProps.config) {
@@ -197,7 +198,7 @@ export default class TinymceEditor extends React.Component<TinymceEditorProps> {
     const {model, onModelChange, outputFormat, onFocus, onBlur} = this.props;
 
     const value = model || '';
-    editor.setContent(value);
+    editor.setContent((this.currentContent = value));
 
     if (onModelChange) {
       editor.on('change keyup setcontent', (e: any) => {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 21b7a73</samp>

This pull request fixes a bug in the `Tinymce` component that could cause data inconsistency between the editor and the model. It ensures that the `this.currentContent` property is always updated before setting the editor content.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 21b7a73</samp>

> _There once was a bug in `Tinymce`_
> _That caused the content to be out of sync_
> _To fix this issue_
> _They changed how they set `this.currentContent`_
> _And now the editor and the model match in a blink_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 21b7a73</samp>

*  Sync `this.currentContent` with editor content and props model to avoid unnecessary updates or discrepancies ([link](https://github.com/baidu/amis/pull/8938/files?diff=unified&w=0#diff-d6c65c2dcd820338178339a1d3f5272f5f7d2cfb02ba4977bdb04516544de8fbL83-R84), [link](https://github.com/baidu/amis/pull/8938/files?diff=unified&w=0#diff-d6c65c2dcd820338178339a1d3f5272f5f7d2cfb02ba4977bdb04516544de8fbL200-R201)) in `Tinymce.tsx`
