### PR TITLE
fix: 修复getSchemaTpl方法错误的引入方式(#11133)

### DIFF
--- a/packages/amis-editor/src/renderer/NavSourceControl.tsx
+++ b/packages/amis-editor/src/renderer/NavSourceControl.tsx
@@ -14,9 +14,7 @@ import {render as renderAmis} from 'amis-core';
 import {FormItem, Button, InputBox, Icon, Modal, toast} from 'amis';
 import {TooltipWrapper} from 'amis-ui';
 
-import {getSchemaTpl} from 'amis-editor';
-
-import {autobind} from 'amis-editor-core';
+import {autobind, getSchemaTpl} from 'amis-editor-core';
 import type {FormControlProps} from 'amis-core';
 import type {SchemaApi} from 'amis';
 import {getOwnValue} from '../util';


### PR DESCRIPTION
### What

getSchemaTpl错误引用诱发amis editor side effect， 导致引入amis editor全部内容， 详见issue

### Why

引入NavSourceControl renderer后amis editor引入全量的plugin, 影响使用

### How

修改getSchemaTpl方法引入方法