### PR TITLE
fix(amis-editor): 地理位置选择器细节调整

### DIFF
--- a/packages/amis-editor/src/plugin/Form/LocationPicker.tsx
+++ b/packages/amis-editor/src/plugin/Form/LocationPicker.tsx
@@ -165,7 +165,7 @@ export class LocationControlPlugin extends BasePlugin {
                   ),
                   size: 'lg',
                   mode: 'horizontal',
-                  required: true,
+                  // required: true, // 默认值不建议必填
                   placeholder: '请输入变量值'
                 }),
                 getSchemaTpl('switch', {
@@ -178,8 +178,8 @@ export class LocationControlPlugin extends BasePlugin {
                 getSchemaTpl('switch', {
                   name: 'onlySelectCurrentLoc',
                   label: tipedLabel(
-                    '只读模式',
-                    '开启后，只能使用当前地理位置，不可选择其他地理位置'
+                    '限制模式',
+                    '开启后，限制只能使用当前地理位置，不可选择其他地理位置'
                   )
                 }),
                 getSchemaTpl('clearable'),


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d97d412</samp>

This change improves the location picker plugin in the `amis-editor` by making the `value` field optional and renaming the `onlySelectCurrentLoc` field to better reflect its functionality.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d97d412</samp>

> _No more `required` value, we choose our own destiny_
> _We change the `label` of the field, we defy the tyranny_
> _We are the location pickers, we roam the land and sea_
> _We use the amis-editor, we unleash our creativity_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d97d412</samp>

* Change the label of the `onlySelectCurrentLoc` field to "限制模式" to match the amis documentation ([link](https://github.com/baidu/amis/pull/8945/files?diff=unified&w=0#diff-8534104c6d1ba261956979c0bdcf04ba4594d8487198264313dbcfe933cefa7eL181-R182))
* Remove the `required` property of the `value` field to allow using the default value without inputting a variable ([link](https://github.com/baidu/amis/pull/8945/files?diff=unified&w=0#diff-8534104c6d1ba261956979c0bdcf04ba4594d8487198264313dbcfe933cefa7eL168-R168))
