### PR TITLE
docs: 将文档左侧导航栏下边距设置成和右侧文档主体下边距一致，以避免底部菜单被浏览器链接遮挡

### DIFF
--- a/examples/style.scss
+++ b/examples/style.scss
@@ -850,7 +850,7 @@ body {
       position: fixed;
       width: 200px;
       top: 100px;
-      bottom: 0;
+      bottom: 25px;
       overflow-y: auto;
       overflow-x: hidden;
       border-right: 1px solid #e8ebee;


### PR DESCRIPTION
### Why

由于下边距是0，当鼠标移动到左侧导航菜单上时，浏览器会默认在左下角预览显示当前菜单的链接，从而遮挡住了最下面的那一个菜单项

<img width="409" alt="image" src="https://github.com/user-attachments/assets/85f90134-cf4e-46bb-86d4-19f260a2aec7">

### How

使用和右侧.Doc-footer同样的下边距，解决该问题，并保持两边间距一样
