### PR TITLE
fix: 文档错误

### DIFF
--- a/docs/zh-CN/concepts/event-action.md
+++ b/docs/zh-CN/concepts/event-action.md
@@ -1717,7 +1717,7 @@ run action ajax
 
 > 1.8.0 及以上版本
 
-通过配置`actionType: 'show'`或`'hidden'`或`'enabled'`或`'disabled'`或`'static'`或`'nostatic'`实现对指定组件的显示、隐藏、启用、禁用，仅支持实现了对应状态控制功能的数据`输入类`组件。
+通过配置`actionType: 'show'`或`'hidden'`或`'enabled'`或`'disabled'`或`'static'`或`'nonstatic'`实现对指定组件的显示、隐藏、启用、禁用，仅支持实现了对应状态控制功能的数据`输入类`组件。
 
 #### 显示与隐藏
 


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 215aaa3</samp>

Fixed a typo in the documentation of `actionType` property in `event-action.md`. Changed `nostatic` to `nonstatic` to reflect the correct value.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 215aaa3</samp>

> _`nostatic` no more_
> _`nonstatic` matches the code_
> _a typo falls like leaves_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 215aaa3</samp>

* Fix a typo in the documentation by changing `nostatic` to `nonstatic` in the `actionType` property value ([link](https://github.com/baidu/amis/pull/8943/files?diff=unified&w=0#diff-9802ca5a2390dc6e213b3d844669c50fb10948dad8ad72a0d360c886731fbd3dL1720-R1720))
