### PR TITLE
fix: #11630 修复 InputFormula 组件 variables 配置表达式时无法获取 api 中数据

### DIFF
--- a/packages/amis-ui/src/components/formula/Picker.tsx
+++ b/packages/amis-ui/src/components/formula/Picker.tsx
@@ -229,7 +229,9 @@ export class FormulaPicker extends React.Component<
 
     if (anyChanged(['variables', 'data'], this.props, prevProps)) {
       const {variables, data} = this.props;
-      if (typeof variables === 'function') {
+      if (Array.isArray(variables) && variables !== prevProps.variables) {
+        this.setState({variables});
+      } else if (typeof variables === 'function') {
         const list = await variables(this.props);
         this.setState({variables: list});
       } else if (typeof variables === 'string' && isExpression(variables)) {


### PR DESCRIPTION
### What
修复 InputFormula 组件 variables 配置表达式时无法获取 api 中数据
### Why
当 variables 为字符串的时候，在 amis 层的 InputFormula 组件中，已经转成了具体的数据。所以到 amis-ui 层的时候已经是具体值了。

https://github.com/baidu/amis/blob/b594a93ef897b1fb52f416b07ab04b7eab9f001d/packages/amis/src/renderers/Form/InputFormula.tsx#L213-L216 

但是在 amis-ui 层 的 formula/Picker 组件里面，只处理了 variables 为 function/string 的时候，变更情况。没有处理 variables 为具体数据时候的情况。

### How

 在 amis-ui 层的 formula/Picker 的 componentDidUpdate 添加一下，props.variables 如果已经是具体数据的情况下变更后， 同步设置state状态。

