### PR TITLE
fix: 设置inTag时，label 为对象时渲染异常

### DIFF
--- a/packages/amis/src/renderers/Words.tsx
+++ b/packages/amis/src/renderers/Words.tsx
@@ -91,7 +91,7 @@ function getLabel(
     }`;
   }
 
-  return item[labelField] || `选项${index}`;
+  return labelToString(item[labelField]) || `选项${index}`;
 }
 
 export class WordsField extends React.Component<WordsProps, object> {


### PR DESCRIPTION
### What

### Why

### How
