### PR TITLE
feat: 增加combo组件unique配置项

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Combo.tsx
+++ b/packages/amis-editor/src/plugin/Form/Combo.tsx
@@ -516,9 +516,8 @@ export class ComboControlPlugin extends BasePlugin {
 
                 {
                   type: 'select',
-                  name: 'uniqueItems',
+                  name: '__uniqueItems',
                   label: '配置唯一项',
-                  multiple: true,
                   source: '${items|pick:name}',
                   pipeIn: (value: any, form: any) => {
                     // 从 items 中获取设置了 unique: true 的项的 name

--- a/packages/amis-editor/src/plugin/Form/Combo.tsx
+++ b/packages/amis-editor/src/plugin/Form/Combo.tsx
@@ -514,6 +514,41 @@ export class ComboControlPlugin extends BasePlugin {
                   ]
                 },
 
+                {
+                  type: 'select',
+                  name: 'uniqueItems',
+                  label: '配置唯一项',
+                  multiple: true,
+                  source: '${items|pick:name}',
+                  pipeIn: (value: any, form: any) => {
+                    // 从 items 中获取设置了 unique: true 的项的 name
+                    const items = form.data.items || [];
+                    return items
+                      .filter((item: any) => item.unique)
+                      .map((item: any) => item.name);
+                  },
+                  onChange: (
+                    value: string[],
+                    oldValue: any,
+                    model: any,
+                    form: any
+                  ) => {
+                    // 获取当前的 items
+                    const items = [...(form.data.items || [])];
+                    // 修改 items 中的 unique 属性
+                    const updatedItems = items.map(item => {
+                      if (value.includes(item.name)) {
+                        return {...item, unique: true};
+                      } else {
+                        const newItem = {...item};
+                        delete newItem.unique;
+                        return newItem;
+                      }
+                    });
+                    // 更新 items
+                    form.setValueByName('items', updatedItems);
+                  }
+                },
                 getSchemaTpl('labelRemark'),
                 getSchemaTpl('remark'),
 

--- a/packages/amis-editor/src/plugin/Form/Combo.tsx
+++ b/packages/amis-editor/src/plugin/Form/Combo.tsx
@@ -536,7 +536,7 @@ export class ComboControlPlugin extends BasePlugin {
                     const items = [...(form.data.items || [])];
                     // 修改 items 中的 unique 属性
                     const updatedItems = items.map(item => {
-                      if (value.includes(item.name)) {
+                      if (value === item.name) {
                         return {...item, unique: true};
                       } else {
                         const newItem = {...item};


### PR DESCRIPTION
### What
在combo组件的配置项中增加一个unique开关，能下拉选择所需要的combo中的列字段进行增加unique：true属性
### Why
经常需要combo进行一个唯一性的判断输入
### How
遍历items属性，并将选中的item增加一个unique：true字段