### PR TITLE
fix: 调整 table 的本地存储策略，增加id区分不同页面的表格列缓存，修复#10983

### DIFF
--- a/packages/amis-core/src/store/iRenderer.ts
+++ b/packages/amis-core/src/store/iRenderer.ts
@@ -22,6 +22,7 @@ import {DataChangeReason} from '../types';
 
 export const iRendererStore = StoreNode.named('iRendererStore')
   .props({
+    crudId: types.optional(types.string, ''),
     hasRemoteData: types.optional(types.boolean, false),
     data: types.optional(types.frozen(), {}),
     initedAt: 0, // 初始 init 的时刻

--- a/packages/amis-core/src/store/table.ts
+++ b/packages/amis-core/src/store/table.ts
@@ -810,8 +810,13 @@ export const TableStore = iRendererStore
     return {
       getSelectionUpperLimit,
 
+      // 前端列缓存，必须有crud的id作为标识，否则会导致读取的缓存列数据错误
       get columnsKey() {
-        return location.pathname + self.path;
+        return (
+          location.pathname +
+          self.path +
+          `${self.crudId ? '?' + self.crudId : ''}`
+        );
       },
 
       get columnsData() {
@@ -1072,6 +1077,11 @@ export const TableStore = iRendererStore
         resolveDefinitions?: (ref: string) => any;
       }
     ) {
+      // 更换为crud组件的id, id赋值后就不能为空，否则缓存列配置会丢失
+      if (!self.crudId) {
+        self.crudId = config.crudId || '';
+      }
+
       config.primaryField !== undefined &&
         (self.primaryField = config.primaryField);
       config.selectable !== undefined && (self.selectable = config.selectable);

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -605,6 +605,7 @@ export default class Table extends React.Component<TableProps, object> {
     this.updateAutoFillHeight = this.updateAutoFillHeight.bind(this);
 
     const {
+      id,
       store,
       columns,
       selectable,
@@ -643,6 +644,7 @@ export default class Table extends React.Component<TableProps, object> {
 
     store.update(
       {
+        crudId: id,
         selectable,
         draggable,
         columns,
@@ -2860,7 +2862,6 @@ export default class Table extends React.Component<TableProps, object> {
     const tableClassName = cx('Table-table', this.props.tableClassName, {
       'Table-table--withCombine': store.combineNum > 0
     });
-
     return (
       <div
         ref={this.dom}

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -861,11 +861,19 @@ export default class Table extends React.Component<TableProps, object> {
       let nextSiblingHeight = 0;
       let nextSibling = selfNode.nextElementSibling as HTMLElement;
       while (nextSibling) {
-        const positon = getComputedStyle(nextSibling).position;
-        if (positon !== 'absolute' && positon !== 'fixed') {
-          nextSiblingHeight +=
-            nextSibling.offsetHeight +
-            getStyleNumber(nextSibling, 'margin-bottom');
+        //TODO 这里先做容器组件的兼容处理，希望大佬们能优化一下
+        // 如果下一个兄弟节点不是 cxd-Container,cxd-Grid-col--xxx2种容器，则计算下一个兄弟节点的高度
+        let classString = Array.from(nextSibling.classList).join(',');
+        if (
+          classString.indexOf(`${ns}Container`) < 0 &&
+          classString.indexOf(`${ns}Grid-col--`) < 0
+        ) {
+          const positon = getComputedStyle(nextSibling).position;
+          if (positon !== 'absolute' && positon !== 'fixed') {
+            nextSiblingHeight +=
+              nextSibling.offsetHeight +
+              getStyleNumber(nextSibling, 'margin-bottom');
+          }
         }
 
         nextSibling = nextSibling.nextElementSibling as HTMLElement;


### PR DESCRIPTION
### What
调整 table 的本地存储策略，增加id区分不同页面的表格列缓存，修复[#10983](https://github.com/baidu/amis/issues/10983)
### Why

### How
