### PR TITLE
修复 CustomStyle 在某些情况下 id 的类型可能是 number 而导致异常报错

### DIFF
--- a/packages/amis-core/src/components/CustomStyle.tsx
+++ b/packages/amis-core/src/components/CustomStyle.tsx
@@ -19,7 +19,8 @@ export const styleIdCount = new Map();
 
 export default function (props: CustomStyleProps) {
   const {config, env, data} = props;
-  const {themeCss, classNames, id, defaultData, wrapperCustomStyle} = config;
+  const {themeCss, classNames, defaultData, wrapperCustomStyle} = config;
+  const id = config.id ? `${config.id}` : config.id;
 
   useEffect(() => {
     if (styleIdCount.has(id)) {


### PR DESCRIPTION
在crud的card模式下（可能还有其他场景），会有 id 为数字的 Tpl 组件的情况，导致 removeCustomStyle 函数报错。 这个跟 #10396 解决的问题是同一个，只是我觉的既然所有的工具函数都是预设了 id 为 string，何不从源头上解决？免得以后更新工具方法的时候还要再写很多防御性代码。