### PR TITLE
tabs在vue下会报错,子表单不支持records选项,主表单是支持的 invalid label 最好改为原始值,比较友好

### DIFF
--- a/packages/amis-core/src/store/formItem.ts
+++ b/packages/amis-core/src/store/formItem.ts
@@ -804,6 +804,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
         json.data?.options ||
         json.data?.items ||
         json.data?.rows ||
+        json.data?.records ||
         json.data ||
         [];
 
@@ -906,7 +907,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
         return;
       }
 
-      const result = json.data?.items || json.data?.rows;
+      const result = json.data?.items || json.data?.rows || json.data?.records;
       // 只处理仅有一个结果的数据
       if (result?.length === 1) {
         return result[0];
@@ -997,6 +998,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
         json.data?.options ||
         json.data.items ||
         json.data.rows ||
+        json.data.records ||
         json.data ||
         [];
       const newLeftOptions = spliceTree(topOption.leftOptions, leftIndexes, 1, {
@@ -1142,6 +1144,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
         json.data?.options ||
         json.data.items ||
         json.data.rows ||
+        json.data.records ||
         json.data ||
         [];
 
@@ -1241,6 +1244,7 @@ export const FormItemStore = StoreNode.named('FormItemStore')
             json.data?.options ||
             json.data.items ||
             json.data.rows ||
+            json.data.records ||
             json.data ||
             [];
 

--- a/packages/amis-core/src/utils/labelToString.ts
+++ b/packages/amis-core/src/utils/labelToString.ts
@@ -2,6 +2,7 @@ import isPlainObject from 'lodash/isPlainObject';
 
 export function labelToString(label: any): string {
   const type = typeof label;
+  console.log(type);
   if (type === 'string') {
     return label;
   } else if (type === 'number') {
@@ -16,5 +17,6 @@ export function labelToString(label: any): string {
     }
   }
 
-  return 'invalid label';
+  // return 'invalid label';
+  return label;
 }

--- a/packages/amis/src/renderers/Tabs.tsx
+++ b/packages/amis/src/renderers/Tabs.tsx
@@ -419,7 +419,7 @@ export default class Tabs extends React.Component<TabsProps, TabsState> {
       const location = props.location;
       let tab: TabSource | null = null;
 
-      if (location && Array.isArray(localTabs)) {
+      if (location && Array.isArray(localTabs) && location.hash) {
         const hash = location.hash.substring(1);
         tab = find(localTabs, tab => tab.hash === hash) as TabSource;
       }


### PR DESCRIPTION
tabs在vue下会报错
子表单不支持records选项,主表单是支持的
invalid label 最好改为原始值,比较友好

### What

### Why
我们项目主要在vue下使用
以上是发现的问题
现在每次更新都得重新编译amis的源代码,希望能接受上面的pull request

谢谢

### How
