### PR TITLE
fix: 修复Editor 打开右键菜单时contextId可能会为空的问题

### DIFF
--- a/packages/amis-editor-core/src/manager.ts
+++ b/packages/amis-editor-core/src/manager.ts
@@ -1381,7 +1381,7 @@ export class EditorManager {
         y: info.y
       },
       menus,
-      () => this.store.setContextId('')
+      ctx => ctx.state.isOpened && this.store.setContextId('')
     );
   }
 

--- a/packages/amis-ui/src/components/ContextMenu.tsx
+++ b/packages/amis-ui/src/components/ContextMenu.tsx
@@ -42,7 +42,7 @@ interface ContextMenuState {
   x: number;
   y: number;
   align?: 'left' | 'right';
-  onClose?: () => void;
+  onClose?: (ctx: ContextMenu) => void;
 }
 
 export class ContextMenu extends React.Component<
@@ -111,7 +111,7 @@ export class ContextMenu extends React.Component<
   openContextMenus(
     info: {x: number; y: number},
     menus: Array<MenuItem>,
-    onClose?: () => void
+    onClose?: (ctx: ContextMenu) => void
   ) {
     if (this.state.isOpened) {
       const {x, y} = this.state;
@@ -153,7 +153,9 @@ export class ContextMenu extends React.Component<
         y: -99999,
         menus: []
       },
-      onClose
+      () => {
+        onClose?.(this);
+      }
     );
   }
 
@@ -185,7 +187,7 @@ export class ContextMenu extends React.Component<
         },
         () => {
           item.onSelect?.(item.data);
-          onClose?.();
+          onClose?.(this);
         }
       );
   }
@@ -318,7 +320,7 @@ export default ThemedContextMenu;
 export async function openContextMenus(
   info: Event | {x: number; y: number},
   menus: Array<MenuItem | MenuDivider>,
-  onClose?: () => void
+  onClose?: (ctx: ContextMenu) => void
 ) {
   return ContextMenu.getInstance().then(instance =>
     instance.openContextMenus(info, menus, onClose)


### PR DESCRIPTION
![image](https://github.com/baidu/amis/assets/16409259/d0a91f70-1cfb-4add-a254-1a988abcf338)
![image](https://github.com/baidu/amis/assets/16409259/0e759660-5923-4312-829b-7750a5ea2ec2)

打开右键按钮时，这里调用了一个异步操作（试了一下，不方便改成同步）
这里偶尔会导致 contextId 为空，然后速搭创建公共组件的时候 store.context 为空，取不到正确的 schema
