### PR TITLE
chore: CRUD 调整方便外围覆盖

### DIFF
--- a/docs/zh-CN/components/crud.md
+++ b/docs/zh-CN/components/crud.md
@@ -401,7 +401,62 @@ interface ParsePrimitiveQueryOptions {
 
 ### 查
 
-查，就不单独介绍了，这个文档绝大部分都是关于查的。
+除了列表查询外，还支持查看详情场景，与编辑不同的地方主要在于弹窗中改成放展示类组件，或者表单项配置静态展示。
+
+```schema: scope="body"
+{
+    "type": "crud",
+    "api": "/api/mock2/sample?orderBy=id&orderDir=desc",
+    "syncLocation": false,
+    "columns": [
+        {
+            "name": "id",
+            "label": "ID"
+        },
+        {
+            "name": "engine",
+            "label": "Rendering engine"
+        },
+        {
+            "name": "browser",
+            "label": "Browser"
+        },
+        {
+            "type": "operation",
+            "label": "操作",
+            "buttons": [
+                {
+                    "label": "详情",
+                    "type": "button",
+                    "actionType": "dialog",
+                    "dialog": {
+                        "title": "查看数据「${id}」",
+                        "body": {
+                            "type": "form",
+                            "initApi": "/api/mock2/sample/${id}",
+                            "body": [
+                                {
+                                    "type": "static",
+                                    "name": "engine",
+                                    "label": "Engine"
+                                },
+                                {
+                                    "type": "input-text",
+                                    "name": "browser",
+                                    "label": "Browser",
+                                    "static": true
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}
+```
+
+弹框里面可用数据自动就是点击的那一行的行数据，如果列表没有返回，可以在 form 里面再配置个 initApi 初始化数据，如果行数据里面有倒是不需要再拉取了。表单项的 name 跟数据 key 对应上便自动回显了。
 
 ## 展示模式
 
@@ -2115,6 +2170,43 @@ interface CRUDMatchFunc {
 
 具体效果请参考[示例](../../../examples/crud/match-func)，从`3.6.0`版本开始，`options`中支持使用`matchSorter`函数处理复杂的过滤场景，比如前缀匹配、模糊匹配等，更多详细内容推荐查看[match-sorter](https://github.com/kentcdodds/match-sorter)。
 
+### 显示序号
+
+通过配置 `showIndex` 为 `true` 启用
+
+```schema: scope="body"
+{
+    "type": "crud",
+    "syncLocation": false,
+    "api": "/api/mock2/sample",
+    "loadDataOnce": true,
+    "showIndex": true,
+    "columns": [
+        {
+            "name": "engine",
+            "label": "Rendering engine"
+        },
+        {
+            "name": "browser",
+            "label": "Browser"
+        },
+        {
+            "name": "platform",
+            "label": "Platform(s)"
+        },
+        {
+            "name": "version",
+            "label": "Engine version"
+        },
+        {
+            "name": "grade",
+            "label": "CSS grade",
+            "sortable": true
+        }
+    ]
+}
+```
+
 ### 批量操作
 
 在`headerToolbar`或者`footerToolbar`数组中添加`bulkActions`字符串，并且在 crud 上配置`bulkActions`行为按钮数组，可以实现选中表格项并批量操作的功能。
@@ -2192,16 +2284,17 @@ interface CRUDMatchFunc {
 
 批量操作会默认将下面数据添加到数据域中以供**按钮行为**使用，需要注意的是**静态**和**批量操作**时的数据域是不同的。**静态数据域**是指渲染批量操作区域时能够获取到的数据，**批量操作数据域**是指触发按钮动作时能够获取到的数据，具体区别参考下表：
 
-| 属性名            | 类型                  | 所属数据域     | 说明                                                                                 | 版本    |
-| ----------------- | --------------------- | -------------- | ------------------------------------------------------------------------------------ | ------- |
-| `currentPageData` | `Array<Column>`       | 静态, 批量操作 | 当前分页数据集合，`Column`为当前 Table 数据结构定义                                  | `2.4.0` |
-| `selectedItems`   | `Array<Column>`       | 静态, 批量操作 | 选中的行数据集合                                                                     |
-| `unSelectedItems` | `Array<Column>`       | 静态, 批量操作 | 未选中的行数据集合                                                                   |
-| `items`           | `Array<Column>`       | 批量操作       | `selectedItems` 的别名                                                               |
-| `rows`            | `Array<Column>`       | 批量操作       | `selectedItems` 的别名，推荐用 `items`                                               |
-| `ids`             | `string`              | 批量操作       | 多个 id 值用英文逗号隔开，前提是行数据中有 id 字段，或者有指定的 `primaryField` 字段 |
-| `event`           | `object`              | 事件动作       | 可以通过`event.data`获取批量操作按钮上绑定的事件动作产生的数据                       |
-| `...rest`         | `Record<string, any>` | 批量操作       | 选中的行数据集合的首个元素的字段，注意列字段如果和以上字段重名时，会被上述字段值覆盖 |
+| 属性名            | 类型                      | 所属数据域     | 说明                                                                                 | 版本    |
+| ----------------- | ------------------------- | -------------- | ------------------------------------------------------------------------------------ | ------- |
+| `currentPageData` | `Array<Column>`           | 静态, 批量操作 | 当前分页数据集合，`Column`为当前 Table 数据结构定义                                  | `2.4.0` |
+| `selectedItems`   | `Array<Column>`           | 静态, 批量操作 | 选中的行数据集合                                                                     |
+| `selectedIndexes` | `Array<string \| number>` | 静态, 批量操作 | 选中的行数据索引集合                                                                 |
+| `unSelectedItems` | `Array<Column>`           | 静态, 批量操作 | 未选中的行数据集合                                                                   |
+| `items`           | `Array<Column>`           | 批量操作       | `selectedItems` 的别名                                                               |
+| `rows`            | `Array<Column>`           | 批量操作       | `selectedItems` 的别名，推荐用 `items`                                               |
+| `ids`             | `string`                  | 批量操作       | 多个 id 值用英文逗号隔开，前提是行数据中有 id 字段，或者有指定的 `primaryField` 字段 |
+| `event`           | `object`                  | 事件动作       | 可以通过`event.data`获取批量操作按钮上绑定的事件动作产生的数据                       |
+| `...rest`         | `Record<string, any>`     | 批量操作       | 选中的行数据集合的首个元素的字段，注意列字段如果和以上字段重名时，会被上述字段值覆盖 |
 
 你可以通过[数据映射](../../docs/concepts/data-mapping)，在`api`中获取这些参数。
 
@@ -2472,6 +2565,261 @@ interface CRUDMatchFunc {
                     ]
                 }
             }
+        }
+    ],
+    "columns": [
+        {
+            "name": "id",
+            "label": "ID"
+        },
+        {
+            "name": "engine",
+            "label": "Rendering engine"
+        },
+        {
+            "name": "browser",
+            "label": "Browser"
+        },
+        {
+            "name": "platform",
+            "label": "Platform(s)"
+        },
+        {
+            "name": "version",
+            "label": "Engine version"
+        },
+        {
+            "name": "grade",
+            "label": "CSS grade"
+        }
+    ]
+}
+```
+
+### 悬浮操作栏
+
+通过配置 `itemActions` 可以启用悬浮操作栏，鼠标悬停到行上，右侧会出现对应的操作按钮。
+
+```schema: scope="body"
+{
+    "type": "crud",
+    "syncLocation": false,
+    "api": "/api/mock2/sample",
+    "checkOnItemClick": true,
+    "itemActions": [
+        {
+          "type": "button",
+          "label": "按钮 1",
+          "actionType": "toast",
+          "toast": {
+            "items": [
+              {
+                "level": "info",
+                "body": "${&|json}"
+              }
+            ]
+          }
+        },
+        {
+          "type": "button",
+          "label": "按钮 2",
+          "actionType": "toast",
+          "toast": {
+            "items": [
+              {
+                "level": "info",
+                "body": "${&|json}"
+              }
+            ]
+          }
+        }
+    ],
+    "columns": [
+        {
+            "name": "id",
+            "label": "ID"
+        },
+        {
+            "name": "engine",
+            "label": "Rendering engine"
+        },
+        {
+            "name": "browser",
+            "label": "Browser"
+        },
+        {
+            "name": "platform",
+            "label": "Platform(s)"
+        },
+        {
+            "name": "version",
+            "label": "Engine version"
+        },
+        {
+            "name": "grade",
+            "label": "CSS grade"
+        }
+    ]
+}
+```
+
+当同时配置 `itemActions` 和 `bulkActions`, 顶部工具栏会根据选择的条数来切换显示按钮。
+
+```schema: scope="body"
+{
+    "type": "crud",
+    "syncLocation": false,
+    "api": "/api/mock2/sample",
+    "checkOnItemClick": true,
+    "bulkActions": [
+        {
+          "type": "button",
+          "label": "批量按钮 1",
+          "actionType": "toast",
+          "toast": {
+            "items": [
+              {
+                "level": "info",
+                "body": "${&|json}"
+              }
+            ]
+          }
+        },
+        {
+          "type": "button",
+          "label": "批量按钮 2",
+          "actionType": "toast",
+          "toast": {
+            "items": [
+              {
+                "level": "info",
+                "body": "${&|json}"
+              }
+            ]
+          }
+        }
+    ],
+    "itemActions": [
+        {
+          "type": "button",
+          "label": "按钮 1",
+          "actionType": "toast",
+          "toast": {
+            "items": [
+              {
+                "level": "info",
+                "body": "${&|json}"
+              }
+            ]
+          }
+        },
+        {
+          "type": "button",
+          "label": "按钮 2",
+          "actionType": "toast",
+          "toast": {
+            "items": [
+              {
+                "level": "info",
+                "body": "${&|json}"
+              }
+            ]
+          }
+        }
+    ],
+    "columns": [
+        {
+            "name": "id",
+            "label": "ID"
+        },
+        {
+            "name": "engine",
+            "label": "Rendering engine"
+        },
+        {
+            "name": "browser",
+            "label": "Browser"
+        },
+        {
+            "name": "platform",
+            "label": "Platform(s)"
+        },
+        {
+            "name": "version",
+            "label": "Engine version"
+        },
+        {
+            "name": "grade",
+            "label": "CSS grade"
+        }
+    ]
+}
+```
+
+如果同时启用时，只想把按钮展示在顶部，而不是悬浮，则需要给按钮上配置 `hiddenOnHover`。
+
+```schema: scope="body"
+{
+    "type": "crud",
+    "syncLocation": false,
+    "api": "/api/mock2/sample",
+    "checkOnItemClick": true,
+    "bulkActions": [
+        {
+          "type": "button",
+          "label": "批量按钮 1",
+          "actionType": "toast",
+          "toast": {
+            "items": [
+              {
+                "level": "info",
+                "body": "${&|json}"
+              }
+            ]
+          }
+        },
+        {
+          "type": "button",
+          "label": "批量按钮 2",
+          "actionType": "toast",
+          "toast": {
+            "items": [
+              {
+                "level": "info",
+                "body": "${&|json}"
+              }
+            ]
+          }
+        }
+    ],
+    "itemActions": [
+        {
+          "type": "button",
+          "label": "按钮 1",
+          "hiddenOnHover": true,
+          "actionType": "toast",
+          "toast": {
+            "items": [
+              {
+                "level": "info",
+                "body": "${&|json}"
+              }
+            ]
+          }
+        },
+        {
+          "type": "button",
+          "label": "按钮 2",
+          "hiddenOnHover": true,
+          "actionType": "toast",
+          "toast": {
+            "items": [
+              {
+                "level": "info",
+                "body": "${&|json}"
+              }
+            ]
+          }
         }
     ],
     "columns": [
@@ -3918,6 +4266,130 @@ itemAction 里的 onClick 还能通过 `data` 参数拿到当前行的数据，�
 }
 ```
 
+## 开启点选
+
+当配置了 `bulkActions` 后，CRUD 会自动变成可点选状态。如果想直接开启可点选，可以配置 `selectable`，同时可以配置 `multiple` 来配置是单选还是多选。但是这个时候没有任何交互，需要配置事件动作，或者在工具栏中添加行为按钮完成交互逻辑。
+
+```schema: scope="body"
+{
+    "type": "crud",
+    "api": "/api/mock2/sample",
+    "syncLocation": false,
+    "selectable": true,
+    "headerToolbar": [
+      {
+        "type": "button",
+        "label": "按钮",
+        "visibleOn": "${selectedItems.length}",
+        "actionType": "toast",
+        "toast": {
+          "items": [
+            {
+              "level": "info",
+              "body": "${selectedItems|json}"
+            }
+          ]
+        }
+      }
+    ],
+    "columns": [
+        {
+            "name": "id",
+            "label": "ID"
+        },
+        {
+            "name": "engine",
+            "label": "Rendering engine"
+        },
+        {
+            "name": "browser",
+            "label": "Browser"
+        },
+        {
+            "name": "platform",
+            "label": "Platform(s)"
+        },
+        {
+            "name": "version",
+            "label": "Engine version"
+        },
+        {
+            "name": "grade",
+            "label": "CSS grade"
+        }
+    ]
+}
+```
+
+多选场景且支持跨页面选择同时支持快速修改
+
+```schema: scope="body"
+{
+  "type": "crud",
+  "api": "/api/mock2/sample",
+  "syncLocation": false,
+  "loadDataOnce": true,
+  "keepItemSelectionOnPageChange": true,
+  "onEvent": {
+    "selectedChange": {
+      "actions": [
+        {
+          "actionType": "toast",
+          "args": {
+            "msg": "已选择数据 ${selectedItems.length} <br /> 未选 ${event.data.unSelectedItems.length} 条 <br /> 已选 indexes ${ENCODEJSON(selectedIndexes)}"
+          }
+        }
+      ]
+    }
+  },
+  "bulkActions": [
+    {
+      "label": "Button(${selectedItems.length})",
+      "type": "button",
+      "onEvent": {
+        "click": {
+          "actions": [
+            {
+              "actionType": "toast",
+              "args": {
+                "msg": "已选择数据 ${ENCODEJSON(ARRAYMAP(selectedItems, item => `${item.id}: ${item.engine}`))} <br /> 未选 ${event.data.unSelectedItems.length} 条 <br /> 已选 indexes ${ENCODEJSON(selectedIndexes)}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "columns": [
+    {
+      "name": "id",
+      "label": "ID"
+    },
+    {
+      "name": "engine",
+      "label": "Rendering engine",
+      "quickEdit": true
+    },
+    {
+      "name": "browser",
+      "label": "Browser"
+    },
+    {
+      "name": "platform",
+      "label": "Platform(s)"
+    },
+    {
+      "name": "version",
+      "label": "Engine version"
+    },
+    {
+      "name": "grade",
+      "label": "CSS grade"
+    }
+  ]
+}
+```
+
 ## 属性表
 
 | 属性名                                | 类型                                                                                    | 默认值                          | 说明                                                                                                                                           | 版本    |
@@ -3992,13 +4464,13 @@ itemAction 里的 onClick 还能通过 `data` 参数拿到当前行的数据，�
 
 除了 Table 组件默认支持的列配置，CRUD 的列配置还额外支持以下属性：
 
-| 属性名             | 类型                                                         | 默认值  | 说明                                                                        | 版本 |
-| ------------------ | ------------------------------------------------------------ | ------- | --------------------------------------------------------------------------- | ---- |
-| sortable           | `boolean`                                                    | `false` | 是否可排序                                                                  |
-| searchable         | `boolean` \| `Schema`                                        | `false` | 是否可快速搜索，开启`autoGenerateFilter`后，`searchable`支持配置`Schema`    |
-| filterable         | `boolean` \| [`QuickFilterConfig`](./crud#quickfilterconfig) | `false` | 是否可快速搜索，`options`属性为静态选项，支持设置`source`属性从接口获取选项 |
-| quickEdit          | `boolean` \| [`QuickEditConfig`](./crud#quickeditconfig)     | -       | 快速编辑，一般需要配合`quickSaveApi`接口使用                                |
-| quickEditEnabledOn | `SchemaExpression`                                           | -       | 开启快速编辑条件[表达式](../../docs/concepts/expression)                    |      |
+| 属性名             | 类型                                                         | 默认值    | 说明                                                                                                           | 版本    |
+| ------------------ | ------------------------------------------------------------ | --------- | -------------------------------------------------------------------------------------------------------------- | ------- |
+| sortable           | `boolean`                                                    | `false`   | 是否可排序                                                                                                     |
+| searchable         | `boolean` \| `Schema`                                        | `false`   | 是否可快速搜索，开启`autoGenerateFilter`后，`searchable`支持配置`Schema`                                       |
+| filterable         | `boolean` \| [`QuickFilterConfig`](./crud#quickfilterconfig) | `false`   | 是否可快速搜索，`options`属性为静态选项，支持设置`source`属性从接口获取选项                                    |
+| quickEdit          | `boolean` \| [`QuickEditConfig`](./crud#quickeditconfig)     | -         | 快速编辑，一般需要配合`quickSaveApi`接口使用                                                                   |
+| quickEditEnabledOn | `SchemaExpression`                                           | -         | 开启快速编辑条件[表达式](../../docs/concepts/expression)                                                       |         |
 | textOverflow       | `string`                                                     | `default` | 文本溢出后展示形式，默认换行处理。可选值 `ellipsis` 溢出隐藏展示， `noWrap` 不换行展示(仅在列为静态文本时生效) | `6.9.0` |
 
 #### QuickFilterConfig
@@ -4057,13 +4529,14 @@ itemAction 里的 onClick 还能通过 `data` 参数拿到当前行的数据，�
 | quickSaveItemFail | `error` 错误原因                                                                                                                                                                                                                                                            | 快速编辑单条保存失败后触发                                     |
 | saveOrderSucc     | `result` 接口数据返回 <br /> `其他` 请参考 [拖拽排序](#拖拽排序) 章节说明                                                                                                                                                                                                   | 拖拽排序保存成功后触发                                         |
 | saveOrderFail     | `error` 错误原因                                                                                                                                                                                                                                                            | 拖拽排序保存失败后触发                                         |
-| selectedChange    | `selectedItems: item[]` 已选择行<br/>`unSelectedItems: item[]` 未选择行                                                                                                                                                                                                     | 手动选择表格项时触发                                           |
+| selectedChange    | `selectedItems: item[]` 已选择行<br/>`selectedIndexes: string[]` 已选择行索引 <br/>`unSelectedItems: item[]` 未选择行                                                                                                                                                       | 手动选择表格项时触发                                           |
 | columnSort        | `orderBy: string` 列排序列名<br/>`orderDir: string` 列排序值                                                                                                                                                                                                                | 点击列排序时触发                                               |
 | columnFilter      | `filterName: string` 列筛选列名<br/>`filterValue: string \| undefined` 列筛选值                                                                                                                                                                                             | 点击列筛选时触发，点击重置后事件参数`filterValue`为`undefined` |
 | columnSearch      | `searchName: string` 列搜索列名<br/>`searchValue: object` 列搜索数据                                                                                                                                                                                                        | 点击列搜索时触发                                               |
 | orderChange       | `movedItems: item[]` 已排序数据                                                                                                                                                                                                                                             | 手动拖拽行排序时触发                                           |
 | columnToggled     | `columns: item[]` 当前显示的列配置数据                                                                                                                                                                                                                                      | 点击自定义列时触发                                             |
 | rowClick          | `item: object` 行点击数据<br/>`index: number` 行索引 <br />`indexPath: string` 行索引路径                                                                                                                                                                                   | 点击整行时触发                                                 |
+| rowDbClick        | `item: object` 行点击数据<br/>`index: number` 行索引 <br />`indexPath: string` 行索引路径                                                                                                                                                                                   | 双击整行时触发                                                 |
 | rowMouseEnter     | `item: object` 行移入数据<br/>`index: number` 行索引 <br />`indexPath: string` 行索引路径                                                                                                                                                                                   | 移入整行时触发                                                 |
 | rowMouseLeave     | `item: object` 行移出数据<br/>`index: number` 行索引 <br />`indexPath: string` 行索引路径                                                                                                                                                                                   | 移出整行时触发                                                 |
 
@@ -4511,6 +4984,68 @@ itemAction 里的 onClick 还能通过 `data` 参数拿到当前行的数据，�
             "confirmText": "确定要批量删除?"
         }
     ],
+    "columns": [
+      {
+        "name": "id",
+        "label": "ID",
+        "searchable": true
+      },
+      {
+        "name": "engine",
+        "label": "Rendering engine",
+        "filterable": {
+            "options": [
+                "Internet Explorer 4.0",
+                "Internet Explorer 5.0"
+            ]
+        }
+      },
+      {
+        "name": "browser",
+        "label": "Browser",
+        "sortable": true
+      },
+      {
+        "name": "platform",
+        "label": "Platform(s)"
+      },
+      {
+        "name": "version",
+        "label": "Engine version"
+      },
+      {
+        "name": "grade",
+        "label": "CSS grade"
+      }
+    ]
+  }
+}
+```
+
+### rowDbClick
+
+双击行记录。
+
+```schema: scope="body"
+{
+  "type": "page",
+  "body": {
+    "type": "crud",
+    "api": "/api/mock2/sample",
+    "syncLocation": false,
+    "onEvent": {
+      "rowDbClick": {
+            "actions": [
+                {
+                    "actionType": "toast",
+                    "args": {
+                        "msgType": "info",
+                        "msg": "行单击数据：${event.data.item|json}；行索引：${event.data.index}"
+                    }
+                }
+            ]
+        }
+    },
     "columns": [
       {
         "name": "id",

--- a/docs/zh-CN/components/table.md
+++ b/docs/zh-CN/components/table.md
@@ -1061,6 +1061,190 @@ popOver 的其它配置请参考 [popover](./popover)
 }
 ```
 
+## 显示序号
+
+通过配置 `showIndex` 为 true，开启展示序号。
+
+```schema: scope="body"
+{
+    "type": "service",
+    "data": {
+        "rows": [
+            {
+                "engine": "Trident",
+                "browser": "Internet Explorer 4.0",
+                "platform": "Win 95+",
+                "version": "4",
+                "grade": "X",
+                "id": 1,
+                "children": [
+                {
+                    "engine": "Trident",
+                    "browser": "Internet Explorer 4.0",
+                    "platform": "Win 95+",
+                    "version": "4",
+                    "grade": "X",
+                    "id": 1001
+                },
+                {
+                    "engine": "Trident",
+                    "browser": "Internet Explorer 5.0",
+                    "platform": "Win 95+",
+                    "version": "5",
+                    "grade": "C",
+                    "id": 1002
+                }
+                ]
+            },
+            {
+                "engine": "Trident",
+                "browser": "Internet Explorer 5.0",
+                "platform": "Win 95+",
+                "version": "5",
+                "grade": "C",
+                "id": 2,
+                "children": [
+                {
+                    "engine": "Trident",
+                    "browser": "Internet Explorer 4.0",
+                    "platform": "Win 95+",
+                    "version": "4",
+                    "grade": "X",
+                    "id": 2001
+                },
+                {
+                    "engine": "Trident",
+                    "browser": "Internet Explorer 5.0",
+                    "platform": "Win 95+",
+                    "version": "5",
+                    "grade": "C",
+                    "id": 2002
+                }
+                ]
+            },
+            {
+                "engine": "Trident",
+                "browser": "Internet Explorer 5.5",
+                "platform": "Win 95+",
+                "version": "5.5",
+                "grade": "A",
+                "id": 3,
+                "children": [
+                {
+                    "engine": "Trident",
+                    "browser": "Internet Explorer 4.0",
+                    "platform": "Win 95+",
+                    "version": "4",
+                    "grade": "X",
+                    "id": 3001
+                },
+                {
+                    "engine": "Trident",
+                    "browser": "Internet Explorer 5.0",
+                    "platform": "Win 95+",
+                    "version": "5",
+                    "grade": "C",
+                    "id": 3002
+                }
+                ]
+            },
+            {
+                "engine": "Trident",
+                "browser": "Internet Explorer 6",
+                "platform": "Win 98+",
+                "version": "6",
+                "grade": "A",
+                "id": 4,
+                "children": [
+                {
+                    "engine": "Trident",
+                    "browser": "Internet Explorer 4.0",
+                    "platform": "Win 95+",
+                    "version": "4",
+                    "grade": "X",
+                    "id": 4001
+                },
+                {
+                    "engine": "Trident",
+                    "browser": "Internet Explorer 5.0",
+                    "platform": "Win 95+",
+                    "version": "5",
+                    "grade": "C",
+                    "id": 4002
+                }
+                ]
+            },
+            {
+                "engine": "Trident",
+                "browser": "Internet Explorer 7",
+                "platform": "Win XP SP2+",
+                "version": "7",
+                "grade": "A",
+                "id": 5,
+                "children": [
+                {
+                    "engine": "Trident",
+                    "browser": "Internet Explorer 4.0",
+                    "platform": "Win 95+",
+                    "version": "4",
+                    "grade": "X",
+                    "id": 5001
+                },
+                {
+                    "engine": "Trident",
+                    "browser": "Internet Explorer 5.0",
+                    "platform": "Win 95+",
+                    "version": "5",
+                    "grade": "C",
+                    "id": 5002
+                }
+                ]
+            }
+        ]
+    },
+    "body": [
+        {
+            "type": "table",
+            "source": "$rows",
+            "className": "m-b-none",
+            "columnsTogglable": false,
+            "showIndex": true,
+            "columns": [
+                {
+                    "name": "engine",
+                    "label": "Engine"
+                },
+
+                {
+                    "name": "grade",
+                    "label": "Grade"
+                },
+
+                {
+                    "name": "version",
+                    "label": "Version"
+                },
+
+                {
+                    "name": "browser",
+                    "label": "Browser"
+                },
+
+                {
+                    "name": "id",
+                    "label": "ID"
+                },
+
+                {
+                    "name": "platform",
+                    "label": "Platform"
+                }
+            ]
+        }
+    ]
+}
+```
+
 ## 底部展示 (Footable)
 
 列太多时，内容没办法全部显示完，可以让部分信息在底部显示，可以让用户展开查看详情。配置很简单，只需要开启 `footable` 属性，同时将想在底部展示的列加个 `breakpoint` 属性为 `*` 即可。
@@ -1836,6 +2020,7 @@ popOver 的其它配置请参考 [popover](./popover)
 | columnsTogglable | `auto` 或者 `boolean`                                    | `auto`                    | 展示列显示开关, 自动即：列数量大于或等于 5 个时自动开启                   |                                   |
 | placeholder      | `string` 或者 `SchemaTpl`                                | `暂无数据`                | 当没数据的时候的文字提示                                                  |                                   |
 | className        | `string`                                                 | `panel-default`           | 外层 CSS 类名                                                             |                                   |
+| showIndex        | `boolean`                                                |                           | 是否展示序号                                                              | 6.11.0                            |
 | tableClassName   | `string`                                                 | `table-db table-striped`  | 表格 CSS 类名                                                             |                                   |
 | headerClassName  | `string`                                                 | `Action.md-table-header`  | 顶部外层 CSS 类名                                                         |                                   |
 | footerClassName  | `string`                                                 | `Action.md-table-footer`  | 底部外层 CSS 类名                                                         |                                   |
@@ -1860,38 +2045,38 @@ popOver 的其它配置请参考 [popover](./popover)
 
 ### 列配置属性表
 
-| 属性名      | 类型                                          | 默认值 | 说明                     | 版本     |
-| ----------- | --------------------------------------------- | ------ | ------------------------ | -------- |
-| label       | [模板](../../docs/concepts/template)          |        | 表头文本内容             |          |
-| name        | `string`                                      |        | 通过名称关联数据         |          |
-| width       | `number` \| `string`                          |        | 列宽                     |          |
-| remark      |                                               |        | 提示信息                 |          |
-| fixed       | `left` \| `right` \| `none`                   |        | 是否固定当前列           |          |
-| popOver     |                                               |        | 弹出框                   |          |
-| copyable    | `boolean` 或 `{icon: string, content:string}` |        | 是否可复制               |          |
-| style       | `object`                                      |        | 单元格自定义样式         |          |
-| innerStyle  | `object`                                      |        | 单元格内部组件自定义样式 | `2.8.1`  |
-| align       | `left` \| `right` \| `center` \| `justify`    |        | 单元格对齐方式           | ` 1.4.0` |
-| headerAlign | `left` \| `right` \| `center` \| `justify`    |        | 表头单元格对齐方式       | `6.7.0`  |
-| vAlign      | `top` \| `middle` \| `bottom`                 |        | 单元格垂直对齐方式       | `6.7.0`  |
-| textOverflow | `string`                                     |`default`| 文本溢出后展示形式，默认换行处理。可选值 `ellipsis` 溢出隐藏展示， `noWrap` 不换行展示(仅在列为静态文本时生效)   | `6.10.0` |
+| 属性名       | 类型                                          | 默认值    | 说明                                                                                                           | 版本     |
+| ------------ | --------------------------------------------- | --------- | -------------------------------------------------------------------------------------------------------------- | -------- |
+| label        | [模板](../../docs/concepts/template)          |           | 表头文本内容                                                                                                   |          |
+| name         | `string`                                      |           | 通过名称关联数据                                                                                               |          |
+| width        | `number` \| `string`                          |           | 列宽                                                                                                           |          |
+| remark       |                                               |           | 提示信息                                                                                                       |          |
+| fixed        | `left` \| `right` \| `none`                   |           | 是否固定当前列                                                                                                 |          |
+| popOver      |                                               |           | 弹出框                                                                                                         |          |
+| copyable     | `boolean` 或 `{icon: string, content:string}` |           | 是否可复制                                                                                                     |          |
+| style        | `object`                                      |           | 单元格自定义样式                                                                                               |          |
+| innerStyle   | `object`                                      |           | 单元格内部组件自定义样式                                                                                       | `2.8.1`  |
+| align        | `left` \| `right` \| `center` \| `justify`    |           | 单元格对齐方式                                                                                                 | ` 1.4.0` |
+| headerAlign  | `left` \| `right` \| `center` \| `justify`    |           | 表头单元格对齐方式                                                                                             | `6.7.0`  |
+| vAlign       | `top` \| `middle` \| `bottom`                 |           | 单元格垂直对齐方式                                                                                             | `6.7.0`  |
+| textOverflow | `string`                                      | `default` | 文本溢出后展示形式，默认换行处理。可选值 `ellipsis` 溢出隐藏展示， `noWrap` 不换行展示(仅在列为静态文本时生效) | `6.10.0` |
 
 ## 事件表
 
 当前组件会对外派发以下事件，可以通过`onEvent`来监听这些事件，并通过`actions`来配置执行的动作，在`actions`中可以通过`${事件参数名}`或`${event.data.[事件参数名]}`来获取事件产生的数据，详细查看[事件动作](../../docs/concepts/event-action)。
 
-| 事件名称       | 事件参数                                                                                  | 说明                 |
-| -------------- | ----------------------------------------------------------------------------------------- | -------------------- |
-| selectedChange | `selectedItems: item[]` 已选择行<br/>`unSelectedItems: item[]` 未选择行                   | 手动选择表格项时触发 |
-| columnSort     | `orderBy: string` 列排序列名<br/>`orderDir: string` 列排序值                              | 点击列排序时触发     |
-| columnFilter   | `filterName: string` 列筛选列名<br/>`filterValue: string` 列筛选值                        | 点击列筛选时触发     |
-| columnSearch   | `searchName: string` 列搜索列名<br/>`searchValue: string` 列搜索数据                      | 点击列搜索时触发     |
-| orderChange    | `movedItems: item[]` 已排序数据                                                           | 手动拖拽行排序时触发 |
-| columnToggled  | `columns: item[]` 当前显示的列配置数据                                                    | 点击自定义列时触发   |
-| rowClick       | `item: object` 行点击数据<br/>`index: number` 行索引 <br />`indexPath: string` 行索引路径 | 单击整行时触发       |
-| rowDbClick     | `item: object` 行点击数据<br/>`index: number` 行索引 <br />`indexPath: string` 行索引路径 | 双击整行时触发       |
-| rowMouseEnter  | `item: object` 行移入数据<br/>`index: number` 行索引 <br />`indexPath: string` 行索引路径 | 移入整行时触发       |
-| rowMouseLeave  | `item: object` 行移出数据<br/>`index: number` 行索引 <br />`indexPath: string` 行索引路径 | 移出整行时触发       |
+| 事件名称       | 事件参数                                                                                                             | 说明                 |
+| -------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| selectedChange | `selectedItems: item[]` 已选择行<br/>`selectedIndexes: string[]` 已选择行索引<br/>`unSelectedItems: item[]` 未选择行 | 手动选择表格项时触发 |
+| columnSort     | `orderBy: string` 列排序列名<br/>`orderDir: string` 列排序值                                                         | 点击列排序时触发     |
+| columnFilter   | `filterName: string` 列筛选列名<br/>`filterValue: string` 列筛选值                                                   | 点击列筛选时触发     |
+| columnSearch   | `searchName: string` 列搜索列名<br/>`searchValue: string` 列搜索数据                                                 | 点击列搜索时触发     |
+| orderChange    | `movedItems: item[]` 已排序数据                                                                                      | 手动拖拽行排序时触发 |
+| columnToggled  | `columns: item[]` 当前显示的列配置数据                                                                               | 点击自定义列时触发   |
+| rowClick       | `item: object` 行点击数据<br/>`index: number` 行索引 <br />`indexPath: string` 行索引路径                            | 单击整行时触发       |
+| rowDbClick     | `item: object` 行点击数据<br/>`index: number` 行索引 <br />`indexPath: string` 行索引路径                            | 双击整行时触发       |
+| rowMouseEnter  | `item: object` 行移入数据<br/>`index: number` 行索引 <br />`indexPath: string` 行索引路径                            | 移入整行时触发       |
+| rowMouseLeave  | `item: object` 行移出数据<br/>`index: number` 行索引 <br />`indexPath: string` 行索引路径                            | 移出整行时触发       |
 
 ### selectedChange
 

--- a/packages/amis-core/src/RootRenderer.tsx
+++ b/packages/amis-core/src/RootRenderer.tsx
@@ -234,11 +234,11 @@ export class RootRenderer extends React.Component<RootRendererProps> {
         );
       });
     } else if (action.actionType === 'toast') {
-      action.toast?.items?.forEach((item: any) => {
+      action.toast?.items?.forEach(({level, body, title, ...item}: any) => {
         env.notify(
-          item.level || 'info',
-          item.body
-            ? render('body', item.body, {
+          level || 'info',
+          body
+            ? render('body', body, {
                 ...this.props,
                 data: ctx,
                 context: store.context
@@ -247,8 +247,8 @@ export class RootRenderer extends React.Component<RootRendererProps> {
           {
             ...action.toast,
             ...item,
-            title: item.title
-              ? render('title', item.title, {
+            title: title
+              ? render('title', title, {
                   ...this.props,
                   data: ctx,
                   context: store.context

--- a/packages/amis-core/src/store/list.ts
+++ b/packages/amis-core/src/store/list.ts
@@ -46,8 +46,7 @@ export const Item = types
           index: self.index,
 
           // 只有table时，也可以获取选中行
-          selectedItems: listStore.selectedItems.map(item => item.data),
-          unSelectedItems: listStore.unSelectedItems.map(item => item.data)
+          ...listStore.eventContext
         }),
         self.data
       );
@@ -101,6 +100,13 @@ export const ListStore = iRendererStore
   .named('ListStore')
   .props({
     items: types.array(Item),
+
+    // 记录原始列表和原始选中的列表
+    // 因为如果是前端分页，上层 crud 或者 input-table 下发到这层的
+    // 是某个页区间的数据，这个时候 items 和 selectedItems 会少很多条
+    fullItems: types.optional(types.array(types.frozen()), []),
+    fullSelectedItems: types.optional(types.array(types.frozen()), []),
+
     selectedItems: types.array(types.reference(Item)),
     primaryField: 'id',
     orderBy: '',
@@ -171,6 +177,45 @@ export const ListStore = iRendererStore
 
       get movedItems() {
         return getMovedItems();
+      },
+
+      /**
+       * 构建事件的上下文数据
+       * @param buildChain
+       * @returns
+       */
+      get eventContext() {
+        const context = {
+          selectedItems: self.selectedItems.map(item => item.data),
+          selectedIndexes: self.selectedItems.map(item => item.index),
+          items: self.items.map(item => item.data),
+          unSelectedItems: this.unSelectedItems.map(item => item.data)
+        };
+
+        // 如果是前端分页情况，需要根据全量数据计算
+        // 如果不是前端分页，数据都没有返回，那种就没办法支持全量数据信息了
+        if (self.fullItems.length > self.items.length) {
+          // todo 这里的选择顺序会一直变，这个有影响吗?
+          const selectedItems = self.fullSelectedItems
+            .filter(
+              item =>
+                !self.items.find(
+                  row => row.pristine === (item.__pristine || item)
+                )
+            )
+            .concat(context.selectedItems);
+
+          context.selectedItems = selectedItems;
+          context.items = self.fullItems.concat();
+          context.unSelectedItems = self.fullItems.filter(
+            item => !selectedItems.includes(item)
+          );
+          context.selectedIndexes = selectedItems.map(item =>
+            self.fullItems.indexOf(item.__pristine || item)
+          );
+        }
+
+        return context;
       }
     };
   })
@@ -196,7 +241,11 @@ export const ListStore = iRendererStore
         (self.itemDraggableOn = config.itemDraggableOn);
     }
 
-    function initItems(items: Array<object>) {
+    function initItems(
+      items: Array<object>,
+      fullItems?: Array<any>,
+      fullSelectedItems?: Array<any>
+    ) {
       let arr = items.map((item, key) => {
         item = isObject(item)
           ? item
@@ -209,14 +258,16 @@ export const ListStore = iRendererStore
           id: guid(),
           index: key,
           newIndex: key,
-          pristine: item,
-          data: item,
-          modified: false
+          pristine: (item as any).__pristine || item,
+          data: item
         };
       });
       self.selectedItems.clear();
       self.items.replace(arr as Array<IItem>);
       self.dragging = false;
+      Array.isArray(fullItems) && self.fullItems.replace(fullItems);
+      Array.isArray(fullSelectedItems) &&
+        self.fullSelectedItems.replace(fullSelectedItems);
     }
 
     function updateSelected(selected: Array<any>, valueField?: string) {
@@ -319,9 +370,7 @@ export const ListStore = iRendererStore
 
     function getData(superData: any): any {
       return createObject(superData, {
-        items: self.items.map(item => item.data),
-        selectedItems: self.selectedItems.map(item => item.data),
-        unSelectedItems: self.unSelectedItems.map(item => item.data)
+        ...self.eventContext
       });
     }
 

--- a/packages/amis-editor/src/plugin/CRUD.tsx
+++ b/packages/amis-editor/src/plugin/CRUD.tsx
@@ -144,6 +144,10 @@ export class CRUDPlugin extends BasePlugin {
                 unSelectedItems: {
                   type: 'array',
                   title: '未选择行记录'
+                },
+                selectedIndexes: {
+                  type: 'array',
+                  title: '已选择行索引'
                 }
               }
             }
@@ -277,6 +281,36 @@ export class CRUDPlugin extends BasePlugin {
       eventName: 'rowClick',
       eventLabel: '行单击',
       description: '点击整行事件',
+      dataSchema: [
+        {
+          type: 'object',
+          properties: {
+            data: {
+              type: 'object',
+              title: '数据',
+              properties: {
+                item: {
+                  type: 'object',
+                  title: '当前行记录'
+                },
+                index: {
+                  type: 'number',
+                  title: '当前行索引'
+                },
+                indexPath: {
+                  type: 'number',
+                  title: '行索引路劲'
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      eventName: 'rowDbClick',
+      eventLabel: '行双击',
+      description: '双击整行事件',
       dataSchema: [
         {
           type: 'object',
@@ -998,7 +1032,8 @@ export class CRUDPlugin extends BasePlugin {
           getSchemaTpl('switch', {
             name: 'filter',
             label: '启用查询条件',
-            visibleOn: 'this.api && this.api.url',
+            visibleOn:
+              'this.api && this.api.url || typeof this.api === "string" && this.api',
             pipeIn: (value: any) => !!value,
             pipeOut: (value: any, originValue: any) => {
               if (value) {
@@ -2330,6 +2365,10 @@ export class CRUDPlugin extends BasePlugin {
               ...childSchema.properties.unSelectedItems.items,
               properties: itemsSchema
             }
+          },
+          selectedIndexes: {
+            type: 'array',
+            title: '已选择行索引'
           },
           count: {
             type: 'number',

--- a/packages/amis-ui/scss/_mixins.scss
+++ b/packages/amis-ui/scss/_mixins.scss
@@ -661,7 +661,8 @@
     line-height: calc(
       var(--Form-input-lineHeight) * var(--Form-input-fontSize) - #{px2rem(2px)}
     );
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     font-size: var(--Pick-base-value-fontSize);
     color: var(--Pick-base-value-color);
     font-weight: var(--Pick-base-value-fontWeight);
@@ -682,9 +683,6 @@
       var(--Pick-base-top-right-border-radius)
       var(--Pick-base-bottom-right-border-radius)
       var(--Pick-base-bottom-left-border-radius);
-    margin-right: var(--gap-xs);
-    margin-bottom: var(--gap-xs);
-    margin-top: var(--gap-xs);
     max-width: px2rem(150px);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -696,7 +694,10 @@
 
     &.is-disabled {
       pointer-events: none;
-      opacity: var(--Button-onDisabled-opacity);
+
+      .#{$ns}#{$component-prefix}-valueIcon {
+        opacity: var(--Button-onDisabled-opacity);
+      }
     }
   }
 
@@ -704,7 +705,7 @@
     color: var(--Pick-base-value-icon-color);
     cursor: pointer;
     border-right: px2rem(1px) solid var(--Form-selectValue-borderColor);
-    padding: 1px 5px;
+    padding: 0 5px;
 
     &:hover {
       background: var(--Pick-base-value-hover-icon-color);

--- a/packages/amis-ui/scss/_properties.scss
+++ b/packages/amis-ui/scss/_properties.scss
@@ -179,6 +179,7 @@ $Table-strip-bg: transparent;
   --ButtonGroup-divider-width: #{px2rem(1px)};
   --ButtonGroup-divider-color: #fff;
   --ButtonGroup-borderWidth: var(--borders-width-2);
+  --Button-onDisabled-opacity: 0.3;
 
   --Breadcrumb-item-fontSize: var(--fontSizeMd);
   --Breadcrumb-item-default-color: var(--colors-neutral-text-5);

--- a/packages/amis-ui/scss/components/_crud.scss
+++ b/packages/amis-ui/scss/components/_crud.scss
@@ -9,6 +9,10 @@
 
   &-selection {
     margin-bottom: var(--gap-base);
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--gap-xs);
+    line-height: 1;
 
     &-overflow {
       &-wrapper {
@@ -25,6 +29,7 @@
           (var(--Picker-tag-height) + var(--Picker-tag-marginBottom)) * 5
         );
 
+        gap: var(--gap-xs);
         @include tag-item(Crud);
       }
     }

--- a/packages/amis-ui/scss/components/form/_picker.scss
+++ b/packages/amis-ui/scss/components/form/_picker.scss
@@ -71,7 +71,8 @@
     font-size: var(--Pick-base-placeholder-fontSize);
     font-weight: var(--Pick-base-placeholder-fontWeight);
     user-select: none;
-    position: absolute;
+    flex: 1;
+    min-width: 0;
     // margin-top: 2 * var(--Form-input-borderWidth);
     line-height: var(--Form-input-lineHeight);
     padding: var(--Pick-base-paddingTop) var(--Pick-base-paddingRight)
@@ -95,15 +96,15 @@
       var(--Pick-base-left-border-color);
   }
 
-  .#{$ns}Picker-values {
-    display: inline;
+  // .#{$ns}Picker-values {
+  //   display: inline;
 
-    .#{$ns}OverflowTpl {
-      .#{$ns}Picker-valueLabel {
-        pointer-events: auto;
-      }
-    }
-  }
+  //   .#{$ns}OverflowTpl {
+  //     .#{$ns}Picker-valueLabel {
+  //       pointer-events: auto;
+  //     }
+  //   }
+  // }
 
   &-valueWrap {
     flex-grow: 1;
@@ -117,8 +118,9 @@
   }
 
   .#{$ns}Picker-valueWrap {
-    margin-bottom: calc(var(--gap-xs) * -1);
-    line-height: 1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--gap-xs);
   }
 
   /* tag 样式 */
@@ -176,6 +178,7 @@
         (var(--Picker-tag-height) + var(--Picker-tag-marginBottom)) * 5
       );
 
+      gap: var(--gap-xs);
       @include tag-item(Picker);
     }
   }

--- a/packages/amis-ui/src/locale/de-DE.ts
+++ b/packages/amis-ui/src/locale/de-DE.ts
@@ -50,6 +50,8 @@ register('de-DE', {
   'CRUD.stat': '{{page}} von {{lastPage}} insgesamt: {{total}}.',
   'CRUD.paginationGoText': 'Wechseln zu',
   'CRUD.paginationPageText': 'Seite',
+  'CRUD.confirmLeaveUnSavedPage':
+    'Ändern Seite wird nicht gespeicherte Daten verlieren, bestätigen Sie bitte.',
   'PaginationWrapper.placeholder': 'Textkörper konfigurieren',
   'Pagination.select': '{{count}} items/page',
   'Pagination.goto': 'goto',

--- a/packages/amis-ui/src/locale/en-US.ts
+++ b/packages/amis-ui/src/locale/en-US.ts
@@ -45,6 +45,8 @@ register('en-US', {
   'CRUD.stat': '{{page}} of {{lastPage}} total: {{total}}.',
   'CRUD.paginationGoText': 'Go to',
   'CRUD.paginationPageText': 'page',
+  'CRUD.confirmLeaveUnSavedPage':
+    'Change page will loss unsaved data, please confirm.',
   'PaginationWrapper.placeholder': 'please config body',
   'Pagination.select': '{{count}} items/page',
   'Pagination.goto': 'goto',

--- a/packages/amis-ui/src/locale/zh-CN.ts
+++ b/packages/amis-ui/src/locale/zh-CN.ts
@@ -48,6 +48,7 @@ register('zh-CN', {
   'CRUD.stat': '{{page}}/{{lastPage}} 共：{{total}} 项',
   'CRUD.paginationGoText': '前往',
   'CRUD.paginationPageText': '页',
+  'CRUD.confirmLeaveUnSavedPage': '分页会丢失未保存的数据，请确认',
   'PaginationWrapper.placeholder': '请配置内容',
   'Pagination.select': '{{count}}条/页',
   'Pagination.goto': '跳转至',

--- a/packages/amis/__tests__/renderers/Picker.test.tsx
+++ b/packages/amis/__tests__/renderers/Picker.test.tsx
@@ -296,13 +296,15 @@ describe('5. Renderer:Picker with overflowConfig', () => {
 
     await wait(500);
 
-    const tags = container.querySelector('.cxd-Picker-values');
+    const tags = container.querySelector('.cxd-Picker-valueWrap');
 
     expect(tags).toBeInTheDocument();
     /** tag 元素数量正确 */
-    expect(tags?.childElementCount).toEqual(3);
+    expect(tags?.childElementCount).toEqual(4); // 还有个 input
     /** 收纳标签文案正确 */
-    expect(tags?.lastElementChild).toHaveTextContent('+ 1 ...');
+    expect(tags?.lastElementChild?.previousSibling).toHaveTextContent(
+      '+ 1 ...'
+    );
   });
 
   test('5-2. Renderer:Picker embeded', async () => {

--- a/packages/amis/__tests__/renderers/__snapshots__/Picker.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/__snapshots__/Picker.test.tsx.snap
@@ -38,16 +38,6 @@ exports[`1. Renderer:Picker base 1`] = `
             >
               picker-placeholder
             </div>
-            <div
-              class="cxd-Picker-valueWrap"
-            >
-              <div
-                class="cxd-Picker-values"
-              />
-              <input
-                value=""
-              />
-            </div>
             <span
               class="cxd-Picker-btn"
             >
@@ -267,22 +257,18 @@ exports[`1. Renderer:Picker base 2`] = `
             class="cxd-Picker-valueWrap"
           >
             <div
-              class="cxd-Picker-values"
+              class="cxd-OverflowTpl cxd-Picker-value"
             >
-              <div
-                class="cxd-OverflowTpl cxd-Picker-value"
+              <span
+                class="cxd-Picker-valueIcon"
               >
-                <span
-                  class="cxd-Picker-valueIcon"
-                >
-                  ×
-                </span>
-                <span
-                  class="cxd-Picker-valueLabel"
-                >
-                  B
-                </span>
-              </div>
+                ×
+              </span>
+              <span
+                class="cxd-Picker-valueLabel"
+              >
+                B
+              </span>
             </div>
             <input
               value=""

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import isEqual from 'lodash/isEqual';
 import pickBy from 'lodash/pickBy';
 import omitBy from 'lodash/omitBy';
+import partition from 'lodash/partition';
 import {
   Renderer,
   RendererProps,
   createObjectFromChain,
   filterTarget,
-  mapTree
+  mapTree,
+  findTree
 } from 'amis-core';
 import {SchemaNode, Schema, ActionObject, PlainObject} from 'amis-core';
 import {CRUDStore, ICRUDStore, getMatchedEventTargets} from 'amis-core';
@@ -21,7 +23,8 @@ import {
   getVariable,
   qsstringify,
   qsparse,
-  isIntegerInRange
+  isIntegerInRange,
+  spliceTree
 } from 'amis-core';
 import {ScopedContext, IScopedContext} from 'amis-core';
 import {Button, SpinnerExtraProps, TooltipWrapper} from 'amis-ui';
@@ -35,7 +38,7 @@ import omit from 'lodash/omit';
 import find from 'lodash/find';
 import findIndex from 'lodash/findIndex';
 import {Html} from 'amis-ui';
-import {Icon} from 'amis-ui';
+import {Icon, confirm} from 'amis-ui';
 import {
   BaseSchema,
   SchemaApi,
@@ -45,7 +48,8 @@ import {
   SchemaName,
   SchemaObject,
   SchemaTokenizeableString,
-  SchemaTpl
+  SchemaTpl,
+  SchemaCollection
 } from '../Schema';
 import {ActionSchema} from './Action';
 import {CardsSchema} from './Cards';
@@ -252,6 +256,13 @@ export interface CRUDCommonSchema extends BaseSchema, SpinnerExtraProps {
    */
   syncLocation?: boolean;
 
+  toolbar?: SchemaCollection;
+
+  /**
+   * 工具栏是否为 inline 模式
+   */
+  toolbarInline?: boolean;
+
   /**
    * 顶部工具栏
    */
@@ -393,6 +404,17 @@ export interface CRUDCommonSchema extends BaseSchema, SpinnerExtraProps {
         types?: ('boolean' | 'number')[];
       }
     | boolean;
+
+  /**
+   * 是否开启行选择功能, 默认为 false
+   * 开启后将支持行选择功能,需要结合事件动作使用
+   */
+  selectable?: boolean;
+
+  /**
+   * 控制是否多选，默认为 false
+   */
+  multiple?: boolean;
 }
 
 export type CRUDCardsSchema = CRUDCommonSchema & {
@@ -435,7 +457,7 @@ const INNER_EVENTS: Array<CRUDRendererEvent> = [
   'selected'
 ];
 
-export default class CRUD extends React.Component<CRUDProps, any> {
+export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
   static propsList: Array<keyof CRUDProps> = [
     'bulkActions',
     'itemActions',
@@ -528,7 +550,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     omitBy(onEvent, (event, key: any) => !INNER_EVENTS.includes(key))
   );
 
-  constructor(props: CRUDProps) {
+  constructor(props: T) {
     super(props);
 
     this.controlRef = this.controlRef.bind(this);
@@ -541,6 +563,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     this.handleBulkGo = this.handleBulkGo.bind(this);
     this.handleDialogConfirm = this.handleDialogConfirm.bind(this);
     this.handleDialogClose = this.handleDialogClose.bind(this);
+    this.handleItemChange = this.handleItemChange.bind(this);
     this.handleSave = this.handleSave.bind(this);
     this.handleSaveOrder = this.handleSaveOrder.bind(this);
     this.handleSelect = this.handleSelect.bind(this);
@@ -552,6 +575,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     this.renderHeaderToolbar = this.renderHeaderToolbar.bind(this);
     this.renderFooterToolbar = this.renderFooterToolbar.bind(this);
     this.clearSelection = this.clearSelection.bind(this);
+    this.filterItemIndex = this.filterItemIndex.bind(this);
 
     const {
       location,
@@ -599,7 +623,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     // 因此需要将componentDidMount中的设置选中项提前到constructor，否则handleSelect里拿不到的选中项
     let val: any;
     if (this.props.pickerMode && (val = getPropValue(this.props))) {
-      store.setSelectedItems(val);
+      this.syncSelectedFromPicker(val);
     }
   }
 
@@ -649,7 +673,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
        * 更新链：Table -> CRUD -> Picker -> Form
        * 对于Picker模式来说，执行到这里的时候store.selectedItems已经更新过了，所以需要额外判断一下
        */
-      store.setSelectedItems(val);
+      this.syncSelectedFromPicker(val);
     }
 
     if (!!this.props.filterTogglable !== !!prevProps.filterTogglable) {
@@ -708,6 +732,11 @@ export default class CRUD extends React.Component<CRUDProps, any> {
         store.initFromScope(props.data, props.source, {
           columns: store.columns ?? props.columns
         });
+
+        if (this.props.pickerMode && (val = getPropValue(this.props))) {
+          this.syncSelectedFromPicker(val);
+        }
+
         this.lastData = next;
       }
     }
@@ -811,6 +840,11 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       const redirect = action.redirect && filter(action.redirect, data);
       redirect && action.blank && env.jumpTo(redirect, action, data);
 
+      // 如果 api 无效，或者不满足发送条件，则直接返回
+      if (!isEffectiveApi(action.api, data)) {
+        return;
+      }
+
       return store
         .saveRemote(action.api!, data, {
           successMessage:
@@ -898,11 +932,10 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       },
       {
         ...selectedItems[0],
+        ...store.eventContext,
         currentPageData: (store.mergedData?.items || []).concat(),
         rows: selectedItems,
         items: selectedItems,
-        selectedItems,
-        unSelectedItems: unSelectedItems,
         ids
       }
     ]);
@@ -975,9 +1008,16 @@ export default class CRUD extends React.Component<CRUDProps, any> {
   }
 
   handleFilterInit(values: object) {
-    const {defaultParams, data, store, orderBy, orderDir, dispatchEvent} =
-      this.props;
-    const params = {...defaultParams};
+    const {
+      defaultParams,
+      columns,
+      matchFunc,
+      store,
+      orderBy,
+      orderDir,
+      dispatchEvent
+    } = this.props;
+    const params: any = {...defaultParams};
 
     if (orderBy) {
       params['orderBy'] = orderBy;
@@ -999,11 +1039,22 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     store.setPristineQuery();
 
     const {pickerMode, options} = this.props;
-
-    pickerMode &&
-      store.updateData({
-        items: options || []
-      });
+    if (pickerMode) {
+      store.initFromScope(
+        {
+          items: options || []
+        },
+        '${items}',
+        {
+          columns: store.columns ?? columns,
+          matchFunc
+        }
+      );
+      let val: any;
+      if ((val = getPropValue(this.props))) {
+        this.syncSelectedFromPicker(val);
+      }
+    }
   }
 
   handleFilterReset(values: object, action: any) {
@@ -1370,7 +1421,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
         page > 1 &&
         lastPage < page
       ) {
-        this.search(
+        await this.search(
           {
             ...store.query,
             [pageField || 'page']: lastPage
@@ -1404,6 +1455,11 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       });
     }
 
+    let val: any;
+    if (this.props.pickerMode && (val = getPropValue(this.props))) {
+      this.syncSelectedFromPicker(val);
+    }
+
     return store.data;
   }
 
@@ -1411,7 +1467,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     return this.search(values, true, clearSelection, forceReload);
   }
 
-  handleChangePage(
+  async handleChangePage(
     page: number,
     perPage?: number,
     dir?: 'forward' | 'backward'
@@ -1423,8 +1479,18 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       pageField,
       perPageField,
       pageDirectionField,
-      autoJumpToTopOnPagerChange
+      autoJumpToTopOnPagerChange,
+      translate: __,
+      api,
+      loadDataOnce
     } = this.props;
+
+    if (api && !loadDataOnce && this.control?.hasModifiedItems()) {
+      const confirmed = await confirm(__('CRUD.confirmLeaveUnSavedPage'));
+      if (!confirmed) {
+        return;
+      }
+    }
 
     let query: any = {
       [pageField || 'page']: page
@@ -1456,6 +1522,36 @@ export default class CRUD extends React.Component<CRUDProps, any> {
         scrolledY && window.scroll(0, scrolledY);
       }
     }
+  }
+
+  syncSelectedFromPicker(value: Array<any>) {
+    const {store, primaryField, strictMode} = this.props;
+    const isSameValue = (
+      a: Record<string, unknown>,
+      item: Record<string, unknown>
+    ) => {
+      const oldValue = a[primaryField || 'id'];
+      const itemValue = item[primaryField || 'id'];
+      const isSame = strictMode
+        ? oldValue === itemValue
+        : oldValue == itemValue;
+      return !!(a === item || (oldValue && isSame));
+    };
+
+    const selectedItems = value.map(
+      item => findTree(store.items, a => isSameValue(a, item)) || item
+    );
+
+    this.props.store.setSelectedItems(selectedItems);
+  }
+
+  handleItemChange(item: object, diff: object, index: string | number) {
+    const {store} = this.props;
+
+    const indexes = `${index}`.split('.').map(item => parseInt(item, 10));
+    const items = spliceTree(store.items, indexes, 1, item);
+
+    store.replaceItems(items);
   }
 
   handleSave(
@@ -1741,75 +1837,103 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       onSelect
     } = this.props;
     let newItems = items;
-    let newUnSelectedItems = unSelectedItems;
+
     if (keepItemSelectionOnPageChange && store.selectedItems.length) {
-      const oldItems = store.selectedItems.concat();
-      const oldUnselectedItems = store.unSelectedItems.concat();
+      const itemsRest = items.concat();
 
-      const isSameValue = (
-        a: Record<string, unknown>,
-        item: Record<string, unknown>
-      ) => {
-        const oldValue = a[primaryField || 'id'];
-        const itemValue = item[primaryField || 'id'];
-        const isSame = strictMode
-          ? oldValue === itemValue
-          : oldValue == itemValue;
-        return a === item || (oldValue && isSame);
-      };
+      newItems = store.selectedItems
+        .map(item => {
+          const idx = itemsRest.findIndex(
+            a => (a.__pristine || a) === (item.__pristine || item)
+          );
 
-      items.forEach(item => {
-        const idx = findIndex(oldItems, a => isSameValue(a, item));
+          if (~idx) {
+            return itemsRest.splice(idx, 1)[0];
+          }
 
-        if (~idx) {
-          oldItems[idx] = item;
-        } else {
-          oldItems.push(item);
-        }
-
-        const idx2 = findIndex(oldUnselectedItems, a => isSameValue(a, item));
-
-        if (~idx2) {
-          oldUnselectedItems.splice(idx2, 1);
-        }
-      });
-
-      unSelectedItems.forEach(item => {
-        const idx = findIndex(oldUnselectedItems, a => isSameValue(a, item));
-
-        const idx2 = findIndex(oldItems, a => isSameValue(a, item));
-
-        if (~idx) {
-          oldUnselectedItems[idx] = item;
-        } else {
-          oldUnselectedItems.push(item);
-        }
-        !~idx && ~idx2 && oldItems.splice(idx2, 1);
-      });
-
-      newItems = oldItems;
-      newUnSelectedItems = oldUnselectedItems;
-
-      // const thisBatch = items.concat(unSelectedItems);
-      // let notInThisBatch = (item: any) =>
-      //   !find(
-      //     thisBatch,
-      //     a => a[primaryField || 'id'] == item[primaryField || 'id']
-      //   );
-
-      // newItems = store.selectedItems.filter(notInThisBatch);
-      // newUnSelectedItems = store.unSelectedItems.filter(notInThisBatch);
-
-      // newItems.push(...items);
-      // newUnSelectedItems.push(...unSelectedItems);
+          return findTree(
+            unSelectedItems,
+            a => (a.__pristine || a) === (item.__pristine || item)
+          )
+            ? null
+            : item;
+        })
+        .filter(item => item)
+        .concat(itemsRest);
     }
 
-    if (pickerMode && multiple === false && newItems.length > 1) {
-      newUnSelectedItems.push.apply(
-        newUnSelectedItems,
-        newItems.splice(0, newItems.length - 1)
-      );
-    }
+    const newUnSelectedItems = store.items
+      .filter(item => !newItems.find(a => (a.__pristine || a) === item))
+      .map(item => unSelectedItems.find(a => a.__pristine === item) || item);
+
+    // if (keepItemSelectionOnPageChange && store.selectedItems.length) {
+    //   const oldItems = store.selectedItems.concat();
+    //   const oldUnselectedItems = store.unSelectedItems.concat();
+
+    //   const isSameValue = (
+    //     a: Record<string, unknown>,
+    //     item: Record<string, unknown>
+    //   ) => {
+    //     const oldValue = a[primaryField || 'id'];
+    //     const itemValue = item[primaryField || 'id'];
+    //     const isSame = strictMode
+    //       ? oldValue === itemValue
+    //       : oldValue == itemValue;
+    //     return a === item || (oldValue && isSame);
+    //   };
+
+    //   items.forEach(item => {
+    //     const idx = findIndex(oldItems, a => isSameValue(a, item));
+
+    //     if (~idx) {
+    //       oldItems[idx] = item;
+    //     } else {
+    //       oldItems.push(item);
+    //     }
+
+    //     const idx2 = findIndex(oldUnselectedItems, a => isSameValue(a, item));
+
+    //     if (~idx2) {
+    //       oldUnselectedItems.splice(idx2, 1);
+    //     }
+    //   });
+
+    //   unSelectedItems.forEach(item => {
+    //     const idx = findIndex(oldUnselectedItems, a => isSameValue(a, item));
+
+    //     const idx2 = findIndex(oldItems, a => isSameValue(a, item));
+
+    //     if (~idx) {
+    //       oldUnselectedItems[idx] = item;
+    //     } else {
+    //       oldUnselectedItems.push(item);
+    //     }
+    //     !~idx && ~idx2 && oldItems.splice(idx2, 1);
+    //   });
+
+    //   newItems = oldItems;
+    //   newUnSelectedItems = oldUnselectedItems;
+
+    //   // const thisBatch = items.concat(unSelectedItems);
+    //   // let notInThisBatch = (item: any) =>
+    //   //   !find(
+    //   //     thisBatch,
+    //   //     a => a[primaryField || 'id'] == item[primaryField || 'id']
+    //   //   );
+
+    //   // newItems = store.selectedItems.filter(notInThisBatch);
+    //   // newUnSelectedItems = store.unSelectedItems.filter(notInThisBatch);
+
+    //   // newItems.push(...items);
+    //   // newUnSelectedItems.push(...unSelectedItems);
+    // }
+
+    // if (pickerMode && multiple === false && newItems.length > 1) {
+    //   newUnSelectedItems.push.apply(
+    //     newUnSelectedItems,
+    //     newItems.splice(0, newItems.length - 1)
+    //   );
+    // }
     // 用 updateSelectData 导致 CRUD 无限刷新
     // store.updateSelectData(newItems, newUnSelectedItems);
     store.setSelectedItems(newItems);
@@ -1930,14 +2054,12 @@ export default class CRUD extends React.Component<CRUDProps, any> {
         'toggleExpanded',
         'setExpanded',
         'initDrag',
-        'cancelDrag'
+        'cancelDrag',
+        'selectAll',
+        'clearAll'
       ].includes(action.actionType)
     ) {
       return this.control?.doAction(action, data, throwErrors, args);
-    } else if (action.actionType === 'selectAll') {
-      return this.handleSelect(store.items.concat(), []);
-    } else if (action.actionType === 'clearAll') {
-      return this.handleSelect([], store.items.concat());
     } else if (action.actionType === 'select') {
       const selectedItems = await getMatchedEventTargets(
         store.items,
@@ -1948,6 +2070,8 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       const unSelectedItems = store.items.filter(
         item => !selectedItems.includes(item)
       );
+      // todo 这里的 selected 和 unselected 不是修改后的
+      //
       return this.handleSelect(selectedItems, unSelectedItems);
     }
 
@@ -1967,11 +2091,14 @@ export default class CRUD extends React.Component<CRUDProps, any> {
   }
 
   clearSelection() {
-    const {store} = this.props;
-    const selected = store.selectedItems.concat();
-    const unSelected = store.unSelectedItems.concat(selected);
+    const {store, itemCheckableOn} = this.props;
+    const [unchecked, checked] = partition(
+      store.selectedItems,
+      item => !itemCheckableOn || evalExpression(itemCheckableOn, item)
+    );
+    const unSelected = store.unSelectedItems.concat(unchecked);
 
-    store.setSelectedItems([]);
+    store.setSelectedItems(checked);
     store.setUnSelectedItems(unSelected);
   }
 
@@ -2029,10 +2156,9 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     let itemBtns: Array<ActionSchema> = [];
     const ctx = createObject(store.mergedData, {
       currentPageData: (store.mergedData?.items || []).concat(),
+      ...store.eventContext,
       rows: selectedItems.concat(),
       items: selectedItems.concat(),
-      selectedItems: selectedItems.concat(),
-      unSelectedItems: unSelectedItems.concat(),
       ids: selectedItems
         .map(item =>
           item.hasOwnProperty(primaryField)
@@ -2395,7 +2521,7 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       });
     } else if (Array.isArray(toolbar)) {
       const children: Array<any> = toolbar
-        .filter((toolbar: any) => isVisible(toolbar, store.filterData))
+        .filter((toolbar: any) => isVisible(toolbar, store.toolbarData))
         .map((toolbar, index) => ({
           dom: this.renderToolbar(toolbar, index, childProps, toolbarRenderer),
           toolbar
@@ -2468,12 +2594,12 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     if (toolbar) {
       if (Array.isArray(headerToolbar)) {
         headerToolbar = toolbarInline
-          ? headerToolbar.concat(toolbar)
-          : [headerToolbar, toolbar];
+          ? headerToolbar.concat(toolbar as any)
+          : ([headerToolbar, toolbar] as any);
       } else if (headerToolbar) {
-        headerToolbar = [headerToolbar, toolbar];
+        headerToolbar = [headerToolbar, toolbar] as any;
       } else {
-        headerToolbar = toolbar;
+        headerToolbar = toolbar as any;
       }
     }
 
@@ -2493,13 +2619,15 @@ export default class CRUD extends React.Component<CRUDProps, any> {
 
     if (toolbar) {
       if (Array.isArray(footerToolbar)) {
-        footerToolbar = toolbarInline
-          ? footerToolbar.concat(toolbar)
-          : [footerToolbar, toolbar];
+        footerToolbar = (
+          toolbarInline
+            ? footerToolbar.concat(toolbar as any)
+            : [footerToolbar, toolbar]
+        ) as any;
       } else if (footerToolbar) {
-        footerToolbar = [footerToolbar, toolbar];
+        footerToolbar = [footerToolbar, toolbar] as any;
       } else {
-        footerToolbar = toolbar;
+        footerToolbar = toolbar as any;
       }
     }
 
@@ -2514,11 +2642,19 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       primaryField,
       valueField,
       translate: __,
-      env
+      env,
+      itemCheckableOn
     } = this.props;
 
+    const checkable = itemCheckableOn
+      ? evalExpression(itemCheckableOn, item)
+      : true;
+
     return (
-      <div key={index} className={cx(`Crud-value`)}>
+      <div
+        key={index}
+        className={cx(`Crud-value`, checkable ? '' : 'is-disabled')}
+      >
         <span
           className={cx('Crud-valueIcon')}
           onClick={this.unSelectItem.bind(this, item, index)}
@@ -2551,10 +2687,15 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       popOverContainer,
       multiple,
       maxTagCount,
-      overflowTagPopover
+      overflowTagPopover,
+      keepItemSelectionOnPageChange
     } = this.props;
 
-    if (!store.selectedItems.length) {
+    if (
+      !store.selectedItems.length ||
+      !keepItemSelectionOnPageChange ||
+      multiple === false
+    ) {
       return null;
     }
 
@@ -2635,7 +2776,67 @@ export default class CRUD extends React.Component<CRUDProps, any> {
     );
   }
 
-  render() {
+  renderFilter() {
+    const {
+      store,
+      render,
+      classnames: cx,
+      filter,
+      translate: __,
+      testIdBuilder,
+      filterCanAccessSuperData = true
+    } = this.props;
+
+    if (!filter && (!store.filterTogggable || store.filterVisible)) {
+      return null;
+    }
+
+    return render(
+      'filter',
+      {
+        title: __('CRUD.filter'),
+        mode: 'inline',
+        submitText: __('search'),
+        ...filter,
+        type: 'form',
+        api: null,
+        testIdBuilder: testIdBuilder?.getChild('filter')
+      },
+      {
+        key: 'filter',
+        panelClassName: cx(
+          'Crud-filter',
+          filter!.panelClassName || 'Panel--default'
+        ),
+        data: store.filterData,
+        onReset: this.handleFilterReset,
+        onSubmit: this.handleFilterSubmit,
+        onInit: this.handleFilterInit,
+        formStore: undefined,
+        canAccessSuperData: filterCanAccessSuperData
+      }
+    );
+  }
+
+  filterItemIndex(index: number | string) {
+    const {store} = this.props;
+    const indexes = `${index}`.split('.').map(index => parseInt(index, 10));
+
+    if (!Array.isArray(store.data.items)) {
+      // something wrong.
+      return index;
+    }
+
+    const top = store.data.items?.[indexes[0]];
+    if (top) {
+      indexes[0] = store.items.findIndex(
+        a => (a.__pristine || a) === (top.__pristine || top)
+      );
+    }
+    return indexes.join('.');
+  }
+
+  renderBody() {
     const {
       className,
       style,
@@ -2679,7 +2880,86 @@ export default class CRUD extends React.Component<CRUDProps, any> {
       testIdBuilder,
       id,
       filterCanAccessSuperData = true,
+      selectable = false,
       ...rest
+    } = this.props;
+
+    return render(
+      'body',
+      {
+        ...rest,
+        id,
+        // 通用事件 例如cus-event 如果直接透传给table 则会被触发2次
+        // 因此只将下层组件table、cards中自定义事件透传下去 否则通过crud配置了也不会执行
+        onEvent: this.filterOnEvent(onEvent),
+        columns: store.columns ?? rest.columns,
+        type: mode || 'table'
+      },
+      {
+        key: 'body',
+        className: cx('Crud-body', bodyClassName),
+        ref: this.controlRef,
+        autoGenerateFilter: !filter && autoGenerateFilter,
+        filterCanAccessSuperData,
+        autoFillHeight: autoFillHeight,
+        selectable: !!(
+          (this.hasBulkActionsToolbar() && this.hasBulkActions()) ||
+          pickerMode ||
+          selectable
+        ),
+        itemActions,
+        multiple:
+          multiple === void 0
+            ? bulkActions && bulkActions.length > 0
+              ? true
+              : false
+            : multiple,
+        selected: store.selectedItemsAsArray,
+        strictMode,
+        keepItemSelectionOnPageChange,
+        maxKeepItemSelectionLength,
+        maxItemSelectionLength,
+        valueField: valueField || primaryField,
+        primaryField: primaryField,
+        hideQuickSaveBtn,
+        items: store.data.items,
+        fullItems: store.itemsAsArray,
+        query: store.query,
+        orderBy: store.query.orderBy,
+        orderDir: store.query.orderDir,
+        popOverContainer,
+        onAction: this.handleAction,
+        onItemChange: this.handleItemChange,
+        onSave: this.handleSave,
+        onSaveOrder: this.handleSaveOrder,
+        onQuery: this.handleQuery,
+        onSelect: this.handleSelect,
+        onPopOverOpened: this.handleChildPopOverOpen,
+        onPopOverClosed: this.handleChildPopOverClose,
+        onSearchableFromReset: this.handleFilterReset,
+        onSearchableFromSubmit: this.handleFilterSubmit,
+        onSearchableFromInit: this.handleFilterInit,
+        headerToolbarRender: this.renderHeaderToolbar,
+        footerToolbarRender: this.renderFooterToolbar,
+        data: store.mergedData,
+        loading: store.loading,
+        host: this,
+        filterItemIndex: this.filterItemIndex,
+        testIdBuilder: testIdBuilder?.getChild('body')
+      }
+    );
+  }
+
+  render() {
+    const {
+      className,
+      style,
+      render,
+      store,
+      classnames: cx,
+      translate: __,
+      testIdBuilder,
+      id
     } = this.props;
 
     return (
@@ -2692,98 +2972,10 @@ export default class CRUD extends React.Component<CRUDProps, any> {
         data-id={id}
         {...testIdBuilder?.getChild('wrapper').getTestId()}
       >
-        {filter && (!store.filterTogggable || store.filterVisible)
-          ? render(
-              'filter',
-              {
-                title: __('CRUD.filter'),
-                mode: 'inline',
-                submitText: __('search'),
-                ...filter,
-                type: 'form',
-                api: null,
-                testIdBuilder: testIdBuilder?.getChild('filter')
-              },
-              {
-                key: 'filter',
-                panelClassName: cx(
-                  'Crud-filter',
-                  filter.panelClassName || 'Panel--default'
-                ),
-                data: store.filterData,
-                onReset: this.handleFilterReset,
-                onSubmit: this.handleFilterSubmit,
-                onInit: this.handleFilterInit,
-                formStore: undefined,
-                canAccessSuperData: filterCanAccessSuperData
-              }
-            )
-          : null}
+        {this.renderFilter()}
+        {this.renderSelection()}
+        {this.renderBody()}
 
-        {keepItemSelectionOnPageChange && multiple !== false
-          ? this.renderSelection()
-          : null}
-
-        {render(
-          'body',
-          {
-            ...rest,
-            id,
-            // 通用事件 例如cus-event 如果直接透传给table 则会被触发2次
-            // 因此只将下层组件table、cards中自定义事件透传下去 否则通过crud配置了也不会执行
-            onEvent: this.filterOnEvent(onEvent),
-            columns: store.columns ?? rest.columns,
-            type: mode || 'table'
-          },
-          {
-            key: 'body',
-            className: cx('Crud-body', bodyClassName),
-            ref: this.controlRef,
-            autoGenerateFilter: !filter && autoGenerateFilter,
-            filterCanAccessSuperData,
-            autoFillHeight: autoFillHeight,
-            selectable: !!(
-              (this.hasBulkActionsToolbar() && this.hasBulkActions()) ||
-              pickerMode
-            ),
-            itemActions,
-            multiple:
-              multiple === void 0
-                ? bulkActions && bulkActions.length > 0
-                  ? true
-                  : false
-                : multiple,
-            selected: store.selectedItemsAsArray,
-            strictMode,
-            keepItemSelectionOnPageChange,
-            maxKeepItemSelectionLength,
-            maxItemSelectionLength,
-            valueField: valueField || primaryField,
-            primaryField: primaryField,
-            hideQuickSaveBtn,
-            items: store.data.items,
-            query: store.query,
-            orderBy: store.query.orderBy,
-            orderDir: store.query.orderDir,
-            popOverContainer,
-            onAction: this.handleAction,
-            onSave: this.handleSave,
-            onSaveOrder: this.handleSaveOrder,
-            onQuery: this.handleQuery,
-            onSelect: this.handleSelect,
-            onPopOverOpened: this.handleChildPopOverOpen,
-            onPopOverClosed: this.handleChildPopOverClose,
-            onSearchableFromReset: this.handleFilterReset,
-            onSearchableFromSubmit: this.handleFilterSubmit,
-            onSearchableFromInit: this.handleFilterInit,
-            headerToolbarRender: this.renderHeaderToolbar,
-            footerToolbarRender: this.renderFooterToolbar,
-            data: store.mergedData,
-            loading: store.loading,
-            host: this,
-            testIdBuilder: testIdBuilder?.getChild('body')
-          }
-        )}
         {render(
           'dialog',
           {
@@ -2804,15 +2996,10 @@ export default class CRUD extends React.Component<CRUDProps, any> {
   }
 }
 
-@Renderer({
-  type: 'crud',
-  storeType: CRUDStore.name,
-  isolateScope: true
-})
-export class CRUDRenderer extends CRUD {
+export class CRUDRendererBase<T extends CRUDProps> extends CRUD<T> {
   static contextType = ScopedContext;
 
-  constructor(props: CRUDProps, context: IScopedContext) {
+  constructor(props: T, context: IScopedContext) {
     super(props);
 
     const scoped = context;
@@ -2908,3 +3095,10 @@ export class CRUDRenderer extends CRUD {
     return store.getData(data);
   }
 }
+
+@Renderer({
+  type: 'crud',
+  storeType: CRUDStore.name,
+  isolateScope: true
+})
+export class CRUDRenderer extends CRUDRendererBase<CRUDProps> {}

--- a/packages/amis/src/renderers/Cards.tsx
+++ b/packages/amis/src/renderers/Cards.tsx
@@ -165,15 +165,27 @@ export interface GridProps
     Omit<CardsSchema, 'className' | 'itemClassName'> {
   store: IListStore;
   selectable?: boolean;
+  // 已选清单
   selected?: Array<any>;
   checkAll?: boolean;
   multiple?: boolean;
   valueField?: string;
   draggable?: boolean;
   dragIcon?: SVGAElement;
+  // 行数据集合
+  items?: Array<object>;
+
+  // 原始数据集合，前端分页时用来保存原始数据
+  fullItems?: Array<object>;
   onSelect: (
     selectedItems: Array<object>,
     unSelectedItems: Array<object>
+  ) => void;
+  // 单条修改时触发
+  onItemChange?: (
+    item: object,
+    diff: object,
+    rowIndex: string | number
   ) => void;
   onSave?: (
     items: Array<object> | object,
@@ -299,7 +311,7 @@ export default class Cards extends React.Component<GridProps, object> {
       }
     }
 
-    updateItems && store.initItems(items);
+    updateItems && store.initItems(items, props.fullItems, props.selected);
     Array.isArray(props.selected) &&
       store.updateSelected(props.selected, props.valueField);
     return updateItems;
@@ -370,15 +382,12 @@ export default class Cards extends React.Component<GridProps, object> {
     this.syncSelected();
 
     const {store, dispatchEvent} = this.props;
-    const selectItems = store.selectedItems.map(row => row.data);
-    const unSelectItems = store.unSelectedItems.map(row => row.data);
 
     dispatchEvent(
       //增删改查卡片模式选择表格项
       'selectedChange',
       createObject(store.data, {
-        selectedItems: selectItems,
-        unSelectedItems: unSelectItems,
+        ...store.eventContext,
         item: item.data
       })
     );
@@ -445,9 +454,17 @@ export default class Cards extends React.Component<GridProps, object> {
   ) {
     item.change(values, savePristine);
 
-    if (!saveImmediately || savePristine) {
+    const {onSave, onItemChange, primaryField} = this.props;
+
+    if (savePristine) {
       return;
     }
+
+    onItemChange?.(
+      item.data,
+      difference(item.data, item.pristine, ['id', primaryField]),
+      item.index
+    );
 
     if (saveImmediately && saveImmediately.api) {
       this.props.onAction(
@@ -462,9 +479,7 @@ export default class Cards extends React.Component<GridProps, object> {
       return;
     }
 
-    const {onSave, primaryField} = this.props;
-
-    if (!onSave) {
+    if (!saveImmediately || !onSave) {
       return;
     }
 
@@ -733,9 +748,7 @@ export default class Cards extends React.Component<GridProps, object> {
       ? headerToolbarRender(
           {
             ...this.props,
-            selectedItems: store.selectedItems.map(item => item.data),
-            items: store.items.map(item => item.data),
-            unSelectedItems: store.unSelectedItems.map(item => item.data)
+            ...store.eventContext
           },
           this.renderToolbar
         )
@@ -784,9 +797,7 @@ export default class Cards extends React.Component<GridProps, object> {
       ? footerToolbarRender(
           {
             ...this.props,
-            selectedItems: store.selectedItems.map(item => item.data),
-            items: store.items.map(item => item.data),
-            unSelectedItems: store.unSelectedItems.map(item => item.data)
+            ...store.eventContext
           },
           this.renderToolbar
         )
@@ -902,7 +913,7 @@ export default class Cards extends React.Component<GridProps, object> {
       return this.renderCheckAll();
     }
 
-    return void 0;
+    return;
   }
 
   // editor中重写，请勿更改前两个参数
@@ -1231,6 +1242,10 @@ export class CardsRenderer extends Cards {
     return store.getData(data);
   }
 
+  hasModifiedItems() {
+    return this.props.store.modified;
+  }
+
   async doAction(
     action: ActionObject,
     ctx: any,
@@ -1244,9 +1259,11 @@ export class CardsRenderer extends Cards {
       case 'selectAll':
         store.clear();
         store.toggleAll();
+        this.syncSelected();
         break;
       case 'clearAll':
         store.clear();
+        this.syncSelected();
         break;
       case 'select':
         const rows = await getMatchedEventTargets<IItem>(
@@ -1260,6 +1277,7 @@ export class CardsRenderer extends Cards {
           rows.map(item => item.data),
           valueField
         );
+        this.syncSelected();
         break;
       case 'initDrag':
         store.startDragging();

--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -387,6 +387,7 @@ export default class FormTable<
     this.emitValue = this.emitValue.bind(this);
     this.tableRef = this.tableRef.bind(this);
     this.flush = this.flush.bind(this);
+    this.filterItemIndex = this.filterItemIndex.bind(this);
 
     if (addHook) {
       this.toDispose.push(addHook(this.flush, 'flush'));
@@ -1294,7 +1295,6 @@ export default class FormTable<
     const ns = this.props.classPrefix;
     const __ = this.props.translate;
     const needConfirm = this.props.needConfirm;
-    const showIndex = this.props.showIndex;
     const isStatic = this.props.static;
     const disabled = this.props.disabled;
 
@@ -1703,25 +1703,6 @@ export default class FormTable<
       }
     }
 
-    if (showIndex) {
-      columns.unshift({
-        label: __('Table.index'),
-        width: 50,
-        children: (props: any) => {
-          const indexes = this.convertToRawPath(props.rowIndexPath as string)
-            .split('.')
-            .map(item => parseInt(item, 10) + 1);
-          return (
-            <td className={props.className}>
-              {props.cellPrefix}
-              <span>{indexes.join('.')}</span>
-              {props.cellAffix}
-            </td>
-          );
-        }
-      });
-    }
-
     return columns;
   }
 
@@ -1951,6 +1932,10 @@ export default class FormTable<
     return disabled || !!this.state.editIndex;
   }
 
+  filterItemIndex(index: number | string) {
+    return this.convertToRawPath(index as string);
+  }
+
   render() {
     const {
       className,
@@ -1982,7 +1967,8 @@ export default class FormTable<
       footerAddBtn,
       toolbarClassName,
       onEvent,
-      testIdBuilder
+      testIdBuilder,
+      showIndex
     } = this.props;
     const maxLength = this.resolveVariableProps(this.props, 'maxLength');
 
@@ -1992,6 +1978,7 @@ export default class FormTable<
 
     const query = this.state.query;
     const filteredItems = this.state.filteredItems;
+    const items = this.state.items;
     let showPager = typeof perPage === 'number';
     let page = this.state.page || 1;
 
@@ -2015,7 +2002,8 @@ export default class FormTable<
             affixRow,
             autoFillHeight,
             tableContentClassName,
-            onEvent
+            onEvent,
+            showIndex
           },
           {
             ref: this.tableRef,
@@ -2044,7 +2032,8 @@ export default class FormTable<
             onQuery: this.handleTableQuery,
             query: query,
             orderBy: query?.orderBy,
-            orderDir: query?.orderDir
+            orderDir: query?.orderDir,
+            filterItemIndex: this.filterItemIndex
           }
         )}
         {footerAddBtnVisible || showPager ? (

--- a/packages/amis/src/renderers/Form/Picker.tsx
+++ b/packages/amis/src/renderers/Form/Picker.tsx
@@ -157,13 +157,13 @@ export default class PickerControl extends React.PureComponent<
         placement: 'top',
         trigger: 'hover',
         showArrow: false,
-        offset: [0, -10]
+        offset: [0, -5]
       },
       overflowTagPopoverInCRUD: {
         placement: 'bottom',
         trigger: 'hover',
         showArrow: false,
-        offset: [0, 10]
+        offset: [0, 0]
       }
     }
   };
@@ -641,7 +641,7 @@ export default class PickerControl extends React.PureComponent<
     }
 
     return (
-      <div className={`${ns}Picker-values`}>
+      <>
         {tags.map((item, index) => {
           if (enableOverflow && index === maxTagCount) {
             return (
@@ -697,7 +697,7 @@ export default class PickerControl extends React.PureComponent<
 
           return this.renderTag(item, index);
         })}
-      </div>
+      </>
     );
   }
 
@@ -804,24 +804,24 @@ export default class PickerControl extends React.PureComponent<
                 <div className={cx('Picker-placeholder')}>
                   {__(placeholder)}
                 </div>
-              ) : null}
+              ) : (
+                <div
+                  className={cx('Picker-valueWrap')}
+                  {...testIdBuilder?.getTestId()}
+                >
+                  {this.renderValues()}
 
-              <div
-                className={cx('Picker-valueWrap')}
-                {...testIdBuilder?.getTestId()}
-              >
-                {this.renderValues()}
-
-                <input
-                  onChange={noop}
-                  value={''}
-                  ref={this.input}
-                  onKeyDown={this.handleKeyDown}
-                  onClick={this.handleFocus}
-                  onBlur={this.handleBlur}
-                  readOnly={mobileUI}
-                />
-              </div>
+                  <input
+                    onChange={noop}
+                    value={''}
+                    ref={this.input}
+                    onKeyDown={this.handleKeyDown}
+                    onClick={this.handleFocus}
+                    onBlur={this.handleBlur}
+                    readOnly={mobileUI}
+                  />
+                </div>
+              )}
 
               {clearable && !disabled && selectedOptions.length ? (
                 <a onClick={this.clearValue} className={cx('Picker-clear')}>

--- a/packages/amis/src/renderers/Table/Cell.tsx
+++ b/packages/amis/src/renderers/Table/Cell.tsx
@@ -24,6 +24,7 @@ export interface CellProps extends ThemeProps {
     node: SchemaNode,
     props?: PlainObject
   ) => JSX.Element;
+  filterItemIndex?: (index: number | string, item: any) => string | number;
   store: ITableStore;
   multiple: boolean;
   canAccessSuperData?: boolean;
@@ -44,6 +45,7 @@ export default function Cell({
   props,
   ignoreDrag,
   render,
+  filterItemIndex,
   store,
   multiple,
   itemBadge,
@@ -85,8 +87,8 @@ export default function Cell({
         <Checkbox
           classPrefix={ns}
           type={multiple ? 'checkbox' : 'radio'}
-          partial={item.partial}
-          checked={item.checked || item.partial}
+          partial={multiple ? item.partial : false}
+          checked={item.checked || (multiple ? item.partial : false)}
           disabled={item.checkdisable || !item.checkable}
           onChange={onCheckboxChange}
           testIdBuilder={testIdBuilder?.getChild('chekbx')}
@@ -124,6 +126,18 @@ export default function Cell({
             <Icon icon="right-arrow-bold" className="icon" />
           </a>
         ) : null}
+      </td>
+    );
+  } else if (column.type === '__index') {
+    return (
+      <td
+        style={style}
+        className={cx(column.pristine.className, stickyClassName)}
+      >
+        {`${filterItemIndex ? filterItemIndex(item.path, item) : item.path}`
+          .split('.')
+          .map(a => parseInt(a, 10) + 1)
+          .join('.')}
       </td>
     );
   }


### PR DESCRIPTION
### What

* CRUD 渲染器支持泛型方便外围扩充
* 解决 itemCheckableOn 在顶部已选清单中依然可以删除的问题
* 调整 picker 部分样式 
* CRUD 支持直接开启可点选
* 补充 CRUD 文档，补充更多的使用场景示例
* 修复 Toast 动作弹出内容不支持模版的问题
* 修复前端分页模式事件上下文中 unSelectedItems 数据不全问题
* 事件上下文中添加 selectedIndexes 记录点选的索引位置
* 修复嵌套模式且为单选时，无法选中父级节点（因为为了照顾多选会自动选中上下级，而实际上单选不需要这么处理）
* table 新增 showIndex 属性，调整 input-table 复用 table 中的 showIndex 能力，crud 适配 showIndex
* 编辑器增加双击事件面板

### Why

### How
