### PR TITLE
fix: Editor:当删除静态展示框的默认值时清除历史残余的value值

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Static.tsx
+++ b/packages/amis-editor/src/plugin/Form/Static.tsx
@@ -328,7 +328,13 @@ export class StaticControlPlugin extends BasePlugin {
               getSchemaTpl('label'),
               // getSchemaTpl('value'),
               getSchemaTpl('valueFormula', {
-                name: 'tpl'
+                name: 'tpl',
+                onChange: (value: any, oldValue: any, item: any, form: any) => {
+                  value === '' &&
+                    form.setValues({
+                      value: undefined
+                    });
+                }
                 // rendererSchema: {
                 //   ...context?.schema,
                 //   type: 'textarea', // 改用多行文本编辑


### PR DESCRIPTION
### What
在 Editor 中，默认值的字段是 tpl、历史上是 value
当清除默认值（tpl）时，value 无法被清除，导致渲染时仍然有值可展示

### Why
应该是以往改动的时候，没有考虑到这种情况