### PR TITLE
修复更新后log的source不支持api对象配置方式的问题

### DIFF
--- a/packages/amis/src/renderers/Log.tsx
+++ b/packages/amis/src/renderers/Log.tsx
@@ -161,11 +161,14 @@ export class Log extends React.Component<LogProps, LogState> {
       );
     }
     if (this.props.source) {
-      const ret = resolveVariableAndFilter(
-        this.props.source,
-        this.props.data,
-        '| raw'
-      );
+      const ret =
+        typeof this.props.source === 'string'
+          ? resolveVariableAndFilter(
+              this.props.source,
+              this.props.data,
+              '| raw'
+            )
+          : this.props.source;
       if (ret && isEffectiveApi(ret)) {
         this.loadLogs();
       } else if (
@@ -187,11 +190,10 @@ export class Log extends React.Component<LogProps, LogState> {
       return;
     }
 
-    const ret = resolveVariableAndFilter(
-      this.props.source,
-      this.props.data,
-      '| raw'
-    );
+    const ret =
+      typeof this.props.source === 'string'
+        ? resolveVariableAndFilter(this.props.source, this.props.data, '| raw')
+        : this.props.source;
 
     if (ret && isEffectiveApi(ret)) {
       // todo 如果原来的请求还在，应该先取消


### PR DESCRIPTION
### What
log渲染器的source上次更新后不支持 api 对象的配置方式了，补上相关逻辑

### Why

### How
