### PR TITLE
fix: 修复子编辑器弹窗撤回按钮遮挡

### DIFF
--- a/packages/amis-editor-core/src/component/SubEditor.tsx
+++ b/packages/amis-editor-core/src/component/SubEditor.tsx
@@ -206,6 +206,7 @@ export class SubEditor extends React.Component<SubEditorProps> {
                 <button
                   type="button"
                   data-tooltip="撤销"
+                  data-position="top"
                   disabled={!subEditorContext.canUndo}
                   onClick={store.undoSubEditor}
                 >
@@ -214,6 +215,7 @@ export class SubEditor extends React.Component<SubEditorProps> {
                 <button
                   type="button"
                   data-tooltip="重做"
+                  data-position="top"
                   disabled={!subEditorContext.canRedo}
                   onClick={store.redoSubEditor}
                 >


### PR DESCRIPTION
### What

子编辑器【撤回】按钮的 tooltip 会遮挡【重做】按钮


### Why
视觉优化

### How

Before：
![截屏2024-04-12 12 08 07](https://github.com/baidu/amis/assets/74137084/ded80349-4573-4c06-84d6-2ee0ae4ee3db)

After：
![截屏2024-04-12 11 58 37](https://github.com/baidu/amis/assets/74137084/527bb2f1-1e7e-4528-a9a1-c2065dda2893)
