### PR TITLE
fix: #10939 修复 broadcast 事件无效

### DIFF
--- a/packages/amis-core/src/SchemaRenderer.tsx
+++ b/packages/amis-core/src/SchemaRenderer.tsx
@@ -238,7 +238,8 @@ export class SchemaRenderer extends React.Component<SchemaRendererProps, any> {
 
     if (ref) {
       // 这里无法区分监听的是不是广播，所以又bind一下，主要是为了绑广播
-      this.unbindEvent = bindEvent(this.ref);
+      this.unbindEvent?.();
+      this.unbindEvent = bindEvent(ref);
     }
     this.cRef = ref;
   }


### PR DESCRIPTION
### What
修复 #10939 广播事件无效。

### Why
6.8 版本，在 `SchemaRenderer` 中，改动了调用 `bindEvent` 时机。

在 每次调用渲染器组件的 `props.dispatchEvent` 实际调用的是 `SchemaRenderer.dispatchEvent` 方法。第二个参数默认传的 `this.cRef`。因此在，"bindEvent" 的时候，也要默认传入 `cRef`

### How

改了下 `bindEvent` 传入的参数为 `cRef`，从而支持 广播事件。
