### PR TITLE
fix: 修复Safari中table的角标配置定位错误问题

### DIFF
--- a/packages/amis-ui/scss/components/_table.scss
+++ b/packages/amis-ui/scss/components/_table.scss
@@ -434,6 +434,7 @@
       > td,
       > th {
         padding: var(--TableCell-paddingY) var(--TableCell-paddingX);
+        position: relative;
 
         &:first-child {
           padding-left: var(--TableCell--edge-paddingX);


### PR DESCRIPTION
### What
safari中
<img width="239" alt="image" src="https://github.com/baidu/amis/assets/30946345/5945c35f-f81e-4853-9f9e-e7d15a5d6074">
正常情况
<img width="259" alt="image" src="https://github.com/baidu/amis/assets/30946345/32937c62-ffff-40a9-8dca-8565ba9cec17">


### Why

### How
