### PR TITLE
fix : input-text选择器模式下，clearable无效问题

### DIFF
--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -839,12 +839,14 @@ export default class TextControl extends React.PureComponent<
               </>
 
               {clearable && !disabled && !readOnly && value ? (
-                <a onClick={this.clearValue}>
+                <a
+                  onClick={this.clearValue}
+                  className={cx('TextControl-clear')}
+                >
                   <Icon
                     icon="input-clear"
                     className="icon"
-                    classNameProp={cx('TextControl-clear')}
-                    iconContent="InputBox-clear"
+                    iconContent="InputText-clear"
                   />
                 </a>
               ) : null}


### PR DESCRIPTION
### What
input-text，如果配置了options，那么“可清除”（clearable）这个属性也会失效，即，input框里不会显示清除图标
### Why
历史版本主题升级时，input-text多选模式的清除按钮类名配置错误
### How
更正input-text多选模式的清除按钮类名