### PR TITLE
fix: 修复 api 配置 query 参数值中存在变量语法经过两次运算的问题

### DIFF
--- a/packages/amis/__tests__/utils/api.test.ts
+++ b/packages/amis/__tests__/utils/api.test.ts
@@ -183,6 +183,52 @@ test('api:buildApi:dataMapping', () => {
       b: 2
     }
   });
+
+  expect(
+    buildApi(
+      {
+        method: 'get',
+        url: '/api/xxx?b=${b}&c=3&d=${d}'
+      },
+      {
+        b: 2,
+        d: 'abc${123}'
+      }
+    )
+  ).toMatchObject({
+    method: 'get',
+    url: '/api/xxx?b=2&c=3&d=abc%24%7B123%7D',
+    query: {
+      b: 2,
+      c: '3',
+      d: 'abc${123}'
+    }
+  });
+
+  expect(
+    buildApi(
+      {
+        method: 'get',
+        url: '/api/xxx?c=3&d=${d}',
+        query: {
+          a: 1,
+          b: '${b}'
+        }
+      },
+      {
+        b: 2,
+        d: 'abc${123}'
+      }
+    )
+  ).toMatchObject({
+    method: 'get',
+    url: '/api/xxx?c=3&d=abc%24%7B123%7D&a=1&b=2',
+    query: {
+      a: 1,
+      b: 2,
+      d: 'abc${123}'
+    }
+  });
 });
 
 test('api:buildApi:autoAppend', () => {


### PR DESCRIPTION
### What

### Why

### How
