### PR TITLE
fix: 修复picker中headerToolbar表单项默认值显示问题

### DIFF
--- a/packages/amis-core/src/WithStore.tsx
+++ b/packages/amis-core/src/WithStore.tsx
@@ -270,7 +270,7 @@ export function HocStoreFactory(renderer: {
                   props.store?.storeType === 'ComboStore'
                   ? undefined
                   : syncDataFromSuper(
-                      props.data,
+                      {...store.data, ...props.data},
                       (props.data as any).__super,
                       (prevProps.data as any).__super,
                       store,


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1b8c4bd</samp>

Fix store data update bug in `WithStore.tsx`. Merge store data and props data before syncing with parent component.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1b8c4bd</samp>

> _`storeData` merges_
> _with `propsData` in sync_
> _autumn bug is fixed_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1b8c4bd</samp>

* Fix store data bug by merging props data and store data before synchronization ([link](https://github.com/baidu/amis/pull/8952/files?diff=unified&w=0#diff-3190e3d0cae811197fa696ddc87a38ccfa3f1c6dba90f662924259ac28ae13acL273-R273))
