### PR TITLE
feat: messages 支持数据渲染

### DIFF
--- a/examples/components/CRUD/Table.jsx
+++ b/examples/components/CRUD/Table.jsx
@@ -303,7 +303,16 @@ export default {
               body: {
                 type: 'form',
                 name: 'sample-edit-form',
-                api: '/api/sample/$id',
+                data:{
+                  env: 'test'
+                },
+                api: {
+                  method:'post',
+                  url:'/api/sample/$id',
+                  messages:{
+                    success: '成功了-${env}'
+                  }
+                },
                 body: [
                   {
                     type: 'input-text',

--- a/packages/amis-core/src/store/service.ts
+++ b/packages/amis-core/src/store/service.ts
@@ -6,7 +6,7 @@ import {ServerError} from '../utils/errors';
 import {normalizeApiResponseData} from '../utils/api';
 import {replaceText} from '../utils/replaceText';
 import {concatData} from '../utils/concatData';
-
+import {filter} from 'amis-core';
 export const ServiceStore = iRendererStore
   .named('ServiceStore')
   .props({
@@ -54,7 +54,7 @@ export const ServiceStore = iRendererStore
     }
 
     function updateMessage(msg?: string, error: boolean = false) {
-      self.msg = (msg && String(msg)) || '';
+      self.msg = (msg && filter(msg, self.data)) || '';
       self.error = error;
     }
 


### PR DESCRIPTION
### What
![image](https://github.com/baidu/amis/assets/104816514/e86e8859-de85-4491-8ef2-3a72475ffa71)
### Why
messages 没有解析数据，直接读取的字符串
### How
packages/amis-core/src/store/service.ts
需要从数据中解析msg