### PR TITLE
fix: 修复picker禁用状态下点击折叠标签仍可打开弹窗

### DIFF
--- a/packages/amis-ui/scss/components/form/_picker.scss
+++ b/packages/amis-ui/scss/components/form/_picker.scss
@@ -98,8 +98,10 @@
   .#{$ns}Picker-values {
     display: inline;
 
-    .#{$ns}Picker-valueLabel {
-      pointer-events: auto;
+    .#{$ns}OverflowTpl {
+      .#{$ns}Picker-valueLabel {
+        pointer-events: auto;
+      }
     }
   }
 


### PR DESCRIPTION
### What

### Why

### How
