### PR TITLE
fix: 修复crud里面使用文本假数据/列表组件渲染报错

### DIFF
--- a/packages/amis-editor-core/src/component/NodeWrapper.tsx
+++ b/packages/amis-editor-core/src/component/NodeWrapper.tsx
@@ -80,7 +80,7 @@ export class NodeWrapper extends React.Component<NodeWrapperProps> {
 
     // 自动合并假数据
     if (isObject(mockProps) && !isEmpty(mockProps)) {
-      rest = merge({}, rest, mockProps);
+      rest = merge(rest, mockProps);
     }
 
     if ($$editor.renderRenderer) {

--- a/packages/amis-editor/src/plugin/Cards.tsx
+++ b/packages/amis-editor/src/plugin/Cards.tsx
@@ -17,6 +17,7 @@ import {
 import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {diff, JSONPipeOut, repeatArray} from 'amis-editor-core';
 import set from 'lodash/set';
+import merge from 'lodash/merge';
 import {escapeFormula, resolveArrayDatasource} from '../util';
 
 export class CardsPlugin extends BasePlugin {
@@ -574,7 +575,12 @@ export class CardsPlugin extends BasePlugin {
     props.className = `${props.className || ''} ae-Editor-list`;
     props.itemsClassName = `${props.itemsClassName || ''} cards-items`;
     if (props.card && !props.card.className?.includes('listItem')) {
-      props.card.className = `${props.card.className || ''} ae-Editor-listItem`;
+      props.card = merge(
+        {
+          className: `${props.card.className || ''} ae-Editor-listItem`
+        },
+        props.card
+      );
     }
 
     // 列表类型内的文本元素显示原始公式

--- a/packages/amis-editor/src/plugin/Each.tsx
+++ b/packages/amis-editor/src/plugin/Each.tsx
@@ -4,7 +4,8 @@ import {EditorNodeType, registerEditorPlugin} from 'amis-editor-core';
 import {BaseEventContext, BasePlugin} from 'amis-editor-core';
 import {getSchemaTpl} from 'amis-editor-core';
 import {escapeFormula} from '../util';
-import {set} from 'lodash';
+import merge from 'lodash/merge';
+import set from 'lodash/set';
 
 export class EachPlugin extends BasePlugin {
   static id = 'EachPlugin';
@@ -362,10 +363,13 @@ export class EachPlugin extends BasePlugin {
     props.value = [{}, {}];
 
     props.className = `${props.className || ''} ae-Editor-list`;
-    if (props.items && !props.items.className?.includes('listItem')) {
-      props.items.className = `${
-        props.items.className || ''
-      } ae-Editor-eachItem`;
+    if (props.items && !props.items.className?.includes('eachItem')) {
+      props.items = merge(
+        {
+          className: `${props.items.className || ''} ae-Editor-eachItem`
+        },
+        props.items
+      );
     }
 
     return props;

--- a/packages/amis-editor/src/plugin/List2.tsx
+++ b/packages/amis-editor/src/plugin/List2.tsx
@@ -12,6 +12,7 @@ import {defaultValue, getSchemaTpl} from 'amis-editor-core';
 import {repeatArray} from 'amis-editor-core';
 import set from 'lodash/set';
 import {escapeFormula, resolveArrayDatasource} from '../util';
+import merge from 'lodash/merge';
 
 export class List2Plugin extends BasePlugin {
   static id = 'List2Plugin';
@@ -450,7 +451,12 @@ export class List2Plugin extends BasePlugin {
     props.className = `${props.className || ''} ae-Editor-list`;
     props.itemsClassName = `${props.itemsClassName || ''} cards-items`;
     if (props.card && !props.card.className?.includes('listItem')) {
-      props.card.className = `${props.card.className || ''} ae-Editor-listItem`;
+      props.card = merge(
+        {
+          className: `${props.card.className || ''} ae-Editor-listItem`
+        },
+        props.card
+      );
     }
 
     // 列表类型内的文本元素显示原始公式


### PR DESCRIPTION
### what
crud里面文本设置假数据时报错，另外crud里面添加列表、each组件时内部对象不可修改导致报错

### Why

### How
