### PR TITLE
自定义脚本中，通过组件的名称来获取组件引用，方便使用

### DIFF
--- a/packages/amis-core/src/actions/CustomAction.ts
+++ b/packages/amis-core/src/actions/CustomAction.ts
@@ -51,11 +51,20 @@ export class CustomAction implements RendererAction {
         'event'
       ) as any;
     }
-
+    const proxy = new Proxy(
+      {},
+      {
+        get(target: {}, p: string | symbol, receiver: any): any {
+          if (typeof p === 'string') {
+            return event.context.scoped?.getComponentByName?.(p);
+          }
+        }
+      }
+    );
     // 外部可以直接调用doAction来完成动作调用
     // 可以通过上下文直接编排动作调用，通过event来进行动作干预
     let result = await (scriptFunc as any)?.call(
-      null,
+      proxy,
       renderer,
       (action: ListenerAction) => runActions(action, renderer, event),
       event,


### PR DESCRIPTION
在自定义js脚本中，经常需要对其他组件进行一些操作，比如提交按钮点击的时候，让某个组件获取焦点之类的。
使用时从简单方便的角度出发，希望可以通过
```javascript
this.name.focus()
```
就可以让**name**这个组件获取焦点。