### PR TITLE
feat(editor): tabs组件去掉默认创建时的文本，直接显示内容区供用户拖拽内容

### DIFF
--- a/packages/amis-editor/src/plugin/Tabs.tsx
+++ b/packages/amis-editor/src/plugin/Tabs.tsx
@@ -42,11 +42,11 @@ export class TabsPlugin extends BasePlugin {
     tabs: [
       {
         title: '选项卡1',
-        body: '内容1'
+        body: []
       },
       {
         title: '选项卡2',
-        body: '内容2'
+        body: []
       }
     ]
   };


### PR DESCRIPTION
### What

### Why

### How
