### PR TITLE
feat: crud自定义列在drag模式下支持全选

### DIFF
--- a/packages/amis/src/renderers/Table/ColumnToggler.tsx
+++ b/packages/amis/src/renderers/Table/ColumnToggler.tsx
@@ -375,11 +375,12 @@ export default class ColumnToggler extends React.Component<
       overlay,
       translate: __,
       footerBtnSize,
+      children,
       env
     } = this.props;
 
     const {enableSorting, tempColumns} = this.state;
-
+    const inDragging = enableSorting && draggable && tempColumns.length > 1;
     return (
       <>
         <Modal
@@ -403,7 +404,9 @@ export default class ColumnToggler extends React.Component<
               <Icon icon="close" className="icon" />
             </a>
           </header>
-
+          {!inDragging && (
+            <ul className={cx('ColumnToggler-modal-content')}>{children}</ul>
+          )}
           <ul className={cx('ColumnToggler-modal-content')} ref={this.dragRef}>
             {Array.isArray(tempColumns)
               ? tempColumns.map((column, index) => (
@@ -419,7 +422,7 @@ export default class ColumnToggler extends React.Component<
                       className={cx('ColumnToggler-menuItem')}
                       key={column.index}
                     >
-                      {enableSorting && draggable && tempColumns.length > 1 ? (
+                      {inDragging ? (
                         <>
                           <a className={cx('ColumnToggler-menuItem-dragBar')}>
                             <Icon icon="drag" className={cx('icon')} />

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -2333,39 +2333,42 @@ export default class Table extends React.Component<TableProps, object> {
           </li>
         ) : null}
 
-        {store.toggableColumns.map(column => (
-          <li
-            className={cx('ColumnToggler-menuItem')}
-            key={column.index}
-            onClick={async () => {
-              const {data, dispatchEvent} = this.props;
-              let columns = store.activeToggaleColumns.map(
-                item => item.pristine
-              );
-              if (!column.toggled) {
-                columns.push(column.pristine);
-              } else {
-                columns = columns.filter(c => c.name !== column.pristine.name);
-              }
-              const rendererEvent = await dispatchEvent(
-                'columnToggled',
-                createObject(data, {
-                  columns
-                })
-              );
+        {!config?.draggable &&
+          store.toggableColumns.map(column => (
+            <li
+              className={cx('ColumnToggler-menuItem')}
+              key={column.index}
+              onClick={async () => {
+                const {data, dispatchEvent} = this.props;
+                let columns = store.activeToggaleColumns.map(
+                  item => item.pristine
+                );
+                if (!column.toggled) {
+                  columns.push(column.pristine);
+                } else {
+                  columns = columns.filter(
+                    c => c.name !== column.pristine.name
+                  );
+                }
+                const rendererEvent = await dispatchEvent(
+                  'columnToggled',
+                  createObject(data, {
+                    columns
+                  })
+                );
 
-              if (rendererEvent?.prevented) {
-                return;
-              }
+                if (rendererEvent?.prevented) {
+                  return;
+                }
 
-              column.toggleToggle();
-            }}
-          >
-            <Checkbox size="sm" classPrefix={ns} checked={column.toggled}>
-              {column.label ? render('tpl', column.label) : null}
-            </Checkbox>
-          </li>
-        ))}
+                column.toggleToggle();
+              }}
+            >
+              <Checkbox size="sm" classPrefix={ns} checked={column.toggled}>
+                {column.label ? render('tpl', column.label) : null}
+              </Checkbox>
+            </li>
+          ))}
       </ColumnToggler>
     );
   }


### PR DESCRIPTION
### What

### Why
目前自定义列全选在配置dragged时不支持全选，在列数较多时有全选的需求
![image](https://github.com/baidu/amis/assets/13268002/7b8754fd-4c97-4754-98f3-0046bedfa46d)
效果如下：
![image](https://github.com/baidu/amis/assets/13268002/8f00ded3-90fd-42e7-b98a-f9b4bacba2af)

### How
