### PR TITLE
fix: 修复有单位时默认值不对,点击事件阻止冒泡

### DIFF
--- a/packages/amis-ui/src/components/NumberInput.tsx
+++ b/packages/amis-ui/src/components/NumberInput.tsx
@@ -240,7 +240,16 @@ export class NumberInput extends React.Component<NumberProps, NumberState> {
   }
 
   @autobind
-  handleEnhanceModeChange(action: 'add' | 'subtract'): void {
+  handleClick(e: React.SyntheticEvent<HTMLElement>) {
+    e.stopPropagation();
+  }
+
+  @autobind
+  handleEnhanceModeChange(
+    action: 'add' | 'subtract',
+    e: React.MouseEvent
+  ): void {
+    e.stopPropagation();
     const {value, step = 1, disabled, readOnly, precision} = this.props;
     // value为undefined会导致溢出错误
     let val = value || 0;
@@ -342,6 +351,7 @@ export class NumberInput extends React.Component<NumberProps, NumberState> {
         disabled={disabled}
         placeholder={placeholder}
         onFocus={this.handleFocus}
+        onClick={this.handleClick}
         onBlur={this.handleBlur}
         stringMode={this.isBig ? true : false}
         keyboard={keyboard}
@@ -386,7 +396,7 @@ export class NumberInput extends React.Component<NumberProps, NumberState> {
                 disabled ? 'Number--enhance-border-disabled' : '',
                 readOnly ? 'Number--enhance-border-readOnly' : ''
               )}
-              onClick={() => this.handleEnhanceModeChange('subtract')}
+              onClick={e => this.handleEnhanceModeChange('subtract', e)}
             >
               <Icon
                 icon="minus"
@@ -403,7 +413,7 @@ export class NumberInput extends React.Component<NumberProps, NumberState> {
                 disabled ? 'Number--enhance-border-disabled' : '',
                 readOnly ? 'Number--enhance-border-readOnly' : ''
               )}
-              onClick={() => this.handleEnhanceModeChange('add')}
+              onClick={e => this.handleEnhanceModeChange('add', e)}
             >
               <Icon
                 icon="plus"

--- a/packages/amis/__tests__/renderers/Form/number.test.tsx
+++ b/packages/amis/__tests__/renderers/Form/number.test.tsx
@@ -185,6 +185,25 @@ test('Renderer:number with unitOptions', async () => {
   expect(container).toMatchSnapshot();
 });
 
+test('Renderer:number with unitOptions and default value', async () => {
+  const {container} = await setup(
+    {
+      unitOptions: ['px', '%', 'em'],
+      value: 12
+    },
+    {},
+    [
+      {
+        type: 'static',
+        name: 'number'
+      }
+    ]
+  );
+
+  const staticDom = container.querySelector('.cxd-PlainField') as Element;
+  expect(staticDom.innerHTML).toBe('12px');
+});
+
 test('Renderer:number with precision and default value', async () => {
   const {input, wrap, container, getByText} = await setup({
     precision: 2,

--- a/packages/amis/src/renderers/Form/InputNumber.tsx
+++ b/packages/amis/src/renderers/Form/InputNumber.tsx
@@ -211,6 +211,10 @@ export default class NumberControl extends React.Component<
     }
 
     this.state = {unit, unitOptions};
+
+    if (unit && value != null) {
+      setPrinstineValue(this.getValue(value));
+    }
   }
 
   /**


### PR DESCRIPTION
### What
1. 有单位时，默认值没有添加上单位
2. 点击事件阻止冒泡
### Why
默认值未处理单位
阻止冒泡事件
### How
