### PR TITLE
fix(editor): 解决getRootManager死循环问题

### DIFF
--- a/packages/amis-editor/src/renderer/event-control/helper.tsx
+++ b/packages/amis-editor/src/renderer/event-control/helper.tsx
@@ -57,7 +57,7 @@ const getRootManager = (manager: any) => {
     if (!rootManager.parent) {
       break;
     }
-    rootManager = manager.parent;
+    rootManager = rootManager.parent;
   }
 
   return rootManager;


### PR DESCRIPTION
### What
在编辑器中，当在多层级弹窗中点选事件详情时会导致死循环

### Why

### How
