### PR TITLE
fix: 解决使用编辑器时 amis-ui 样式变量重复引入

### DIFF
--- a/packages/amis-editor-core/scss/editor.scss
+++ b/packages/amis-editor-core/scss/editor.scss
@@ -1,7 +1,6 @@
 @import '../../../node_modules/amis-ui/scss/functions';
 @import '../../../node_modules/amis-ui/scss/variables';
 @import '../../../node_modules/amis-ui/scss/mixins';
-@import '../../../node_modules/amis-ui/scss/components';
 @import './mixin';
 @import './variables';
 @import './backTop';


### PR DESCRIPTION
close #9406

### What
使用 amis-editor 时，会重复引用 amis-ui/scss/_components.scss 

![1](https://github.com/baidu/amis/assets/74137084/b9fee44f-1dc0-4ba8-b86e-c4897dfb2754)
![2](https://github.com/baidu/amis/assets/74137084/2c252408-686c-4054-9232-b8fb4be4d11e)

第一份来自于 amis-ui/scss/themes/cxd.scss 引入的 components.scss
第二份来自于 amis-editor-core/scss/editor.scss 引入的 components.scss

### Why

因为 amis-editor 依赖 amis-ui。amis-ui 会引用相应的主题样式。
如：`amis-ui/scss/themes/cxd.scss`

因此第二份引入的样式是冗余的。

收益：
1. 移除后页面样式无影响
2. 能够降低 amis-editor-core/lib/style.css 体积 200+kb

**复现案例来自于 amis 仓库中的 examples。**
复现路径： `npm start`，访问 localhost:8080/packages/amis-editor；查看 network

开发环境：

优化前：
![3](https://github.com/baidu/amis/assets/74137084/ce82eb3e-a1ff-4a9f-a1c4-9e9f6cd5f23a)
优化后：
![4](https://github.com/baidu/amis/assets/74137084/fb8b62f1-c23b-47a0-9f97-d72338bc39a9)

生产环境：
amis-editor-core/lib/style.css 从 437kb 降低至 182 kb

### How
删除 amis-editor-core 中的样式变量引用。
