### PR TITLE
fix: 修复 picker 组件数据由接口返回时列不可拖动调整宽度问题 Close: #10791

### DIFF
--- a/packages/amis/src/renderers/Table/ColGroup.tsx
+++ b/packages/amis/src/renderers/Table/ColGroup.tsx
@@ -50,7 +50,7 @@ export function ColGroup({
     return () => {
       observer.disconnect();
     };
-  }, []);
+  }, [columns.length]);
 
   // 解决 chrome 91 以下版本的设置 colgroup>col 的 width 属性无效的问题
   // 低版本同时设置 thead>th


### PR DESCRIPTION
### What

### Why

可以拖动的前提是列设置了 realWidth， 而那个 case，的单选列是有数据后出来的，这个 case 新出来的列没有设置宽度，所以不能拖动。所以列发生变化的时候，之前的监控逻辑需要重新加载

### How
