### PR TITLE
feat: Nav组件增加悬浮面板模式

### DIFF
--- a/docs/zh-CN/components/nav.md
+++ b/docs/zh-CN/components/nav.md
@@ -640,7 +640,6 @@ order: 58
             "children": [
                 {
                     "label": "Nav 9-1",
-                    "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
                     "to": "?to=nav9-1",
                     "children": [
                         {
@@ -650,7 +649,6 @@ order: 58
                         },
                         {
                             "label": "Nav 9-1-2",
-                            "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
                             "to": "?to=nav9-1-2"
                         }
                     ]

--- a/docs/zh-CN/components/nav.md
+++ b/docs/zh-CN/components/nav.md
@@ -423,6 +423,249 @@ order: 58
 }
 ```
 
+## 悬浮面板模式
+
+设置`mode`属性为 panel，开启悬浮面板模式，最多支持 3 级菜单
+
+```schema: scope="body"
+{
+    "type": "nav",
+    "stacked": false,
+    "mode": "panel",
+    "overflow": {
+        "enable": true
+    },
+    "links": [
+        {
+            "label": "Nav 4",
+            "to": "?to=nav4",
+            "children": [
+                {
+                    "label": "Nav 4-1",
+                    "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                    "to": "?to=nav13"
+                },
+                {
+                    "label": "Nav 4-2",
+                    "icon": "fa fa-user",
+                    "to": "?to=nav13"
+                }
+            ]
+        },
+        {
+            "label": "Nav 5",
+            "to": "?to=nav5",
+            "children": [
+                {
+                    "label": "Nav 5-1",
+                    "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                    "to": "?to=nav13",
+                    "children": [
+                        {
+                            "label": "Nav 5-1-1",
+                            "icon": "fa fa-user",
+                            "to": "?to=nav13"
+                        },
+                        {
+                            "label": "Nav 5-1-2",
+                            "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                            "to": "http://www.baidu.com/",
+                            "target": "_blank"
+                        }
+                    ]
+                },
+                {
+                    "label": "Nav 5-2",
+                    "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                    "to": "?to=nav13"
+                }
+            ]
+        },
+        {
+            "label": "Nav 6",
+            "to": "?to=nav6"
+        },
+        {
+            "label": "Nav 7",
+            "to": "?to=nav7"
+        },
+        {
+            "label": "Nav 8",
+            "to": "?to=nav8"
+        },
+        {
+            "label": "Nav 9",
+            "to": "?to=nav9"
+        },
+        {
+            "label": "Nav 10",
+            "to": "?to=nav10"
+        },
+        {
+            "label": "Nav 11",
+            "to": "?to=nav11",
+            "children": [
+                {
+                    "label": "Nav 13",
+                    "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                    "to": "?to=nav13"
+                }
+            ]
+        },
+        {
+            "label": "Nav 12",
+            "to": "?to=nav12",
+            "children": [
+                {
+                    "label": "Nav 12-1",
+                    "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                    "to": "?to=nav13",
+                    "children": [
+                        {
+                            "label": "Nav 12-1-1",
+                            "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                            "to": "?to=nav13"
+                        },
+                        {
+                            "label": "Nav 12-1-2",
+                            "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                            "to": "?to=nav13"
+                        }
+                    ]
+                },
+                {
+                    "label": "Nav 5-2",
+                    "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                    "to": "?to=nav13"
+                }
+            ]
+        }
+    ]
+}
+```
+
+设置竖向展示
+
+```schema: scope="body"
+{
+    "type": "nav",
+    "stacked": true,
+    "mode": "panel",
+    "overflow": {
+        "enable": true
+    },
+    "style": {
+      "width": 200
+    },
+    "links": [
+        {
+            "label": "Nav 4",
+            "to": "?to=nav4",
+            "children": [
+                {
+                    "label": "Nav 4-1",
+                    "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                    "to": "?to=nav13"
+                },
+                {
+                    "label": "Nav 4-2",
+                    "icon": "fa fa-user",
+                    "to": "?to=nav13"
+                }
+            ]
+        },
+        {
+            "label": "Nav 5",
+            "to": "?to=nav5",
+            "children": [
+                {
+                    "label": "Nav 5-1",
+                    "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                    "to": "?to=nav13",
+                    "children": [
+                        {
+                            "label": "Nav 5-1-1",
+                            "icon": "fa fa-user",
+                            "to": "?to=nav13"
+                        },
+                        {
+                            "label": "Nav 5-1-2",
+                            "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                            "to": "http://www.baidu.com/",
+                            "target": "_blank"
+                        }
+                    ]
+                },
+                {
+                    "label": "Nav 5-2",
+                    "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                    "to": "?to=nav13"
+                }
+            ]
+        },
+        {
+            "label": "Nav 6",
+            "to": "?to=nav6"
+        },
+        {
+            "label": "Nav 7",
+            "to": "?to=nav7"
+        },
+        {
+            "label": "Nav 8",
+            "to": "?to=nav8"
+        },
+        {
+            "label": "Nav 9",
+            "to": "?to=nav9"
+        },
+        {
+            "label": "Nav 10",
+            "to": "?to=nav10"
+        },
+        {
+            "label": "Nav 11",
+            "to": "?to=nav11",
+            "children": [
+                {
+                    "label": "Nav 13",
+                    "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                    "to": "?to=nav13"
+                }
+            ]
+        },
+        {
+            "label": "Nav 12",
+            "to": "?to=nav12",
+            "children": [
+                {
+                    "label": "Nav 12-1",
+                    "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                    "to": "?to=nav13",
+                    "children": [
+                        {
+                            "label": "Nav 12-1-1",
+                            "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                            "to": "?to=nav13"
+                        },
+                        {
+                            "label": "Nav 12-1-2",
+                            "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                            "to": "?to=nav13"
+                        }
+                    ]
+                },
+                {
+                    "label": "Nav 5-2",
+                    "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
+                    "to": "?to=nav13"
+                }
+            ]
+        }
+    ]
+}
+```
+
 ## 导航缩起
 
 `collapsed`属性控制导航的展开和缩起，缩起状态下，导航内容仅展示图标或第一个文字，悬浮展开全部内容或子导航项
@@ -790,7 +1033,7 @@ order: 58
 | 属性名                            | 类型                                      | 默认值                          | 说明                                                                                     | 版本    |
 | --------------------------------- | ----------------------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------- | ------- |
 | type                              | `string`                                  | `"nav"`                         | 指定为 Nav 渲染器                                                                        |
-| mode                              | `string`                                  | `"inline"`                      | 导航模式，悬浮或者内联，默认内联模式                                                     |
+| mode                              | `string`                                  | `"inline"`                      | 导航模式，悬浮/内联/悬浮面板，默认内联模式                                               |
 | collapsed                         | `boolean`                                 |                                 | 控制导航是否缩起                                                                         |
 | indentSize                        | `number`                                  | `16`                            | 层级缩进值，仅内联模式下生效                                                             |
 | level                             | `number`                                  |                                 | 控制导航最大展示层级数                                                                   |

--- a/docs/zh-CN/components/nav.md
+++ b/docs/zh-CN/components/nav.md
@@ -437,37 +437,37 @@ order: 58
     },
     "links": [
         {
-            "label": "Nav 4",
-            "to": "?to=nav4",
+            "label": "Nav 1",
+            "to": "?to=nav1",
             "children": [
                 {
-                    "label": "Nav 4-1",
+                    "label": "Nav 1-1",
                     "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
-                    "to": "?to=nav13"
+                    "to": "?to=nav1-1"
                 },
                 {
-                    "label": "Nav 4-2",
+                    "label": "Nav 1-2",
                     "icon": "fa fa-user",
-                    "to": "?to=nav13"
+                    "to": "?to=nav1-2"
                 }
             ]
         },
         {
-            "label": "Nav 5",
-            "to": "?to=nav5",
+            "label": "Nav 2",
+            "to": "?to=nav2",
             "children": [
                 {
-                    "label": "Nav 5-1",
+                    "label": "Nav 2-1",
                     "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
-                    "to": "?to=nav13",
+                    "to": "?to=nav2-1",
                     "children": [
                         {
-                            "label": "Nav 5-1-1",
+                            "label": "Nav 2-1-1",
                             "icon": "fa fa-user",
-                            "to": "?to=nav13"
+                            "to": "?to=nav2-1-1"
                         },
                         {
-                            "label": "Nav 5-1-2",
+                            "label": "Nav 2-1-2",
                             "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
                             "to": "http://www.baidu.com/",
                             "target": "_blank"
@@ -475,11 +475,23 @@ order: 58
                     ]
                 },
                 {
-                    "label": "Nav 5-2",
+                    "label": "Nav 2-2",
                     "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
-                    "to": "?to=nav13"
+                    "to": "?to=nav2-2"
                 }
             ]
+        },
+        {
+            "label": "Nav 3",
+            "to": "?to=nav3"
+        },
+        {
+            "label": "Nav 4",
+            "to": "?to=nav4"
+        },
+        {
+            "label": "Nav 5",
+            "to": "?to=nav5"
         },
         {
             "label": "Nav 6",
@@ -491,52 +503,40 @@ order: 58
         },
         {
             "label": "Nav 8",
-            "to": "?to=nav8"
-        },
-        {
-            "label": "Nav 9",
-            "to": "?to=nav9"
-        },
-        {
-            "label": "Nav 10",
-            "to": "?to=nav10"
-        },
-        {
-            "label": "Nav 11",
-            "to": "?to=nav11",
+            "to": "?to=nav8",
             "children": [
                 {
-                    "label": "Nav 13",
+                    "label": "Nav 8-1",
                     "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
-                    "to": "?to=nav13"
+                    "to": "?to=nav8-1"
                 }
             ]
         },
         {
-            "label": "Nav 12",
-            "to": "?to=nav12",
+            "label": "Nav 9",
+            "to": "?to=nav9",
             "children": [
                 {
-                    "label": "Nav 12-1",
+                    "label": "Nav 9-1",
                     "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
-                    "to": "?to=nav13",
+                    "to": "?to=nav9-1",
                     "children": [
                         {
-                            "label": "Nav 12-1-1",
+                            "label": "Nav 9-1-1",
                             "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
-                            "to": "?to=nav13"
+                            "to": "?to=nav9-1-1"
                         },
                         {
-                            "label": "Nav 12-1-2",
+                            "label": "Nav 9-1-2",
                             "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
                             "to": "?to=nav13"
                         }
                     ]
                 },
                 {
-                    "label": "Nav 5-2",
+                    "label": "Nav 9-2",
                     "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
-                    "to": "?to=nav13"
+                    "to": "?to=nav9-2"
                 }
             ]
         }
@@ -559,37 +559,37 @@ order: 58
     },
     "links": [
         {
-            "label": "Nav 4",
-            "to": "?to=nav4",
+            "label": "Nav 1",
+            "to": "?to=nav1",
             "children": [
                 {
-                    "label": "Nav 4-1",
+                    "label": "Nav 1-1",
                     "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
-                    "to": "?to=nav13"
+                    "to": "?to=nav1-1"
                 },
                 {
-                    "label": "Nav 4-2",
+                    "label": "Nav 1-2",
                     "icon": "fa fa-user",
-                    "to": "?to=nav13"
+                    "to": "?to=nav1-2"
                 }
             ]
         },
         {
-            "label": "Nav 5",
-            "to": "?to=nav5",
+            "label": "Nav 2",
+            "to": "?to=nav2",
             "children": [
                 {
-                    "label": "Nav 5-1",
+                    "label": "Nav 2-1",
                     "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
-                    "to": "?to=nav13",
+                    "to": "?to=nav2-1",
                     "children": [
                         {
-                            "label": "Nav 5-1-1",
+                            "label": "Nav 2-1-1",
                             "icon": "fa fa-user",
-                            "to": "?to=nav13"
+                            "to": "?to=nav2-1-1"
                         },
                         {
-                            "label": "Nav 5-1-2",
+                            "label": "Nav 2-1-2",
                             "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
                             "to": "http://www.baidu.com/",
                             "target": "_blank"
@@ -597,11 +597,23 @@ order: 58
                     ]
                 },
                 {
-                    "label": "Nav 5-2",
+                    "label": "Nav 2-2",
                     "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
-                    "to": "?to=nav13"
+                    "to": "?to=nav2-2"
                 }
             ]
+        },
+        {
+            "label": "Nav 3",
+            "to": "?to=nav3"
+        },
+        {
+            "label": "Nav 4",
+            "to": "?to=nav4"
+        },
+        {
+            "label": "Nav 5",
+            "to": "?to=nav5"
         },
         {
             "label": "Nav 6",
@@ -613,52 +625,40 @@ order: 58
         },
         {
             "label": "Nav 8",
-            "to": "?to=nav8"
-        },
-        {
-            "label": "Nav 9",
-            "to": "?to=nav9"
-        },
-        {
-            "label": "Nav 10",
-            "to": "?to=nav10"
-        },
-        {
-            "label": "Nav 11",
-            "to": "?to=nav11",
+            "to": "?to=nav8",
             "children": [
                 {
-                    "label": "Nav 13",
+                    "label": "Nav 8-1",
                     "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
-                    "to": "?to=nav13"
+                    "to": "?to=nav8-1"
                 }
             ]
         },
         {
-            "label": "Nav 12",
-            "to": "?to=nav12",
+            "label": "Nav 9",
+            "to": "?to=nav9",
             "children": [
                 {
-                    "label": "Nav 12-1",
+                    "label": "Nav 9-1",
                     "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
-                    "to": "?to=nav13",
+                    "to": "?to=nav9-1",
                     "children": [
                         {
-                            "label": "Nav 12-1-1",
+                            "label": "Nav 9-1-1",
                             "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
-                            "to": "?to=nav13"
+                            "to": "?to=nav9-1-1"
                         },
                         {
-                            "label": "Nav 12-1-2",
+                            "label": "Nav 9-1-2",
                             "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
-                            "to": "?to=nav13"
+                            "to": "?to=nav9-1-2"
                         }
                     ]
                 },
                 {
-                    "label": "Nav 5-2",
+                    "label": "Nav 9-2",
                     "icon": "https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg",
-                    "to": "?to=nav13"
+                    "to": "?to=nav9-2"
                 }
             ]
         }

--- a/packages/amis-ui/scss/components/_menu.scss
+++ b/packages/amis-ui/scss/components/_menu.scss
@@ -162,6 +162,7 @@
       display: none;
     }
   }
+
   &-panel {
     &-wrapper {
       display: flex;
@@ -173,13 +174,23 @@
       display: flex;
       align-items: center;
       color: var(--Menu-light-fontColor);
+      font-size: var(--Nav-item-fontSize);
 
       &:hover {
         color: var(--Menu-light-fontColor-onHover);
       }
+      
+      &__icon-wrapper {
+        width: var(--Tabs-linkFontSize);
+        height: var(--Tabs-linkFontSize);
+        line-height: var(--Tabs-linkFontSize);
+        margin-right: 8px;
+      }
 
       &__icon {
-        margin-right: 8px;
+        fill: currentColor;
+        width: 100%;
+        height: 100%;
       }
 
       &__label {
@@ -382,6 +393,7 @@
   &-vertical.#{$ns}Nav-Menu-sub {
     min-width: px2rem(160px);
   }
+  
 
   &-item,
   &-submenu-title {

--- a/packages/amis-ui/scss/components/_menu.scss
+++ b/packages/amis-ui/scss/components/_menu.scss
@@ -162,6 +162,52 @@
       display: none;
     }
   }
+  &-panel {
+    &-wrapper {
+      display: flex;
+      width: 100%;
+      padding: 12px;
+    }
+
+    &-item {
+      display: flex;
+      align-items: center;
+      color: var(--Menu-light-fontColor);
+
+      &:hover {
+        color: var(--Menu-light-fontColor-onHover);
+      }
+
+      &__icon {
+        margin-right: 8px;
+      }
+
+      &__label {
+        &.is-group-header {
+          color: var(--Menu-light-groupTitle-fontColor);
+        }
+      }
+    }
+
+    &-group {
+      display: flex;
+      width: 100%;
+
+      &-item {
+        min-width: 120px;
+
+        &__header {
+          border-bottom: 1px solid #e8e8e8;
+          margin-bottom: 10px;
+          margin-bottom: 10px;
+        }
+      }
+
+      &-item + &-item {
+        margin-left: 16px;
+      }
+    }
+  }
 
   &-overflow-item {
     flex: none;

--- a/packages/amis-ui/src/components/menu/MenuContext.tsx
+++ b/packages/amis-ui/src/components/menu/MenuContext.tsx
@@ -6,7 +6,7 @@
 
 import {createContext} from 'react';
 import type {SubMenuProps} from './SubMenu';
-import {NavigationItem} from './index';
+import type {NavigationItem} from './';
 export interface MenuContextProps {
   /**
    * 主题色

--- a/packages/amis-ui/src/components/menu/MenuContext.tsx
+++ b/packages/amis-ui/src/components/menu/MenuContext.tsx
@@ -6,7 +6,7 @@
 
 import {createContext} from 'react';
 import type {SubMenuProps} from './SubMenu';
-
+import {NavigationItem} from './index';
 export interface MenuContextProps {
   /**
    * 主题色
@@ -26,10 +26,10 @@ export interface MenuContextProps {
   /**
    * 布局
    *
-   * @type {('inline' | 'float')}
+   * @type {('inline' | 'float' | 'panel')}
    * @memberof MenuContextProps
    */
-  mode?: 'inline' | 'float';
+  mode?: 'inline' | 'float' | 'panel';
 
   /**
    * mode不为horizontal时
@@ -77,6 +77,16 @@ export interface MenuContextProps {
     key: string;
     domEvent: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>;
     props: SubMenuProps;
+  }) => void;
+
+  /**
+   * 面板菜单中的菜单项点击事件
+   */
+  onPanelMenuClick?: (PanelItemMenuInfo: {
+    key: string;
+    domEvent: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>;
+    keyPath: string[];
+    props: NavigationItem;
   }) => void;
 
   onDragStart?: (

--- a/packages/amis-ui/src/components/menu/PanelMenu.tsx
+++ b/packages/amis-ui/src/components/menu/PanelMenu.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import type {NavigationItem} from './index';
+import type {NavigationItem} from './';
 import {ClassNamesFn, themeable} from 'amis-core';
 import {Item as RcItem} from 'rc-menu';
 import {MenuContextProps, MenuContext} from './MenuContext';

--- a/packages/amis-ui/src/components/menu/PanelMenu.tsx
+++ b/packages/amis-ui/src/components/menu/PanelMenu.tsx
@@ -1,0 +1,134 @@
+/**
+ * @file PanelMenu
+ * @description 导航子菜单
+ * @author fex
+ */
+
+import React from 'react';
+import {NavigationItem} from './index';
+import {ClassNamesFn, themeable} from 'amis-core';
+import {Item as RcItem} from 'rc-menu';
+import {MenuContextProps, MenuContext} from './MenuContext';
+
+// 判断是否为图片路径
+function isImgPath(raw: string) {
+  return (
+    typeof raw === 'string' && (!!~raw.indexOf('.') || /^\/images\//.test(raw))
+  );
+}
+
+interface PanelMenuProps extends NavigationItem {
+  cx: ClassNamesFn;
+}
+
+/**
+ * 面板菜单 菜单项组件
+ */
+function PanelMenuItem(props: PanelMenuProps) {
+  const {cx, isGroupHeader, link, label} = props;
+  const context: MenuContextProps = React.useContext(MenuContext);
+  const {onPanelMenuClick} = context;
+
+  function onMenuClick({domEvent, keyPath}: any) {
+    onPanelMenuClick?.({key: props.id || '', domEvent, props, keyPath});
+  }
+
+  return (
+    <RcItem key={props.id} {...props} onClick={onMenuClick}>
+      <div className={cx('Nav-Menu-panel-item')}>
+        {isImgPath(link?.icon) ? (
+          <img
+            className={cx(`Nav-Menu-panel-item__icon`)}
+            width="14px"
+            src={link?.icon}
+          />
+        ) : (
+          <i className={cx(`Nav-Menu-panel-item__icon`, link.icon)} />
+        )}
+        <span
+          className={cx(
+            'Nav-Menu-panel-item__label',
+            isGroupHeader ? 'is-group-header' : ''
+          )}
+        >
+          {label}
+        </span>
+      </div>
+    </RcItem>
+  );
+}
+
+interface PanelMenuGroupProps {
+  cx: ClassNamesFn;
+  children?: Array<NavigationItem>;
+}
+/**
+ * 面板菜单 菜单分组
+ */
+function PanelMenuGroup(props: PanelMenuGroupProps) {
+  const {cx, children = []} = props;
+  return (
+    <div className={cx('Nav-Menu-panel-group')}>
+      {children.map((child: NavigationItem) => (
+        <div key={child.id} className={cx('Nav-Menu-panel-group-item')}>
+          <div className={cx('Nav-Menu-panel-group-item__header')}>
+            <PanelMenuItem
+              cx={cx}
+              {...child}
+              isGroupHeader={true}
+            ></PanelMenuItem>
+          </div>
+          <div className={cx('Nav-Menu-panel-group-item__content')}>
+            {child?.children?.map((subChild: NavigationItem) => (
+              <PanelMenuItem
+                key={subChild.id}
+                cx={cx}
+                {...subChild}
+              ></PanelMenuItem>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface PanelMenuListProps {
+  cx: ClassNamesFn;
+  children?: Array<NavigationItem>;
+}
+/**
+ * 面板菜单 菜单列表
+ */
+function PanelMenuList(props: PanelMenuListProps) {
+  const {cx, children = []} = props;
+  return (
+    <div className={cx('Nav-Menu-panel-list')}>
+      {children.map((child: NavigationItem) => (
+        <PanelMenuItem key={child.id} cx={cx} {...child}></PanelMenuItem>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * 面板菜单
+ */
+function PanelMenu(props: NavigationItem) {
+  const {classnames: cx, children = []} = props;
+  // 是否有三级菜单
+  const hasThirdLevelMenu = children?.some(
+    (child: any) => child?.children?.length
+  );
+  return (
+    <section key={props.id} className={cx('Nav-Menu-panel-wrapper')}>
+      {hasThirdLevelMenu ? (
+        <PanelMenuGroup cx={cx} children={children} />
+      ) : (
+        <PanelMenuList cx={cx} children={children} />
+      )}
+    </section>
+  );
+}
+
+export default themeable(PanelMenu);

--- a/packages/amis-ui/src/components/menu/PanelMenu.tsx
+++ b/packages/amis-ui/src/components/menu/PanelMenu.tsx
@@ -5,18 +5,11 @@
  */
 
 import React from 'react';
-import {NavigationItem} from './index';
+import type {NavigationItem} from './index';
 import {ClassNamesFn, themeable} from 'amis-core';
 import {Item as RcItem} from 'rc-menu';
 import {MenuContextProps, MenuContext} from './MenuContext';
-
-// 判断是否为图片路径
-function isImgPath(raw: string) {
-  return (
-    typeof raw === 'string' && (!!~raw.indexOf('.') || /^\/images\//.test(raw))
-  );
-}
-
+import Icon from '../Icon';
 interface PanelMenuProps extends NavigationItem {
   cx: ClassNamesFn;
 }
@@ -36,14 +29,13 @@ function PanelMenuItem(props: PanelMenuProps) {
   return (
     <RcItem key={props.id} {...props} onClick={onMenuClick}>
       <div className={cx('Nav-Menu-panel-item')}>
-        {isImgPath(link?.icon) ? (
-          <img
-            className={cx(`Nav-Menu-panel-item__icon`)}
-            width="14px"
-            src={link?.icon}
-          />
-        ) : (
-          <i className={cx(`Nav-Menu-panel-item__icon`, link.icon)} />
+        {!!link?.icon && (
+          <span className={cx(`Nav-Menu-panel-item__icon-wrapper`)}>
+            <Icon
+              className={cx(`Nav-Menu-panel-item__icon`)}
+              icon={link?.icon}
+            />
+          </span>
         )}
         <span
           className={cx(
@@ -78,15 +70,13 @@ function PanelMenuGroup(props: PanelMenuGroupProps) {
               isGroupHeader={true}
             ></PanelMenuItem>
           </div>
-          <div className={cx('Nav-Menu-panel-group-item__content')}>
-            {child?.children?.map((subChild: NavigationItem) => (
-              <PanelMenuItem
-                key={subChild.id}
-                cx={cx}
-                {...subChild}
-              ></PanelMenuItem>
-            ))}
-          </div>
+          {child?.children?.map((subChild: NavigationItem) => (
+            <PanelMenuItem
+              key={subChild.id}
+              cx={cx}
+              {...subChild}
+            ></PanelMenuItem>
+          ))}
         </div>
       ))}
     </div>

--- a/packages/amis/__tests__/renderers/Nav.test.tsx
+++ b/packages/amis/__tests__/renderers/Nav.test.tsx
@@ -1151,3 +1151,72 @@ test('Renderer:Nav with updateItems', async () => {
     ).length
   ).toEqual(2);
 });
+
+// 14.Nav悬浮面板
+test('Render Nav with panel mode', async () => {
+  const {container} = render(
+    amisRender(
+      {
+        type: 'nav',
+        stacked: false,
+        mode: 'panel',
+        links: [
+          {
+            label: 'Nav 1',
+            to: '?to=nav1',
+            children: [
+              {
+                label: 'Nav 1-1',
+                icon: 'https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg',
+                to: '?to=nav1-1'
+              },
+              {
+                label: 'Nav 1-2',
+                icon: 'fa fa-user',
+                to: '?to=nav1-2'
+              }
+            ]
+          },
+          {
+            label: 'Nav 2',
+            to: '?to=nav2',
+            children: [
+              {
+                label: 'Nav 2-1',
+                icon: 'https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg',
+                to: '?to=nav2-1',
+                children: [
+                  {
+                    label: 'Nav 2-1-1',
+                    icon: 'fa fa-user',
+                    to: '?to=nav2-1-1'
+                  },
+                  {
+                    label: 'Nav 2-1-2',
+                    icon: 'https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg',
+                    to: 'http://www.baidu.com/',
+                    target: '_blank'
+                  }
+                ]
+              },
+              {
+                label: 'Nav 2-2',
+                icon: 'https://suda.cdn.bcebos.com/images%2F2021-01%2Fdiamond.svg',
+                to: '?to=nav2-2'
+              }
+            ]
+          },
+          {
+            label: 'Nav 3',
+            to: '?to=nav3'
+          }
+        ]
+      },
+      {},
+      makeEnv({})
+    )
+  );
+  expect(container).toMatchSnapshot();
+  let panelItemsSelector = '.cxd-Nav-Menu-panel-wrapper .cxd-Nav-Menu-panel-group-item';
+  expect(container.querySelectorAll(panelItemsSelector).length).toBe(2);
+});

--- a/packages/amis/__tests__/renderers/Nav.test.tsx
+++ b/packages/amis/__tests__/renderers/Nav.test.tsx
@@ -1216,7 +1216,6 @@ test('Render Nav with panel mode', async () => {
       makeEnv({})
     )
   );
-  expect(container).toMatchSnapshot();
   let panelItemsSelector = '.cxd-Nav-Menu-panel-wrapper .cxd-Nav-Menu-panel-group-item';
   expect(container.querySelectorAll(panelItemsSelector).length).toBe(2);
 });

--- a/packages/amis/src/renderers/Nav.tsx
+++ b/packages/amis/src/renderers/Nav.tsx
@@ -244,7 +244,7 @@ export interface NavSchema extends BaseSchema {
   /**
    * 垂直模式 非折叠状态下 控制菜单打开方式
    */
-  mode?: 'float' | 'inline'; // float（悬浮）inline（内联） 默认inline
+  mode?: 'panel' | 'float' | 'inline'; // panel（悬浮面板） float（悬浮）inline（内联） 默认inline
 
   /**
    * 自定义展开图标


### PR DESCRIPTION
### What

扩展了Nav组件的mode参数，设置mode为panel后，用悬浮面板展示Nav的二级、三级菜单。最大支持到三级。

### Why

实现效果
![image](https://github.com/user-attachments/assets/d6f6e604-307e-4f9d-a0db-8b2fdd001100)

### How

调整amis renders中的Nav、 amis ui 中的Menu，增加mode参数。在amis ui的Menu中控制渲染，当mode:panel时，使用PanelMenu组件渲染导航的二级、三级菜单。
