### PR TITLE
feat: 为carousel增加纵向模式和鼠标滑动模式

### DIFF
--- a/packages/amis-ui/scss/components/_carousel.scss
+++ b/packages/amis-ui/scss/components/_carousel.scss
@@ -202,4 +202,65 @@
     z-index: 100;
     text-align: center;
   }
+
+  &-vertical.#{$ns}Carousel {
+    .#{$ns}Carousel-dotsControl {
+      right: 0;
+      bottom: auto;
+      height: 100%;
+      width: auto;
+      display: flex;
+      flex-direction: column;
+      top: 0;
+      justify-content: center;
+    }
+    .#{$ns}Carousel-leftArrow, .#{$ns}Carousel-rightArrow {
+      height: 10%;
+      width: 100%;
+      left: 0;
+      right: 0;
+      bottom: unset;
+    }
+    .#{$ns}Carousel-leftArrow {
+      top: 0;
+      svg {
+        transform: translate(-50%, -50%) rotate(90deg);
+      }
+    }
+    .#{$ns}Carousel-rightArrow {
+      bottom: 0;
+      top: unset;
+      svg {
+        transform: translate(-50%, -50%) rotate(90deg);
+      }
+    }
+
+    .#{$ns}Carousel-item.slide {
+      transform: translateY(100%);
+    }
+
+    .#{$ns}Carousel-item.slide.in {
+      transform: translateY(0);
+    }
+
+    .#{$ns}Carousel-item.slide.out {
+      transform: translateY(-100%);
+    }
+
+    .#{$ns}Carousel-item.slideRight {
+      transform: translateY(-100%);
+    }
+
+    .#{$ns}Carousel-item.slideRight.in {
+      transform: translateY(0);
+    }
+
+    .#{$ns}Carousel-item.slideRight.out {
+      transform: translateY(100%);
+    }
+  }
+
+  img {
+    pointer-events: none;
+  }
 }


### PR DESCRIPTION
### What
为carousel增加纵向模式和鼠标滑动模式。增加了如下配置：
/**
   * 轮播图方向，默认为水平方向
   */
  direction?: 'horizontal' | 'vertical';

  /**
   * 是否循环播放, 默认为 true。
   */
  loop?: boolean;

  /**
   * 是否支持鼠标事件
   * 默认为 true。
   */
  mouseEvent?: boolean;
### Why
carousel目前只支持横向模式，而且翻页只能通过点击和自动翻页。增加滑动模式后，支持页面在移动端的滑动来操作翻页
### How
在componentDidMount后通过监听mousedown/mouseup/mouseleave/touchstart/touchend事件，在鼠标/手势移动超过20px后，认为滑动。并且禁用了image的交互来防止对图片的拖拽