### PR TITLE
build: 通过lintstaged对scss文件进行增量校验，避免npm run stylelint全量校验的时间浪费

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged
-npm run stylelint

--- a/package.json
+++ b/package.json
@@ -36,8 +36,11 @@
     }
   },
   "lint-staged": {
-    "{packages,examples}/**/{src,examples}/**/**/*.{tsx,jsx,ts}": [
+    "{packages,examples}/**/{src,examples}/**/**/*.{tsx,jsx,ts,scss}": [
       "prettier --write"
+    ],
+    "*.{scss}": [
+      "stylelint --fix"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
### Why

项目中并无lintstaged配置文件，所以huksy中的npx lint-staged命令并未实际执行任何操作，而npm run stylelint会在每次commit时对packages下的所有scss进行检验，效率较低
