### PR TITLE
fix: 修复单元格中直接放表单项 name 为带路径的变量时值修改不符合预期的问题

### DIFF
--- a/packages/amis/src/renderers/Table/TableRow.tsx
+++ b/packages/amis/src/renderers/Table/TableRow.tsx
@@ -6,6 +6,7 @@ import {
   RendererEvent,
   RendererProps,
   autobind,
+  setVariable,
   traceProps
 } from 'amis-core';
 import {Action} from '../Action';
@@ -157,15 +158,10 @@ export class TableRow extends React.PureComponent<
     }
 
     const {item, onQuickChange} = this.props;
+    const data: any = {};
+    setVariable(data, name, value);
 
-    onQuickChange?.(
-      item,
-      {
-        [name]: value
-      },
-      submit,
-      changePristine
-    );
+    onQuickChange?.(item, data, submit, changePristine);
   }
 
   render() {


### PR DESCRIPTION
### What

### Why

### How
