### PR TITLE
fix: 刷新表格时，清空表格行状态，例如switch选中、select选中等 

### DIFF
--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -703,6 +703,10 @@ export default class Table extends React.Component<TableProps, object> {
     if (updateRows) {
       store.initRows(rows, props.getEntryId, props.reUseRow);
     } else if (props.reUseRow === false) {
+    /**
+     * 在reUseRow为false情况下，支持强制刷新表格行状态
+     * 适用的情况：用户每次刷新，调用接口，返回的数据都是一样的，导致updateRows为false，故针对每次返回数据一致的情况，需要强制表格更新
+     */
       updateRows = true;
       store.initRows(value, props.getEntryId, props.reUseRow);
     }

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -700,7 +700,13 @@ export default class Table extends React.Component<TableProps, object> {
       }
     }
 
-    updateRows && store.initRows(rows, props.getEntryId, props.reUseRow);
+    if (updateRows) {
+      store.initRows(rows, props.getEntryId, props.reUseRow);
+    } else if (props.reUseRow === false) {
+      updateRows = true;
+      store.initRows(value, props.getEntryId, props.reUseRow);
+    }
+
     Array.isArray(props.selected) &&
       store.updateSelected(props.selected, props.valueField);
     return updateRows;


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 64a06fd</samp>

Fixed a table data update bug and improved performance by refactoring the `TableStore` class and the `Table` component. Added a new `getRows` function to create and compare row objects in `packages/amis-core/src/store/table.ts` and `packages/amis/src/renderers/Table/index.tsx`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 64a06fd</samp>

> _`Table` component_
> _uses `getRows` to fix bug_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 64a06fd</samp>

*  Refactor `initRows` function in `TableStore` class to extract `getRows` function that returns row objects based on input rows and `getEntryId` function ([link](https://github.com/baidu/amis/pull/8951/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1387-R1390), [link](https://github.com/baidu/amis/pull/8951/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cL1437-R1445))
* Add `getRows` function to the list of actions that can be invoked on `TableStore` instance to expose it to other components or modules ([link](https://github.com/baidu/amis/pull/8951/files?diff=unified&w=0#diff-ae98aab16ce6e5aab35f5adf3debffd7a84d243bf69a51f82c78e6ea57ef0a2cR1895))
* Use `getRows` function in `Table` component to compare input value with current rows and update table data if needed ([link](https://github.com/baidu/amis/pull/8951/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL703-R715))
