### PR TITLE
fix: 部分情况下，select树模式中全选、多选不生效

### DIFF
--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -1460,7 +1460,7 @@ export class TreeSelector extends React.Component<
     const {options, onlyChildren, valueField} = this.props;
     const flattendOptions = flattenTree(options, item =>
       onlyChildren
-        ? item.children
+        ? item.children?.length
           ? null
           : item
         : this.isEmptyOrNotExist(item[valueField || 'value'])

--- a/packages/amis/src/renderers/Form/Select.tsx
+++ b/packages/amis/src/renderers/Form/Select.tsx
@@ -719,7 +719,8 @@ class TransferDropdownRenderer extends BaseTransferRenderer<TransferDropDownProp
       showInvalidMatch,
       checkAll,
       checkAllLabel,
-      overlay
+      overlay,
+      valueField
     } = this.props;
 
     // 目前 LeftOptions 没有接口可以动态加载
@@ -776,6 +777,7 @@ class TransferDropdownRenderer extends BaseTransferRenderer<TransferDropDownProp
           checkAllLabel={checkAllLabel}
           checkAll={checkAll}
           overlay={overlay}
+          valueField={valueField}
         />
 
         <Spinner


### PR DESCRIPTION
设置valueField 或者 children为空数组时，select树模式中全选、多选不生效