### PR TITLE
merge the latest store data

### DIFF
--- a/packages/amis-core/src/actions/Action.ts
+++ b/packages/amis-core/src/actions/Action.ts
@@ -234,10 +234,10 @@ export const runAction = async (
   // 注意：并行ajax请求结果必须通过event取值
   const mergeData = createObject(
     createObject(
-      renderer.props.data.__super
-        ? createObject(renderer.props.data.__super, additional)
+      renderer.props.store?.data.__super
+        ? createObject(renderer.props.store?.data.__super, additional)
         : additional,
-      renderer.props.data
+      renderer.props.store?.data
     ),
     event.data
   );


### PR DESCRIPTION
### What
在执行Action的时候，取不到最新的数据
```json
{
  "type": "page",
  "body": {
    "type": "form",
    "debug": true,
    "body": [
      {
        "name": "name",
        "type": "input-text",
        "label": "测试一下"
      },
      {
        "name": "text",
        "type": "input-text",
        "label": "text",
        "onEvent": {
          "blur": {
            "actions": [
              {
                "actionType": "toast",
                "args": {
                  "msg": "${name}"
                }
              }
            ]
          }
        }
      }
    ]
  }
}
```
在第二个域blur的时候，获取不到第一个域里输入的最新值
### Why
第一个域change的时候修改的是store里的值，并不体现的props的data里。
### How
合并store中的数据，供action使用
