### PR TITLE
fix: 分页组件activePage为非number类型时导致设计器卡死

### DIFF
--- a/packages/amis/src/renderers/Pagination.tsx
+++ b/packages/amis/src/renderers/Pagination.tsx
@@ -103,7 +103,7 @@ export default class Pagination extends React.Component<PaginationProps> {
     } else if (typeof num === 'number') {
       result = num;
     }
-    return result ?? defaultValue;
+    return typeof result === 'number' && !isNaN(result) ? result : defaultValue;
   }
 
   @autobind


### PR DESCRIPTION
### What

### Why

### How
