### PR TITLE
解决在B事件里操作A文本框的resetValue或者clearValue导致失焦的问题，可能引发多次失去焦点事件

### DIFF
--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -335,7 +335,7 @@ export default class TextControl extends React.PureComponent<
         inputValue: pristineVal
       },
       () => {
-        this.focus();
+        //this.focus();
         this.loadAutoComplete();
       }
     );
@@ -373,7 +373,7 @@ export default class TextControl extends React.PureComponent<
         inputValue: resetValue
       },
       () => {
-        this.focus();
+        //this.focus();
         this.loadAutoComplete();
       }
     );


### PR DESCRIPTION
resetValue和clearValue应该只做reset和clear的事情，不应该管理焦点。