### PR TITLE
fix: 修正tabs特定场景下，切换标签页报错问题；对应issue#9544

### DIFF
--- a/packages/amis-ui/src/components/Tabs.tsx
+++ b/packages/amis-ui/src/components/Tabs.tsx
@@ -388,8 +388,8 @@ export class Tabs extends React.Component<TabsProps, any> {
     }
     const {activeKey, children} = this.props;
     const currentKey = key !== undefined ? key : activeKey;
-    const currentIndex = (children as any[])?.findIndex(
-      (item: any) => item.props.eventKey === currentKey
+    const currentIndex = (children as any[])?.findIndex((item: any) =>
+      item === null ? false : item.props.eventKey === currentKey
     );
     const li = this.navMain.current?.children || [];
     const currentLi = li[currentIndex] as HTMLElement;


### PR DESCRIPTION
### What
tabs组件，tabs属性内容使用了visibleOn属性，切换到visibloeOn属性的后一个标签页，会报错
### Why
tabs属性中的内容使用了visibleOn，会导致children内生成null元素，访问null元素的属性会报错
### How
判断如果是null元素，直接返回false