### PR TITLE
fix: schema中删除editorState

### DIFF
--- a/docs/zh-CN/components/dialog.md
+++ b/docs/zh-CN/components/dialog.md
@@ -945,7 +945,6 @@ feedback 反馈弹框是指，在 ajax 请求后，可以显示一个弹框，�
                       "type": "input-text",
                       "name": "name",
                       "id": "u:00ef9e3fe9db",
-                      "editorState": "default",
                       "mode": "horizontal",
                       "size": "md",
                       "value": "Amis"

--- a/packages/amis-editor-core/src/store/editor.ts
+++ b/packages/amis-editor-core/src/store/editor.ts
@@ -555,8 +555,7 @@ export const MainStore = types
                 key !== '$$comments' &&
                 key !== '$$commonSchema') ||
               typeof props === 'function' || // pipeIn 和 pipeOut
-              key.substring(0, 2) === '__' ||
-              key === 'editorState') // 样式不需要出现做json中,
+              key.substring(0, 2) === '__')
         );
       },
 

--- a/packages/amis-editor-core/src/util.ts
+++ b/packages/amis-editor-core/src/util.ts
@@ -1249,6 +1249,9 @@ export function clearDirtyCssKey(data: any) {
     if (key.startsWith('.') || key.startsWith('#')) {
       delete temp[key];
     }
+    if (key === 'editorState') {
+      delete temp[key];
+    }
   });
   return temp;
 }

--- a/packages/amis-editor/src/plugin/Button.tsx
+++ b/packages/amis-editor/src/plugin/Button.tsx
@@ -368,7 +368,7 @@ export class ButtonPlugin extends BasePlugin {
             body: [
               {
                 type: 'select',
-                name: 'editorState',
+                name: '__editorState',
                 label: '状态',
                 selectFirst: true,
                 options: [
@@ -387,11 +387,11 @@ export class ButtonPlugin extends BasePlugin {
                 ]
               },
               ...buttonStateFunc(
-                "${editorState == 'default' || !editorState}",
+                "${__editorState == 'default' || !__editorState}",
                 'default'
               ),
-              ...buttonStateFunc("${editorState == 'hover'}", 'hover'),
-              ...buttonStateFunc("${editorState == 'active'}", 'active')
+              ...buttonStateFunc("${__editorState == 'hover'}", 'hover'),
+              ...buttonStateFunc("${__editorState == 'active'}", 'active')
             ]
           },
           getSchemaTpl('theme:cssCode', {

--- a/packages/amis-editor/src/plugin/Form/InputImage.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputImage.tsx
@@ -479,7 +479,7 @@ export class ImageControlPlugin extends BasePlugin {
               body: [
                 {
                   type: 'select',
-                  name: 'editorState',
+                  name: '__editorState',
                   label: '状态',
                   selectFirst: true,
                   options: [
@@ -498,11 +498,11 @@ export class ImageControlPlugin extends BasePlugin {
                   ]
                 },
                 ...inputStateFunc(
-                  "${editorState == 'default' || !editorState}",
+                  "${__editorState == 'default' || !__editorState}",
                   'default'
                 ),
-                ...inputStateFunc("${editorState == 'hover'}", 'hover'),
-                ...inputStateFunc("${editorState == 'active'}", 'active'),
+                ...inputStateFunc("${__editorState == 'hover'}", 'hover'),
+                ...inputStateFunc("${__editorState == 'active'}", 'active'),
                 getSchemaTpl('theme:radius', {
                   name: `${addBtnCssClassName}.border-radius`,
                   label: '圆角',

--- a/packages/amis-editor/src/plugin/Form/Picker.tsx
+++ b/packages/amis-editor/src/plugin/Form/Picker.tsx
@@ -480,7 +480,7 @@ export class PickerControlPlugin extends BasePlugin {
               body: [
                 {
                   type: 'select',
-                  name: 'editorState',
+                  name: '__editorState',
                   label: '状态',
                   selectFirst: true,
                   options: [
@@ -503,13 +503,13 @@ export class PickerControlPlugin extends BasePlugin {
                   ]
                 },
                 ...pickStyleFunc(
-                  "${editorState == 'default' || !editorState}",
+                  "${__editorState == 'default' || !__editorState}",
                   'default'
                 ),
-                ...pickStyleStateFunc("${editorState == 'hover'}", 'hover'),
-                ...pickStyleStateFunc("${editorState == 'focus'}", 'active'),
+                ...pickStyleStateFunc("${__editorState == 'hover'}", 'hover'),
+                ...pickStyleStateFunc("${__editorState == 'focus'}", 'active'),
                 ...pickDisabledSateFunc(
-                  "${editorState == 'disabled'}",
+                  "${__editorState == 'disabled'}",
                   'disabled'
                 )
               ]

--- a/packages/amis-editor/src/renderer/style-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/style-control/helper.tsx
@@ -4,7 +4,7 @@ export const inputStateTpl = (className: string, path: string = '') => {
   return [
     {
       type: 'select',
-      name: 'editorState',
+      name: '__editorState',
       label: '状态',
       selectFirst: true,
       options: [
@@ -23,13 +23,13 @@ export const inputStateTpl = (className: string, path: string = '') => {
       ]
     },
     ...inputStateFunc(
-      "${editorState == 'default' || !editorState}",
+      "${__editorState == 'default' || !__editorState}",
       'default',
       className,
       path
     ),
-    ...inputStateFunc("${editorState == 'hover'}", 'hover', className, path),
-    ...inputStateFunc("${editorState == 'active'}", 'active', className, path)
+    ...inputStateFunc("${__editorState == 'hover'}", 'hover', className, path),
+    ...inputStateFunc("${__editorState == 'active'}", 'active', className, path)
   ];
 };
 

--- a/packages/amis-editor/src/tpl/style.tsx
+++ b/packages/amis-editor/src/tpl/style.tsx
@@ -634,7 +634,7 @@ setSchemaTpl(
     const styles = [
       {
         type: 'select',
-        name: 'editorState',
+        name: '__editorState',
         label: '状态',
         selectFirst: true,
         options: [
@@ -653,11 +653,11 @@ setSchemaTpl(
         ]
       },
       ...styleStateFunc(
-        "${editorState == 'default' || !editorState}",
+        "${__editorState == 'default' || !__editorState}",
         'default'
       ),
-      ...styleStateFunc("${editorState == 'hover'}", 'hover'),
-      ...styleStateFunc("${editorState == 'active'}", 'active')
+      ...styleStateFunc("${__editorState == 'hover'}", 'hover'),
+      ...styleStateFunc("${__editorState == 'active'}", 'active')
     ];
 
     return {


### PR DESCRIPTION
### What

### Why
editorState是在编辑外观的过程中出现的只有编辑器才需要一个标识变量，不应该存储到schema中

### How
