### PR TITLE
fix: 解决日期框在点击自身日历的时候依然触发焦点离开事件的错误

### DIFF
--- a/packages/amis-ui/src/components/DatePicker.tsx
+++ b/packages/amis-ui/src/components/DatePicker.tsx
@@ -525,6 +525,10 @@ export class DatePicker extends React.Component<DateProps, DatePickerState> {
   }
 
   handleBlur(e: React.SyntheticEvent<HTMLDivElement>) {
+    const targetElement = e.relatedTarget;
+    if (targetElement === this.dom || targetElement === this.inputRef.current) {
+      return;
+    }
     this.setState({
       isFocused: false
     });


### PR DESCRIPTION
### What

### Why

### How
