### PR TITLE
fix: 图片组件优化:调整预览标题位置;优化上传组件文件提及限制提示;修复编辑器拖拽后修改宽高无效的问题

### DIFF
--- a/packages/amis-editor/src/plugin/Form/InputImage.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputImage.tsx
@@ -372,7 +372,19 @@ export class ImageControlPlugin extends BasePlugin {
               getSchemaTpl('switch', {
                 name: 'limit',
                 label: '图片限制',
-                pipeIn: (value: any) => !!value
+                pipeIn: (value: any) => !!value,
+                onChange: (
+                  value: any,
+                  oldValue: boolean,
+                  model: any,
+                  form: any
+                ) => {
+                  if (!value) {
+                    form.setValues({
+                      maxSize: undefined
+                    });
+                  }
+                }
               }),
 
               {

--- a/packages/amis-editor/src/plugin/Image.tsx
+++ b/packages/amis-editor/src/plugin/Image.tsx
@@ -190,12 +190,30 @@ export class ImagePlugin extends BasePlugin {
               {
                 name: 'width',
                 label: '宽度',
-                type: 'input-number'
+                type: 'input-number',
+                onChange: (value: any) => {
+                  const node = context.node;
+                  node.updateState({
+                    width: value
+                  });
+                  requestAnimationFrame(() => {
+                    node.calculateHighlightBox();
+                  });
+                }
               },
               {
                 name: 'height',
                 label: '高度',
-                type: 'input-number'
+                type: 'input-number',
+                onChange: (value: any) => {
+                  const node = context.node;
+                  node.updateState({
+                    height: value
+                  });
+                  requestAnimationFrame(() => {
+                    node.calculateHighlightBox();
+                  });
+                }
               },
 
               isUnderField

--- a/packages/amis-ui/scss/components/_image-gallery.scss
+++ b/packages/amis-ui/scss/components/_image-gallery.scss
@@ -17,6 +17,7 @@
   border: none;
   border-radius: 0;
   max-width: 1010px !important;
+  padding-top: 0;
 
   &-close {
     position: absolute;
@@ -36,12 +37,13 @@
   }
 
   &-title {
-    height: px2rem(30px);
+    height: px2rem(18px);
     vertical-align: top;
-    line-height: px2rem(30px);
+    line-height: px2rem(18px);
     font-size: px2rem(12px);
     color: var(--white);
     text-align: center;
+    margin-bottom: 18px;
   }
 
   &-main {

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -1671,7 +1671,6 @@ export default class ImageControl extends React.Component<
             accept={accept}
             multiple={dropMultiple}
             disabled={disabled}
-            maxSize={crop ? undefined : maxSize}
           >
             {({
               getRootProps,


### PR DESCRIPTION
## input-image 组件
1.图片预览标题与关闭icon，保持在同一行
![image](https://github.com/baidu/amis/assets/16409259/2e7b7c27-c734-441a-b36a-4ad025082004)

2. 图片设置大小上限，上传oversize文件时提示异常，修改为不走rc的提示，走自定义提示
![image](https://github.com/baidu/amis/assets/16409259/060d9d09-77f9-4aee-8a95-1fcbcfd49a7a)
修改后
![image](https://github.com/baidu/amis/assets/16409259/7fd16565-347e-468b-a93a-73d925ca60d7)

3. 修复编辑器中设置maxSize后，关闭图片限制后仍然会校验maxSize的问题

## image组件 编辑器
1. 修复 编辑器 拖动图片大小后修改宽高失效 的问题