### PR TITLE
fix: api query开启过滤空值时, 若参数值是表达式且其执行结果为date类型导致该参数被删除

### DIFF
--- a/packages/amis-core/src/utils/api.ts
+++ b/packages/amis-core/src/utils/api.ts
@@ -144,7 +144,12 @@ export function buildApi(
       (api as ApiObject)?.filterEmptyQuery
         ? {
             filter: (key: string, value: any) => {
-              return value === '' ? undefined : value;
+              return value === ''
+                ? undefined
+                : // qs源码中有filter后，不会默认使用serializeDate处理date类型
+                value instanceof Date
+                ? Date.prototype.toISOString.call(value)
+                : value;
             }
           }
         : undefined


### PR DESCRIPTION
### What

### Why

### How
