### PR TITLE
fix: 修复数据绑定组件选中值回传不正确的问题(#11126)

### DIFF
--- a/packages/amis-editor/src/renderer/DataBindingControl.tsx
+++ b/packages/amis-editor/src/renderer/DataBindingControl.tsx
@@ -130,7 +130,10 @@ export class DataBindingControl extends React.Component<
 
           return render('content', schema!, {
             onSelect: onChange,
-            value: value ? value.value : result
+            value:
+              value && typeof value === 'object'
+                ? value?.selected?.value ?? value?.value
+                : result
           });
         }}
         value={result}


### PR DESCRIPTION
### What

数据绑定成功后， 重新打开数据绑定组件后， 回传的值不正确， 详见issue

### Why

需要定开一个数据绑定组件， 阻塞在此bug

### How

参考内部实现， 调整代码