### PR TITLE
fix: 修复combo内select的options使用valueField时options会被全部禁用的问题

### DIFF
--- a/packages/amis-core/src/store/formItem.ts
+++ b/packages/amis-core/src/store/formItem.ts
@@ -1410,14 +1410,16 @@ export const FormItemStore = StoreNode.named('FormItemStore')
           group.items.forEach(item => {
             if (self !== item) {
               options.push(
-                ...item.selectedOptions.map((item: any) => item && item.value)
+                ...item.selectedOptions.map(
+                  (item: any) => item && item[valueField]
+                )
               );
             }
           });
 
         if (filteredOptions.length && options.length) {
           filteredOptions = mapTree(filteredOptions, item => {
-            if (~options.indexOf(item.value)) {
+            if (~options.indexOf(item[valueField])) {
               return {
                 ...item,
                 disabled: true


### PR DESCRIPTION
### What
```
{
  "type": "page",
  "body": {
    "type": "combo",
    "name": "combo2",
    "label": "Combo 多选展示",
    "multiple": true,
    "items": [
      {
        "name": "text",
        "label": "文本",
        "type": "input-text"
      },
      {
        "name": "select",
        "label": "选项",
        "type": "select",
        "unique": true,
        "labelField": "name",
        "valueField": "id",
        "options": [
          {
            "name": "选项1",
            "id": 1
          },
          {
            "name": "选项2",
            "id": 2
          },
          {
            "name": "选项3",
            "id": 3
          },
        ]
      }
    ]
  }
}
```
以上schema选择一项后，其他select的options会被全部禁用
### Why
syncOptions中，使用 valueField 时，item.value 取不到值，导致了异常
### How
```
item.value -> item[valueField]
```