### PR TITLE
fix : 修复switch配置truevalue/falsevalue后,默认值不更新问题

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Switch.tsx
+++ b/packages/amis-editor/src/plugin/Form/Switch.tsx
@@ -202,11 +202,12 @@ export class SwitchControlPlugin extends BasePlugin {
                     : value;
                 },
                 pipeOut: (value: any, origin: any, data: any) => {
-                  return value && value === (data.trueValue || true)
-                    ? data.trueValue || true
-                    : value && value !== (data.falseValue || false)
+                  const {trueValue = true, falseValue = false} = data || {};
+                  return value && value === trueValue
+                    ? trueValue
+                    : value && value !== falseValue
                     ? value
-                    : data.falseValue || false;
+                    : falseValue;
                 }
               }),
               getSchemaTpl('labelRemark'),


### PR DESCRIPTION
### What
<img width="1335" alt="image" src="https://github.com/baidu/amis/assets/42052862/5f1117a2-cfd8-4de1-9b6d-37de769a61b2">
switch配置truevalue/falsevalue后，修改默认值还是true和false
### Why
falsevalue设置为0时，返回值为false
### How
采用解构的方式取值，不使用 falsevalue || false的形式