### PR TITLE
fix: 刷新表格时，清空表格行状态，例如switch选中、select选中等  (#8951)

### DIFF
--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -700,7 +700,17 @@ export default class Table extends React.Component<TableProps, object> {
       }
     }
 
-    updateRows && store.initRows(rows, props.getEntryId, props.reUseRow);
+    if (updateRows) {
+      store.initRows(rows, props.getEntryId, props.reUseRow);
+    } else if (props.reUseRow === false) {
+    /**
+     * 在reUseRow为false情况下，支持强制刷新表格行状态
+     * 适用的情况：用户每次刷新，调用接口，返回的数据都是一样的，导致updateRows为false，故针对每次返回数据一致的情况，需要强制表格更新
+     */
+      updateRows = true;
+      store.initRows(value, props.getEntryId, props.reUseRow);
+    }
+
     Array.isArray(props.selected) &&
       store.updateSelected(props.selected, props.valueField);
     return updateRows;


### PR DESCRIPTION
* fix: 支持刷新表格时，清空表格状态

* fix: 支持刷新表格时，清空表格状态

### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at aeb26db</samp>

Added a new prop `reUseRow` to the Table and CRUD renderers, which controls whether the table state is preserved or reset when the data is reloaded. Added a test case to verify the prop's behavior. Modified the Table component logic to respect the prop's value.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at aeb26db</samp>

> _`reUseRow` is false_
> _Table updates with new data_
> _A fresh start in spring_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at aeb26db</samp>

*  Add a `reUseRow` prop to the Table component to control whether the table state should be reset when the API returns the same data ([link](https://github.com/baidu/amis/pull/8966/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL703-R713))
*  Modify the Table component logic to force the update of the rows with the new value if `reUseRow` is false and `updateRows` is false ([link](https://github.com/baidu/amis/pull/8966/files?diff=unified&w=0#diff-a8b4227510cc7dd856d8854c10b9d18799441b0a9ee0733efd30d7ede190844aL703-R713))
*  Add a test case 21 in `CRUD.test.tsx` to verify the behavior of the `reUseRow` prop ([link](https://github.com/baidu/amis/pull/8966/files?diff=unified&w=0#diff-0d07c5f793889442c3a5bbba3eef9b9194da770b0844eff3c7910f39d9895838R24), [link](https://github.com/baidu/amis/pull/8966/files?diff=unified&w=0#diff-0d07c5f793889442c3a5bbba3eef9b9194da770b0844eff3c7910f39d9895838R1319-R1398))
*  Simulate toggling a switch column, reloading the data, and checking that the switch state is cleared in the test case 21 ([link](https://github.com/baidu/amis/pull/8966/files?diff=unified&w=0#diff-0d07c5f793889442c3a5bbba3eef9b9194da770b0844eff3c7910f39d9895838R1319-R1398))
