### PR TITLE
fix: 修复 table 中有表单项带路径时会把对应对象其他属性弄丢的问题

### DIFF
--- a/packages/amis/src/renderers/Form/InputNumber.tsx
+++ b/packages/amis/src/renderers/Form/InputNumber.tsx
@@ -213,7 +213,7 @@ export default class NumberControl extends React.Component<
         toFixed(value.toString(), '.', normalizedPrecision)
       );
 
-      if (!isNaN(normalizedValue)) {
+      if (!isNaN(normalizedValue) && normalizedValue !== value) {
         setPrinstineValue(normalizedValue);
       }
     }

--- a/packages/amis/src/renderers/Table/TableRow.tsx
+++ b/packages/amis/src/renderers/Table/TableRow.tsx
@@ -7,6 +7,7 @@ import {
   RendererProps,
   TestIdBuilder,
   autobind,
+  keyToPath,
   setVariable,
   traceProps
 } from 'amis-core';
@@ -162,6 +163,11 @@ export class TableRow extends React.PureComponent<
 
     const {item, onQuickChange} = this.props;
     const data: any = {};
+    const keyPath = keyToPath(name);
+    // 如果是带路径的值变化，最好是能保留原来的对象的其他属性
+    if (keyPath.length > 1) {
+      data[keyPath[0]] = {...item.data[keyPath[0]]};
+    }
     setVariable(data, name, value);
 
     onQuickChange?.(item, data, submit, changePristine);


### PR DESCRIPTION
### What

### Why

### How
