### PR TITLE
fix：配置scrolly时使用粘性定位固定表头

### DIFF
--- a/packages/amis-ui/src/components/table/index.tsx
+++ b/packages/amis-ui/src/components/table/index.tsx
@@ -1681,7 +1681,7 @@ export class Table extends React.PureComponent<TableProps, TableState> {
           </div>
         ) : null}
 
-        {hasScrollY || (sticky && !autoFillHeight) ? (
+        {(hasScrollY || sticky) && !autoFillHeight ? (
           this.renderScrollTable()
         ) : (
           <div


### PR DESCRIPTION
### What

### Why

### How
