### PR TITLE
fix: 注册异步渲染器时删除占位渲染器，修复设置了显隐条件时无法正确渲染的问题

### DIFF
--- a/packages/amis-core/src/factory.tsx
+++ b/packages/amis-core/src/factory.tsx
@@ -262,6 +262,17 @@ export function registerRenderer(config: RendererConfig): RendererConfig {
   } else if (exists) {
     // 如果已经存在，合并配置，并用合并后的配置
     Object.assign(exists, config);
+
+    // 如果已经有了占位渲染器，在注册异步渲染器的时候把占位渲染器删掉
+    // 否则会导致有些情况下无法渲染（设置了 visibleOn/hiddenOn 条件的无法渲染）
+    if (
+      exists.component === Placeholder &&
+      !config.component &&
+      config.getComponent
+    ) {
+      delete exists.component;
+      delete exists.Renderer;
+    }
     renderer = exists;
   }
 

--- a/packages/amis-core/src/factory.tsx
+++ b/packages/amis-core/src/factory.tsx
@@ -269,8 +269,8 @@ export function registerRenderer(config: RendererConfig): RendererConfig {
       !config.component &&
       config.getComponent
     ) {
-      let {component, Renderer, ...rest} = renderer;
-      renderer = {...rest, ...config};
+      delete renderer.component;
+      delete renderer.Renderer;
     }
   }
 

--- a/packages/amis-core/src/factory.tsx
+++ b/packages/amis-core/src/factory.tsx
@@ -261,19 +261,17 @@ export function registerRenderer(config: RendererConfig): RendererConfig {
     );
   } else if (exists) {
     // 如果已经存在，合并配置，并用合并后的配置
-    Object.assign(exists, config);
-
-    // 如果已经有了占位渲染器，在注册异步渲染器的时候把占位渲染器删掉
-    // 否则会导致有些情况下无法渲染（设置了 visibleOn/hiddenOn 条件的无法渲染）
+    renderer = Object.assign(exists, config);
+    // 如果已存在的配置有占位组件，并且新的配置是异步渲染器，在把占位组件删除
+    // 避免遇到设置了 visibleOn/hiddenOn 条件的 Schema 无法渲染的问题
     if (
       exists.component === Placeholder &&
       !config.component &&
       config.getComponent
     ) {
-      delete exists.component;
-      delete exists.Renderer;
+      let {component, Renderer, ...rest} = renderer;
+      renderer = {...rest, ...config};
     }
-    renderer = exists;
   }
 
   renderer.weight = renderer.weight || 0;


### PR DESCRIPTION
优化异步渲染器注册逻辑

### What
- 当已存在占位渲染器时，在注册异步渲染器时删除占位渲染器

### Why
- 解决了在某些情况下（如设置了 visibleOn/hiddenOn 条件）无法渲染的问题