### PR TITLE
styles: 修复ConditionBuilder下拉浮层被Table表头遮挡问题

### DIFF
--- a/packages/amis-ui/scss/components/_condition-builder.scss
+++ b/packages/amis-ui/scss/components/_condition-builder.scss
@@ -302,7 +302,7 @@
         padding: 10px;
         margin: -10px 0px;
         background: $white;
-        z-index: 2;
+        z-index: $zindex-dropdown;
       }
       > .#{$ns}CBGroupOrItem-dragbar {
         left: px2rem(-5px);


### PR DESCRIPTION
### What

### Why

table fixed header的z-index: $zindex-sticky 900

### How
