### PR TITLE
fix: 表单项静态展示不应该自动获取展示父级value

### DIFF
--- a/packages/amis/src/renderers/Form/StaticHoc.tsx
+++ b/packages/amis/src/renderers/Form/StaticHoc.tsx
@@ -106,7 +106,11 @@ export function supportStatic<T extends FormControlProps>() {
         } = props;
 
         let body;
-        const displayValue = getPropValue(props);
+        const displayValue = getPropValue(
+          props,
+          undefined,
+          props.canAccessSuperData ?? false
+        );
         const isValueEmpty = displayValue == null || displayValue === '';
 
         if (


### PR DESCRIPTION
### What

### Why

### How
