### PR TITLE
fix: 增加height允许传入字符串类型，兼容滑动过程中元素被其他元素获取焦点时事件缺少touchlist

### DIFF
--- a/packages/amis/src/renderers/Carousel.tsx
+++ b/packages/amis/src/renderers/Carousel.tsx
@@ -488,10 +488,16 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
     if ((event as MouseEvent<HTMLDivElement>).screenX !== undefined) {
       screenX = (event as MouseEvent<HTMLDivElement>).screenX;
       screenY = (event as MouseEvent<HTMLDivElement>).screenY;
-    } else {
-      // 兼容触摸事件有的时候touches列表为空的情况（焦点被其他元素获取）
-      screenX = (event as TouchEvent<HTMLDivElement>)?.touches?.[0]?.screenX;
-      screenY = (event as TouchEvent<HTMLDivElement>)?.touches?.[0]?.screenY;
+    } else if ((event as TouchEvent<HTMLDivElement>).touches?.length) {
+      // touchStart 事件
+      screenX = (event as TouchEvent<HTMLDivElement>).touches[0]?.screenX;
+      screenY = (event as TouchEvent<HTMLDivElement>).touches[0]?.screenY;
+    } else if ((event as TouchEvent<HTMLDivElement>).changedTouches?.length) {
+      // touchEnd 事件
+      screenX = (event as TouchEvent<HTMLDivElement>).changedTouches[0]
+        ?.screenX;
+      screenY = (event as TouchEvent<HTMLDivElement>).changedTouches[0]
+        ?.screenY;
     }
 
     return {

--- a/packages/amis/src/renderers/Carousel.tsx
+++ b/packages/amis/src/renderers/Carousel.tsx
@@ -581,15 +581,15 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
     // 不允许传0，需要有最小高度
     if (width) {
       // 数字类型认为是px单位，否则传入字符串直接赋给style对象
-      typeof width === 'number'
+      !isNaN(Number(width))
         ? (carouselStyles.width = width + 'px')
-        : (carouselStyles.width = width);
+        : (carouselStyles.width = width as string);
     }
 
     if (height) {
-      typeof height === 'number'
+      !isNaN(Number(height))
         ? (carouselStyles.height = height + 'px')
-        : (carouselStyles.height = height);
+        : (carouselStyles.height = height as string);
     }
 
     const [dots, arrows] = [


### PR DESCRIPTION
### What
增加height允许传入字符串类型，修复touchEnd使用事件中changedTouches属性获取鼠标坐标
### Why
1. 高度和宽度有时需要传入100%字符串类型
2. 修复touchEnd使用事件中changedTouches属性获取鼠标坐标
### How
