### PR TITLE
fix(editor): 修复编辑器自定义样式和固定样式渲染混乱问题

### DIFF
--- a/packages/amis-core/src/utils/style-helper.ts
+++ b/packages/amis-core/src/utils/style-helper.ts
@@ -45,19 +45,74 @@ interface extra {
   suf?: string;
 }
 
-export function findOrCreateStyle(id: string, doc?: Document) {
+/**
+ * 查找或创建style标签
+ * @param param
+ * @param param.classId 根据classId查找或创建style标签
+ * @param param.id 用于赋值给style的class
+ * @param param.doc 文档对象，默认为document
+ * @param param.before 插入到某个class为id的style标签之前
+ */
+
+export function findOrCreateStyle({
+  classId,
+  doc,
+  before,
+  id
+}: {
+  classId: string;
+  doc?: Document;
+  before?: string;
+  id?: string;
+}) {
   doc = doc || document;
-  let varStyleTag = doc.getElementById(id);
+  let varStyleTag = doc.getElementById(classId);
   if (!varStyleTag) {
     varStyleTag = doc.createElement('style');
-    varStyleTag.id = id;
-    doc.body.appendChild(varStyleTag);
+    varStyleTag.id = classId;
+    varStyleTag.setAttribute('class', id || '');
+    const beforeStyleTag = doc.getElementsByClassName(
+      before || ''
+    )?.[0] as HTMLElement;
+    // 如果存在before则插入到before之前，否则插入到body中
+    if (beforeStyleTag) {
+      beforeStyleTag.before(varStyleTag);
+    } else {
+      doc.body.appendChild(varStyleTag);
+    }
   }
+
   return varStyleTag;
 }
 
-export function insertStyle(style: string, id: string, doc?: Document) {
-  const varStyleTag = findOrCreateStyle('amis-' + id, doc);
+/*
+ * 插入样式
+ * @param param
+ * @param param.style 样式内容
+ * @param param.classId 样式标识，会绑定到id上
+ * @param param.id id,会绑定到class上
+ * @param param.doc 文档对象
+ * @param param.before 插入到某个id之前
+ */
+export function insertStyle({
+  style,
+  classId,
+  id,
+  doc,
+  before
+}: {
+  style: string;
+  classId: string;
+  id?: string;
+  doc?: Document;
+  before?: string;
+}) {
+  const varStyleTag = findOrCreateStyle({
+    classId: 'amis-' + classId,
+    doc,
+    before,
+    id
+  });
 
   // bca-disable-line
   varStyleTag.innerHTML = style;
@@ -68,7 +123,7 @@ export function insertStyle(style: string, id: string, doc?: Document) {
 }
 
 export function addStyle(style: string, id: string) {
-  const varStyleTag = findOrCreateStyle(id);
+  const varStyleTag = findOrCreateStyle({classId: id});
   // bca-disable-line
   varStyleTag.innerHTML += style;
 }
@@ -274,7 +329,14 @@ export function insertCustomStyle(prams: {
   if (typeof data?.index === 'number') {
     classId += `-${data.index}`;
   }
-  insertStyle(value, classId, doc);
+  // 这里需要插入到wrapperCustomStyle的前面
+  insertStyle({
+    style: value,
+    classId,
+    doc,
+    id: classId.replace(/(-.*)/, ''),
+    before: classId.replace(/(-.*)/, '')
+  });
 }
 
 /**
@@ -387,11 +449,12 @@ export function insertEditCustomStyle(params: {
     });
   }
 
-  insertStyle(
-    content,
-    'wrapperCustomStyle-' + (id?.replace('u:', '') || uuid()) + index,
-    doc
-  );
+  insertStyle({
+    style: content,
+    classId: 'wrapperCustomStyle-' + (id?.replace('u:', '') || uuid()) + index,
+    doc,
+    id: id?.replace('u:', '').replace(/(-.*)/, '')
+  });
 }
 
 export interface InsertCustomStyle {

--- a/packages/amis/src/renderers/Nav.tsx
+++ b/packages/amis/src/renderers/Nav.tsx
@@ -891,7 +891,10 @@ export class Navigation extends React.Component<
         classNameId = cx(`Nav-PopupClassName-${id}`);
         if (!document.getElementById(classNameId)) {
           // rc-menu的浮层只支持配置popupClassName 因此需要将配置的style插入到页面 然后将className赋值给浮层
-          insertStyle(`.${classNameId} ${styleText}`, classNameId);
+          insertStyle({
+            style: `.${classNameId} ${styleText}`,
+            classId: classNameId
+          });
         }
       } catch (e) {}
     }


### PR DESCRIPTION
### What
![image](https://github.com/baidu/amis/assets/30946345/cddd246a-1a4c-4f5e-9020-6012f1fad3aa)
固定样式（基本样式、内容区样式等）和自定义样式渲染时机混乱，导致编辑态和预览态效果不一致

### Why

### How
