### PR TITLE
fix: 修复 dispatchInited 可能出现Uncaught (in promise) Error: [mobx-state-tree] You are trying to read or write to an object that is no longer part of a state tree.

### DIFF
--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -713,7 +713,7 @@ export default class Form extends React.Component<FormProps, object> {
   async dispatchInited(value: any) {
     const {data, store, dispatchEvent} = this.props;
 
-    if (store.fetching) {
+    if (!isAlive(store) || store.fetching) {
       return value;
     }
 


### PR DESCRIPTION
修改dispatchInited方法，主要解决：当跳转到包含Form的新页面，新页面还没加载完成时，快速后退导致的报错：Uncaught (in promise) Error: [mobx-state-tree] You are trying to read or write to an object that is no longer part of a state tree.
