### PR TITLE
chore: 补充react-overlays至dep(#11117)

### DIFF
--- a/packages/amis-core/package.json
+++ b/packages/amis-core/package.json
@@ -64,6 +64,7 @@
     "qs": "6.9.7",
     "react-intersection-observer": "9.5.2",
     "react-json-view": "1.21.3",
+    "react-overlays": "5.1.1",
     "tslib": "^2.3.1",
     "uncontrollable": "7.2.1"
   },


### PR DESCRIPTION
### What

amis-core中引用了react-overlays, 但是package.json中不存在。 详细信息可见原issue

### Why

### How
