### PR TITLE
feat: 新增TransferPicker的编辑器插件

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Transfer.tsx
+++ b/packages/amis-editor/src/plugin/Form/Transfer.tsx
@@ -1,8 +1,17 @@
-import {EditorManager, EditorNodeType, getSchemaTpl} from 'amis-editor-core';
+import {
+  EditorManager,
+  EditorNodeType,
+  defaultValue,
+  getSchemaTpl
+} from 'amis-editor-core';
 import {registerEditorPlugin} from 'amis-editor-core';
 import {BasePlugin, BaseEventContext} from 'amis-editor-core';
 import {getEventControlConfig} from '../../renderer/event-control/helper';
-import {RendererPluginAction, RendererPluginEvent} from 'amis-editor-core';
+import {
+  RendererPluginAction,
+  RendererPluginEvent,
+  undefinedPipeOut
+} from 'amis-editor-core';
 
 import {ValidatorTag} from '../../validator';
 import {tipedLabel} from 'amis-editor-core';
@@ -373,7 +382,59 @@ export class TransferPlugin extends BasePlugin {
               label: 'AddOn',
               visibleOn: 'this.addOn && this.addOn.type === "text"'
             })
-          ])
+          ]),
+          ...(this.rendererName === 'transfer-picker'
+            ? [
+                {
+                  title: '边框',
+                  key: 'borderMode',
+                  body: [getSchemaTpl('borderMode')]
+                },
+                {
+                  title: '弹窗',
+                  key: 'picker',
+                  body: [
+                    {
+                      name: 'pickerSize',
+                      type: 'select',
+                      pipeIn: defaultValue(''),
+                      pipeOut: undefinedPipeOut,
+                      label: '弹窗大小',
+                      options: [
+                        {
+                          label: '默认',
+                          value: ''
+                        },
+                        {
+                          value: 'sm',
+                          label: '小'
+                        },
+
+                        {
+                          label: '中',
+                          value: 'md'
+                        },
+
+                        {
+                          label: '大',
+                          value: 'lg'
+                        },
+
+                        {
+                          label: '特大',
+                          value: 'xl'
+                        },
+
+                        {
+                          label: '全屏',
+                          value: 'full'
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            : [])
         ])
       },
       {

--- a/packages/amis-editor/src/plugin/Form/TransferPicker.tsx
+++ b/packages/amis-editor/src/plugin/Form/TransferPicker.tsx
@@ -1,0 +1,51 @@
+import {registerEditorPlugin} from 'amis-editor-core';
+
+import {TransferPlugin} from './Transfer';
+
+export class TransferPickerPlugin extends TransferPlugin {
+  static id = 'TransferPickerPlugin';
+  // 关联渲染器名字
+  rendererName = 'transfer-picker';
+  $schema = '/schemas/TransferPickerControlSchema.json';
+
+  // 组件名称
+  name = '穿梭选择器';
+  isBaseComponent = true;
+  icon = 'fa fa-th-list';
+  pluginIcon = 'transfer-plugin';
+  description = '穿梭选择器组件';
+  docLink = '/amis/zh-CN/components/form/transfer-picker';
+  tags = ['表单项'];
+  scaffold = {
+    label: '分组',
+    type: 'transfer-picker',
+    name: 'transfer-picker',
+    options: [
+      {
+        label: '诸葛亮',
+        value: 'zhugeliang'
+      },
+      {
+        label: '曹操',
+        value: 'caocao'
+      }
+    ],
+    selectMode: 'list',
+    resultListModeFollowSelect: false
+  };
+  previewSchema: any = {
+    type: 'form',
+    className: 'text-left',
+    mode: 'horizontal',
+    wrapWithPanel: false,
+    body: [
+      {
+        ...this.scaffold
+      }
+    ]
+  };
+
+  notRenderFormZone = true;
+}
+
+registerEditorPlugin(TransferPickerPlugin);

--- a/packages/amis-editor/src/plugin/index.ts
+++ b/packages/amis-editor/src/plugin/index.ts
@@ -45,6 +45,7 @@ export * from './Form/InputRange'; // 滑块
 export * from './Form/InputRating'; // 评分
 export * from './Form/InputCity'; // 城市选择
 export * from './Form/Transfer'; // 穿梭器
+export * from './Form/TransferPicker'; // 穿梭选择器
 export * from './Form/TabsTransfer'; // 组合穿梭器
 export * from './Form/InputColor'; // 颜色框
 export * from './Form/ConditionBuilder'; // 条件组合


### PR DESCRIPTION
### What
新增TransferPicker组件的编辑器插件

### Why
TransferPicker组件功能强大，但目前缺少对编辑器的支持，新增编辑器插件后更方便用户Transfer的基础配置、事件等操作

### How
TransferPicker组件继承于Transfer组件，在其基础上扩展了borderMode和pickerSize两个属性，所以编辑器插件基本复用了Transfer插件。

新增部分：
![image](https://github.com/baidu/amis/assets/791228/7904e72c-06ac-4950-b5ff-f5792dbd1fa0)


发现了个问题：组件中pickerSize提供了xs选项，但modal样式并不支持xs尺寸，所以在编辑器中并未提供xs的选择
![image](https://github.com/baidu/amis/assets/791228/81a2dcfb-d7bb-4777-b9e0-96bb543b782b)
该问题未在组件中解决
