### PR TITLE
fix: issue#9468,inputtag在输入内容为空，回车触发表单提交，假死问题

### DIFF
--- a/packages/amis/src/renderers/Form/InputTag.tsx
+++ b/packages/amis/src/renderers/Form/InputTag.tsx
@@ -506,6 +506,8 @@ export default class TagControl extends React.PureComponent<
       this.setState({
         inputValue: ''
       });
+    } else if (!value && evt.key === 'Enter') {
+      this.handleBlur(evt);
     }
   }
 


### PR DESCRIPTION
### What
inputtag在带有提交地址的Form中，内容为空，回车，出现假死问题。对应issue#9468
### Why
inputtag组件内容为空时，回车提交，触发Form的提交。input-tag失焦，但是内部的handlerBlur回调没有执行【查询资料发现，由于某些原因，浏览器并不保证所有的blur事件都会被执行】，导致inputtag组件的下拉未收起，其浮层遮挡了所有的可是元素，用户操作没有反应，给人一种假死的感觉
### How
在inputtag组件的handleKeyDown中，增加分支条件。判断value为空且输入回车时，调用handleBlur，关闭弹窗，再触发Form的表单提交，可以解决当前问题
