### PR TITLE
fix: jssdk导出npm扩展包缺失依赖

### DIFF
--- a/examples/loader.ts
+++ b/examples/loader.ts
@@ -35,7 +35,11 @@
     '@fex/amis': __moduleId('amis'),
     '@fex/amis-ui': __moduleId('amis-ui'),
     '@fex/amis-core': __moduleId('amis-core'),
-    '@fex/amis-formula': __moduleId('amis-formula')
+    '@fex/amis-formula': __moduleId('amis-formula'),
+    'amis-ui': __moduleId('amis-ui'),
+    'amis-core': __moduleId('amis-core'),
+    'amis-formula': __moduleId('amis-formula'),
+    'copy-to-clipboard': __moduleId('copy-to-clipboard')
   };
 
   Object.keys(mapping).forEach(key => {


### PR DESCRIPTION
### What
解决通过jssdk导出页面时自定义组件及npm自定义组件模块缺失不可用问题
