### PR TITLE
fix(amis-theme-editor-helper): 字体、边框、内外边距等外观配置增加默认placeholder

### DIFF
--- a/packages/amis-theme-editor-helper/src/renderers/Border.tsx
+++ b/packages/amis-theme-editor-helper/src/renderers/Border.tsx
@@ -270,16 +270,18 @@ function BoxBorder(props: BorderProps & FormControlProps) {
             }-border-width`}
             state={state}
             inheritValue={editorThemePath ? 'inherit' : ''}
-            placeholder={editorDefaultValue?.[getKey('width')]}
+            placeholder={editorDefaultValue?.[getKey('width')] || '边框粗细'}
           />
           <div className="Theme-Border-settings-style-color">
             <Select
               options={borderStyleOptions}
               value={borderData[getKey('style')]}
-              placeholder={getLabel(
-                editorDefaultValue?.[getKey('style')],
-                borderStyleOptions
-              )}
+              placeholder={
+                getLabel(
+                  editorDefaultValue?.[getKey('style')],
+                  borderStyleOptions
+                ) || '边框样式'
+              }
               onChange={(item: any) => changeItem('style')(item.value)}
               clearable={!!editorDefaultValue}
               renderMenu={(item: Options) => {
@@ -322,7 +324,7 @@ function BoxBorder(props: BorderProps & FormControlProps) {
               itemName={`${
                 borderType === 'all' ? 'top' : borderType
               }-border-color`}
-              placeholder={editorDefaultValue?.[getKey('color')]}
+              placeholder={editorDefaultValue?.[getKey('color')] || '边框颜色'}
             />
           </div>
         </div>

--- a/packages/amis-theme-editor-helper/src/renderers/Font.tsx
+++ b/packages/amis-theme-editor-helper/src/renderers/Font.tsx
@@ -1001,7 +1001,7 @@ function FontEditor(props: FontEditorProps) {
                   }}
                   itemName="color"
                   state={state}
-                  placeholder={editorDefaultValue?.color}
+                  placeholder={editorDefaultValue?.color || '字体颜色'}
                   editorInheritValue={editorInheritValue?.color}
                 />
               </div>
@@ -1019,7 +1019,7 @@ function FontEditor(props: FontEditorProps) {
                   menuTpl="label"
                   state={state}
                   inheritValue={editorThemePath ? 'inherit' : ''}
-                  placeholder={editorDefaultValue?.fontSize}
+                  placeholder={editorDefaultValue?.fontSize || '字体大小'}
                 />
               </div>
             )}
@@ -1038,7 +1038,7 @@ function FontEditor(props: FontEditorProps) {
                   menuTpl="label"
                   state={state}
                   inheritValue={editorThemePath ? 'inherit' : ''}
-                  placeholder={editorDefaultValue?.fontWeight}
+                  placeholder={editorDefaultValue?.fontWeight || '字体字重'}
                 />
                 {(!hideLineHeight || !hideFontFamily) && (
                   <div className="Theme-FontEditor-item-label">字重</div>
@@ -1058,7 +1058,7 @@ function FontEditor(props: FontEditorProps) {
                   menuTpl="label"
                   state={state}
                   inheritValue={editorThemePath ? 'inherit' : ''}
-                  placeholder={editorDefaultValue?.lineHeight}
+                  placeholder={editorDefaultValue?.lineHeight || '字体行高'}
                 />
                 <div className="Theme-FontEditor-item-label">行高</div>
               </div>

--- a/packages/amis-theme-editor-helper/src/renderers/PaddingAndMargin.tsx
+++ b/packages/amis-theme-editor-helper/src/renderers/PaddingAndMargin.tsx
@@ -231,7 +231,7 @@ function PaddingAndMarginDialog(props: PaddingAndMarginProps) {
                   itemName="margin-all"
                   state={state}
                   inheritValue={editorThemePath ? 'inherit' : ''}
-                  placeholder={editorDefaultValue?.margin}
+                  placeholder={editorDefaultValue?.margin || '外边距'}
                 />
                 <div className="Theme-PaddingAndMargin-input-label">外边距</div>
               </div>
@@ -250,7 +250,7 @@ function PaddingAndMarginDialog(props: PaddingAndMarginProps) {
                   itemName="padding-all"
                   state={state}
                   inheritValue={editorThemePath ? 'inherit' : ''}
-                  placeholder={editorDefaultValue?.padding}
+                  placeholder={editorDefaultValue?.padding || '内边距'}
                 />
                 <div className="Theme-PaddingAndMargin-input-label">内边距</div>
               </div>

--- a/packages/amis-theme-editor-helper/src/renderers/Radius.tsx
+++ b/packages/amis-theme-editor-helper/src/renderers/Radius.tsx
@@ -196,7 +196,7 @@ function BoxRadius(props: RadiusProps & RendererProps) {
             itemName={'all-border-radius'}
             state={state}
             inheritValue={editorThemePath ? 'inherit' : ''}
-            placeholder={editorDefaultValue?.[getKey('all')]}
+            placeholder={editorDefaultValue?.[getKey('all')] || '圆角'}
           />
         </div>
       </div>


### PR DESCRIPTION
用于解决以下问题：
1、很多内置组件相关配置项没有配置主题路径值（editorThemePath），导致placeholder为空，没有任何提示；
2、报表组件和自定义组件也存在以上问题。