### PR TITLE
fix: 修复文件上传中事件修改表单项本身的值后, 表单校验卡住的问题

### DIFF
--- a/packages/amis/src/renderers/Form/InputFile.tsx
+++ b/packages/amis/src/renderers/Form/InputFile.tsx
@@ -732,6 +732,9 @@ export default class FileControl extends React.Component<FileProps, FileState> {
               const idx = files.indexOf(file as FileX);
 
               if (!~idx) {
+                // 事件里面可能把当前表单值给改了
+                this.current = null;
+                requestAnimationFrame(this.tick);
                 return;
               }
 

--- a/packages/amis/src/renderers/Form/InputImage.tsx
+++ b/packages/amis/src/renderers/Form/InputImage.tsx
@@ -804,6 +804,9 @@ export default class ImageControl extends React.Component<
               const idx = files.indexOf(file);
 
               if (!~idx) {
+                // 事件里面可能把当前表单值给改了
+                this.current = null;
+                requestAnimationFrame(this.tick);
                 return;
               }
 


### PR DESCRIPTION
### What

### Why

文件上传成功后通过 success 事件把当前文件框的值改了，然后这个控件会一直处于上传中的状态。
上层表单提交的时候会一直等待这个控件上传完成。

### How
