### PR TITLE
feat: 修正crud2移动端简单查询折叠器箭头方向,没数据时不显示[没有更多了]文案

### DIFF
--- a/packages/amis-ui/scss/components/_crud2.scss
+++ b/packages/amis-ui/scss/components/_crud2.scss
@@ -145,6 +145,10 @@
       width: 100%;
     }
 
+    .#{$ns}Cards-placeholder {
+      font-size: var(--fonts-size-7);
+    }
+
     .#{$ns}Card {
       --Card-borderRadius: var(--sizes-size-5);
       --gap-base: var(--sizes-size-9);

--- a/packages/amis-ui/scss/components/_panel.scss
+++ b/packages/amis-ui/scss/components/_panel.scss
@@ -161,8 +161,9 @@
 
   &-arrow {
     transition: transform 0.1s ease-in;
+    transform: rotate(180deg);
     &.is-collapsed {
-      transform: rotate(180deg);
+      transform: rotate(0deg);
     }
   }
 

--- a/packages/amis/src/renderers/CRUD2.tsx
+++ b/packages/amis/src/renderers/CRUD2.tsx
@@ -1590,6 +1590,7 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
               store.lastPage > 0 &&
               store.page >= store.lastPage
             }
+            completedText={store.total > 0 ? undefined : ''}
           >
             {body}
           </PullRefresh>


### PR DESCRIPTION
### What

### Why

### How
