### PR TITLE
FEAT: 快速编辑成功后 dispatch 事件

### DIFF
--- a/docs/zh-CN/components/table2.md
+++ b/docs/zh-CN/components/table2.md
@@ -3558,6 +3558,7 @@ order: 67
   "body": {
     "type": "service",
     "api": "/api/sample?perPage=5",
+    "id": "service-container",
     "body": [
       {
         "type": "table2",
@@ -3565,6 +3566,25 @@ order: 67
         "quickSaveApi": {
           "url": "/api/mock2/sample/bulkUpdate",
           "method": "put"
+        },
+        "draggable": true,
+        "onEvent": {
+          "quickSaveSubmitted": {
+            "actions": [
+              {
+                "actionType": "reload",
+                "componentId": "service-container"
+              }
+            ]
+          },
+          "orderChange": {
+            "actions": [
+              {
+                "actionType": "reload",
+                "componentId": "service-container"
+              }
+            ]
+          }
         },
         "columns": [
           {

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -1424,7 +1424,8 @@ export default class Table2 extends React.Component<Table2Props, object> {
       keyField,
       env,
       messages,
-      reload
+      reload,
+      dispatchEvent
     } = this.props;
 
     if (Array.isArray(rows)) {
@@ -1454,6 +1455,7 @@ export default class Table2 extends React.Component<Table2Props, object> {
           errorMessage: messages && messages.saveSuccess
         })
         .then(() => {
+          dispatchEvent('quickSaveSubmitted', data);
           reload && this.reloadTarget(filterTarget(reload, data), data);
         })
         .catch(() => {});
@@ -1473,6 +1475,7 @@ export default class Table2 extends React.Component<Table2Props, object> {
       store
         .saveRemote(quickSaveItemApi, sendData)
         .then(() => {
+          dispatchEvent('quickSaveSubmitted', sendData);
           reload && this.reloadTarget(filterTarget(reload, data), data);
         })
         .catch(() => {


### PR DESCRIPTION
### What
#10599 

### Why
- 目前代码中快速编辑功能在提交后后，会用快速编辑后返回的 data 来更新 table2 的数据内容
-  table2 快速编辑功能，示例 api 的更新接口成功后，接口不会返回 data 字段，因此不会更新，数据前后 diff 还是相同的，所以快速编辑的按钮还会存在
- 我觉得实际使用场景中，更新接口不返回更新后数据的场景应该很常见，需要支持一下这种场景

### How
- 在快速编辑成功之后，dispath 相关事件，在事件中可以自定义地去 reload 目标组件的数据
