### PR TITLE
fix: 修复表单项公式默认值优先级高于实际返回值的问题

### DIFF
--- a/packages/amis-core/src/renderers/wrapControl.tsx
+++ b/packages/amis-core/src/renderers/wrapControl.tsx
@@ -474,45 +474,46 @@ export function wrapControl<
             const {formStore: form, data, canAccessSuperData} = this.props;
             const isExp = isExpression(value);
 
-            if (isExp) {
-              model.changeTmpValue(
-                FormulaExec['formula'](value, data), // 对组件默认值进行运算
-                'formulaChanged'
-              );
-            } else {
-              let initialValue = model.extraName
-                ? [
-                    getVariable(
-                      data,
-                      model.name,
-                      canAccessSuperData ?? form?.canAccessSuperData
-                    ),
-                    getVariable(
-                      data,
-                      model.extraName,
-                      canAccessSuperData ?? form?.canAccessSuperData
-                    )
-                  ]
-                : getVariable(
+            let initialValue = model.extraName
+              ? [
+                  getVariable(
                     data,
                     model.name,
                     canAccessSuperData ?? form?.canAccessSuperData
-                  );
+                  ),
+                  getVariable(
+                    data,
+                    model.extraName,
+                    canAccessSuperData ?? form?.canAccessSuperData
+                  )
+                ]
+              : getVariable(
+                  data,
+                  model.name,
+                  canAccessSuperData ?? form?.canAccessSuperData
+                );
 
-              if (
-                model.extraName &&
-                initialValue.every((item: any) => item === undefined)
-              ) {
-                initialValue = undefined;
-              }
-
-              model.changeTmpValue(
-                initialValue ?? replaceExpression(value),
-                typeof initialValue !== 'undefined'
-                  ? 'initialValue'
-                  : 'defaultValue'
-              );
+            if (
+              model.extraName &&
+              initialValue.every((item: any) => item === undefined)
+            ) {
+              initialValue = undefined;
             }
+
+            if (typeof initialValue === 'undefined') {
+              value = isExp
+                ? FormulaExec['formula'](value, data)
+                : replaceExpression(value);
+            }
+
+            model.changeTmpValue(
+              initialValue ?? value, // 对组件默认值进行运算
+              typeof initialValue !== 'undefined'
+                ? 'initialValue'
+                : isExp
+                ? 'formulaChanged'
+                : 'defaultValue'
+            );
           }
 
           disposeModel() {


### PR DESCRIPTION
### What

问题 schema

```json
{
  "type": "page",
  "title": "表单页面",
  "body": [
    {
      "type": "form",
      "mode": "horizontal",
      "initApi": {
        "method": "get",
        "url": "/api/sample/show?id=${id}",
        "mockResponse": {
          "status": 200,
          "data": {
            "id": 1,
            "varc": "123",
            "vard": "124xxx",
            "combo": [
              {
                "vara": "123",
                "varb": "123xxx"
              }
            ],
            "vare": "xxx"
          }
        }
      },
      "body": [
        {
          "label": "Combo",
          "type": "combo",
          "name": "combo",
          "multiple": true,
          "items": [
            {
              "type": "input-text",
              "name": "vara"
            },
            {
              "type": "input-text",
              "name": "varb",
              "value": "${vara}yyy"
            }
          ]
        },
        {
          "type": "input-text",
          "name": "varc",
          "value": "234"
        },
        {
          "type": "input-text",
          "name": "vard",
          "value": "${varc}yyy"
        },
        {
          "type": "input-text",
          "name": "vare",
          "value": "yyyy"
        }
      ]
    }
  ]
}
```

### Why

公式默认值在 form 与在 combo 内部表现不统一，预期初始值高于表达式，除非表达式关联变量发生变化，才更新公式结果

### How
