### PR TITLE
chore: 弹窗默认属性show改为 false

### DIFF
--- a/packages/amis/src/renderers/Dialog.tsx
+++ b/packages/amis/src/renderers/Dialog.tsx
@@ -176,7 +176,7 @@ export default class Dialog extends React.Component<DialogProps> {
     title: 'Dialog.title',
     bodyClassName: '',
     confirm: true,
-    show: true,
+    show: false,
     lazyRender: false,
     showCloseButton: true,
     wrapperComponent: Modal,


### PR DESCRIPTION
弹窗默认展示show改为false, 直接渲染弹窗不应该弹出，应该是被动的，由外部控制 show 属性来弹出
