### PR TITLE
revert: #8553

### DIFF
--- a/packages/amis-core/src/renderers/wrapControl.tsx
+++ b/packages/amis-core/src/renderers/wrapControl.tsx
@@ -868,9 +868,7 @@ export function wrapControl<
               formItem: this.model,
               formMode: control.mode || formMode,
               ref: this.controlRef,
-              data: model
-                ? model.getMergedData(data || store?.data)
-                : data || store?.data,
+              data: data || store?.data,
               name: model?.name ?? control.name,
               value,
               changeMotivation: model?.changeMotivation,
@@ -883,8 +881,8 @@ export function wrapControl<
               prinstine: model ? model.prinstine : undefined,
               setPrinstineValue: this.setPrinstineValue,
               onValidate: this.validate,
-              onFlushChange: this.flushChange,
-              render: this.renderChild // 如果覆盖，那么用的就是 form 上的 render，这个里面用到的 data 是比较旧的。
+              onFlushChange: this.flushChange
+              // render: this.renderChild // 如果覆盖，那么用的就是 form 上的 render，这个里面用到的 data 是比较旧的。
               // !没了这个， tree 里的 options 渲染会出问题
               // todo 理论上不应该影响，待确认
               // _filteredOptions: this.model?.filteredOptions


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0865e6d</samp>

Simplify and fix data and render props for control component in `wrapControl.tsx`. Avoid data inconsistency and performance issues caused by unnecessary data merging and rendering.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0865e6d</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The `wrapControl` component with a clear and wise mind_
> _He shunned the faulty `model.getMergedData` and the `render` prop_
> _Like Heracles who cleansed the Augean stables with a single mop_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0865e6d</samp>

*  Simplify and fix data prop for control components ([link](https://github.com/baidu/amis/pull/8955/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL871-R871))
*  Remove render prop for control components to avoid outdated data and improve performance ([link](https://github.com/baidu/amis/pull/8955/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL886-R885))
*  Comment out render prop and add todo comment to confirm its removal later ([link](https://github.com/baidu/amis/pull/8955/files?diff=unified&w=0#diff-90c0a356944c15700458026e9b959ac639d10063a89d69773b83d722fda3764aL886-R885))
