### PR TITLE
fix: 修复 select 同时配置 source 和 options 时,页面切换选项有可能被重置为 options 而不是 sour…

### DIFF
--- a/packages/amis-core/src/renderers/Options.tsx
+++ b/packages/amis-core/src/renderers/Options.tsx
@@ -425,7 +425,7 @@ export function registerOptionsControl(config: OptionsConfig) {
       const props = this.props;
       const formItem = props.formItem as IFormItemStore;
 
-      if (prevProps.options !== props.options && formItem) {
+      if (!props.source && prevProps.options !== props.options && formItem) {
         formItem.setOptions(
           normalizeOptions(props.options || [], undefined, props.valueField),
           this.changeOptionValue,


### PR DESCRIPTION
…ce 加载部分

### What

### Why

### How
