### PR TITLE
refactor: nextApi check can be simplified

### DIFF
--- a/packages/amis-core/src/utils/api.ts
+++ b/packages/amis-core/src/utils/api.ts
@@ -742,7 +742,7 @@ export function isApiOutdated(
   }
 
   // 通常是编辑器里加了属性，一开始没值，后来有了
-  if (prevApi === undefined && !nextApi !== undefined) {
+  if (prevApi === undefined) {
     return true;
   }
 


### PR DESCRIPTION
### What

First, `!nextApi` is always `boolean`, so I expect it should be `nextApi !== undefined` at first place.

Secondly, `nextApi` has already been guaranteed to be truthy at https://github.com/baidu/amis/blob/d43922db81798c3fd16072aa873bf8390653319f/packages/amis-core/src/utils/api.ts#L740-L742, so the check here is just redundant.

### Why

N/A

### How

N/A
