### PR TITLE
fix: 调整 formItem 下面的事件触发参数让其拿到最新的 Close: #10376

### DIFF
--- a/packages/amis-core/src/actions/Action.ts
+++ b/packages/amis-core/src/actions/Action.ts
@@ -221,11 +221,13 @@ export const runAction = async (
   let action: ListenerAction = {...actionConfig};
   action.args = {...actionConfig.args};
 
+  const rendererProto = renderer.props.getData?.() ?? renderer.props.data;
+
   // __rendererData默认为renderer.props.data，兼容表单项值变化时的data读取
   if (!event.data?.__rendererData) {
     additional = {
       event,
-      __rendererData: renderer.props.data // 部分组件交互后会有更新，如果想要获取那部分数据，可以通过事件数据获取
+      __rendererData: rendererProto // 部分组件交互后会有更新，如果想要获取那部分数据，可以通过事件数据获取
     };
   }
 
@@ -234,10 +236,10 @@ export const runAction = async (
   // 注意：并行ajax请求结果必须通过event取值
   const mergeData = createObject(
     createObject(
-      renderer.props.data.__super
-        ? createObject(renderer.props.data.__super, additional)
+      rendererProto.__super
+        ? createObject(rendererProto.__super, additional)
         : additional,
-      renderer.props.data
+      rendererProto
     ),
     event.data
   );

--- a/packages/amis-core/src/renderers/Item.tsx
+++ b/packages/amis-core/src/renderers/Item.tsx
@@ -2161,6 +2161,7 @@ export function asFormItem(config: Omit<FormItemConfig, 'component'>) {
           constructor(props: FormControlProps) {
             super(props);
             this.refFn = this.refFn.bind(this);
+            this.getData = this.getData.bind(this);
 
             const {validations, formItem: model} = props;
 
@@ -2203,6 +2204,10 @@ export function asFormItem(config: Omit<FormItemConfig, 'component'>) {
             this.ref = ref;
           }
 
+          getData() {
+            return this.props.data;
+          }
+
           renderControl() {
             const {
               // 这里解构，不可轻易删除，避免被rest传到子组件
@@ -2228,6 +2233,9 @@ export function asFormItem(config: Omit<FormItemConfig, 'component'>) {
               <>
                 <Control
                   {...rest}
+                  // 因为 formItem 内部可能不会更新到最新的 data，所以暴露个方法可以获取到最新的
+                  // 获取不到最新的因为做了限制，只有表单项目 name 关联的数值变化才更新
+                  getData={this.getData}
                   mobileUI={mobileUI}
                   onOpenDialog={this.handleOpenDialog}
                   size={config.sizeMutable !== false ? undefined : size}

--- a/packages/amis-core/src/utils/renderer-event.ts
+++ b/packages/amis-core/src/utils/renderer-event.ts
@@ -328,14 +328,15 @@ export const resolveEventData = (
   data: any,
   valueKey: string = 'value'
 ) => {
+  const proto = props.getData?.() ?? props.data;
   return createObject(
-    props.data,
+    proto,
     props.name && valueKey
       ? {
           ...data,
           [props.name]: data[valueKey],
           __rendererData: {
-            ...props.data,
+            ...proto,
             [props.name]: data[valueKey]
           }
         }


### PR DESCRIPTION
### What

通过下发方法，让 formItem 节流渲染的的控件也有办法拿到最新的数据，同时调整时间派发的数据获取方式

### Why

### How
