### PR TITLE
fix: 修复tab组件透传className未赋值

### DIFF
--- a/packages/amis-ui/src/components/Tabs.tsx
+++ b/packages/amis-ui/src/components/Tabs.tsx
@@ -609,6 +609,7 @@ export class Tabs extends React.Component<TabsProps, any> {
       iconPosition,
       title,
       toolbar,
+      className,
       tabClassName,
       closable: tabClosable,
       tip,
@@ -671,6 +672,7 @@ export class Tabs extends React.Component<TabsProps, any> {
           titleClassName,
           activeKey === eventKey ? 'is-active' : '',
           disabled ? 'is-disabled' : '',
+          className,
           tabClassName
         )}
         key={this.generateTabKey(hash, eventKey, index)}


### PR DESCRIPTION
### What
![image](https://github.com/user-attachments/assets/2856402a-f447-47a8-bcf9-50e558085ffc)

### Why

### How
