### PR TITLE
fix: transfer、transferPicker分页和搜索相关的问题修复和优化

### DIFF
--- a/packages/amis-ui/src/components/TabsTransfer.tsx
+++ b/packages/amis-ui/src/components/TabsTransfer.tsx
@@ -54,6 +54,10 @@ export interface TabsTransferProps
   ctx?: Record<string, any>;
   selectMode?: 'table' | 'list' | 'tree' | 'chained' | 'associated';
   searchable?: boolean;
+  /**
+   * 是否默认都展开
+   */
+  initiallyOpen?: boolean;
 }
 
 export interface TabsTransferState {
@@ -352,6 +356,7 @@ export class TabsTransfer extends React.Component<
       virtualThreshold,
       onlyChildren,
       loadingConfig,
+      initiallyOpen = true,
       valueField = 'value',
       labelField = 'label',
       deferField = 'defer'
@@ -403,6 +408,7 @@ export class TabsTransfer extends React.Component<
         virtualThreshold={virtualThreshold}
         valueField={valueField}
         labelField={labelField}
+        initiallyOpen={initiallyOpen}
       />
     ) : selectMode === 'chained' ? (
       <ChainedCheckboxes

--- a/packages/amis-ui/src/components/TabsTransfer.tsx
+++ b/packages/amis-ui/src/components/TabsTransfer.tsx
@@ -127,7 +127,6 @@ export class TabsTransfer extends React.Component<
         if (!Array.isArray(result)) {
           throw new Error('onSearch 需要返回数组');
         }
-
         this.setState({
           searchResult: result
         });
@@ -171,12 +170,15 @@ export class TabsTransfer extends React.Component<
       onlyChildren,
       selectMode,
       loadingConfig,
+      activeKey,
+      options: optionsConfig,
       valueField = 'value',
       labelField = 'label'
     } = this.props;
     const options = searchResult || [];
     const mode = searchResultMode || selectMode; // 没有配置时默认和左侧选项展示形式一致
 
+    const activeTab = optionsConfig[activeKey];
     return mode === 'table' ? (
       <TableCheckboxes
         placeholder={noResultsText}
@@ -204,6 +206,7 @@ export class TabsTransfer extends React.Component<
         showIcon={false}
         multiple={true}
         cascade={true}
+        autoCheckChildren={activeTab.autoCheckChildren}
         itemRender={
           optionItemRender
             ? (item: Option, states: ItemRenderStates) =>

--- a/packages/amis-ui/src/components/TabsTransferPicker.tsx
+++ b/packages/amis-ui/src/components/TabsTransferPicker.tsx
@@ -51,6 +51,7 @@ export class TransferPicker extends React.Component<TabsTransferPickerProps> {
       popOverContainer,
       maxTagCount,
       overflowTagPopover,
+      placeholder,
       ...rest
     } = this.props;
 
@@ -100,7 +101,7 @@ export class TransferPicker extends React.Component<TabsTransferPickerProps> {
             result={value}
             onResultChange={onChange}
             onResultClick={onClick}
-            placeholder={__('Select.placeholder')}
+            placeholder={placeholder ?? __('Select.placeholder')}
             disabled={disabled}
             itemRender={option => (
               <span>{(option && option[labelField]) || 'undefiend'}</span>

--- a/packages/amis-ui/src/components/Transfer.tsx
+++ b/packages/amis-ui/src/components/Transfer.tsx
@@ -157,6 +157,10 @@ export interface TransferProps
     perPage?: number,
     direction?: 'forward' | 'backward'
   ) => void;
+  /**
+   * 是否默认都展开
+   */
+  initiallyOpen?: boolean;
 }
 
 export interface TransferState {
@@ -816,7 +820,8 @@ export class Transfer<
       loadingConfig,
       checkAll,
       checkAllLabel,
-      onlyChildren
+      onlyChildren,
+      initiallyOpen = true
     } = props;
 
     return selectMode === 'table' ? (
@@ -859,6 +864,7 @@ export class Transfer<
         loadingConfig={loadingConfig}
         checkAllLabel={checkAllLabel}
         checkAll={checkAll}
+        initiallyOpen={initiallyOpen}
       />
     ) : selectMode === 'chained' ? (
       <ChainedSelection

--- a/packages/amis-ui/src/components/Transfer.tsx
+++ b/packages/amis-ui/src/components/Transfer.tsx
@@ -80,7 +80,7 @@ export interface TransferProps
   onSearch?: (
     term: string,
     setCancel: (cancel: () => void) => void,
-    targePage?: {page: number; perPage?: number}
+    targetPage?: {page: number; perPage?: number}
   ) => Promise<{
     items: Options;
     page?: number;

--- a/packages/amis-ui/src/components/Transfer.tsx
+++ b/packages/amis-ui/src/components/Transfer.tsx
@@ -161,6 +161,10 @@ export interface TransferProps
    * 是否默认都展开
    */
   initiallyOpen?: boolean;
+  /**
+   * ui级联关系，true代表级联选中，false代表不级联，默认为true
+   */
+  autoCheckChildren?: boolean;
 }
 
 export interface TransferState {
@@ -821,6 +825,7 @@ export class Transfer<
       checkAll,
       checkAllLabel,
       onlyChildren,
+      autoCheckChildren = true,
       initiallyOpen = true
     } = props;
 
@@ -865,6 +870,7 @@ export class Transfer<
         checkAllLabel={checkAllLabel}
         checkAll={checkAll}
         initiallyOpen={initiallyOpen}
+        autoCheckChildren={autoCheckChildren}
       />
     ) : selectMode === 'chained' ? (
       <ChainedSelection

--- a/packages/amis-ui/src/components/Transfer.tsx
+++ b/packages/amis-ui/src/components/Transfer.tsx
@@ -171,7 +171,7 @@ export interface TransferState {
   tempValue?: Array<Option> | Option;
   inputValue: string;
   searchResult: Options | null;
-  searchResultPage: {page?: number; perPage?: number; total?: number} | null;
+  searchResultPage?: {page?: number; perPage?: number; total?: number} | null;
   isTreeDeferLoad: boolean;
   resultSelectMode: 'list' | 'tree' | 'table';
 }

--- a/packages/amis-ui/src/components/TransferPicker.tsx
+++ b/packages/amis-ui/src/components/TransferPicker.tsx
@@ -72,6 +72,7 @@ export class TransferPicker extends React.Component<
       popOverContainer,
       maxTagCount,
       overflowTagPopover,
+      placeholder,
       ...rest
     } = this.props;
 
@@ -130,7 +131,7 @@ export class TransferPicker extends React.Component<
             result={value}
             onResultChange={onChange}
             onResultClick={onClick}
-            placeholder={__('Select.placeholder')}
+            placeholder={placeholder ?? __('Select.placeholder')}
             disabled={disabled}
             borderMode={borderMode}
             itemRender={option => (

--- a/packages/amis-ui/src/components/TransferPicker.tsx
+++ b/packages/amis-ui/src/components/TransferPicker.tsx
@@ -37,6 +37,9 @@ export class TransferPicker extends React.Component<
   optionModified = false;
   @autobind
   handleConfirm(value: any) {
+    this.setState({
+      tempValue: null
+    });
     this.props.onChange?.(value, this.optionModified);
     this.optionModified = false;
   }
@@ -48,6 +51,9 @@ export class TransferPicker extends React.Component<
 
   @autobind
   onBlur() {
+    this.setState({
+      tempValue: null
+    });
     this.props.onBlur?.();
   }
 

--- a/packages/amis-ui/src/components/TransferPicker.tsx
+++ b/packages/amis-ui/src/components/TransferPicker.tsx
@@ -23,7 +23,17 @@ export interface TransferPickerProps extends Omit<TransferProps, 'itemRender'> {
   popOverContainer?: any;
 }
 
-export class TransferPicker extends React.Component<TransferPickerProps> {
+export interface TransferPickerState {
+  tempValue?: any;
+}
+
+export class TransferPicker extends React.Component<
+  TransferPickerProps,
+  TransferPickerState
+> {
+  state: TransferPickerState = {
+    tempValue: null
+  };
   optionModified = false;
   @autobind
   handleConfirm(value: any) {
@@ -59,6 +69,15 @@ export class TransferPicker extends React.Component<TransferPickerProps> {
       ...rest
     } = this.props;
 
+    const tp = {
+      value: this.state.tempValue || value,
+      onChange: (value: any) => {
+        this.setState({
+          tempValue: value
+        });
+      }
+    };
+
     return (
       <PickerContainer
         title={__('Select.placeholder')}
@@ -84,13 +103,13 @@ export class TransferPicker extends React.Component<TransferPickerProps> {
                   this.optionModified = true;
                   setState({options, value});
                 } else {
-                  onChange(value);
+                  tp.onChange(value);
                 }
               }}
             />
           );
         }}
-        value={value}
+        value={tp.value}
         onConfirm={this.handleConfirm}
         size={size}
       >

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -760,6 +760,11 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       stopAutoRefreshWhenModalIsOpen
     } = this.props;
 
+    if (store.loading) {
+      //由于curd的loading样式未遮罩按钮部分，如果处于加载中时不处理操作
+      return;
+    }
+
     if (action.actionType === 'dialog') {
       store.setCurrentAction(action);
       const idx: number = (ctx as any).index;

--- a/packages/amis/src/renderers/Form/TabsTransfer.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransfer.tsx
@@ -121,7 +121,7 @@ export class BaseTabsTransferRenderer<
       }
     } else if (term) {
       return filterTree(
-        options,
+        option.children || options,
         (option: Option, key: number, level: number, paths: Array<Option>) => {
           return !!(
             (Array.isArray(option.children) && option.children.length) ||

--- a/packages/amis/src/renderers/Form/TabsTransfer.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransfer.tsx
@@ -307,7 +307,8 @@ export class TabsTransferRenderer extends BaseTabsTransferRenderer<TabsTransferP
       valueTpl,
       menuTpl,
       data,
-      mobileUI
+      mobileUI,
+      initiallyOpen = true
     } = this.props;
 
     return (
@@ -341,6 +342,7 @@ export class TabsTransferRenderer extends BaseTabsTransferRenderer<TabsTransferP
           valueField={valueField}
           ctx={data}
           mobileUI={mobileUI}
+          initiallyOpen={initiallyOpen}
         />
 
         <Spinner

--- a/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
@@ -112,7 +112,8 @@ export class TabsTransferPickerRenderer extends BaseTabsTransferRenderer<TabsTra
       mobileUI,
       env,
       maxTagCount,
-      overflowTagPopover
+      overflowTagPopover,
+      placeholder
     } = this.props;
 
     return (
@@ -120,6 +121,7 @@ export class TabsTransferPickerRenderer extends BaseTabsTransferRenderer<TabsTra
         <TabsTransferPicker
           activeKey={this.state.activeKey}
           onTabChange={this.onTabChange}
+          placeholder={placeholder}
           value={selectedOptions}
           disabled={disabled}
           options={options}

--- a/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TabsTransferPicker.tsx
@@ -113,7 +113,8 @@ export class TabsTransferPickerRenderer extends BaseTabsTransferRenderer<TabsTra
       env,
       maxTagCount,
       overflowTagPopover,
-      placeholder
+      placeholder,
+      initiallyOpen = true
     } = this.props;
 
     return (
@@ -152,6 +153,7 @@ export class TabsTransferPickerRenderer extends BaseTabsTransferRenderer<TabsTra
           popOverContainer={env?.getModalContainer}
           maxTagCount={maxTagCount}
           overflowTagPopover={overflowTagPopover}
+          initiallyOpen={initiallyOpen}
         />
 
         <Spinner

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -364,7 +364,7 @@ export class BaseTransferRenderer<
   async handleSearch(
     term: string,
     cancelExecutor: Function,
-    targePage?: {page: number; perPage?: number}
+    targetPage?: {page: number; perPage?: number}
   ) {
     const {
       searchApi,
@@ -381,7 +381,7 @@ export class BaseTransferRenderer<
       try {
         const payload = await env.fetcher(
           searchApi,
-          createObject(data, {term, ...(targePage ? targePage : {})}),
+          createObject(data, {term, ...(targetPage ? targetPage : {})}),
           {
             cancelExecutor
           }
@@ -398,10 +398,10 @@ export class BaseTransferRenderer<
         }
 
         let currentPage = {};
-        if (targePage) {
+        if (targetPage) {
           currentPage = {
             page: payload.data.page,
-            perPage: targePage.perPage,
+            perPage: targetPage.perPage,
             total: payload.data.count
           };
         }

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -24,7 +24,8 @@ import {
   optionValueCompare,
   resolveVariable,
   ActionObject,
-  toNumber
+  toNumber,
+  evalExpression
 } from 'amis-core';
 import {SpinnerExtraProps, Transfer, Spinner, ResultList} from 'amis-ui';
 import {
@@ -184,7 +185,7 @@ export interface TransferControlSchema
    */
   pagination?: {
     /** 是否左侧选项分页，默认不开启 */
-    enable: boolean;
+    enable: SchemaExpression;
     /** 分页组件CSS类名 */
     className?: string;
     /** 是否开启前端分页 */
@@ -634,6 +635,7 @@ export class BaseTransferRenderer<
       formItem,
       env,
       popOverContainer,
+      data,
       autoCheckChildren = true,
       initiallyOpen = true
     } = this.props;
@@ -707,7 +709,11 @@ export class BaseTransferRenderer<
               'popOverContainerSelector'
             ]),
             enable:
-              !!formItem?.enableSourcePagination &&
+              (pagination && pagination.enable !== undefined
+                ? !!(typeof pagination.enable === 'string'
+                    ? evalExpression(pagination.enable, data)
+                    : pagination.enable)
+                : !!formItem?.enableSourcePagination) &&
               (!selectMode ||
                 selectMode === 'list' ||
                 selectMode === 'table') &&

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -170,6 +170,11 @@ export interface TransferControlSchema
   onlyChildren?: boolean;
 
   /**
+   * 是否默认都展开
+   */
+  initiallyOpen?: boolean;
+
+  /**
    * 分页配置，selectMode为默认和table才会生效
    * @since 3.6.0
    */
@@ -624,7 +629,8 @@ export class BaseTransferRenderer<
       pagination,
       formItem,
       env,
-      popOverContainer
+      popOverContainer,
+      initiallyOpen = true
     } = this.props;
 
     // 目前 LeftOptions 没有接口可以动态加载
@@ -710,6 +716,7 @@ export class BaseTransferRenderer<
             popOverContainer: popOverContainer ?? env?.getModalContainer
           }}
           onPageChange={this.handlePageChange}
+          initiallyOpen={initiallyOpen}
         />
 
         <Spinner

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -173,6 +173,10 @@ export interface TransferControlSchema
    * 是否默认都展开
    */
   initiallyOpen?: boolean;
+  /**
+   * ui级联关系，true代表级联选中，false代表不级联，默认为true
+   */
+  autoCheckChildren?: boolean;
 
   /**
    * 分页配置，selectMode为默认和table才会生效
@@ -630,6 +634,7 @@ export class BaseTransferRenderer<
       formItem,
       env,
       popOverContainer,
+      autoCheckChildren = true,
       initiallyOpen = true
     } = this.props;
 
@@ -717,8 +722,8 @@ export class BaseTransferRenderer<
           }}
           onPageChange={this.handlePageChange}
           initiallyOpen={initiallyOpen}
+          autoCheckChildren={autoCheckChildren}
         />
-
         <Spinner
           overlay
           key="info"

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -187,7 +187,7 @@ export interface TransferControlSchema
     /** 是否左侧选项分页，默认不开启 */
     enable: SchemaExpression;
     /** 分页组件CSS类名 */
-    className?: string;
+    className?: SchemaClassName;
     /** 是否开启前端分页 */
     loadDataOnce?: boolean;
   } & Pick<

--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -175,9 +175,9 @@ export interface TransferControlSchema
    */
   pagination?: {
     /** 是否左侧选项分页，默认不开启 */
-    enable: SchemaExpression;
+    enable: boolean;
     /** 分页组件CSS类名 */
-    className?: SchemaClassName;
+    className?: string;
     /** 是否开启前端分页 */
     loadDataOnce?: boolean;
   } & Pick<

--- a/packages/amis/src/renderers/Form/TransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TransferPicker.tsx
@@ -164,11 +164,11 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
           overflowTagPopover={overflowTagPopover}
           pagination={{
             ...pick(pagination, [
-              'className',
               'layout',
               'perPageAvailable',
               'popOverContainerSelector'
             ]),
+            className: pagination?.className as any,
             enable:
               (pagination && pagination.enable !== undefined
                 ? !!(typeof pagination.enable === 'string'

--- a/packages/amis/src/renderers/Form/TransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TransferPicker.tsx
@@ -1,4 +1,9 @@
-import {OptionsControlProps, OptionsControl, resolveEventData} from 'amis-core';
+import {
+  OptionsControlProps,
+  OptionsControl,
+  resolveEventData,
+  evalExpression
+} from 'amis-core';
 import React from 'react';
 import {Spinner, SpinnerExtraProps} from 'amis-ui';
 import {BaseTransferRenderer, TransferControlSchema} from './Transfer';
@@ -97,6 +102,7 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
       overflowTagPopover,
       pagination,
       formItem,
+      data,
       popOverContainer,
       placeholder,
       autoCheckChildren = true,
@@ -164,7 +170,11 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
               'popOverContainerSelector'
             ]),
             enable:
-              !!formItem?.enableSourcePagination &&
+              (pagination && pagination.enable !== undefined
+                ? !!(typeof pagination.enable === 'string'
+                    ? evalExpression(pagination.enable, data)
+                    : pagination.enable)
+                : !!formItem?.enableSourcePagination) &&
               (!selectMode ||
                 selectMode === 'list' ||
                 selectMode === 'table') &&

--- a/packages/amis/src/renderers/Form/TransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TransferPicker.tsx
@@ -7,6 +7,7 @@ import {autobind, createObject} from 'amis-core';
 import {ActionObject, toNumber} from 'amis-core';
 import {supportStatic} from './StaticHoc';
 import {isMobile} from 'amis-core';
+import pick from 'lodash/pick';
 
 /**
  * TransferPicker 穿梭器的弹框形态
@@ -93,7 +94,10 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
       mobileUI,
       env,
       maxTagCount,
-      overflowTagPopover
+      overflowTagPopover,
+      pagination,
+      formItem,
+      popOverContainer
     } = this.props;
 
     // 目前 LeftOptions 没有接口可以动态加载
@@ -148,6 +152,28 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
           popOverContainer={env?.getModalContainer}
           maxTagCount={maxTagCount}
           overflowTagPopover={overflowTagPopover}
+          pagination={{
+            ...pick(pagination, [
+              'className',
+              'layout',
+              'perPageAvailable',
+              'popOverContainerSelector'
+            ]),
+            enable:
+              !!formItem?.enableSourcePagination &&
+              (!selectMode ||
+                selectMode === 'list' ||
+                selectMode === 'table') &&
+              options.length > 0,
+            maxButtons: Number.isInteger(pagination?.maxButtons)
+              ? pagination?.maxButtons
+              : 5,
+            page: formItem?.sourcePageNum,
+            perPage: formItem?.sourcePerPageNum,
+            total: formItem?.sourceTotalNum,
+            popOverContainer: popOverContainer ?? env?.getModalContainer
+          }}
+          onPageChange={this.handlePageChange}
         />
 
         <Spinner

--- a/packages/amis/src/renderers/Form/TransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TransferPicker.tsx
@@ -98,7 +98,8 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
       pagination,
       formItem,
       popOverContainer,
-      placeholder
+      placeholder,
+      initiallyOpen = true
     } = this.props;
 
     // 目前 LeftOptions 没有接口可以动态加载
@@ -176,6 +177,7 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
             popOverContainer: popOverContainer ?? env?.getModalContainer
           }}
           onPageChange={this.handlePageChange}
+          initiallyOpen={initiallyOpen}
         />
 
         <Spinner

--- a/packages/amis/src/renderers/Form/TransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TransferPicker.tsx
@@ -97,7 +97,8 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
       overflowTagPopover,
       pagination,
       formItem,
-      popOverContainer
+      popOverContainer,
+      placeholder
     } = this.props;
 
     // 目前 LeftOptions 没有接口可以动态加载
@@ -119,6 +120,7 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
     return (
       <div className={cx('TransferControl', className)}>
         <TransferPicker
+          placeholder={placeholder}
           borderMode={borderMode}
           selectMode={selectMode}
           value={selectedOptions}

--- a/packages/amis/src/renderers/Form/TransferPicker.tsx
+++ b/packages/amis/src/renderers/Form/TransferPicker.tsx
@@ -99,6 +99,7 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
       formItem,
       popOverContainer,
       placeholder,
+      autoCheckChildren = true,
       initiallyOpen = true
     } = this.props;
 
@@ -177,6 +178,7 @@ export class TransferPickerRenderer extends BaseTransferRenderer<TabsTransferPro
             popOverContainer: popOverContainer ?? env?.getModalContainer
           }}
           onPageChange={this.handlePageChange}
+          autoCheckChildren={autoCheckChildren}
           initiallyOpen={initiallyOpen}
         />
 


### PR DESCRIPTION
### What
1. 新增TransferPicker的分页支持

2. 修复Transfer组件开发分页时，搜索不支持分页的问题

3. 新增TransferPicker和TabsTransferPicker支持placeholder配置项

4. 修复TabsTransfer在多tab状态下搜索问题

5. Transfer组件及相关的Tabs和Picker，增加tree模式下的initiallyOpen支持

6. 修复CRUD组件在loading状态下按钮仍然可以触发操作

7. 修复Transfer组件autoCheckChildren的传参问题

本次提交是 #9195 的rebase，并增加了第7点内容

### Why
1. 在3.6.1版本Transfer新增了分页功能，但是TransferPicker以及TabsTransferPicker并不支持

2. Transfer组件在开启分页和搜索时，用户进行搜索操作；请求接口搜索到结果时页码组件并未刷新，仍然使用默认数据的分页而不是使用搜索结果的分页

3. TransferPicker和TabsTransferPicker目前并不支持配置placeholder，作为表单的组件应该统一支持这个配置项

4. 在TabsTransfer组件下，如果数据是静态的、多个tabs并且开启了搜索，当用户停留在某个tab下时，搜索出来的内容时全部tab的，而且内容显示错乱

5. Transfer组件在tree模式下，当前默认是展开所有选项的，而用户可能会出现数据量过多默认需要收起的情况，所以希望新增tree组件的initiallyOpen配置项来支持

6. CRUD组件在加载中状态时所有按钮本应该被遮罩住的，但是发现代码有关于遮罩会导致弹层被影响所以去掉了按钮的遮罩，导致用户可以加载中时操作按钮重复触发行为

7. 发现Transfer组件缺少了对InputTree组件属性autoCheckChildren的传参，这是InputTree组件已经实现的功能

### How
1. 参考Transfer的实现方式，差别的地方是在TransferPicker中选择选项并不会直接修改表单值，必须在用户点击确定后，所以这里在组件中新增了临时状态存储。
	提交编号: 71192e5
	临时状态在每次确定或者取消时清理
	提交编号: 6ae1a56

2. Transfer组件新增搜索分页的存储和分页逻辑。
	提交编号: 6ae1a56

3. placeholder配置转递给UI组件
	提交编号: 33c30d5

4. 修复成只能搜索到当前tab下的数据
	提交编号: f0e1757

5. 修改Transfer、TransferPicker、TabsTransferPicker将initiallyOpen传递给tree组件
	提交编号: 5791ae3

6. 因为不熟悉被注解掉的代码影响范围不好去修复该问题，所以使用临时解决方案，在用户点击按钮时发现是加载中时跳出逻辑
	提交编号: 01c4c63

7. 增加autoCheckChildren的参数传递
	提交编号: 01021297


