### PR TITLE
fix: 表格设置sticky后，如果开启选择或拖拽功能，其头部sticky未生效

### DIFF
--- a/packages/amis-ui/src/components/table/Head.tsx
+++ b/packages/amis-ui/src/components/table/Head.tsx
@@ -194,6 +194,7 @@ export default class Head extends React.PureComponent<Props> {
                   wrapperComponent="th"
                   rowSpan={this.thColumns.length}
                   className={cx('Table-dragCell')}
+                  selfSticky={selfSticky}
                   col="drag"
                   classnames={cx}
                   classPrefix={classPrefix}
@@ -207,6 +208,7 @@ export default class Head extends React.PureComponent<Props> {
                   rowSpan={this.thColumns.length}
                   fixed={rowSelectionFixed ? 'left' : ''}
                   className={cx('Table-checkCell')}
+                  selfSticky={selfSticky}
                   col="select"
                   classnames={cx}
                   classPrefix={classPrefix}


### PR DESCRIPTION
### What

修复表格设置sticky:true后，开启选择或拖拽功能，其头部未被应用sticky样式

### Why

设置sticky:true、autoFillHeight:{maxHeight:360}

![image](https://github.com/user-attachments/assets/d7b566a4-3e05-43a9-8725-9e131fe6b11c)

### How

组件补全selfSticky属性，[相关pr](https://github.com/baidu/amis/pull/11637)