### PR TITLE
fix: editor-修复穿梭器表格形式设置表格列不填写字段名时valueTpl为undefined的问题

### DIFF
--- a/packages/amis-editor/src/renderer/TransferTableControl.tsx
+++ b/packages/amis-editor/src/renderer/TransferTableControl.tsx
@@ -324,7 +324,7 @@ export default class TransferTableOption extends React.Component<
     return {
       type: 'action',
       actionType: 'dialog',
-      label: '添加表格列',
+      label: '设置表格列',
       level: 'enhance',
       dialog: {
         title: '设置表格列选项',
@@ -348,12 +348,14 @@ export default class TransferTableOption extends React.Component<
               {
                 type: 'input-text',
                 name: 'label',
-                placeholder: '标题'
+                placeholder: '标题',
+                required: true
               },
               {
                 type: 'input-text',
                 name: 'name',
-                placeholder: '绑定字段名'
+                placeholder: '绑定字段名',
+                required: true
               },
               {
                 type: 'select',
@@ -417,7 +419,7 @@ export default class TransferTableOption extends React.Component<
         {
           type: 'action',
           actionType: 'dialog',
-          label: '添加表格行',
+          label: '设置表格行',
           level: 'enhance',
           disabled: columns && columns.length === 0,
           block: true,


### PR DESCRIPTION
### What
![image](https://github.com/baidu/amis/assets/16409259/3fe3df72-e502-49af-b50c-313cdd253058)

### Why
添加表格列时，没有填写 字段名，导致取不到值字段
### How
设置表格列时，将标题和字段名设置为必填
![image](https://github.com/baidu/amis/assets/16409259/c81fb183-3b9b-4acb-8a2b-f2b53d03a120)
