### PR TITLE
fix: combo中超长字符串导致group的tab删除按钮消失

### DIFF
--- a/packages/amis-ui/scss/components/_tabs.scss
+++ b/packages/amis-ui/scss/components/_tabs.scss
@@ -191,11 +191,16 @@
         padding: var(--Tabs-linkPadding);
         text-decoration: none;
         cursor: pointer;
-        display: block;
-
-        text-overflow: ellipsis;
+        display: flex;
+        align-items: center;
+        max-width: 100%;
         overflow: hidden;
-        white-space: nowrap;
+
+        .#{$ns}Tabs-link-text {
+          text-overflow: ellipsis;
+          overflow: hidden;
+          white-space: nowrap;
+        }
 
         > .#{$ns}Icon {
           margin-right: var(--Tabs-icon-gap);

--- a/packages/amis-ui/scss/components/form/_combo.scss
+++ b/packages/amis-ui/scss/components/form/_combo.scss
@@ -382,6 +382,7 @@
   float: right;
   > a svg {
     margin-right: var(--gap-xs);
+    top: 0;
   }
 }
 

--- a/packages/amis-ui/src/components/Tabs.tsx
+++ b/packages/amis-ui/src/components/Tabs.tsx
@@ -642,15 +642,17 @@ export class Tabs extends React.Component<TabsProps, any> {
             {icon ? (
               iconPosition === 'right' ? (
                 <>
-                  {title} {iconElement}
+                  <span className={cx('Tabs-link-text mr-1')}>{title}</span>
+                  {iconElement}
                 </>
               ) : (
                 <>
-                  {iconElement} {title}
+                  {iconElement}
+                  <span className={cx('Tabs-link-text ml-1')}>{title}</span>
                 </>
               )
             ) : (
-              title
+              <span className={cx('Tabs-link-text')}>{title}</span>
             )}
             {React.isValidElement(toolbar) ? toolbar : null}
           </>

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/combo.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/combo.test.tsx.snap
@@ -2127,7 +2127,11 @@ exports[`Renderer:combo with tabsMode 1`] = `
                                   <a
                                     title="这是第3个"
                                   >
-                                    这是第3个
+                                    <span
+                                      class="cxd-Tabs-link-text"
+                                    >
+                                      这是第3个
+                                    </span>
                                     <div
                                       class="cxd-Combo-tab-delBtn "
                                       data-position="bottom"
@@ -2146,7 +2150,11 @@ exports[`Renderer:combo with tabsMode 1`] = `
                                   <a
                                     title="这是第4个"
                                   >
-                                    这是第4个
+                                    <span
+                                      class="cxd-Tabs-link-text"
+                                    >
+                                      这是第4个
+                                    </span>
                                     <div
                                       class="cxd-Combo-tab-delBtn "
                                       data-position="bottom"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/tabs.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/tabs.test.tsx.snap
@@ -54,7 +54,11 @@ exports[`Renderer:tabs 1`] = `
                     <a
                       title="基本配置"
                     >
-                      基本配置
+                      <span
+                        class="cxd-Tabs-link-text"
+                      >
+                        基本配置
+                      </span>
                     </a>
                   </li>
                   <li
@@ -63,7 +67,11 @@ exports[`Renderer:tabs 1`] = `
                     <a
                       title="其他配置"
                     >
-                      其他配置
+                      <span
+                        class="cxd-Tabs-link-text"
+                      >
+                        其他配置
+                      </span>
                     </a>
                   </li>
                 </ul>

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/tabsTransfer.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/tabsTransfer.test.tsx.snap
@@ -93,7 +93,11 @@ exports[`Renderer:tabsTransfer 1`] = `
                                     <a
                                       title="成员"
                                     >
-                                      成员
+                                      <span
+                                        class="cxd-Tabs-link-text"
+                                      >
+                                        成员
+                                      </span>
                                     </a>
                                   </li>
                                   <li
@@ -102,7 +106,11 @@ exports[`Renderer:tabsTransfer 1`] = `
                                     <a
                                       title="用户"
                                     >
-                                      用户
+                                      <span
+                                        class="cxd-Tabs-link-text"
+                                      >
+                                        用户
+                                      </span>
                                     </a>
                                   </li>
                                 </ul>
@@ -735,7 +743,11 @@ exports[`Renderer:tabsTransfer with deferApi 1`] = `
                                     <a
                                       title="成员"
                                     >
-                                      成员
+                                      <span
+                                        class="cxd-Tabs-link-text"
+                                      >
+                                        成员
+                                      </span>
                                     </a>
                                   </li>
                                   <li
@@ -744,7 +756,11 @@ exports[`Renderer:tabsTransfer with deferApi 1`] = `
                                     <a
                                       title="用户"
                                     >
-                                      用户
+                                      <span
+                                        class="cxd-Tabs-link-text"
+                                      >
+                                        用户
+                                      </span>
                                     </a>
                                   </li>
                                 </ul>

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/tabsTransferPicker.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/tabsTransferPicker.test.tsx.snap
@@ -315,7 +315,11 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                         <a
                           title="成员"
                         >
-                          成员
+                          <span
+                            class="cxd-Tabs-link-text"
+                          >
+                            成员
+                          </span>
                         </a>
                       </li>
                       <li
@@ -324,7 +328,11 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                         <a
                           title="角色"
                         >
-                          角色
+                          <span
+                            class="cxd-Tabs-link-text"
+                          >
+                            角色
+                          </span>
                         </a>
                       </li>
                       <li
@@ -333,7 +341,11 @@ exports[`Renderer:TabsTransferPicker: dialog open 1`] = `
                         <a
                           title="部门"
                         >
-                          部门
+                          <span
+                            class="cxd-Tabs-link-text"
+                          >
+                            部门
+                          </span>
                         </a>
                       </li>
                     </ul>

--- a/packages/amis/__tests__/renderers/__snapshots__/Portlet.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Portlet.test.tsx.snap
@@ -28,7 +28,11 @@ exports[`Renderer:portlet 1`] = `
                 <a
                   title="Tab 1"
                 >
-                  Tab 1
+                  <span
+                    class="cxd-Tabs-link-text"
+                  >
+                    Tab 1
+                  </span>
                 </a>
               </li>
               <li
@@ -37,7 +41,11 @@ exports[`Renderer:portlet 1`] = `
                 <a
                   title="Tab 2"
                 >
-                  Tab 2
+                  <span
+                    class="cxd-Tabs-link-text"
+                  >
+                    Tab 2
+                  </span>
                 </a>
               </li>
               <div

--- a/packages/amis/__tests__/renderers/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Tabs.test.tsx.snap
@@ -54,7 +54,11 @@ exports[`Renderer:tabs as form item 1`] = `
                     <a
                       title="Tab 1"
                     >
-                      Tab 1
+                      <span
+                        class="cxd-Tabs-link-text"
+                      >
+                        Tab 1
+                      </span>
                     </a>
                   </li>
                   <li
@@ -63,7 +67,11 @@ exports[`Renderer:tabs as form item 1`] = `
                     <a
                       title="Tab 2"
                     >
-                      Tab 2
+                      <span
+                        class="cxd-Tabs-link-text"
+                      >
+                        Tab 2
+                      </span>
                     </a>
                   </li>
                 </ul>
@@ -183,7 +191,11 @@ exports[`Renderer:tabs change active tab 1`] = `
               <a
                 title="基本配置"
               >
-                基本配置
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  基本配置
+                </span>
               </a>
               <span
                 class="cxd-Tabs-link-close"
@@ -200,7 +212,11 @@ exports[`Renderer:tabs change active tab 1`] = `
               <a
                 title="其他配置"
               >
-                其他配置
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  其他配置
+                </span>
               </a>
               <span
                 class="cxd-Tabs-link-close"
@@ -300,7 +316,11 @@ exports[`Renderer:tabs change active tab 2`] = `
               <a
                 title="基本配置"
               >
-                基本配置
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  基本配置
+                </span>
               </a>
               <span
                 class="cxd-Tabs-link-close"
@@ -317,7 +337,11 @@ exports[`Renderer:tabs change active tab 2`] = `
               <a
                 title="其他配置"
               >
-                其他配置
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  其他配置
+                </span>
               </a>
               <span
                 class="cxd-Tabs-link-close"
@@ -491,7 +515,11 @@ exports[`Renderer:tabs tabsMode 1`] = `
               <a
                 title="基本配置"
               >
-                基本配置
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  基本配置
+                </span>
               </a>
             </li>
             <li
@@ -500,7 +528,11 @@ exports[`Renderer:tabs tabsMode 1`] = `
               <a
                 title="其他配置"
               >
-                其他配置
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  其他配置
+                </span>
               </a>
             </li>
           </ul>
@@ -592,7 +624,11 @@ exports[`Renderer:tabs tabsMode 2`] = `
               <a
                 title="基本配置"
               >
-                基本配置
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  基本配置
+                </span>
               </a>
             </li>
             <li
@@ -601,7 +637,11 @@ exports[`Renderer:tabs tabsMode 2`] = `
               <a
                 title="其他配置"
               >
-                其他配置
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  其他配置
+                </span>
               </a>
             </li>
           </ul>
@@ -726,7 +766,11 @@ exports[`Renderer:tabs tabsMode 3`] = `
           <a
             title="基本配置"
           >
-            基本配置
+            <span
+              class="cxd-Tabs-link-text"
+            >
+              基本配置
+            </span>
           </a>
         </li>
         <li
@@ -735,7 +779,11 @@ exports[`Renderer:tabs tabsMode 3`] = `
           <a
             title="其他配置"
           >
-            其他配置
+            <span
+              class="cxd-Tabs-link-text"
+            >
+              其他配置
+            </span>
           </a>
         </li>
       </ul>
@@ -819,7 +867,11 @@ exports[`Renderer:tabs tabsMode 4`] = `
           <a
             title="基本配置"
           >
-            基本配置
+            <span
+              class="cxd-Tabs-link-text"
+            >
+              基本配置
+            </span>
           </a>
           <div
             class="chrome-tab-background"
@@ -848,7 +900,11 @@ exports[`Renderer:tabs tabsMode 4`] = `
           <a
             title="其他配置"
           >
-            其他配置
+            <span
+              class="cxd-Tabs-link-text"
+            >
+              其他配置
+            </span>
           </a>
           <div
             class="chrome-tab-background"
@@ -958,7 +1014,11 @@ exports[`Renderer:tabs tabsMode 5`] = `
               <a
                 title="基本配置"
               >
-                基本配置
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  基本配置
+                </span>
               </a>
             </li>
             <li
@@ -967,7 +1027,11 @@ exports[`Renderer:tabs tabsMode 5`] = `
               <a
                 title="其他配置"
               >
-                其他配置
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  其他配置
+                </span>
               </a>
             </li>
           </ul>
@@ -1059,7 +1123,11 @@ exports[`Renderer:tabs tabsMode 6`] = `
               <a
                 title="基本配置"
               >
-                基本配置
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  基本配置
+                </span>
               </a>
             </li>
             <li
@@ -1068,7 +1136,11 @@ exports[`Renderer:tabs tabsMode 6`] = `
               <a
                 title="其他配置"
               >
-                其他配置
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  其他配置
+                </span>
               </a>
             </li>
           </ul>
@@ -1160,7 +1232,11 @@ exports[`Renderer:tabs tabsMode 7`] = `
               <a
                 title="基本配置"
               >
-                基本配置
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  基本配置
+                </span>
               </a>
             </li>
             <li
@@ -1169,7 +1245,11 @@ exports[`Renderer:tabs tabsMode 7`] = `
               <a
                 title="其他配置"
               >
-                其他配置
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  其他配置
+                </span>
               </a>
             </li>
           </ul>
@@ -1255,7 +1335,11 @@ exports[`Renderer:tabs tabsMode 8`] = `
           <a
             title="基本配置"
           >
-            基本配置
+            <span
+              class="cxd-Tabs-link-text"
+            >
+              基本配置
+            </span>
           </a>
         </li>
         <li
@@ -1264,7 +1348,11 @@ exports[`Renderer:tabs tabsMode 8`] = `
           <a
             title="其他配置"
           >
-            其他配置
+            <span
+              class="cxd-Tabs-link-text"
+            >
+              其他配置
+            </span>
           </a>
         </li>
       </ul>
@@ -1315,7 +1403,11 @@ exports[`Renderer:tabs toolbar 1`] = `
               <a
                 title="基本配置"
               >
-                基本配置
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  基本配置
+                </span>
               </a>
             </li>
             <li
@@ -1324,7 +1416,11 @@ exports[`Renderer:tabs toolbar 1`] = `
               <a
                 title="其他配置"
               >
-                其他配置
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  其他配置
+                </span>
               </a>
             </li>
             <div
@@ -1428,7 +1524,11 @@ exports[`Renderer:tabs with collapseOnExceed: popover show 1`] = `
               <a
                 title="Tab 1"
               >
-                Tab 1
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  Tab 1
+                </span>
               </a>
             </li>
             <li
@@ -1437,7 +1537,11 @@ exports[`Renderer:tabs with collapseOnExceed: popover show 1`] = `
               <a
                 title="Tab 2"
               >
-                Tab 2
+                <span
+                  class="cxd-Tabs-link-text"
+                >
+                  Tab 2
+                </span>
               </a>
             </li>
             <li
@@ -1575,7 +1679,11 @@ exports[`Renderer:tabs with collapseOnExceed: popover show 1`] = `
           <a
             title="Tab 3"
           >
-            Tab 3
+            <span
+              class="cxd-Tabs-link-text"
+            >
+              Tab 3
+            </span>
           </a>
         </li>
         <li
@@ -1584,7 +1692,11 @@ exports[`Renderer:tabs with collapseOnExceed: popover show 1`] = `
           <a
             title="Tab 4"
           >
-            Tab 4
+            <span
+              class="cxd-Tabs-link-text"
+            >
+              Tab 4
+            </span>
           </a>
         </li>
         <li
@@ -1593,7 +1705,11 @@ exports[`Renderer:tabs with collapseOnExceed: popover show 1`] = `
           <a
             title="Tab 5"
           >
-            Tab 5
+            <span
+              class="cxd-Tabs-link-text"
+            >
+              Tab 5
+            </span>
           </a>
         </li>
       </ul>


### PR DESCRIPTION
### What
移动了一下按钮的位置，和文字同级
p.s. 
- 按钮的data-tooltip没有用，因为外层有overflow: hidden, 之前也一直没显示
