### PR TITLE
fix: 修复popover存在多个子popover时,错误关闭父级问题

### DIFF
--- a/packages/amis-core/src/components/Overlay.tsx
+++ b/packages/amis-core/src/components/Overlay.tsx
@@ -17,7 +17,8 @@ import {
   noop,
   ownerDocument,
   resizeSensor,
-  RootClose
+  RootClose,
+  uuid
 } from '../utils';
 
 export const SubPopoverDisplayedID = 'data-sub-popover-displayed';
@@ -39,6 +40,7 @@ class Position extends React.Component<any, any> {
   watchedTarget: any;
   parentPopover: any;
   // setState: (state: any) => void;
+  componentId: string;
 
   static defaultProps = {
     containerPadding: 0,
@@ -57,6 +59,7 @@ class Position extends React.Component<any, any> {
     };
 
     this._lastTarget = null;
+    this.componentId = uuid();
   }
 
   updatePosition(target: any) {
@@ -68,7 +71,10 @@ class Position extends React.Component<any, any> {
 
       if (!this.parentPopover && parentPopover) {
         this.parentPopover = parentPopover;
-        this.parentPopover.setAttribute(SubPopoverDisplayedID, true);
+        this.parentPopover.setAttribute(
+          SubPopoverDisplayedID + '-' + this.componentId,
+          true
+        );
       }
     }
 
@@ -152,11 +158,17 @@ class Position extends React.Component<any, any> {
   };
 
   componentWillUnmount() {
+    // 一个 PopOver 关闭时，需把挂载父 PopOver 的标记去掉
+    // 这里可能会存在多个子 PopOver 的情况，所以需要加上 componentId
     if (
       this.parentPopover &&
-      this.parentPopover.getAttribute(SubPopoverDisplayedID)
+      this.parentPopover.getAttribute(
+        SubPopoverDisplayedID + '-' + this.componentId
+      )
     ) {
-      this.parentPopover.removeAttribute(SubPopoverDisplayedID);
+      this.parentPopover.removeAttribute(
+        SubPopoverDisplayedID + '-' + this.componentId
+      );
       this.parentPopover = null;
     }
 
@@ -188,7 +200,8 @@ class Position extends React.Component<any, any> {
         ...child.props.style,
         left: positionLeft,
         top: positionTop
-      }
+      },
+      componentId: this.componentId
     });
   }
 }

--- a/packages/amis-core/src/components/PopOver.tsx
+++ b/packages/amis-core/src/components/PopOver.tsx
@@ -125,7 +125,9 @@ export class PopOver extends React.PureComponent<PopOverProps, PopOverState> {
       closeOnOutside &&
       target &&
       this.wrapperRef.current &&
-      !this.wrapperRef.current.getAttribute(SubPopoverDisplayedID) &&
+      !this.wrapperRef.current
+        .getAttributeNames()
+        .find(n => n.startsWith(SubPopoverDisplayedID)) &&
       ((!this.wrapperRef.current.contains(target) &&
         !target.closest('[role=dialog]')) ||
         (target.matches(`.${ns}Modal`) && target === this.wrapperRef.current))
@@ -198,6 +200,7 @@ export class PopOver extends React.PureComponent<PopOverProps, PopOverState> {
       classPrefix: ns,
       classnames: cx,
       className,
+      componentId,
       ...rest
     } = this.props;
 

--- a/packages/amis-theme-editor-helper/src/style/_padding-and-margin.scss
+++ b/packages/amis-theme-editor-helper/src/style/_padding-and-margin.scss
@@ -202,6 +202,7 @@ $bg: url('data:image/svg+xml;base64,Cjxzdmcgd2lkdGg9IjI1NnB4IiBoZWlnaHQ9IjEzMnB4
     }
     &-popover {
       padding: px2rem(16px) px2rem(12px);
+      width: px2rem(200px);
       .cxd-Form-item {
         margin-bottom: 0;
       }

--- a/packages/amis-ui/src/components/Tooltip.tsx
+++ b/packages/amis-ui/src/components/Tooltip.tsx
@@ -49,6 +49,7 @@ export class Tooltip extends React.Component<TooltipProps> {
       onMouseEnter,
       onMouseLeave,
       bodyClassName,
+      componentId,
       ...rest
     } = this.props;
 


### PR DESCRIPTION
### What

### Why

### How
