### PR TITLE
fix: 直接调用dispose函数清空编辑器插件，避免类型异常引起组件崩溃

### DIFF
--- a/packages/amis-ui/src/components/Editor.tsx
+++ b/packages/amis-ui/src/components/Editor.tsx
@@ -118,7 +118,7 @@ export class Editor extends React.Component<EditorProps, EditorState> {
   container: any;
   currentValue: any;
   preventTriggerChangeEvent: boolean;
-  disposes: Array<{dispose: () => void}> = [];
+  disposes: Array<() => void> = [];
   constructor(props: EditorProps) {
     super(props);
 
@@ -176,7 +176,7 @@ export class Editor extends React.Component<EditorProps, EditorState> {
       const editorWillUnmount = this.props.editorWillUnmount;
       editorWillUnmount && editorWillUnmount(this.editor, monaco);
     }
-    this.disposes.forEach(({dispose}) => dispose());
+    this.disposes.forEach(dispose => dispose());
     this.disposes = [];
     this.editor?.dispose();
   }
@@ -187,7 +187,7 @@ export class Editor extends React.Component<EditorProps, EditorState> {
       this.loadMonaco();
     } else {
       try {
-        this.disposes.forEach(({dispose}) => dispose());
+        this.disposes.forEach(dispose => dispose());
         this.disposes = [];
         if (this.editor) {
           this.editor.getModel().dispose();


### PR DESCRIPTION
在文档中编辑代码后，组件会崩溃

fix: 修复 DiffEditor 可能显示最新值的问题
1513c5402a343146e562378880795917d0e1e55c 引起的异常
