### PR TITLE
style: 优化编辑器中 icon 样式

### DIFF
--- a/packages/amis-editor-core/scss/control/_status.scss
+++ b/packages/amis-editor-core/scss/control/_status.scss
@@ -6,10 +6,13 @@
   }
   &-tip-icon {
     margin-left: 0.25rem;
-    line-height: 16px;
+    line-height: 14px;
+    display: inline-block;
+    cursor: pointer;
+
     .icon {
-      width: 16px;
-      height: 16px;
+      width: 14px;
+      height: 14px;
       fill: #84868c;
     }
   }


### PR DESCRIPTION
### What

问题，独占了一行整个空白处都能 hover

<img width="460" alt="image" src="https://github.com/baidu/amis/assets/2698393/204a9dbb-cb65-463a-b8fe-78e8757a61ad">


修改后：
<img width="511" alt="image" src="https://github.com/baidu/amis/assets/2698393/03bfe966-845d-43e8-bdb3-7a315f4e8f27">


### Why

### How
