### PR TITLE
chore: 删除多余的git配置，提升代码可维护性

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ node_modules
 /toolkit/amis-renderer
 /toolkit/output
 /coverage
-/schema.json
 /npm
 /mock/cfc/cfc.zip
 .rollup.cache


### PR DESCRIPTION

### What

### Why
schema.json只会被构建到packages/amis目录中，根目录中不会有该文件，且amis/.gitignore中已经忽略了schema.json
### How
