### PR TITLE
fix(inputNumber): 编辑器右侧面板默认打开千分符配置

### DIFF
--- a/packages/amis-editor/src/plugin/Form/InputNumber.tsx
+++ b/packages/amis-editor/src/plugin/Form/InputNumber.tsx
@@ -40,7 +40,8 @@ export class NumberControlPlugin extends BasePlugin {
     label: '数字',
     name: 'number',
     showSteps: true,
-    keyboard: true
+    keyboard: true,
+    kilobitSeparator: true
   };
   previewSchema: any = {
     type: 'form',


### PR DESCRIPTION
保持与只读态和最终渲染态里的千分符渲染结果一致

### What
修改 input-number 组件在编辑器右侧面板的千分符配置，改成默认打开

### Why
![image](https://github.com/user-attachments/assets/edefaf72-796f-48a5-942d-34089f8413eb)
数字输入框的千分符配置在最终渲染时默认会设置为 true
而编辑器里配置 input-number 组件时默认不会带上千分符配置属性，导致在编辑态的预览时看到的数据是不带千分符的，这与最终的渲染结果不一致

### How
input-number 组件里的默认属性中新增 kilobitSeparator: true