### PR TITLE
fix: input-tree数量超过100时内容不显示

### DIFF
--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -1548,7 +1548,7 @@ export class TreeSelector extends React.Component<
       return (
         <div ref={this.virtualListRef}>
           <VirtualList
-            height={virtualHeight !== undefined ? virtualHeight : 266}
+            height={virtualHeight || 266}
             itemCount={list.length}
             prefix={this.renderCheckAll()}
             itemSize={itemHeight}


### PR DESCRIPTION
### What

### Why

### How
