### PR TITLE
fix: 修复CRUD通过tag栏取消选择和清空选择时不会触发onSelect事件的问题，该问题会导致嵌入式的picker表现异常

### DIFF
--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -1805,7 +1805,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
   }
 
   unSelectItem(item: any, index: number) {
-    const {store} = this.props;
+    const {store, onSelect} = this.props;
     const selected = store.selectedItems.concat();
     const unSelected = store.unSelectedItems.concat();
 
@@ -1814,15 +1814,18 @@ export default class CRUD extends React.Component<CRUDProps, any> {
 
     store.setSelectedItems(selected);
     store.setUnSelectedItems(unSelected);
+    onSelect && onSelect(selected, unSelected);
   }
 
   clearSelection() {
-    const {store} = this.props;
+    const {store, onSelect} = this.props;
     const selected = store.selectedItems.concat();
     const unSelected = store.unSelectedItems.concat();
+    const newUnSelected = unSelected.concat(selected);
 
     store.setSelectedItems([]);
-    store.setUnSelectedItems(unSelected.concat(selected));
+    store.setUnSelectedItems(newUnSelected);
+    onSelect && onSelect([], newUnSelected);
   }
 
   hasBulkActionsToolbar() {


### PR DESCRIPTION
### What

让 unSelect 和 clearSelect 触发 onSelect 事件

### Why

见 #6491 问题，picker组件的内嵌模式当取消选择非当前页的条目时，不会更新字段值，因为没有触发 onSelect 事件

### How
