### PR TITLE
fix(amis-ui): dependencies中引入video-react@0.15.0依赖，避免_thirds.scss中引入依赖报错的问题

### DIFF
--- a/packages/amis-ui/package.json
+++ b/packages/amis-ui/package.json
@@ -73,6 +73,7 @@
     "sortablejs": "1.15.0",
     "tinymce": "^6.1.2",
     "tslib": "^2.3.1",
+    "video-react": "0.15.0",
     "uncontrollable": "7.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### What
```shell
vite v4.4.4 building for production...
✓ 53 modules transformed.
✓ built in 3.36s
[vite:css] [sass] Can't find stylesheet to import.
  ╷
7 │ @import '../../../node_modules/video-react/dist/video-react';
  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
  node_modules/amis-ui/scss/_thirds.scss 7:9         @import
  node_modules/amis-ui/scss/themes/_common.scss 1:9  @import
  node_modules/amis-ui/scss/themes/cxd.scss 5:9      @import
  node_modules/amis-ui/scss/themes/default.scss 2:9  root stylesheet
file: /Users/macbookpro/Documents/zmn/zmn-plat-menu-frontend/node_modules/amis-ui/scss/themes/default.scss
```
```shell
bash-5.1$ npm list video-react
zmn-plat-menu-frontend@1.0.0 /Users/macbookpro/Documents/zmn/zmn-plat-menu-frontend
└─┬ zmn@12.14.2-next.2
  └─┬ amis@6.10.0
    └── video-react@0.15.0

bash-5.1$ [ -d "node_modules/video-react" ] && echo "video-react directory exists" || echo "video-react directory does not exist"
video-react directory does not exist
bash-5.1$ 
```
### Why
安装依赖时，由于amis依赖video-react@0.15.0但amis-ui并没有依赖该包，由于是固定版本（没有^前缀）video-react被安装到amis/node_modules目录中，而没有被提升到根目录下的node_modules，从而导致构建依赖报错
### How

在amis-ui下面也安装video-react@0.15.0，使相同的依赖可以提升到./node_modules下在

PS:
为什么要在_third.scss中使用../../../node_modules相对路径的语法，而不是直接引入npm包的语法呢，是否可以直接修改源代码不要引入node_nodules目录？
