### PR TITLE
feat: 弹框增加按钮管理配置

### DIFF
--- a/packages/amis-editor/src/plugin/Dialog.tsx
+++ b/packages/amis-editor/src/plugin/Dialog.tsx
@@ -298,6 +298,8 @@ export class DialogPlugin extends BasePlugin {
                 name: 'title'
               },
 
+              getSchemaTpl('button-manager'),
+
               getSchemaTpl('switch', {
                 label: '展示关闭按钮',
                 name: 'showCloseButton',

--- a/packages/amis-editor/src/plugin/Drawer.tsx
+++ b/packages/amis-editor/src/plugin/Drawer.tsx
@@ -171,6 +171,7 @@ export class DrawerPlugin extends BasePlugin {
                 label: '显示蒙层',
                 pipeIn: defaultValue(true)
               }),
+              getSchemaTpl('button-manager'),
               getSchemaTpl('switch', {
                 name: 'showCloseButton',
                 label: '展示关闭按钮',

--- a/packages/amis-editor/src/tpl/common.tsx
+++ b/packages/amis-editor/src/tpl/common.tsx
@@ -6,7 +6,7 @@ import {
   tipedLabel,
   EditorManager
 } from 'amis-editor-core';
-import type {SchemaObject} from 'amis';
+import {render, type SchemaObject} from 'amis';
 import flatten from 'lodash/flatten';
 import {InputComponentName} from '../component/InputComponentName';
 import {FormulaDateType} from '../renderer/FormulaControl';
@@ -1850,4 +1850,40 @@ setSchemaTpl('inputForbid', {
   label: '禁止输入',
   name: 'inputForbid',
   inputClassName: 'is-inline'
+});
+
+setSchemaTpl('button-manager', () => {
+  return getSchemaTpl('combo-container', {
+    type: 'combo',
+    label: '按钮管理',
+    name: 'actions',
+    mode: 'normal',
+    multiple: true,
+    addable: true,
+    draggable: true,
+    editable: false,
+    items: [
+      {
+        component: (props: any) => {
+          return render({
+            ...props.data,
+            onEvent: {},
+            actionType: '',
+            onClick: (e: any, props: any) => {
+              const editorStore = (window as any).editorStore;
+              const subEditorStore = editorStore.getSubEditorRef()?.store;
+              (subEditorStore || editorStore).setActiveIdByComponentId(
+                props.id
+              );
+            }
+          });
+        }
+      }
+    ],
+    addButtonText: '新增按钮',
+    scaffold: {
+      type: 'button',
+      label: '按钮'
+    }
+  });
 });

--- a/packages/amis/src/renderers/Action.tsx
+++ b/packages/amis/src/renderers/Action.tsx
@@ -707,9 +707,7 @@ export class Action extends React.Component<ActionProps, ActionState> {
   render() {
     const {
       type,
-      icon,
       iconClassName,
-      rightIcon,
       rightIconClassName,
       loadingClassName,
       primary,
@@ -791,6 +789,8 @@ export class Action extends React.Component<ActionProps, ActionState> {
       }) as string;
       disabled = true;
     }
+    const icon = filter(this.props.icon, data);
+    const rightIcon = filter(this.props.rightIcon, data);
 
     const iconElement = (
       <Icon


### PR DESCRIPTION
### What
![image](https://github.com/user-attachments/assets/3e16b856-1436-4ab6-a78c-78324e6c42ae)
点击按钮跳转到对应按钮的配置面板

### Why

### How
