### PR TITLE
fix: 修复sdk下helper.css样式权重较低问题

### DIFF
--- a/fis-conf.js
+++ b/fis-conf.js
@@ -82,8 +82,8 @@ Resource.extend({
 fis.set('project.files', [
   'schema.json',
   '/examples/map.json',
-  '/scss/helper.scss',
   '/scss/themes/*.scss',
+  '/scss/helper.scss',
   '/examples/*.html',
   '/examples/app/*.html',
   '/examples/*.tpl',


### PR DESCRIPTION
### What

### Why

### How
