### PR TITLE
fix: #11270 修复 Wizard 向导组件 单步Step 自定义actions 执行 onEvent  事件异常

### DIFF
--- a/packages/amis/src/renderers/Wizard.tsx
+++ b/packages/amis/src/renderers/Wizard.tsx
@@ -1074,7 +1074,7 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
         <>
           {step.actions.map((action, index) =>
             render(`action/${index}`, action, {
-              key: index,
+              key: `${currentStepIndex}-${index}`,
               data: createObject(this.props.data, {
                 currentStep: currentStepIndex
               }),


### PR DESCRIPTION
### What

#11270 Wizard 向导组件，如果配置 自定义actions 执行 onEvent 的时候，会异常1次触发多余事件，

### Why

这个好像是 事件机制 引起的，在 SchemaRenderer 里，给每一个组件 进行了一次 bindEvent。在 Wizard 向导组件 Step 的 actions 里，比较特殊。actions渲染的 button 的时候 key 设置的是 action 的 index。切换 step 的时候，index 不会变，key也没有变，就导致这个问题了。

### How

简单改的话，就是改了下 渲染 button 时的 key, 用 step的索引和 action 的 index 组合一下。每次切换 step 每一个 action 的 key 都变了。

