### PR TITLE
fix: inputTree defer模式下悬浮不展示操作按钮 #10873

### DIFF
--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -1306,12 +1306,11 @@ export class TreeSelector extends React.Component<
                 : `${item[labelField]}`}
             </span>
 
-            {!disabled &&
-            !isAdding &&
-            !isEditing &&
-            !(item[deferField] && !item.loaded) ? (
+            {!disabled && !isAdding && !isEditing ? (
               <div className={cx('Tree-item-icons')}>
-                {creatable && hasAbility(item, 'creatable') ? (
+                {creatable &&
+                !(item[deferField] && !item.loaded) &&
+                hasAbility(item, 'creatable') ? (
                   <TooltipWrapper
                     placement={'bottom'}
                     tooltip={__(createTip)}


### PR DESCRIPTION
### What
#10873 

### Why

### How
