### PR TITLE
修复input-text组件 autoComplete、creatable属性导致弹框不消失的bug

### DIFF
--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -388,8 +388,8 @@ export default class TextControl extends React.PureComponent<
     onChange(this.normalizeValue(newValue));
   }
 
-  async handleClick() {
-    const {dispatchEvent, value} = this.props;
+  async handleClick(event: React.MouseEvent) {
+    const {dispatchEvent, value, multiple} = this.props;
     const rendererEvent = await dispatchEvent(
       'click',
       resolveEventData(this.props, {
@@ -402,9 +402,11 @@ export default class TextControl extends React.PureComponent<
     }
     // 已经 focus 的就不重复执行，否则总重新定位光标
     this.state.isFocused || this.focus();
-    this.setState({
-      isOpen: true
-    });
+    if(multiple ||(event.target as HTMLElement).tagName.toLowerCase() === 'input'){
+      this.setState({
+        isOpen: true
+      });
+    }
   }
 
   async handleFocus(e: any) {


### PR DESCRIPTION
input-text组件使用autoComplete属性时 点击了选项 选项组弹框不消失 需要点击空白处才能消失
然后发现   creatable: false 也会同样导致这个bug


``````
(event.target as HTMLElement).tagName.toLowerCase() === 'input'
``````
这个修改的方式可能不太规范，因为不太了解整个项目，不知道怎么判断点击的是选项还是文本框本身，大佬可以指点一下

### What

### Why

### How
