### PR TITLE
style(amis): 修复crud2/部分场景/列级元素内部tooltip提示位置异常问题

### DIFF
--- a/packages/amis-ui/scss/components/_crud2.scss
+++ b/packages/amis-ui/scss/components/_crud2.scss
@@ -7,6 +7,10 @@
     margin-bottom: var(--gap-base);
   }
 
+  .#{$ns}Table-render-wrapper {
+    position: relative;
+  }
+
   &-selectionLabel {
     display: inline-block;
     vertical-align: top;


### PR DESCRIPTION
修复前：
<img width="1426" alt="image" src="https://github.com/baidu/amis/assets/11958920/9e7e5544-2880-43fe-b73b-62c8d2118178">

修复后：
<img width="1440" alt="image" src="https://github.com/baidu/amis/assets/11958920/333045e9-639a-4b08-a67a-dba4cda5ab83">
