### PR TITLE
fit： 解决表格行编辑的时候的弹窗，无法获取返回值的问题

### DIFF
--- a/packages/amis/src/renderers/Table/TableRow.tsx
+++ b/packages/amis/src/renderers/Table/TableRow.tsx
@@ -132,7 +132,7 @@ export class TableRow extends React.PureComponent<
   @autobind
   handleAction(e: React.UIEvent<any>, action: Action, ctx: any) {
     const {onAction, item} = this.props;
-    onAction && onAction(e, action, ctx || item.locals);
+    return onAction && onAction(e, action, ctx || item.locals);
   }
 
   @autobind

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -220,6 +220,7 @@ export type TableColumnWithType = SchemaObject & TableColumnObject;
 export type TableColumn = TableColumnWithType | TableColumnObject;
 
 type AutoFillHeightObject = Record<'height' | 'maxHeight', number>;
+
 /**
  * Table 表格渲染器。
  * 文档：https://aisuda.bce.baidu.com/amis/zh-CN/components/table
@@ -1025,7 +1026,7 @@ export default class Table extends React.Component<TableProps, object> {
     const {onAction} = this.props;
 
     // todo
-    onAction(e, action, ctx);
+    return onAction(e, action, ctx);
   }
 
   async handleCheck(item: IRow, value?: boolean, shift?: boolean) {
@@ -1375,6 +1376,7 @@ export default class Table extends React.Component<TableProps, object> {
   }
 
   tableUnWatchResize?: () => void;
+
   tableRef(ref: HTMLTableElement) {
     this.table = ref;
     isAlive(this.props.store) && this.props.store.setTable(ref);


### PR DESCRIPTION
### What
表格行的编辑按钮，弹出对话框时，无法获取返回值
### Why
handleAction没有把promise给返回回去，导致别人waitForAction的时候获取了个undefine报错
### How
