### PR TITLE
fix: 修复 inputTable 列检索同级别存在同名表单项值时搜索框查询条件自动被赋值问题

### DIFF
--- a/packages/amis/src/renderers/Table/HeadCellSearchDropdown.tsx
+++ b/packages/amis/src/renderers/Table/HeadCellSearchDropdown.tsx
@@ -102,6 +102,7 @@ export function HeadCellSearchDropDown({
         ...schema,
         type: 'form',
         wrapperComponent: 'div',
+        canAccessSuperData: false,
         actions: [
           {
             type: 'button',
@@ -210,9 +211,7 @@ export function HeadCellSearchDropDown({
             {
               render('quick-search-form', formSchema, {
                 popOverContainer,
-                data: {
-                  ...data
-                },
+                data: data,
                 onSubmit: handleSubmit,
                 onAction: handleAction
               }) as JSX.Element


### PR DESCRIPTION
### What

### Why

### How
