### PR TITLE
fix: 修复 condition-builder 操作符只有一个时不可以点选的问题

### DIFF
--- a/packages/amis-ui/src/components/condition-builder/Item.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Item.tsx
@@ -223,7 +223,7 @@ export class ConditionItem extends React.Component<ConditionItemProps> {
       return (
         <PopOverContainer
           mobileUI={mobileUI}
-          disabled={operators.length < 2}
+          disabled={!!(value?.op && operators.length < 2)}
           popOverContainer={popOverContainer || (() => findDOMNode(this))}
           popOverRender={({onClose}) => (
             <GroupedSelection


### PR DESCRIPTION
### What

### Why

### How
