### PR TITLE
解决在组件不输入内容的情况下，LEN函数返回9的错误（undefined字符串的长度）

### DIFF
--- a/packages/amis-formula/src/evalutor.ts
+++ b/packages/amis-formula/src/evalutor.ts
@@ -1110,6 +1110,9 @@ export class Evaluator {
    * @returns {number} 长度
    */
   fnLEN(text: string) {
+    if (text === undefined || text === null) {
+      return 0;
+    }
     text = this.normalizeText(text);
     return text?.length;
   }


### PR DESCRIPTION
在表达式里计算文本长度的时候，如果文本框不输入值，fnLEN会计算undefined的长度，返回是9，与预期不符。