### PR TITLE
fix: #11612 修复 JSONSchema 反显的时候出现异常

### DIFF
--- a/packages/amis-ui/src/components/json-schema/Object.tsx
+++ b/packages/amis-ui/src/components/json-schema/Object.tsx
@@ -210,7 +210,8 @@ export function InputJSONSchemaObject(
           },
           value: value?.[key] ?? ''
         });
-      } else {
+      } else if (exists) {
+        // 当 value 的 key 在 members 中存在时，再修改
         arr.splice(idx, 1, {
           ...exists,
           value: value?.[key]


### PR DESCRIPTION
### What

#11612 JSONSchema 反显时， schema 的 `object`类型存在`"additionalProperties": false`时， 表单项的value值里面存在一个，`object` 中未定义的 属性时，会出现一个 无法选属性的框，并且出现“添加属性”按钮。

### Why

amis ui 层，JSONSchema 组件，props.value 变化的时候，同步更新 members 数组的时候，将不存在的在 member 中的 key 进行更新了。当 key 不在 member 存在的时候，进行更新应该从代码逻辑上就有问题，导致数据不对了。

### How

 key 在 member 存在的时候再更新。

