### PR TITLE
fix: 修复 tabs 的 title 渲染上下文信息错误问题 Close: #10259

### DIFF
--- a/packages/amis/src/renderers/Tabs.tsx
+++ b/packages/amis/src/renderers/Tabs.tsx
@@ -728,7 +728,9 @@ export default class Tabs extends React.Component<TabsProps, TabsState> {
     const {render} = this.props;
     return typeof title === 'string' || !title
       ? filter(title, data)
-      : render(`tab-title/${index}`, title, {...data, index});
+      : render(`tab-title/${index}`, title, {
+          data: {index, __index: index, ...data}
+        });
   }
 
   renderToolbar() {


### PR DESCRIPTION
### What

### Why

Close: #10259

### How
