### PR TITLE
fix: Firefox浏览器Crud设置autoFillHeight，无数据时表头被拉伸

### DIFF
--- a/packages/amis-ui/scss/components/_table.scss
+++ b/packages/amis-ui/scss/components/_table.scss
@@ -1032,7 +1032,11 @@
         border-top: none; // 不然会导致拖动时顶部露出内容
 
         &.#{$ns}Table-table--tableFillHeight {
-          min-height: 100%; // 为了让表格占满高度
+          > tbody {
+            height: calc(
+              var(--Table-content-height) - var(--Table-thead-height)
+            );
+          }
         }
       }
 

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -952,6 +952,10 @@ export default class Table<
         )}px`;
 
     tableContent.style[heightField] = tableContentHeight;
+    tableContent.style.setProperty(
+      `--Table-content-${heightField}`,
+      tableContentHeight
+    );
   }
 
   componentDidUpdate(prevProps: TableProps) {


### PR DESCRIPTION
### What

火狐浏览器，Crud设置autoFillHeight后，如果无数据，表头被拉伸

![image](https://github.com/user-attachments/assets/d0ea7a93-8acf-43fb-8db0-b2d64c8b64f8)

**正常情况**

autoFillHeight:true （暂无数据 居中）

![image](https://github.com/user-attachments/assets/89f8a7f5-fb27-4b49-84a8-79d9f096aae1)

autoFillHeight:false

![image](https://github.com/user-attachments/assets/20ed546a-c142-4b17-8837-bdf83bc72455)


### Why

**产生原因**

火狐浏览器下，table外层设置固定高度、table设置min-height:100%后，会被拉伸

![image](https://github.com/user-attachments/assets/f92900af-f806-45ae-84d1-36ea39e9c186)

**相关pr**

https://github.com/baidu/amis/issues/11419

**为什么文档中demo正常？**

![image](https://github.com/user-attachments/assets/88e08a30-ad40-49d9-8212-f8a81c570ba1)

计算得到的高度为负值，高度未生效，等同于autoFillHeight:false

### How

项目中已计算thead大小，利用tableContentHeight获得tbody大小