### PR TITLE
fix: 修复editor中的右键菜单偶尔出现后立刻消失的问题

### DIFF
--- a/packages/amis-editor-core/src/component/Editor.tsx
+++ b/packages/amis-editor-core/src/component/Editor.tsx
@@ -418,8 +418,8 @@ export default class Editor extends Component<EditorProps> {
 
   // 右键菜单
   @autobind
-  handleContextMenu(e: React.MouseEvent<HTMLElement>) {
-    closeContextMenus();
+  async handleContextMenu(e: React.MouseEvent<HTMLElement>) {
+    await closeContextMenus();
     let targetId: string = '';
     let region = '';
 


### PR DESCRIPTION
### What
由于 `closeContextMenus` 是异步操作，偶尔会有出现后立刻消失的问题

### Why

### How
