### PR TITLE
feat: CRUD & CRUD2 parsePrimitiveQuery配置支持转化数字类型

### DIFF
--- a/docs/zh-CN/components/crud.md
+++ b/docs/zh-CN/components/crud.md
@@ -204,14 +204,28 @@ CRUD 组件对数据源接口的数据结构要求如下：
 
 > `3.5.0`及以上版本
 
-`syncLocation`开启后，CRUD 在初始化数据域时，将会对 url 中的 Query 进行转换，将原始类型的字符串格式的转化为同位类型，目前仅支持**布尔类型**
+`syncLocation`开启后，CRUD 在初始化数据域时，将会对 url 中的 Query 进行转换，将原始类型的字符串格式的转化为同位类型。`3.6.0`版本后支持对象格式，该配置默认开启，且默认仅转化布尔值。
+
+#### ParsePrimitiveQueryOptions
+```typescript
+interface ParsePrimitiveQueryOptions {
+  parsePrimitiveQuery: {
+    enable: boolean;
+    types?: ('boolean' | 'number')[]
+  }
+}
+```
+
+比如开启设置 `{"parsePrimitiveQuery": {"enable": true, "types": ["boolean", "number"]}}` 后：
 
 ```
-"true"  ==> true
-"false" ==> false
+"true"   ==> true
+"false"  ==> false
+"123"    ==> 123
+"123.4"  ==> 123.4
 ```
 
-如果只想保持字符串格式，可以设置`"parsePrimitiveQuery": false`关闭该特性，具体效果参考[示例](../../../examples/crud/parse-primitive-query)。
+如果只想保持字符串格式，可以设置`"parsePrimitiveQuery": false` 或者 `"parsePrimitiveQuery": {"enable": false}` 关闭该特性，具体效果参考[示例](../../../examples/crud/parse-primitive-query)。如果想实现字段定制化转化类型，可以使用[配置API请求数据](../../docs/types/api#配置请求数据)，通过表达式控制接口传递的参数类型。
 
 ## 功能
 
@@ -3381,6 +3395,8 @@ itemAction 里的 onClick 还能通过 `data` 参数拿到当前行的数据，�
 | autoFillHeight                        | `boolean` 丨 `{height: number}`                                                         |                                 | 内容区域自适应高度                                                                                                                             |
 | canAccessSuperData                    | `boolean`                                                                               | `true`                          | 指定是否可以自动获取上层的数据并映射到表格行数据上，如果列也配置了该属性，则列的优先级更高                                                     |
 | matchFunc                             | `string`                                                                                | [`CRUDMatchFunc`](#匹配函数)    | 自定义匹配函数, 当开启`loadDataOnce`时，会基于该函数计算的匹配结果进行过滤，主要用于处理列字段类型较为复杂或者字段值格式和后端返回不一致的场景 | `3.5.0` |
+| parsePrimitiveQuery                         | [`ParsePrimitiveQueryOptions`](#ParsePrimitiveQueryOptions)                                                                                | `true`    | 是否开启Query信息转换，开启后将会对url中的Query进行转换，默认开启，默认仅转化布尔值 | `3.6.0` |
+
 
 注意除了上面这些属性，CRUD 在不同模式下的属性需要参考各自的文档，比如
 

--- a/examples/components/CRUD/ParsePrimitiveQuery.jsx
+++ b/examples/components/CRUD/ParsePrimitiveQuery.jsx
@@ -5,7 +5,7 @@ export default {
       "type": "alert",
       "body": {
         "type": "html",
-        "html": "<code>parsePrimitiveQuery</code>默认开启，开启后会对url中的Query进行转换，将原始类型的字符串格式的转化为同位类型，目前仅支持<strong>布尔类型</strong>"
+        "html": "<code>parsePrimitiveQuery</code>默认开启，开启后会对url中的Query进行转换，将原始类型的字符串格式的转化为同位类型"
       },
       "level": "info",
       "showCloseButton": true,
@@ -17,6 +17,10 @@ export default {
       "name": "crud",
       "syncLocation": true,
       "api": "/api/mock2/crud/table5",
+      "parsePrimitiveQuery": {
+        "enable": true,
+        "types": ["boolean", "number"]
+      },
       "filter": {
         "debug": true,
         "title": "条件搜索",
@@ -30,6 +34,16 @@ export default {
                 "label": "已核验",
                 "size": "sm",
                 "value": false
+              },
+              {
+                "type": "select",
+                "name": "version",
+                "label": "版本",
+                "options": [
+                  {"label": "5.5", value: 5.5},
+                  {"label": "6", value: 6},
+                  {"label": "7", value: 7}
+                ]
               }
             ]
           }
@@ -67,6 +81,10 @@ export default {
             ]
           }
         },
+        {
+          "name": "version",
+          "label": "版本"
+        }
       ]
     }
   ]

--- a/packages/amis/src/renderers/CRUD2.tsx
+++ b/packages/amis/src/renderers/CRUD2.tsx
@@ -196,9 +196,14 @@ export interface CRUD2CommonSchema extends BaseSchema, SpinnerExtraProps {
   primaryField?: string;
 
   /**
-   * 是否开启Query信息转换，开启后将会对url中的Query进行转换，将字符串格式的布尔值转化为同位类型
+   * 是否开启Query信息转换，开启后将会对url中的Query进行转换，默认开启，默认仅转化布尔值
    */
-  parsePrimitiveQuery?: boolean;
+  parsePrimitiveQuery?:
+    | {
+        enable: boolean;
+        types?: ('boolean' | 'number')[];
+      }
+    | boolean;
 }
 
 export type CRUD2CardsSchema = CRUD2CommonSchema & {
@@ -305,19 +310,20 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
       perPageField,
       parsePrimitiveQuery
     } = props;
+    const parseQueryOptions = this.getParseQueryOptions(props);
 
     this.mounted = true;
 
     if (syncLocation && location && (location.query || location.search)) {
       store.updateQuery(
-        parseQuery(location, {parsePrimitive: parsePrimitiveQuery}),
+        parseQuery(location, parseQueryOptions),
         undefined,
         pageField,
         perPageField
       );
     } else if (syncLocation && !location && window.location.search) {
       store.updateQuery(
-        parseQuery(window.location, {parsePrimitive: parsePrimitiveQuery}),
+        parseQuery(window.location, parseQueryOptions),
         undefined,
         pageField,
         perPageField
@@ -389,7 +395,7 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
     ) {
       // 同步地址栏，那么直接检测 query 是否变了，变了就重新拉数据
       store.updateQuery(
-        parseQuery(props.location, {parsePrimitive: parsePrimitiveQuery}),
+        parseQuery(props.location, this.getParseQueryOptions(props)),
         undefined,
         props.pageField,
         props.perPageField
@@ -437,6 +443,25 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
   componentWillUnmount() {
     this.mounted = false;
     clearTimeout(this.timer);
+  }
+
+  getParseQueryOptions(props: CRUD2Props) {
+    const {parsePrimitiveQuery} = props;
+    type PrimitiveQueryObj = Exclude<
+      CRUD2Props['parsePrimitiveQuery'],
+      boolean
+    >;
+
+    const normalizedOptions = {
+      parsePrimitive: !!(isObject(parsePrimitiveQuery)
+        ? (parsePrimitiveQuery as PrimitiveQueryObj)?.enable
+        : parsePrimitiveQuery),
+      primitiveTypes: (parsePrimitiveQuery as PrimitiveQueryObj)?.types ?? [
+        'boolean'
+      ]
+    };
+
+    return normalizedOptions;
   }
 
   @autobind
@@ -502,6 +527,7 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
       perPageField,
       parsePrimitiveQuery
     } = this.props;
+    const parseQueryOptions = this.getParseQueryOptions(this.props);
     let {query, resetQuery, replaceQuery, loadMore, resetPage} = data || {};
 
     query =
@@ -511,7 +537,7 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
 
     /** 把布尔值反解出来 */
     if (parsePrimitiveQuery) {
-      query = parsePrimitiveQueryString(query);
+      query = parsePrimitiveQueryString(query, parseQueryOptions);
     }
 
     store.updateQuery(


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0203ac7</samp>

This pull request adds a new feature to the `CRUD` and `CRUD2` components, to enable parsing primitive values (such as numbers and booleans) from the query string or the props. It also updates the documentation and the example code to demonstrate the usage and the benefits of this feature. It introduces a new prop `parsePrimitiveQuery` that can be configured with an object or a boolean, and a new option `primitiveTypes` that can be used to specify the types of values to be parsed.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0203ac7</samp>

> _Sing, O Muse, of the skillful work of the code-smiths_
> _Who enhanced the CRUD component with a new feature_
> _To parse the primitive values from the query strings_
> _With fine-grained control and flexible options._

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0203ac7</samp>

*  Add support for object format and number type in `parsePrimitiveQuery` feature of `CRUD` and `CRUD2` components ([link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653L207-R228), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653L3384-R3400), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8b7ddba661c5078c57bc1077528d745a2f0382307af0d0f0a463a92c40e30e6dL8-R8), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8b7ddba661c5078c57bc1077528d745a2f0382307af0d0f0a463a92c40e30e6dR20-R23), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8b7ddba661c5078c57bc1077528d745a2f0382307af0d0f0a463a92c40e30e6dR37-R46), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8b7ddba661c5078c57bc1077528d745a2f0382307af0d0f0a463a92c40e30e6dR84-R87), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL2053-R2098), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL2085-R2121), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL2094-R2128), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L29-R29), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L379-R386), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L548-R555), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L556-R561), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L563-R568), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L657-R662), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R713-R728), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R1020), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1011-R1033), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL199-R206), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaR313), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL313-R319), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL320-R326), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL392-R398), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaR448-R466), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaR530), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL514-R540))
  * Update the documentation of the feature in `docs/zh-CN/components/crud.md` ([link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653L207-R228), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-95eedf8e35f124d56f35a016c1df591c4070cb9aff56cfefc58b33512de87653L3384-R3400))
  * Update the example code and data of the feature in `examples/components/CRUD/ParsePrimitiveQuery.jsx` ([link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8b7ddba661c5078c57bc1077528d745a2f0382307af0d0f0a463a92c40e30e6dL8-R8), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8b7ddba661c5078c57bc1077528d745a2f0382307af0d0f0a463a92c40e30e6dR20-R23), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8b7ddba661c5078c57bc1077528d745a2f0382307af0d0f0a463a92c40e30e6dR37-R46), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8b7ddba661c5078c57bc1077528d745a2f0382307af0d0f0a463a92c40e30e6dR84-R87))
  * Modify the `parsePrimitiveQueryString` function in `packages/amis-core/src/utils/helper.ts` to accept an `options` parameter with `types` property ([link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL2053-R2098))
  * Modify the `parseQuery` function in `packages/amis-core/src/utils/helper.ts` to pass the `primitiveTypes` option to the `parsePrimitiveQueryString` function ([link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL2085-R2121), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-642e6cf444d0298f029744a52f8f4d8ae391d2965d65bbff2478c9838d792f3aL2094-R2128))
  * Modify the `CRUDCommonSchema` and `CRUD2CommonSchema` interfaces in `packages/amis/src/renderers/CRUD.tsx` and `packages/amis/src/renderers/CRUD2.tsx` to change the type of the `parsePrimitiveQuery` property ([link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L379-R386), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL199-R206))
  * Add a new method `getParseQueryOptions` to the `CRUD` and `CRUD2` components in `packages/amis/src/renderers/CRUD.tsx` and `packages/amis/src/renderers/CRUD2.tsx` to normalize the `parsePrimitiveQuery` prop into an object ([link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R713-R728), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaR448-R466))
  * Add a new variable `parseQueryOptions` to the `CRUD` and `CRUD2` components' constructors and methods in `packages/amis/src/renderers/CRUD.tsx` and `packages/amis/src/renderers/CRUD2.tsx` to store and pass the normalized options to the `parseQuery` and `parsePrimitiveQueryString` functions ([link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L548-R555), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L556-R561), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L563-R568), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L657-R662), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56R1020), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-8fb8c997f3ff51bc659043405077ecb4d0707fcd69ab31bd7cdcb5eeb5c0bd56L1011-R1033), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaR313), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL313-R319), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL320-R326), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL392-R398), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaR530), [link](https://github.com/baidu/amis/pull/8962/files?diff=unified&w=0#diff-ac9a942989e1d8a2eab79d6c33ea3acb4906919c86541c9f458acbe5543efdfaL514-R540))
