### PR TITLE
fix(Form): 修复 FormItem 的 colSize 属性逻辑

### DIFF
--- a/packages/amis-core/src/renderers/Form.tsx
+++ b/packages/amis-core/src/renderers/Form.tsx
@@ -1838,6 +1838,8 @@ export default class Form extends React.Component<FormProps, object> {
                   flex:
                     colSize && !['1', 'auto'].includes(colSize)
                       ? `0 0 ${colSize}`
+                      : colSize === undefined || colSize === null
+                      ? undefined
                       : '1'
                 }}
               >

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/combo.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/combo.test.tsx.snap
@@ -94,7 +94,6 @@ exports[`Renderer:combo with addable & addattop & addBtn & addButtonText & addBu
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -208,7 +207,6 @@ exports[`Renderer:combo with addable & addattop & addBtn & addButtonText & addBu
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -271,7 +269,6 @@ exports[`Renderer:combo with addable & addattop & addBtn & addButtonText & addBu
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -381,7 +378,6 @@ exports[`Renderer:combo with addable & addattop & addBtn & addButtonText & addBu
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -444,7 +440,6 @@ exports[`Renderer:combo with addable & addattop & addBtn & addButtonText & addBu
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -1192,7 +1187,6 @@ exports[`Renderer:combo with draggable 1`] = `
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -1224,7 +1218,6 @@ exports[`Renderer:combo with draggable 1`] = `
                                   </div>
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -1312,7 +1305,6 @@ exports[`Renderer:combo with draggable 1`] = `
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -1344,7 +1336,6 @@ exports[`Renderer:combo with draggable 1`] = `
                                   </div>
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -1779,7 +1770,6 @@ exports[`Renderer:combo with removable & deleteBtn & deleteApi & deleteConfirmTe
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -1883,7 +1873,6 @@ exports[`Renderer:combo with removable & deleteBtn & deleteApi & deleteConfirmTe
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -1995,7 +1984,6 @@ exports[`Renderer:combo with removable & deleteBtn & deleteApi & deleteConfirmTe
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/inputArray.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/inputArray.test.tsx.snap
@@ -94,7 +94,6 @@ exports[`Renderer:inputArray 1`] = `
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -292,7 +291,6 @@ exports[`Renderer:inputArray with draggable & draggableTip 1`] = `
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -368,7 +366,6 @@ exports[`Renderer:inputArray with draggable & draggableTip 1`] = `
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -444,7 +441,6 @@ exports[`Renderer:inputArray with draggable & draggableTip 1`] = `
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -634,7 +630,6 @@ exports[`Renderer:inputArray with minLength & maxLength 1`] = `
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -687,7 +682,6 @@ exports[`Renderer:inputArray with minLength & maxLength 1`] = `
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -862,7 +856,6 @@ exports[`Renderer:inputArray with removable & addable & addButtonText: false 1`]
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -915,7 +908,6 @@ exports[`Renderer:inputArray with removable & addable & addButtonText: false 1`]
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"
@@ -1077,7 +1069,6 @@ exports[`Renderer:inputArray with removable & addable & addButtonText: false 2`]
                                 >
                                   <div
                                     class="cxd-Form-col"
-                                    style="flex: 1;"
                                   >
                                     <div
                                       class="cxd-Form-item cxd-Form-item--row"

--- a/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
+++ b/packages/amis/__tests__/renderers/Form/__snapshots__/inputTable.test.tsx.snap
@@ -1680,7 +1680,6 @@ exports[`Renderer:input-table with combo column 1`] = `
                                       >
                                         <div
                                           class="cxd-Form-col"
-                                          style="flex: 1;"
                                         >
                                           <div
                                             class="cxd-Form-item cxd-Form-item--row"
@@ -1745,7 +1744,6 @@ exports[`Renderer:input-table with combo column 1`] = `
                                         </div>
                                         <div
                                           class="cxd-Form-col"
-                                          style="flex: 1;"
                                         >
                                           <div
                                             class="cxd-Form-item cxd-Form-item--row"


### PR DESCRIPTION
### What

- 在设置 flex 属性时，增加了对 colSize 为 undefined 或 null 的处理
- 避免在这些情况下将 flex 设置为 '1'，以保留更多的样式灵活性

### Why

考虑这类布局：
![image](https://github.com/user-attachments/assets/90b9ab7c-32dd-4081-a3bc-153876964b1c)

如果不考虑 colSize 未设置（或清空设置）的情况，表单将会丧失上图这种布局方式的灵活性。
增加这个逻辑可兼顾多种需求。