### PR TITLE
fix(amis-editor): api中心类型的接口校验设置弹窗中含表达式的query等参数初次渲染不正确

### DIFF
--- a/packages/amis-editor/src/renderer/ValidationControl.tsx
+++ b/packages/amis-editor/src/renderer/ValidationControl.tsx
@@ -340,7 +340,6 @@ export default class ValidationControl extends React.Component<
           wrapperComponent: 'div',
           mode: 'horizontal',
           data: {
-            validateApi: this.props.data.validateApi,
             switchStatus: this.props.data.validateApi !== undefined
           },
           preventEnterSubmit: true,
@@ -369,6 +368,10 @@ export default class ValidationControl extends React.Component<
               className: 'ae-ExtendMore ae-ValidationControl-item-input',
               bodyClassName: 'w-full',
               visibleOn: 'this.switchStatus',
+              data: {
+                // 放在form中则包含的表达式会被求值
+                validateApi: this.props.data.validateApi
+              },
               body: [
                 getSchemaTpl('apiControl', {
                   name: 'validateApi',


### PR DESCRIPTION

![image](https://github.com/baidu/amis/assets/92133492/ffdd81a3-4bba-4897-81c3-51b6412e742f)


### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0fb2f27</samp>

Simplify validation logic for `SchemaApi` component in `amis-editor`. Remove `validateApi` prop and use extra data to avoid double evaluation.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0fb2f27</samp>

> _`validateApi` gone_
> _Extra data simplifies_
> _Validation in spring_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0fb2f27</samp>

*  Remove `validateApi` prop from `SchemaApi` component to avoid double evaluation of expression ([link](https://github.com/baidu/amis/pull/8950/files?diff=unified&w=0#diff-1845950896a98c0d1091a85a09550577f5dd9da74fcdf7fb004643fbbf003298L343))
*  Pass `validateApi` prop as part of `data` prop to `SchemaApi` component to enable API request with extra data ([link](https://github.com/baidu/amis/pull/8950/files?diff=unified&w=0#diff-1845950896a98c0d1091a85a09550577f5dd9da74fcdf7fb004643fbbf003298R371-R374))
