### PR TITLE
fix: input-tree图标为url时，未限制img图片宽高

### DIFF
--- a/packages/amis-ui/scss/components/form/_tree.scss
+++ b/packages/amis-ui/scss/components/form/_tree.scss
@@ -351,7 +351,8 @@
   &-rootIcon,
   &-folderIcon,
   &-leafIcon {
-    > svg {
+    > svg,
+    .img {
       top: 0;
       width: px2rem(14px);
       height: px2rem(14px);


### PR DESCRIPTION
### What

### Why

### How
