### PR TITLE
fix: 在容器组件左右布局里，2个crud组件开启内容自适应，第一个crud组件无法填充展示的bug修复 #10981

### DIFF
--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -859,11 +859,19 @@ export default class Table extends React.Component<TableProps, object> {
       let nextSiblingHeight = 0;
       let nextSibling = selfNode.nextElementSibling as HTMLElement;
       while (nextSibling) {
-        const positon = getComputedStyle(nextSibling).position;
-        if (positon !== 'absolute' && positon !== 'fixed') {
-          nextSiblingHeight +=
-            nextSibling.offsetHeight +
-            getStyleNumber(nextSibling, 'margin-bottom');
+        //TODO 这里先做容器组件的兼容处理，希望大佬们能优化一下
+        // 如果下一个兄弟节点不是 cxd-Container,cxd-Grid-col--xxx2种容器，则计算下一个兄弟节点的高度
+        let classString = Array.from(nextSibling.classList).join(',');
+        if (
+          classString.indexOf(`${ns}Container`) < 0 &&
+          classString.indexOf(`${ns}Grid-col--`) < 0
+        ) {
+          const positon = getComputedStyle(nextSibling).position;
+          if (positon !== 'absolute' && positon !== 'fixed') {
+            nextSiblingHeight +=
+              nextSibling.offsetHeight +
+              getStyleNumber(nextSibling, 'margin-bottom');
+          }
         }
 
         nextSibling = nextSibling.nextElementSibling as HTMLElement;


### PR DESCRIPTION
### What
在容器组件左右布局里，2个crud组件开启内容自适应，第一个crud组件无法填充展示的bug修复 [#10981](https://github.com/baidu/amis/issues/10981)
### Why

### How
