### PR TITLE
feat(popoverContainer): overlay 宽度支持关键字

### DIFF
--- a/packages/amis-ui/src/components/PopOverContainer.tsx
+++ b/packages/amis-ui/src/components/PopOverContainer.tsx
@@ -124,6 +124,10 @@ export class PopOverContainer extends React.Component<
         `calc(${targetWidth}px $1 $2)`
       );
     }
+    // 关键字
+    if (/^(auto|min-content|max-content|fit-content)$/.test(overlayWidth)) {
+      return overlayWidth;
+    }
 
     return;
   }


### PR DESCRIPTION
### What
select 选择器的下拉框宽度支持关键字

### Why
当前 select 下拉框宽度无法设置为 auto，因为默认设置为选择器的宽度，即使添加 overlay.width 也不能设置 auto 等关键字，也就是说不能以下拉框内容作为宽度。

Before：
![before](https://github.com/user-attachments/assets/aea11a56-f0cd-45c1-9d55-55fd0a76cd5c)
对应的 css 代码：
![before-1](https://github.com/user-attachments/assets/b0932f18-ea9c-4a62-8ecc-c6d74fced099)

amis 配置：
```json
{
  "type": "select",
  "label": "选项",
  "name": "select",
  "options": [
    {
      "label": "超级长的A超级长的A超级长的A超级长的A",
      "value": "A"
    },
    {
      "label": "选项B",
      "value": "B"
    }
  ],
  "id": "u:af74f5354c70",
  "multiple": false,
  "mode": "inline",
  "size": "sm"
}
```

After：
![after](https://github.com/user-attachments/assets/ed0bfdcd-f337-4cbc-af6c-f848a1234f33)
对应的 CSS 代码：
![after-1](https://github.com/user-attachments/assets/5e865cdb-af6d-4a76-bae1-d189e4ed4a34)

amis 配置：
```json
{
  "type": "select",
  "label": "选项",
  "name": "select",
  "options": [
    {
      "label": "超级长的A超级长的A超级长的A超级长的A",
      "value": "A"
    },
    {
      "label": "选项B",
      "value": "B"
    }
  ],
  "id": "u:af74f5354c70",
  "multiple": false,
  "mode": "inline",
  "size": "sm",
  "overlay": {
    "width": "auto" // 增加关键字的支持
  }
}
```

### How

让 `overlay.width` 支持关键字设置