### PR TITLE
bugfix:从 scope 中注销组件时，自动从父级 scope 中移除当前 scope

### DIFF
--- a/packages/amis-core/src/Scoped.tsx
+++ b/packages/amis-core/src/Scoped.tsx
@@ -156,6 +156,9 @@ function createScopedTools(
     unRegisterComponent(component: ScopedComponentType) {
       // 自己本身实际上注册在父级 Scoped 上。
       if (component.props.$path === path && parent) {
+        // 如果是自己，尝试把自己从父级 Scoped 上移除，否则在某些场景下会导致父级的 children 一直增长。
+        const idx = parent.children!.indexOf(self);
+        ~idx && parent.children!.splice(idx, 1);
         return parent.unRegisterComponent(component);
       }
 


### PR DESCRIPTION
从 scope 中注销组件时，自动从父级 scope 中移除当前 scope，不然的话在反复打开弹窗等场景下会导致父级 scope 的 children 一直增长

### What

### Why

### How
