### PR TITLE
fix: 修复 frolaEditor 使用时可能出现死循环的问题

### DIFF
--- a/packages/amis-ui/src/components/RichText.tsx
+++ b/packages/amis-ui/src/components/RichText.tsx
@@ -244,8 +244,10 @@ class FroalaEditorComponent extends React.Component<FroalaEditorComponentProps> 
       modelContent = returnedHtml;
     }
 
-    this.oldModel = modelContent;
-    this.props.onModelChange(modelContent);
+    if (this.oldModel !== modelContent) {
+      this.oldModel = modelContent;
+      this.props.onModelChange(modelContent);
+    }
   }
 
   initListeners() {


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ae61a8d</samp>

Fix a bug in the Froala editor component that causes performance issues when editing rich text. Add a check for model content changes in `RichText.tsx` before triggering `onModelChange`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ae61a8d</samp>

> _`onModelChange` waits_
> _Only if content differs_
> _Autumn leaves don't fall_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ae61a8d</samp>

*  Prevent unnecessary re-rendering of Froala editor by checking model content ([link](https://github.com/baidu/amis/pull/8939/files?diff=unified&w=0#diff-d1c163fef540f545bcf929dda99f5afb3b0f2c9d14c184546e265d61914ab950L247-R250))
