### PR TITLE
解决bug:https://github.com/baidu/amis/issues/9146

### DIFF
--- a/packages/amis-ui/scss/components/_column-toggler.scss
+++ b/packages/amis-ui/scss/components/_column-toggler.scss
@@ -46,6 +46,8 @@
     box-shadow: var(--DropDown-menu-boxShadow);
     min-width: var(--DropDown-menu-minWidth);
     text-align: left;
+    max-height: 500px;
+    overflow: auto;
   }
 
   &--alignRight &-menu {


### PR DESCRIPTION
解决crud列过多的时候，左边上角显示列展开无法显示完整
![image](https://github.com/user-attachments/assets/b0611512-8777-43d6-84c9-a503da5deaa7)

### What

### Why

### How
