### PR TITLE
fix: issue#10515 修复code组件值为空控制台报错

### DIFF
--- a/packages/amis/src/renderers/Code.tsx
+++ b/packages/amis/src/renderers/Code.tsx
@@ -199,7 +199,7 @@ export default class Code extends React.Component<CodeProps> {
 
     if (this?.monaco?.editor && dom) {
       const {tabSize} = props;
-      const sourceCode = getPropValue(this.props);
+      const sourceCode = getPropValue(this.props) ?? '';
       const language = this.resolveLanguage();
       const theme = this.registerAndGetTheme();
       /**
@@ -230,7 +230,7 @@ export default class Code extends React.Component<CodeProps> {
 
     this.monaco = monaco;
     const {tabSize} = this.props;
-    const sourceCode = getPropValue(this.props);
+    const sourceCode = getPropValue(this.props) ?? '';
     const language = this.resolveLanguage();
     const dom = this.codeRef.current;
 


### PR DESCRIPTION
### What
issue#10515 修复code组件值为空控制台报错

### Why
code组件值为undefined时，会导致monaco-editor内部出现报错

### How
如果值为undefined时将值设置为空字符串
