### PR TITLE
fix-darkModeCss

### DIFF
--- a/examples/style.scss
+++ b/examples/style.scss
@@ -11,7 +11,8 @@ body {
     }
 
     .markdown-body {
-      color: #fff;
+      color: rgb(100 116 139 / 1);
+      background-color: var(--colors-neutral-fill-11) !important;
     }
   }
 }


### PR DESCRIPTION
### What
<img width="1074" alt="Pasted Graphic 1" src="https://github.com/baidu/amis/assets/42144027/664c47c1-5610-4f00-a6f0-304ce256650b">
<img width="1100" alt="Pasted Graphic 2" src="https://github.com/baidu/amis/assets/42144027/b5c5a9ff-d18d-4c19-8d6f-68470ee4dae8">

### How
####Error
```css
.markdown-body {
      color: #fff;
}
```
####fix
```css
.markdown-body {
      color: rgb(100 116 139 / 1);
      background-color: var(--colors-neutral-fill-11) !important;
}
```