### PR TITLE
fix: 修复数字输入框存在后缀时，清空数据，光标位置定位不准确

### DIFF
--- a/packages/amis/src/renderers/Form/InputNumber.tsx
+++ b/packages/amis/src/renderers/Form/InputNumber.tsx
@@ -508,6 +508,14 @@ export default class NumberControl extends React.Component<
                 value = numberFormatter(value, finalPrecision);
               }
             }
+            if (
+              suffix &&
+              userTyping &&
+              this.input?.selectionStart === input.length
+            ) {
+              return `${prefix || ''}${value}`;
+            }
+
             return `${prefix || ''}${value}${suffix || ''}`;
           }
         : undefined;


### PR DESCRIPTION
### What

### Why

### How
