### PR TITLE
feat: 新增Tabs Hash模式

### DIFF
--- a/packages/amis/src/renderers/Tabs.tsx
+++ b/packages/amis/src/renderers/Tabs.tsx
@@ -97,12 +97,6 @@ export interface TabSchema extends Omit<BaseSchema, 'type'> {
    * 是否禁用
    */
   disabled?: boolean;
-  /**
-   * host/#/a/b/c#d => d
-   * host/#/a=b#c = > c
-   * host/#/a/b/c?a=a#f => f
-   */
-  hashRouter?: boolean;
 }
 
 /**
@@ -220,6 +214,12 @@ export interface TabsSchema extends BaseSchema {
    * 是否滑动切换只在移动端生效
    */
   swipeable?: boolean;
+  /**
+   * host/#/a/b/c#d => d
+   * host/#/a=b#c = > c
+   * host/#/a/b/c?a=a#f => f
+   */
+  hashRouter?: boolean;
 }
 
 export interface TabsProps

--- a/packages/amis/src/renderers/Tabs.tsx
+++ b/packages/amis/src/renderers/Tabs.tsx
@@ -30,6 +30,7 @@ import {str2AsyncFunction} from 'amis-core';
 import {ScopedContext, IScopedContext} from 'amis-core';
 import type {TabsMode} from 'amis-ui/lib/components/Tabs';
 import isNaN from 'lodash/isNaN';
+import {string} from 'prop-types';
 
 export interface TabSchema extends Omit<BaseSchema, 'type'> {
   /**
@@ -96,6 +97,12 @@ export interface TabSchema extends Omit<BaseSchema, 'type'> {
    * 是否禁用
    */
   disabled?: boolean;
+  /**
+   * host/#/a/b/c#d => d
+   * host/#/a=b#c = > c
+   * host/#/a/b/c?a=a#f => f
+   */
+  hashRouter?: boolean;
 }
 
 /**
@@ -222,6 +229,12 @@ export interface TabsProps
   defaultKey?: string | number;
   location?: any;
   tabRender?: (tab: TabSchema, props: TabsProps, index: number) => JSX.Element;
+  /**
+   * host/#/a/b/c#d => d
+   * host/#/a=b#c = > c
+   * host/#/a/b/c?a=a#f => f
+   */
+  hashRouter?: boolean;
 }
 
 interface TabSource extends TabSchema {
@@ -254,13 +267,18 @@ export default class Tabs extends React.Component<TabsProps, TabsState> {
     super(props);
 
     const location = props.location || window.location;
-    const {tabs, source, data} = props;
+    const {tabs, source, data, hashRouter} = props;
     let activeKey: any = 0;
 
     if (typeof props.activeKey !== 'undefined') {
       activeKey = props.activeKey;
     } else if (location && Array.isArray(tabs)) {
-      const hash = location.hash.substring(1);
+      const hash = hashRouter
+        ? location.hash
+            .split('#')
+            .filter((itemHash: string) => !!itemHash)
+            .pop()
+        : location.hash.substring(1);
       const tab: TabSource = find(tabs, tab => tab.hash === hash) as TabSource;
 
       if (tab) {


### PR DESCRIPTION
### What

新增Tabs Hash模式

### Why

1. Bug：在hash模式下(host/#/a/b/c#d)，Tabs `配置 hash`会失效以及handleSelect env.updateLocation(`#${key}`)也会失效。
2. 特性：

```typescript
 host/#/a/b/c#d => d
 host/#/a=b#c = > c
 host/#/a/b/c?a=a#f => f

```
备注：env.updateLocation需要用户自己实现。

### How
