### PR TITLE
fix：表单项值非string时，部分校验规则一直生效

### DIFF
--- a/packages/amis-core/src/store/formItem.ts
+++ b/packages/amis-core/src/store/formItem.ts
@@ -1524,6 +1524,19 @@ export const FormItemStore = StoreNode.named('FormItemStore')
         | 'defaultValue' // 默认值
     ) {
       self.tmpValue = value;
+
+      // 处理 input-text, textarea 组件的 value为string类型
+      if (['input-text', 'textarea'].includes(self.type)) {
+        self.tmpValue =
+          typeof value === 'undefined' || value === null
+            ? ''
+            : typeof value === 'string'
+            ? value
+            : value instanceof Date
+            ? value.toISOString()
+            : JSON.stringify(value);
+      }
+
       if (changeReason) {
         self.changeMotivation = changeReason;
       }


### PR DESCRIPTION
### What
<img width="253" alt="f59af8e43bb38ab28e071d1f63ee5915" src="https://github.com/user-attachments/assets/af57baac-c02f-45ad-b6ca-6ab96053120c">
### Why

### How
