### PR TITLE
fix: #11535 crud的source切换后分页失效问题修复

### DIFF
--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -703,24 +703,25 @@ export default class Table extends React.Component<TableProps, object> {
     const value = getPropValue(props, (props: TableProps) => props.items);
     let rows: Array<object> = [];
     let updateRows = false;
-    const resolved = resolveVariableAndFilter(source, props.data, '| raw');
-    const prev = prevProps
-      ? resolveVariableAndFilter(source, prevProps.data, '| raw')
-      : null;
 
     // 要严格比较前后的value值，否则某些情况下会导致循环update无限渲染
-    if (
-      Array.isArray(value) &&
-      (!prevProps ||
+    if (Array.isArray(value)) {
+      if (
+        !prevProps ||
         !isEqual(
           getPropValue(prevProps, (props: TableProps) => props.items),
           value
-        ) ||
-        resolved !== prev)
-    ) {
-      updateRows = true;
-      rows = value;
+        )
+      ) {
+        updateRows = true;
+        rows = value;
+      }
     } else if (typeof source === 'string') {
+      const resolved = resolveVariableAndFilter(source, props.data, '| raw');
+      const prev = prevProps
+        ? resolveVariableAndFilter(source, prevProps.data, '| raw')
+        : null;
+
       if (prev === resolved) {
         updateRows = false;
       } else {

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -703,6 +703,10 @@ export default class Table extends React.Component<TableProps, object> {
     const value = getPropValue(props, (props: TableProps) => props.items);
     let rows: Array<object> = [];
     let updateRows = false;
+    const resolved = resolveVariableAndFilter(source, props.data, '| raw');
+    const prev = prevProps
+      ? resolveVariableAndFilter(source, prevProps.data, '| raw')
+      : null;
 
     // 要严格比较前后的value值，否则某些情况下会导致循环update无限渲染
     if (
@@ -711,16 +715,12 @@ export default class Table extends React.Component<TableProps, object> {
         !isEqual(
           getPropValue(prevProps, (props: TableProps) => props.items),
           value
-        ))
+        ) ||
+        resolved !== prev)
     ) {
       updateRows = true;
       rows = value;
     } else if (typeof source === 'string') {
-      const resolved = resolveVariableAndFilter(source, props.data, '| raw');
-      const prev = prevProps
-        ? resolveVariableAndFilter(source, prevProps.data, '| raw')
-        : null;
-
       if (prev === resolved) {
         updateRows = false;
       } else {


### PR DESCRIPTION
### What
修复 #11535 


### Why
crud使用本地数据源时需要分页，source改变后，crud会自动计算好分页后的数据，这里不应该走进下面代码，只有单独使用table时才会进。
<img width="594" alt="image" src="https://github.com/user-attachments/assets/7361c22e-c501-4674-adeb-1d5fa60ce633" />


### How
