### PR TITLE
fix(amis-editor): 修复容器清空功能icon偶发不显示问题

### DIFF
--- a/packages/amis-editor-core/src/component/RegionHLBox.tsx
+++ b/packages/amis-editor-core/src/component/RegionHLBox.tsx
@@ -54,7 +54,7 @@ export default class RegionHighlightBox extends React.Component<HighlightBoxProp
           'ae-Editor-rhlbox',
           isDragEnter ? 'is-dragenter' : '',
           !isOnlyChildRegion && isHiglightHover ? 'region-hover' : '',
-          isHiglight ? 'is-highlight' : '',
+          isOnlyChildRegion || isHiglight ? 'is-highlight' : '',
           dx < 87 && dy < 21 && node.x < 190 ? 'region-label-within' : ''
         )}
         style={{


### PR DESCRIPTION
修复的问题现象：通过大纲或者面包屑选中容器组件的时候，没有显示清空功能icon。