### PR TITLE
feat: 表单提交前进行强制校验

### DIFF
--- a/packages/amis-core/src/store/form.ts
+++ b/packages/amis-core/src/store/form.ts
@@ -548,7 +548,7 @@ export const FormStore = ServiceStore.named('FormStore')
       self.submiting = true;
 
       try {
-        yield validate(hooks, undefined, true, failedMessage, validateErrCb);
+        yield validate(hooks, true, true, failedMessage, validateErrCb);
 
         if (fn) {
           const diff = difference(self.data, self.pristine);

--- a/packages/amis-editor/src/renderer/event-control/index.tsx
+++ b/packages/amis-editor/src/renderer/event-control/index.tsx
@@ -329,7 +329,20 @@ export class EventControl extends React.Component<
     if (config.actionType) {
       onEventConfig[event] = {
         ...onEventConfig[event],
-        actions: (onEventConfig[event].actions || []).concat(config)
+        actions: (onEventConfig[event].actions || []).concat(
+          // 临时处理，后面干掉这么多交互属性
+          Object.defineProperties(config, {
+            __cmptTreeSource: {
+              enumerable: false
+            },
+            __nodeSchema: {
+              enumerable: false
+            },
+            __subActions: {
+              enumerable: false
+            }
+          })
+        )
       };
     }
 

--- a/packages/amis/__tests__/event-action/renderers/form/__snapshots__/form.test.tsx.snap
+++ b/packages/amis/__tests__/event-action/renderers/form/__snapshots__/form.test.tsx.snap
@@ -336,6 +336,248 @@ exports[`doAction:form clear 1`] = `
 </div>
 `;
 
+exports[`doAction:form force validate before submit 1`] = `
+<div>
+  <div
+    class="cxd-Page"
+  >
+    <div
+      class="cxd-Page-content"
+    >
+      <div
+        class="cxd-Page-main"
+      >
+        <div
+          class="cxd-Page-body"
+          role="page-body"
+        >
+          <div
+            class="cxd-Panel cxd-Panel--default cxd-Panel--form"
+          >
+            <div
+              class="cxd-Panel-heading"
+            >
+              <h3
+                class="cxd-Panel-title"
+              >
+                <span
+                  class="cxd-TplField"
+                >
+                  <span>
+                    表单
+                  </span>
+                </span>
+              </h3>
+            </div>
+            <div
+              class="cxd-Panel-body"
+            >
+              <form
+                class="cxd-Form cxd-Form--normal"
+                novalidate=""
+              >
+                <input
+                  style="display: none;"
+                  type="submit"
+                />
+                <div
+                  class="cxd-Form-item cxd-Form-item--normal is-error has-error--equalsField"
+                  data-role="form-item"
+                >
+                  <div
+                    class="cxd-Form-control is-error has-error--equalsField cxd-TextControl"
+                  >
+                    <div
+                      class="cxd-TextControl-input"
+                    >
+                      <input
+                        autocomplete="off"
+                        class=""
+                        name="value1"
+                        placeholder=""
+                        size="10"
+                        type="text"
+                        value="1"
+                      />
+                    </div>
+                  </div>
+                  <ul
+                    class="cxd-Form-feedback"
+                  >
+                    <li>
+                      输入的数据与 value2 值不一致
+                    </li>
+                  </ul>
+                </div>
+                <div
+                  class="cxd-Form-item cxd-Form-item--normal is-error has-error--equalsField"
+                  data-role="form-item"
+                >
+                  <div
+                    class="cxd-Form-control is-error has-error--equalsField cxd-TextControl"
+                  >
+                    <div
+                      class="cxd-TextControl-input"
+                    >
+                      <input
+                        autocomplete="off"
+                        class=""
+                        name="value2"
+                        placeholder=""
+                        size="10"
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                  <ul
+                    class="cxd-Form-feedback"
+                  >
+                    <li>
+                      输入的数据与 value1 值不一致
+                    </li>
+                  </ul>
+                </div>
+              </form>
+            </div>
+            <div
+              class="cxd-Panel-footerWrap"
+            >
+              <div
+                class="cxd-Panel-btnToolbar cxd-Panel-footer"
+              >
+                <button
+                  class="cxd-Button cxd-Button--primary cxd-Button--size-default"
+                  type="submit"
+                >
+                  <span>
+                    提交
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`doAction:form force validate before submit 2`] = `
+<div>
+  <div
+    class="cxd-Page"
+  >
+    <div
+      class="cxd-Page-content"
+    >
+      <div
+        class="cxd-Page-main"
+      >
+        <div
+          class="cxd-Page-body"
+          role="page-body"
+        >
+          <div
+            class="cxd-Panel cxd-Panel--default cxd-Panel--form"
+          >
+            <div
+              class="cxd-Panel-heading"
+            >
+              <h3
+                class="cxd-Panel-title"
+              >
+                <span
+                  class="cxd-TplField"
+                >
+                  <span>
+                    表单
+                  </span>
+                </span>
+              </h3>
+            </div>
+            <div
+              class="cxd-Panel-body"
+            >
+              <form
+                class="cxd-Form cxd-Form--normal"
+                novalidate=""
+              >
+                <input
+                  style="display: none;"
+                  type="submit"
+                />
+                <div
+                  class="cxd-Form-item cxd-Form-item--normal"
+                  data-role="form-item"
+                >
+                  <div
+                    class="cxd-Form-control cxd-TextControl"
+                  >
+                    <div
+                      class="cxd-TextControl-input"
+                    >
+                      <input
+                        autocomplete="off"
+                        class=""
+                        name="value1"
+                        placeholder=""
+                        size="10"
+                        type="text"
+                        value="1"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="cxd-Form-item cxd-Form-item--normal"
+                  data-role="form-item"
+                >
+                  <div
+                    class="cxd-Form-control cxd-TextControl"
+                  >
+                    <div
+                      class="cxd-TextControl-input"
+                    >
+                      <input
+                        autocomplete="off"
+                        class=""
+                        name="value2"
+                        placeholder=""
+                        size="10"
+                        type="text"
+                        value="1"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </form>
+            </div>
+            <div
+              class="cxd-Panel-footerWrap"
+            >
+              <div
+                class="cxd-Panel-btnToolbar cxd-Panel-footer"
+              >
+                <button
+                  class="cxd-Button cxd-Button--primary cxd-Button--size-default"
+                  type="submit"
+                >
+                  <span>
+                    提交
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`doAction:form reset 1`] = `
 <div>
   <div

--- a/packages/amis/__tests__/event-action/renderers/form/form.test.tsx
+++ b/packages/amis/__tests__/event-action/renderers/form/form.test.tsx
@@ -283,6 +283,78 @@ test('doAction:form submit', async () => {
   expect(container).toMatchSnapshot();
 });
 
+test('doAction:form force validate before submit', async () => {
+  const notify = jest.fn();
+  const {container, getByText, queryByText} = render(
+    amisRender(
+      {
+        type: 'page',
+        body: [
+          {
+            type: 'form',
+            body: [
+              {
+                type: 'input-text',
+                name: 'value1',
+                validations: {
+                  equalsField: 'value2'
+                },
+                value: 1
+              },
+              {
+                name: 'value2',
+                type: 'input-text',
+                validations: {
+                  equalsField: 'value1'
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {},
+      makeEnv({
+        notify
+      })
+    )
+  );
+
+  await waitFor(() => {
+    expect(getByText('提交')).toBeInTheDocument();
+  });
+
+  fireEvent.click(getByText(/提交/));
+
+  await wait(300);
+
+  await waitFor(() => {
+    expect(queryByText('输入的数据与 value2 值不一致')).toBeInTheDocument();
+    expect(queryByText('输入的数据与 value1 值不一致')).toBeInTheDocument();
+  });
+
+  expect(container).toMatchSnapshot();
+
+  fireEvent.change(container.querySelector('[name="value2"]')!, {
+    target: {value: '1'}
+  });
+
+  await wait(300);
+
+  await waitFor(() => {
+    expect(queryByText('输入的数据与 value1 值不一致')).not.toBeInTheDocument();
+  });
+
+  fireEvent.click(getByText(/提交/));
+
+  await wait(300);
+
+  await waitFor(() => {
+    expect(queryByText('输入的数据与 value2 值不一致')).not.toBeInTheDocument();
+  });
+
+  expect(container).toMatchSnapshot();
+});
+
 test('doAction:form setValue', async () => {
   const notify = jest.fn();
   const fetcher = jest.fn().mockImplementation(() =>


### PR DESCRIPTION
### What
表单提交前进行强制校验

### Why
之前提交前虽然会校验，但会使用缓存，即已经校验过的不再校验，不能覆盖某些特殊场景（如自定义的双向联合校验后报错无法清除），所以需要进行强制校验
