### PR TITLE
fix: 修复 excel 渲染时合并单元格垂直方向不正确问题 Closes #9936

### DIFF
--- a/packages/amis/package.json
+++ b/packages/amis/package.json
@@ -62,7 +62,7 @@
     "moment": "^2.19.4",
     "moment-timezone": "^0.5.34",
     "mpegts.js": "^1.6.10",
-    "office-viewer": "^0.3.8",
+    "office-viewer": "^0.3.9",
     "prop-types": "^15.6.1",
     "qrcode.react": "^3.1.0",
     "react-cropper": "^2.1.8",

--- a/packages/office-viewer/package.json
+++ b/packages/office-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-viewer",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "office 文档在线预览",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/packages/office-viewer/src/excel/sheet/getViewPointData.ts
+++ b/packages/office-viewer/src/excel/sheet/getViewPointData.ts
@@ -137,7 +137,7 @@ export function getViewPointData(
                   yOffset += getRowHeight(i);
                 }
 
-                y == yOffset;
+                y -= yOffset;
 
                 const value = getSheetRowData(startRow)[startCol];
 


### PR DESCRIPTION
### What

### Why

### How
