### PR TITLE
pick: fix: 修复 combo 中有 pipeIn & pipeOut 场景时报错 Close: #8970

### DIFF
--- a/packages/amis-core/src/renderers/wrapControl.tsx
+++ b/packages/amis-core/src/renderers/wrapControl.tsx
@@ -868,9 +868,7 @@ export function wrapControl<
               formItem: this.model,
               formMode: control.mode || formMode,
               ref: this.controlRef,
-              data: model
-                ? model.getMergedData(data || store?.data)
-                : data || store?.data,
+              data: data || store?.data,
               name: model?.name ?? control.name,
               value,
               changeMotivation: model?.changeMotivation,
@@ -883,8 +881,8 @@ export function wrapControl<
               prinstine: model ? model.prinstine : undefined,
               setPrinstineValue: this.setPrinstineValue,
               onValidate: this.validate,
-              onFlushChange: this.flushChange,
-              render: this.renderChild // 如果覆盖，那么用的就是 form 上的 render，这个里面用到的 data 是比较旧的。
+              onFlushChange: this.flushChange
+              // render: this.renderChild // 如果覆盖，那么用的就是 form 上的 render，这个里面用到的 data 是比较旧的。
               // !没了这个， tree 里的 options 渲染会出问题
               // todo 理论上不应该影响，待确认
               // _filteredOptions: this.model?.filteredOptions

--- a/packages/amis/src/renderers/Form/Combo.tsx
+++ b/packages/amis/src/renderers/Form/Combo.tsx
@@ -544,7 +544,8 @@ export default class ComboControl extends React.Component<ComboProps> {
     const {flat, joinValues, delimiter, type, formItem} = props;
     // 因为 combo 多个子表单可能同时发生变化。
     // onChagne 触发多次，上次变更还没应用到 props.value 上来，这次触发变更就会包含历史数据，把上次触发的数据给重置成旧的了。
-    let value = formItem?.tmpValue || props.value;
+    // 通过 props.getValue() 拿到的是最新的
+    let value = props.getValue();
 
     if (joinValues && flat && typeof value === 'string') {
       value = value.split(delimiter || ',');


### PR DESCRIPTION
### What

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at bee6b17</samp>

Fixed a bug in `Combo` form renderer that caused stale values to be used. Changed the value assignment to use `props.getValue()` instead of `props.value` or `formItem.tmpValue` in `packages/amis/src/renderers/Form/Combo.tsx`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at bee6b17</samp>

> _`value` from props_
> _fixes combo form bug now_
> _autumn leaves falling_

### Why

<!-- author to complete -->

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at bee6b17</samp>

* Fix a bug where combo form values may not update correctly ([link](https://github.com/baidu/amis/pull/8981/files?diff=unified&w=0#diff-48e04f2be56e70eb26ad89e8cd9421938c8770b070ed23326a85d564336f7829L547-R548))
