### PR TITLE
fix: 图片展示的标题和描述居中样式设置效果不符合预期 (#11454)

### DIFF
--- a/packages/amis-ui/scss/components/_images.scss
+++ b/packages/amis-ui/scss/components/_images.scss
@@ -65,7 +65,7 @@
   }
 
   &--thumb &-info {
-    width: px2rem(110px);
+    width: 100%;
     padding: 0;
   }
 


### PR DESCRIPTION
### What

### Why

### How
