### PR TITLE
fix: 修复 select 值格式是对象时初始化值不正确的问题

### DIFF
--- a/packages/amis-ui/scss/components/_condition-builder.scss
+++ b/packages/amis-ui/scss/components/_condition-builder.scss
@@ -455,6 +455,10 @@
   margin: px2rem(3px);
   flex: 1;
   min-width: px2rem(100px);
+
+  > * {
+    width: 100%;
+  }
 }
 
 .#{$ns}CBFormula {


### PR DESCRIPTION
### What

### Why

之前处理时机尚早，选项还没拉取回来

### How
