### PR TITLE
fix: number with precision should be string format

### DIFF
--- a/packages/amis/src/renderers/Number.tsx
+++ b/packages/amis/src/renderers/Number.tsx
@@ -118,9 +118,7 @@ export class NumberField extends React.Component<NumberProps> {
         viewValue = <span>{value}</span>;
       } else {
         if (typeof value === 'number' && precision) {
-          value = getMiniDecimal(
-            toFixed(num2str(value), '.', precision)
-          ).toNumber();
+          value = toFixed(num2str(value), '.', precision);
         }
 
         if (kilobitSeparator) {


### PR DESCRIPTION
### What
修复 #10566 

### Why
带精度的 `Number` 组件，value 应该是 string 格式，否则像 `1.20` 之类的数字，展示时末尾的零会丢失

### How
直接移除了 `getMiniDecimal` 的调用
