### PR TITLE
chore: jssdk 中使用代码编辑器在不同的 locale 下加载编辑器对应的语言文件 Close: #8880

### DIFF
--- a/examples/loadMonacoEditor.ts
+++ b/examples/loadMonacoEditor.ts
@@ -19,10 +19,21 @@ function filterUrl(url: string) {
 }
 
 function onLoad(req: any, callback: (result: any) => void) {
+  const locale =
+    ((window as any).__amis_monaco_editor_locale &&
+      (
+        {
+          'zh-CN': 'zh-cn',
+          'en-US': '',
+          'de-DE': 'de'
+        } as any
+      )[(window as any).__amis_monaco_editor_locale]) ||
+    '';
+
   const config = {
     'vs/nls': {
       availableLanguages: {
-        '*': 'zh-cn'
+        '*': locale
       }
     },
     'paths': {

--- a/packages/amis-ui/src/components/Editor.tsx
+++ b/packages/amis-ui/src/components/Editor.tsx
@@ -201,6 +201,9 @@ export class Editor extends React.Component<EditorProps, EditorState> {
   }
 
   loadMonaco() {
+    // 由于 require.config({'vs/nls': { availableLanguages: { '*': 'xxxx' }}}) 只能在初始化之前设置有用，所以这里只能用全局变量的方式来设置。
+    // 另外此方式只是针对 jssdk 和平台有效，对于其他方式还需要再想想。
+    (window as any).__amis_monaco_editor_locale = this.props.locale;
     import('monaco-editor').then(monaco => this.initMonaco(monaco));
   }
 


### PR DESCRIPTION
### What

### Why

Close: #8880

### How
