### PR TITLE
style: 修复Alert在编辑时样式和预览时样式不一致问题

### DIFF
--- a/packages/amis-ui/scss/components/_alert.scss
+++ b/packages/amis-ui/scss/components/_alert.scss
@@ -48,6 +48,7 @@
     }
 
     .#{$ns}Alert-desc {
+      min-height: #{px2rem(24px)};
       line-height: #{px2rem(24px)};
     }
   }


### PR DESCRIPTION
### What

### Why

alert继承了RegionWrapper的min-height

### How
