### PR TITLE
style: 修复设计态弹窗中放 fieldset 渲染器宽度过宽的问题

### DIFF
--- a/packages/amis-ui/scss/components/_collapse.scss
+++ b/packages/amis-ui/scss/components/_collapse.scss
@@ -17,6 +17,8 @@
     var(--collapse-default-bottom-left-border-radius);
   padding: 0;
   line-height: px2rem(20px);
+  // 很神奇，设计态弹窗里面放个字段级 fieldset 就会撑开好宽
+  min-width: 0;
   // overflow: hidden;
 
   &-header {

--- a/packages/amis-ui/scss/components/form/_input-group.scss
+++ b/packages/amis-ui/scss/components/form/_input-group.scss
@@ -22,6 +22,11 @@
     white-space: nowrap;
   }
 
+  & > .#{$ns}Form-control {
+    flex: 1;
+    min-width: 0;
+  }
+
   &-addOn {
     background: var(--InputGroup-addOn-bg);
     border: var(--InputGroup-addOn-borderWidth) solid
@@ -80,6 +85,7 @@
   .#{$ns}SearchBox {
     flex-basis: 0;
     flex-grow: 1;
+    min-width: 0;
     display: inline-flex;
 
     &:not(:first-child) {


### PR DESCRIPTION
### What

### Why

<img width="1252" alt="image" src="https://github.com/baidu/amis/assets/2698393/c3edc3aa-1a21-414e-84eb-d324b06812c3">


### How
