### PR TITLE
chore(amis): rollup配置文件中删除未使用的变量引入，避免编译时警告

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ node_modules
 /toolkit/amis-renderer
 /toolkit/output
 /coverage
-/schema.json
 /npm
 /mock/cfc/cfc.zip
 .rollup.cache

--- a/packages/amis/rollup.config.js
+++ b/packages/amis/rollup.config.js
@@ -5,18 +5,10 @@ import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import license from 'rollup-plugin-license';
 import autoExternal from 'rollup-plugin-auto-external';
-import {
-  name,
-  version,
-  author,
-  main,
-  module,
-  dependencies
-} from './package.json';
+import {name, version, author, main, module} from './package.json';
 import path from 'path';
 import fs from 'fs';
 import svgr from '@svgr/rollup';
-import moment from 'moment';
 import babel from 'rollup-plugin-babel';
 
 const settings = {


### PR DESCRIPTION
### What

### Why
<img width="1112" alt="image" src="https://github.com/user-attachments/assets/831f8a77-19c3-4ade-a346-39414a611eae" />

### How
