### PR TITLE
fix: input-number用修改formatter的方式替换移动光标的方式 解决光标漂浮问题

### DIFF
--- a/packages/amis-ui/src/components/NumberInput.tsx
+++ b/packages/amis-ui/src/components/NumberInput.tsx
@@ -244,9 +244,6 @@ export class NumberInput extends React.Component<NumberProps, NumberState> {
   handleChange(value: any) {
     const {min, max, step, precision, resetValue, clearValueOnEmpty, onChange} =
       this.props;
-    /*
-    // 备注1: 输入过程中不立即进行normalizeValue数值处理（比如 四舍五入）
-    // 备注2: rc-input-number自身会进行数据纠正操作
     const finalPrecision = NumberInput.normalizePrecision(precision, step);
     const result = NumberInput.normalizeValue(
       value,
@@ -256,13 +253,6 @@ export class NumberInput extends React.Component<NumberProps, NumberState> {
       resetValue,
       clearValueOnEmpty,
       this.isBig
-    );
-    onChange?.(result);
-    */
-    const result = NumberInput.normalizeValue2(
-      value,
-      resetValue,
-      clearValueOnEmpty
     );
     onChange?.(result);
   }


### PR DESCRIPTION
### What
- input-number用修改formatter的方式替换移动光标的方式 解决光标漂浮问题
- 还原输入过程中进行normalizeValue数值处理的逻辑

### Why
光标漂浮相关issue
https://github.com/baidu/amis/issues/8405
https://github.com/baidu/amis/issues/7558
https://github.com/baidu/amis/issues/8795

输入过程需要实时 normalizeValue数值处理，否则change事件等逻辑会不符合预期

### How
