### PR TITLE
fix: 修复级联选择器数据源异常label为数组时页面崩溃的问题

### DIFF
--- a/packages/amis/src/renderers/Form/NestedSelect.tsx
+++ b/packages/amis/src/renderers/Form/NestedSelect.tsx
@@ -29,7 +29,8 @@ import {
   ActionObject,
   renderTextByKeyword,
   getVariable,
-  TestIdBuilder
+  TestIdBuilder,
+  labelToString
 } from 'amis-core';
 import {findDOMNode} from 'react-dom';
 import xor from 'lodash/xor';
@@ -250,15 +251,17 @@ export default class NestedSelectControl extends React.Component<
     const regexp = string2regExp(inputValue);
 
     if (hideNodePathLabel) {
-      return option[labelField || 'label'];
+      return labelToString(option[labelField || 'label']);
     }
     const ancestors = getTreeAncestors(options, option, true);
 
-    const optionText = option[labelField || 'label'];
+    const optionText = labelToString(option[labelField || 'label']);
     const splitJoin = ' / ';
 
     const title = ancestors
-      ? ancestors.map(item => item[labelField || 'label']).join(splitJoin)
+      ? ancestors
+          .map(item => labelToString(item[labelField || 'label']))
+          .join(splitJoin)
       : optionText;
 
     return (
@@ -269,7 +272,7 @@ export default class NestedSelectControl extends React.Component<
       >
         {ancestors
           ? ancestors.map((item, index) => {
-              const label = item[labelField || 'label'];
+              const label = labelToString(item[labelField || 'label']);
               const value = item[valueField || 'value'];
               const isEnd = index === ancestors.length - 1;
               return (
@@ -709,7 +712,7 @@ export default class NestedSelectControl extends React.Component<
                 selfChecked = true;
               }
 
-              let label = option[labelField || 'label'];
+              let label = labelToString(option[labelField || 'label']);
 
               return (
                 <div


### PR DESCRIPTION
当数据源为api返回是以下内容时
```
{
    "status": 0,
    "msg": "",
    "data": {
      "links":
        [{ "label": "Nav 1", "to": "?cat=1", "value": "1", "icon": "fa fa-user" }, { "label": "Nav 2", "unfolded": true, "children": [{ "label": "Nav 2-1", "children": [{ "label": "Nav 2-1-1", "to": "?cat=2-1", "value": "2-1" }] }, { "label": "Nav 2-2", "to": "?cat=2-2", "value": "2-2" }] }, { "label": "Nav 3", "to": "?cat=3", "value": "3", "defer": true }],
      "value": "?cat=1"
    }
  }
```
会引发页面崩溃
![image](https://github.com/user-attachments/assets/df642b3d-47b5-48f3-8b85-14d990dada59)

需要对labelji进行兼容处理