### PR TITLE
fix: 移动端弹窗、抽屉配置了closeOnOutside， 移动端下拉类型的表单选择后整个弹窗关闭

### DIFF
--- a/packages/amis-ui/src/components/Drawer.tsx
+++ b/packages/amis-ui/src/components/Drawer.tsx
@@ -44,6 +44,7 @@ export interface DrawerProps {
   onEntered?: () => void;
   drawerClassName?: string;
   drawerMaskClassName?: string;
+  mobileUI?: boolean;
 }
 export interface DrawerState {}
 const fadeStyles: {
@@ -168,7 +169,7 @@ export class Drawer extends React.Component<DrawerProps, DrawerState> {
   @autobind
   handleRootMouseDownCapture(e: MouseEvent) {
     const target = e.target as HTMLElement;
-    const {closeOnOutside, classPrefix: ns} = this.props;
+    const {closeOnOutside, classPrefix: ns, mobileUI} = this.props;
     const isLeftButton =
       (e.button === 1 && window.event !== null) || e.button === 0;
 
@@ -177,7 +178,9 @@ export class Drawer extends React.Component<DrawerProps, DrawerState> {
       closeOnOutside &&
       target &&
       this.modalDom &&
-      ((!this.modalDom.contains(target) && !target.closest('[role=dialog]')) ||
+      ((!mobileUI &&
+        !this.modalDom.contains(target) &&
+        !target.closest('[role=dialog]')) ||
         (target.matches(`.${ns}Drawer-overlay`) &&
           target.parentElement === this.modalDom))
     ); // 干脆过滤掉来自弹框里面的点击

--- a/packages/amis-ui/src/components/Modal.tsx
+++ b/packages/amis-ui/src/components/Modal.tsx
@@ -270,7 +270,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
   @autobind
   handleRootMouseDownCapture(e: MouseEvent) {
     const target = e.target as HTMLElement;
-    const {closeOnOutside, classPrefix: ns} = this.props;
+    const {closeOnOutside, classPrefix: ns, mobileUI} = this.props;
     const isLeftButton =
       (e.button === 1 && window.event !== null) || e.button === 0;
 
@@ -279,7 +279,9 @@ export class Modal extends React.Component<ModalProps, ModalState> {
       closeOnOutside &&
       target &&
       this.modalDom &&
-      ((!this.modalDom.contains(target) && !target.closest('[role=dialog]')) ||
+      ((!mobileUI &&
+        !this.modalDom.contains(target) &&
+        !target.closest('[role=dialog]')) ||
         (target.matches(`.${ns}Modal`) && target === this.modalDom))
     ); // 干脆过滤掉来自弹框里面的点击
   }


### PR DESCRIPTION
### What
移动端场景： 弹窗或者抽屉配置了closeOnOutside：true，其中的表单有popup弹出层的选项选择后整个表单即可关闭了，正常应该不关闭。
### Why
移动端popup弹窗直接弹在body下，脱离了dialog

### How
判断如果是移动端不执行dialog 中查找元素逻辑