### PR TITLE
fix: 修复轮播图有 style 且设置了 width\height 时会导致 js 报错渲染失败

### DIFF
--- a/packages/amis/src/renderers/Carousel.tsx
+++ b/packages/amis/src/renderers/Carousel.tsx
@@ -582,7 +582,7 @@ export class Carousel extends React.Component<CarouselProps, CarouselState> {
     let body: JSX.Element | null = null;
     let carouselStyles: {
       [propName: string]: string;
-    } = style || {};
+    } = style ? {...style} : {};
 
     // 不允许传0，需要有最小高度
     if (width) {


### PR DESCRIPTION
### What

### Why

### How
