### PR TITLE
fix: diff-editor 主题色

### DIFF
--- a/packages/amis/src/renderers/Form/DiffEditor.tsx
+++ b/packages/amis/src/renderers/Form/DiffEditor.tsx
@@ -73,7 +73,7 @@ function normalizeValue(value: any, language?: string) {
 export class DiffEditor extends React.Component<DiffEditorProps, any> {
   static defaultProps: Partial<DiffEditorProps> = {
     language: 'javascript',
-    theme: 'vs',
+    editorTheme: 'vs',
     options: {
       automaticLayout: false,
       selectOnLineNumbers: true,
@@ -304,7 +304,7 @@ export class DiffEditor extends React.Component<DiffEditorProps, any> {
       size,
       options,
       language,
-      theme,
+      editorTheme,
       classnames: cx
     } = this.props;
 
@@ -326,7 +326,7 @@ export class DiffEditor extends React.Component<DiffEditorProps, any> {
           onChange={onChange}
           disabled={disabled}
           language={language}
-          theme={theme}
+          editorTheme={editorTheme}
           editorDidMount={this.handleEditorMounted}
           editorFactory={this.editorFactory}
           options={{


### PR DESCRIPTION
### What
diff-editor 的 主题色 theme 设置不生效
### Why

### How
editor props的主题色为 editorTheme ，而 diff-editor 为 theme ，修改为 editorTheme 即可