### PR TITLE
fix: inputTable开启拖拽后会导致表头文字可拖拽

### DIFF
--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -500,6 +500,7 @@ export default class Table extends React.Component<TableProps, object> {
     'hideQuickSaveBtn',
     'itemCheckableOn',
     'itemDraggableOn',
+    'draggable',
     'checkOnItemClick',
     'hideCheckToggler',
     'itemAction',


### PR DESCRIPTION
### What
#10877 
draggable不应该是render('table'）的第三个参数，会透传覆盖别的render渲染元素

### Why

### How
