### PR TITLE
fix: 修复日期时间范围选择组件bug

### DIFF
--- a/packages/amis-editor-core/src/component/factory.tsx
+++ b/packages/amis-editor-core/src/component/factory.tsx
@@ -21,7 +21,8 @@ import {
   JSONPipeIn,
   JSONPipeOut,
   JSONUpdate,
-  getFixDialogType
+  getFixDialogType,
+  appTranslate
 } from '../util';
 import {createObjectFromChain} from 'amis-core';
 import {ErrorBoundary} from 'amis-core';
@@ -106,7 +107,7 @@ export function makeWrapper(
         manager.dataSchema.addScope([], this.scopeId);
         if (info.name) {
           const nodeSchema = manager.store.getNodeById(info.id)?.schema;
-          const tag = nodeSchema?.title ?? nodeSchema?.name;
+          const tag = appTranslate(nodeSchema?.title ?? nodeSchema?.name);
           manager.dataSchema.current.tag = `${info.name}${
             tag ? ` : ${tag}` : ''
           }`;

--- a/packages/amis-ui/src/components/DateRangePicker.tsx
+++ b/packages/amis-ui/src/components/DateRangePicker.tsx
@@ -525,7 +525,8 @@ export class DateRangePicker extends React.Component<
     value: any,
     format: string,
     joinValues: boolean,
-    delimiter: string
+    delimiter: string,
+    data: any
   ) {
     if (!value) {
       return {
@@ -538,8 +539,8 @@ export class DateRangePicker extends React.Component<
       value = value.split(delimiter);
     }
 
-    const startDate = moment(value?.[0], format);
-    const endDate = moment(value?.[1], format);
+    const startDate = filterDate(value?.[0], data, format);
+    const endDate = filterDate(value?.[1], data, format);
 
     /**
      * 不合法的value输入都丢弃
@@ -604,13 +605,15 @@ export class DateRangePicker extends React.Component<
       inputFormat,
       displayFormat,
       dateFormat,
-      timeFormat
+      timeFormat,
+      data
     } = this.props;
     const {startDate, endDate} = DateRangePicker.unFormatValue(
       value,
       valueFormat || (format as string),
       joinValues,
-      delimiter
+      delimiter,
+      data
     );
 
     let curDateFormat = dateFormat ?? '';
@@ -684,7 +687,8 @@ export class DateRangePicker extends React.Component<
       displayFormat,
       dateFormat,
       timeFormat,
-      delimiter
+      delimiter,
+      data
     } = props;
     if (
       prevProps.displayFormat != displayFormat ||
@@ -719,7 +723,8 @@ export class DateRangePicker extends React.Component<
         value,
         valueFormat || (format as string),
         joinValues,
-        delimiter
+        delimiter,
+        data
       );
       this.setState({
         startDate,
@@ -809,13 +814,15 @@ export class DateRangePicker extends React.Component<
         joinValues,
         delimiter,
         inputFormat,
-        displayFormat
+        displayFormat,
+        data
       } = this.props;
       const {startDate, endDate} = DateRangePicker.unFormatValue(
         value,
         valueFormat || (format as string),
         joinValues,
-        delimiter
+        delimiter,
+        data
       );
       this.setState({
         startDate,
@@ -1436,7 +1443,8 @@ export class DateRangePicker extends React.Component<
       joinValues,
       delimiter,
       inputFormat,
-      displayFormat
+      displayFormat,
+      data
     } = this.props;
     if (!resetValue) {
       return;
@@ -1445,7 +1453,8 @@ export class DateRangePicker extends React.Component<
       resetValue,
       valueFormat || (format as string),
       joinValues,
-      delimiter
+      delimiter,
+      data
     );
     onChange(resetValue);
     this.setState({
@@ -1535,6 +1544,11 @@ export class DateRangePicker extends React.Component<
       currentDate.isBetween(startDate, endDate, 'day', '[]')
     ) {
       props.className += ' rdtBetween';
+    }
+
+    // 如果已经选择了开始时间和结束时间，那么中间的时间都不应该高亮
+    if (startDate && endDate && props.className.includes('rdtActive')) {
+      props.className = props.className.replace('rdtActive', '');
     }
 
     if (startDate && currentDate.isSame(startDate, 'day')) {

--- a/packages/amis-ui/src/components/MonthRangePicker.tsx
+++ b/packages/amis-ui/src/components/MonthRangePicker.tsx
@@ -113,17 +113,29 @@ export class MonthRangePicker extends React.Component<
     this.state = {
       isOpened: false,
       isFocused: false,
-      ...DateRangePicker.unFormatValue(value, format, joinValues, delimiter)
+      ...DateRangePicker.unFormatValue(
+        value,
+        format,
+        joinValues,
+        delimiter,
+        this.props.data
+      )
     };
   }
 
   componentDidUpdate(prevProps: MonthRangePickerProps) {
     const props = this.props;
-    const {value, format, joinValues, delimiter} = props;
+    const {value, format, joinValues, delimiter, data} = props;
 
     if (prevProps.value !== value) {
       this.setState({
-        ...DateRangePicker.unFormatValue(value, format, joinValues, delimiter)
+        ...DateRangePicker.unFormatValue(
+          value,
+          format,
+          joinValues,
+          delimiter,
+          data
+        )
       });
     }
   }
@@ -577,14 +589,16 @@ export class MonthRangePicker extends React.Component<
       ranges,
       shortcuts,
       label,
-      translate: __
+      translate: __,
+      data
     } = this.props;
     const {isOpened, isFocused, startDate, endDate} = this.state;
     const selectedDate = DateRangePicker.unFormatValue(
       value,
       format,
       joinValues,
-      delimiter
+      delimiter,
+      data
     );
     const startViewValue = selectedDate.startDate
       ? selectedDate.startDate.format(inputFormat)


### PR DESCRIPTION
## 问题：
1. 在crud中日期范围组件显示错误
{
  "type": "crud",
  "syncLocation": false,
  "columns": [
    {
      "name": "id",
      "label": "ID",
      "type": "text",
      "id": "u:f980a646c8fc"
    }
  ],
  "headerToolbar": [
    {
      "type": "input-datetime-range",
      "label": "日期范围",
      "name": "date-range",
      "value": "-6days, +1days",
      "id": "u:6b0f8b9bb91b"
    }
  ]
}
![image](https://github.com/baidu/amis/assets/30946345/04fe4046-117a-4f2f-b647-5ff42be0451e)

2. 日期范围组件左侧点击两次，右侧再点击一次，左侧会出现3个高亮的时间
![image](https://github.com/baidu/amis/assets/30946345/4a5f4288-5ccc-43fb-b380-b989586ccbc9)

## 修改：
1. moment函数处理+60days类似的时间是错误的，所以改为filterDate处理
2. 如果同时存在开始和结束时间了，就剔除选中时间的高亮