### PR TITLE
fix: 修复select组件change事件的选中数据问题

### DIFF
--- a/packages/amis/src/renderers/Form/Transfer.tsx
+++ b/packages/amis/src/renderers/Form/Transfer.tsx
@@ -261,6 +261,7 @@ export class BaseTransferRenderer<
     } = this.props;
     let newValue: any = value;
     let newOptions = options.concat();
+    let selectedItems = value;
 
     if (Array.isArray(value)) {
       newValue = value.map(item => {
@@ -347,7 +348,8 @@ export class BaseTransferRenderer<
       resolveEventData(this.props, {
         value: newValue,
         options,
-        items: options // 为了保持名字统一
+        items: options, // 为了保持名字统一
+        selectedItems
       })
     );
     if (rendererEvent?.prevented) {


### PR DESCRIPTION
### What
解决 https://github.com/baidu/amis/issues/11431 ，当设置了 selectMode 后触发的 change 事件未能正确包含 selectedItems

### Why
使用了 BaseTransferRenderer 进行渲染，但是未实现 change 事件中透传 selectedItems

### How
BaseTransferRenderer 的 chang 事件处理器中透传选中的值