### PR TITLE
fix: 修复由#8822引入的crud多选问题

### DIFF
--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -1051,13 +1051,7 @@ export const TableStore = iRendererStore
         );
       }
 
-      if (config.multiple !== undefined) {
-        self.multiple = config.multiple;
-      } else {
-        // 如果通过crud或picker，multiple始终设置了true或false
-        // 如果仅使用table，默认multiple为true，但props未设置multiple的情况下其实是展示单选
-        self.multiple = false;
-      }
+      config.multiple !== undefined && (self.multiple = config.multiple);
       config.footable !== undefined && (self.footable = config.footable);
       config.expandConfig !== undefined &&
         (self.expandConfig = config.expandConfig);

--- a/packages/amis/__tests__/renderers/Table.test.tsx
+++ b/packages/amis/__tests__/renderers/Table.test.tsx
@@ -958,19 +958,7 @@ describe('Renderer:table selectable & itemCheckableOn', () => {
     ]
   };
 
-  test('radio style', async () => {
-    const {container} = render(amisRender(schema, {}, makeEnv({})));
-    await waitFor(() => {
-      expect(container.querySelector('[type=radio]')).toBeInTheDocument();
-    });
-
-    expect(
-      container.querySelector('[data-id="1"] [type=radio][disabled=""]')!
-    ).toBeInTheDocument();
-  });
-
   test('checkbox style', async () => {
-    schema.multiple = true;
     const {container} = render(amisRender(schema, {}, makeEnv({})));
     await waitFor(() => {
       expect(container.querySelector('[type=checkbox]')).toBeInTheDocument();
@@ -978,6 +966,18 @@ describe('Renderer:table selectable & itemCheckableOn', () => {
 
     expect(
       container.querySelector('[data-id="1"] [type=checkbox][disabled=""]')!
+    ).toBeInTheDocument();
+  });
+
+  test('radio style', async () => {
+    schema.multiple = false;
+    const {container} = render(amisRender(schema, {}, makeEnv({})));
+    await waitFor(() => {
+      expect(container.querySelector('[type=radio]')).toBeInTheDocument();
+    });
+
+    expect(
+      container.querySelector('[data-id="1"] [type=radio][disabled=""]')!
     ).toBeInTheDocument();
   });
 });

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -1764,8 +1764,6 @@ export default class Table extends React.Component<TableProps, object> {
       store,
       query,
       onQuery,
-      multiple,
-      env,
       render,
       classPrefix: ns,
       resizable,
@@ -1809,7 +1807,7 @@ export default class Table extends React.Component<TableProps, object> {
           style={style}
           className={cx(column.pristine.className, stickyClassName)}
         >
-          {store.rows.length && multiple ? (
+          {store.rows.length && store.multiple ? (
             <Checkbox
               classPrefix={ns}
               partial={store.someChecked && !store.allChecked}
@@ -2042,11 +2040,8 @@ export default class Table extends React.Component<TableProps, object> {
     const {
       render,
       store,
-      multiple,
       classPrefix: ns,
       classnames: cx,
-      checkOnItemClick,
-      popOverContainer,
       canAccessSuperData,
       itemBadge,
       translate
@@ -2062,7 +2057,7 @@ export default class Table extends React.Component<TableProps, object> {
         ignoreDrag={ignoreDrag}
         render={render}
         store={store}
-        multiple={multiple}
+        multiple={store.multiple}
         canAccessSuperData={canAccessSuperData}
         classnames={cx}
         classPrefix={ns}


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4eebfa3</samp>

This pull request refactors the table component and its related store and test files. It removes unnecessary props, simplifies the logic of the `multiple` property, and ensures consistency between the component and the store. It also updates the test cases to reflect the changes in the default `multiple` value.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4eebfa3</samp>

> _The table component was a mess_
> _With props that caused confusion and stress_
> _So they used `TableStore`_
> _To simplify the core_
> _And make the component do more with less_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4eebfa3</samp>

*  Simplify the logic of setting the `multiple` property of the `TableStore` by using a short-circuit assignment instead of an if-else statement ([link](https://github.com/baidu/amis/pull/8948/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1054-R1054))
*  Remove the `multiple` and `env` props from the `Table` component and use the `store.multiple` property instead ([link](https://github.com/baidu/amis/pull/8948/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1767-L1768), [link](https://github.com/baidu/amis/pull/8948/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL1812-R1810))
*  Remove the `multiple`, `checkOnItemClick`, and `popOverContainer` props from the `TableRow` component and use the `store.multiple` and `store.checkOnItemClick` properties instead ([link](https://github.com/baidu/amis/pull/8948/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2045-R2044), [link](https://github.com/baidu/amis/pull/8948/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL2065-R2060))
*  Swap the order of the test cases for the radio and checkbox styles of the `Table` component to match the default `multiple` value ([link](https://github.com/baidu/amis/pull/8948/files?diff=unified&w=0#diff-ab6375ec2ae128616c420f8f69f82b06b74a43ca22329f77f5246eb808368298L961-R980))
