### PR TITLE
fix: #10951 修复 InputTable 在 配置 perPage 开启分页场景时，底部新增按钮展示异常

### DIFF
--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -1941,6 +1941,13 @@ export default class FormTable extends React.Component<TableProps, TableState> {
       offset = (page - 1) * perPage;
     }
 
+    // 底部新增按钮是否显示
+    const footerAddBtnVisible =
+      !isStatic &&
+      addable &&
+      showFooterAddBtn !== false &&
+      (!maxLength || maxLength > this.state.items.length);
+
     return (
       <div className={cx('InputTable', className)}>
         {render(
@@ -1983,13 +1990,9 @@ export default class FormTable extends React.Component<TableProps, TableState> {
             testIdBuilder: testIdBuilder?.getChild('table')
           }
         )}
-        {(!isStatic &&
-          addable &&
-          showFooterAddBtn !== false &&
-          (!maxLength || maxLength > items.length)) ||
-        showPager ? (
+        {footerAddBtnVisible || showPager ? (
           <div className={cx('InputTable-toolbar', toolbarClassName)}>
-            {addable && showFooterAddBtn !== false
+            {footerAddBtnVisible
               ? render(
                   'button',
                   {


### PR DESCRIPTION
### What

修复 #10951 , `InputTable` 在配置 `perPage` 开启分页时，新增按钮展示异常问题。

1. 配置 `perPage`, `maxLength` 时 ，且数量超出限制时，新增按钮未正常隐藏。
2. 配置 `perPage`, `addable`  时，在 static 静态模式下，新增按钮仍然展示。 

### Why

问题1:  `maxLength` 只取了当页的 `items` 数量对比， 应该使用全量数据对比。
问题2: 底部新增按钮限制条件，在有分页器时，就只有 `addable && showFooterAddBtn !== false`, 与不存在 分页器的时候，表现不一样。按理说，无论分页不分页，底部新增按钮，展示逻辑应该一样。


### How

调整下底部按钮展示逻辑，保持与是否分页无关。
