### PR TITLE
fix: 在地图的值修改后，需要刷新地图展示

### DIFF
--- a/packages/amis-ui/src/components/BaiduMapPicker.tsx
+++ b/packages/amis-ui/src/components/BaiduMapPicker.tsx
@@ -113,6 +113,13 @@ export class BaiduMapPicker extends React.Component<
     delete this.map;
   }
 
+  componentDidUpdate(prevProps: Readonly<MapPickerProps>): void {
+    // 值更新后需要重绘地图
+    if (prevProps.value !== this.props.value) {
+      this.initMap();
+    }
+  }
+
   @autobind
   async initMap() {
     const autoSelectCurrentLoc = this.props.autoSelectCurrentLoc ?? false;


### PR DESCRIPTION
### What
在地图的值修改后，需要刷新地图展示
### Why
做为受控组件的地图组件，在外部value变化后，地图位置不变。因为没有监听value变化
### How
用componentDidUpdate监听value变化，初始化地图
