### PR TITLE
后端开发者，发现当前不支持gif的裁剪，进行修改。可参考。

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "dependencies": {
     "path-to-regexp": "^6.2.0",
     "postcss": "^8.4.14",
-    "qs": "6.9.7"
+    "qs": "6.9.7",
+    "super-image-cropper": "^1.0.18"
   },
   "devDependencies": {
     "@babel/generator": "^7.22.9",

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -10,7 +10,12 @@ import {
   PlainObject
 } from 'amis-core';
 // import 'cropperjs/dist/cropper.css';
+
+import {SuperImageCropper} from 'super-image-cropper';
 const Cropper = React.lazy(() => import('react-cropper'));
+
+const imageCropper = new SuperImageCropper();
+
 import DropZone from 'react-dropzone';
 import {FileRejection, ErrorCode, DropEvent} from 'react-dropzone';
 import 'blueimp-canvastoblob';
@@ -1100,18 +1105,39 @@ export default class ImageControl extends React.Component<
 
   handleCrop() {
     const {cropFormat, cropQuality} = this.props;
-    this.cropper.getCroppedCanvas().toBlob(
-      (file: File) => {
-        this.addFiles([file]);
+
+    imageCropper
+      .crop({
+        cropperInstance: this.cropper,
+        // src: this.cropper.url,
+        gifJsOptions: {
+          quality: cropQuality || 1
+        },
+        outputType: 'blob' // optional, default blob url
+      })
+      .then(blob => {
+        this.addFiles([blob]);
         this.setState({
           cropFile: undefined,
           locked: false,
           lockedReason: ''
         });
-      },
-      cropFormat || 'image/png',
-      cropQuality || 1
-    );
+        cropFormat || 'image/png';
+        // cropQuality || 1
+      });
+
+    // this.cropper.getCroppedCanvas().toBlob(
+    //   (file: File) => {
+    //     this.addFiles([file]);
+    //     this.setState({
+    //       cropFile: undefined,
+    //       locked: false,
+    //       lockedReason: ''
+    //     });
+    //   },
+    //   cropFormat || 'image/png',
+    //   cropQuality || 1
+    // );
   }
 
   cancelCrop() {


### PR DESCRIPTION
### 裁剪图片支持gif裁剪后仍旧是gif

### 原来裁剪生成图片，只获取了Canvas的第一帧图片

### 只需改动原来的裁剪生产blob的地方
