### PR TITLE
fix: 修复 jssdk 模式下 inputTree 的按钮提示不可见 Close: #9834

### DIFF
--- a/packages/amis-core/src/components/Overlay.tsx
+++ b/packages/amis-core/src/components/Overlay.tsx
@@ -20,6 +20,7 @@ import {
   RootClose,
   uuid
 } from '../utils';
+import {EnvContext} from '../env';
 
 export const SubPopoverDisplayedID = 'data-sub-popover-displayed';
 
@@ -240,6 +241,8 @@ export default class Overlay extends React.Component<
   static defaultProps = {
     placement: 'auto'
   };
+  static contextType = EnvContext;
+  declare context: React.ContextType<typeof EnvContext>;
   constructor(props: OverlayProps) {
     super(props as any);
 
@@ -301,9 +304,10 @@ export default class Overlay extends React.Component<
       offset,
       ...props
     } = this.props;
-    const container = this.getContainerSelector()
-      ? this.getContainerSelector
-      : this.props.container;
+    const container =
+      (this.getContainerSelector()
+        ? this.getContainerSelector
+        : this.props.container) || this.context?.getModalContainer;
     const mountOverlay = props.show || (Transition && !this.state.exited);
     if (!mountOverlay) {
       // Don't bother showing anything if we don't have to.

--- a/packages/amis-ui/src/components/TooltipWrapper.tsx
+++ b/packages/amis-ui/src/components/TooltipWrapper.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import Html from './Html';
-import {uncontrollable} from 'amis-core';
+import {EnvContext, uncontrollable} from 'amis-core';
 import {findDOMNode} from 'react-dom';
 import Tooltip from './Tooltip';
 import {ClassNamesFn, themeable} from 'amis-core';

--- a/packages/amis/src/renderers/Form/InputTree.tsx
+++ b/packages/amis/src/renderers/Form/InputTree.tsx
@@ -474,7 +474,9 @@ export default class TreeControl extends React.Component<TreeProps, TreeState> {
       searchConfig = {},
       heightAuto,
       mobileUI,
-      testIdBuilder
+      testIdBuilder,
+      popOverContainer,
+      env
     } = this.props;
     let {highlightTxt} = this.props;
     const {filteredOptions, keyword} = this.state;


### PR DESCRIPTION
### What

### Why

### How
