### PR TITLE
fix(amis-ui): 使用svg链接作为图标源时默认不将其转换成DOM渲染，以便向下兼容

### DIFF
--- a/packages/amis-ui/src/components/icons.tsx
+++ b/packages/amis-ui/src/components/icons.tsx
@@ -305,7 +305,16 @@ function svgString2Dom(
 function LinkIcon({
   icon,
   vendor,
-  options: {className, classNameProp, style, cx, classPrefix, events, extra}
+  options: {
+    className,
+    classNameProp,
+    style,
+    cx,
+    classPrefix,
+    events,
+    extra,
+    convertSvgLinkToDom = false
+  }
 }: {
   icon: string;
   vendor?: string;
@@ -314,7 +323,7 @@ function LinkIcon({
   };
 }) {
   const [svgIcon, setSvgIcon] = React.useState<string | undefined>(undefined);
-  if (icon.endsWith('.svg')) {
+  if (icon.endsWith('.svg') && convertSvgLinkToDom) {
     useEffect(() => {
       try {
         fetch(icon)
@@ -394,7 +403,8 @@ export function Icon({
   width,
   height,
   extra,
-  testIdBuilder
+  testIdBuilder,
+  convertSvgLinkToDom = false
 }: {
   icon: string;
   iconContent?: string;
@@ -569,7 +579,8 @@ export function Icon({
           cx,
           classPrefix,
           events,
-          extra
+          extra,
+          convertSvgLinkToDom
         }}
       />
     );


### PR DESCRIPTION
Closes #11503

看看这样修改是否可行，可行再添加单元测试