### PR TITLE
fix: 修复变量命名冲突导致功能失效，修复弹出层内容堆叠在一起。新增标签内文本溢出后,hover展示全部信息

### DIFF
--- a/docs/zh-CN/components/form/picker.md
+++ b/docs/zh-CN/components/form/picker.md
@@ -1211,7 +1211,7 @@ order: 35
 | pickerSchema   | `string`                                                                                     | `{mode: 'list', listItem: {title: '${label}'}}` | 即用 List 类型的渲染，来展示列表信息。更多配置参考 [CRUD](../crud)                          |
 | embed          | `boolean`                                                                                    | `false`                                         | 是否使用内嵌模式                                                                            |
 | overflowConfig | `OverflowConfig`                                                                             | 参考[OverflowConfig](./#overflowconfig)         | 开启最大标签展示数量的相关配置 `3.4.0`                                                      |
-| removable  | `removable`                                                                              | `true`                                          | 用于控制是否显示选中项的删除图标，默认值为 `true`                                           | `6.10.0` |
+| itemClearable  | `itemClearable`                                                                              | `true`                                          | 用于控制是否显示选中项的删除图标，默认值为 `true`                                           | `6.10.0` |
 
 ### OverflowConfig
 

--- a/packages/amis-editor/src/plugin/Form/Picker.tsx
+++ b/packages/amis-editor/src/plugin/Form/Picker.tsx
@@ -402,7 +402,7 @@ export class PickerControlPlugin extends BasePlugin {
               },
               {
                 type: 'switch',
-                name: 'removable',
+                name: 'itemClearable',
                 label: '选中项可删除',
                 pipeIn: defaultValue(true),
                 inputClassName: 'is-inline '

--- a/packages/amis-ui/scss/components/_crud.scss
+++ b/packages/amis-ui/scss/components/_crud.scss
@@ -13,7 +13,7 @@
     &-overflow {
       &-wrapper {
         display: flex;
-        flex-flow: column nowrap;
+        flex-wrap: wrap;
         justify-content: flex-start;
         align-items: flex-start;
         overflow-x: hidden;

--- a/packages/amis-ui/scss/components/form/_picker.scss
+++ b/packages/amis-ui/scss/components/form/_picker.scss
@@ -162,7 +162,7 @@
   &-overflow {
     &-wrapper {
       display: flex;
-      flex-flow: column nowrap;
+      flex-wrap: wrap;
       justify-content: flex-start;
       align-items: flex-start;
       overflow-x: hidden;

--- a/packages/amis/__tests__/renderers/__snapshots__/Picker.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Picker.test.tsx.snap
@@ -270,7 +270,7 @@ exports[`1. Renderer:Picker base 2`] = `
               class="cxd-Picker-values"
             >
               <div
-                class="cxd-Picker-value"
+                class="cxd-OverflowTpl cxd-Picker-value"
               >
                 <span
                   class="cxd-Picker-valueIcon"

--- a/packages/amis/__tests__/renderers/__snapshots__/Picker.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Picker.test.tsx.snap
@@ -273,6 +273,11 @@ exports[`1. Renderer:Picker base 2`] = `
                 class="cxd-Picker-value"
               >
                 <span
+                  class="cxd-Picker-valueIcon"
+                >
+                  ×
+                </span>
+                <span
                   class="cxd-Picker-valueLabel"
                 >
                   B

--- a/packages/amis/src/renderers/Form/Picker.tsx
+++ b/packages/amis/src/renderers/Form/Picker.tsx
@@ -26,7 +26,7 @@ import {
   isIntegerInRange,
   setThemeClassName
 } from 'amis-core';
-import {Html, Icon, TooltipWrapper} from 'amis-ui';
+import {Html, Icon, OverflowTpl, TooltipWrapper} from 'amis-ui';
 import {FormOptionsSchema, SchemaTpl} from '../../Schema';
 import intersectionWith from 'lodash/intersectionWith';
 import type {TooltipWrapperSchema} from '../TooltipWrapper';
@@ -543,7 +543,9 @@ export default class PickerControl extends React.PureComponent<
     } = this.props;
 
     return (
-      <div
+      <OverflowTpl
+        inline={false}
+        tooltip={getVariable(item, labelField || 'label')}
         key={index}
         className={cx(
           `${ns}Picker-value`,
@@ -601,7 +603,7 @@ export default class PickerControl extends React.PureComponent<
             }`
           )}
         </span>
-      </div>
+      </OverflowTpl>
     );
   }
 

--- a/packages/amis/src/renderers/Form/Picker.tsx
+++ b/packages/amis/src/renderers/Form/Picker.tsx
@@ -105,7 +105,7 @@ export interface PickerControlSchema extends FormOptionsSchema {
   /**
    * 选中项可删除，默认为true
    */
-  removable?: boolean;
+  itemClearable?: boolean;
 }
 
 export interface PickerProps extends OptionsControlProps {
@@ -529,7 +529,7 @@ export default class PickerControl extends React.PureComponent<
 
   renderTag(item: Option, index: number) {
     const {
-      removable = true,
+      itemClearable = true,
       classPrefix: ns,
       classnames: cx,
       labelField,
@@ -558,7 +558,7 @@ export default class PickerControl extends React.PureComponent<
           }
         )}
       >
-        {removable && (
+        {itemClearable && (
           <span
             className={cx(
               `${ns}Picker-valueIcon`,


### PR DESCRIPTION
### What

### Why

### How
