### PR TITLE
fix: 查询条件过滤空条件时, api query参数值的表达式执行结果为date类型时导致参数不生效

### DIFF
--- a/packages/amis-core/src/utils/api.ts
+++ b/packages/amis-core/src/utils/api.ts
@@ -146,7 +146,12 @@ export function buildApi(
       (api as ApiObject)?.filterEmptyQuery
         ? {
             filter: (key: string, value: any) => {
-              return value === '' ? undefined : value;
+              return value === ''
+                ? undefined
+                : // qs源码中有filter后，不会默认使用serializeDate处理date类型
+                value instanceof Date
+                ? Date.prototype.toISOString.call(value)
+                : value;
             }
           }
         : undefined


### PR DESCRIPTION
### What

### Why

### How
