### PR TITLE
chore: 升级amis-publish版本,支持根据分支的最新版本号来自动升级版本号

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@types/react-dom": "^18.0.8",
     "@types/react-syntax-highlighter": "^15.5.11",
     "@vitejs/plugin-react": "^2.2.0",
-    "amis-publish": "^1.0.1",
+    "amis-publish": "^1.0.3",
     "copy-to-clipboard": "3.3.1",
     "echarts": "5.4.0",
     "express": "^4.18.2",


### PR DESCRIPTION
### What
支持根据分支的最新版本号来自动升级版本号
如：
290-6.4.0分支：
<img width="424" alt="image" src="https://github.com/baidu/amis/assets/30946345/c897ca9d-f3fa-471f-80a6-f79ed60bd9a1">
280-6.3.0分支：
<img width="381" alt="image" src="https://github.com/baidu/amis/assets/30946345/bde8ccec-20a8-423c-84db-d8f170a1f6cd">


### Why

### How
