### PR TITLE
fix: 修复表格开启整行选择后，点击单选或复选框无响应

### DIFF
--- a/docs/zh-CN/components/table2.md
+++ b/docs/zh-CN/components/table2.md
@@ -4176,9 +4176,10 @@ order: 67
 | disableOn           | `string`                           |            | 当前行是否可选择条件，要用 [表达式](../../docs/concepts/expression)                                                |
 | selections          | `selections`                       |            | 自定义筛选菜单，内置`all`（全选）、`invert`（反选）、`none`（取消选择）、`odd`（选择奇数项）、`even`（选择偶数项） |
 | selectedRowKeys     | `Array<string>` \| `Array<number>` |            | 已选择项                                                                                                           |
-| selectedRowKeysExpr | `string`                           |            | 已选择项表达式                                                                                                 |
+| selectedRowKeysExpr | `string`                           |            | 已选择项表达式                                                                                                     |
 | columnWidth         | `number`                           |            | 自定义选择列列宽                                                                                                   |
 | rowClick            | `boolean`                          |            | 单条任意区域选中                                                                                                   |
+| rowClickIgControl   | `boolean`                          |            | 点击控件时也会触发 rowClick 事件                                                                                   |
 
 ### 选择菜单配置属性表
 
@@ -4196,42 +4197,42 @@ order: 67
 | disableOn           | `string`                           |        | 当前行是否可选择条件，要用 [表达式](../../docs/concepts/expression)                                                |
 | selections          | `selections`                       |        | 自定义筛选菜单，内置`all`（全选）、`invert`（反选）、`none`（取消选择）、`odd`（选择奇数项）、`even`（选择偶数项） |
 | selectedRowKeys     | `Array<string>` \| `Array<number>` |        | 已选择项                                                                                                           |
-| selectedRowKeysExpr | `string`                           |        | 已选择项表达式                                                                                                 |
+| selectedRowKeysExpr | `string`                           |        | 已选择项表达式                                                                                                     |
 | columnWidth         | `number`                           |        | 自定义选择列列宽                                                                                                   |
 
 ## 列配置属性表
 
-| 属性名     | 类型                                          | 默认值  | 说明             |
-| ---------- | --------------------------------------------- | ------- | ---------------- |
-| label      | [模板](../../docs/concepts/template)          |         | 表头文本内容     |
-| name       | `string`                                      |         | 通过名称关联数据 |
-| fixed      | `left` \| `right` \| `none`                   |         | 是否固定当前列   |
-| popOver    |                                               |         | 弹出框           |
-| quickEdit  |                                               |         | 快速编辑         |
-| copyable   | `boolean` 或 `{icon: string, content:string}` |         | 是否可复制       |
-| sortable   | `boolean`                                     | `false` | 是否可排序       |
-| searchable | `boolean` \| `Schema`                         | `false` | 是否可快速搜索   |
-| width      | `number` \| `string`                          | 列宽    |
-| remark     |                                               |         | 提示信息         |
-| textOverflow | `string`                                    |`default`| 文本溢出后展示形式，默认换行处理。可选值 `ellipsis` 溢出隐藏展示， `noWrap` 不换行展示(仅在列为静态文本时生效)   |
+| 属性名       | 类型                                          | 默认值    | 说明                                                                                                           |
+| ------------ | --------------------------------------------- | --------- | -------------------------------------------------------------------------------------------------------------- |
+| label        | [模板](../../docs/concepts/template)          |           | 表头文本内容                                                                                                   |
+| name         | `string`                                      |           | 通过名称关联数据                                                                                               |
+| fixed        | `left` \| `right` \| `none`                   |           | 是否固定当前列                                                                                                 |
+| popOver      |                                               |           | 弹出框                                                                                                         |
+| quickEdit    |                                               |           | 快速编辑                                                                                                       |
+| copyable     | `boolean` 或 `{icon: string, content:string}` |           | 是否可复制                                                                                                     |
+| sortable     | `boolean`                                     | `false`   | 是否可排序                                                                                                     |
+| searchable   | `boolean` \| `Schema`                         | `false`   | 是否可快速搜索                                                                                                 |
+| width        | `number` \| `string`                          | 列宽      |
+| remark       |                                               |           | 提示信息                                                                                                       |
+| textOverflow | `string`                                      | `default` | 文本溢出后展示形式，默认换行处理。可选值 `ellipsis` 溢出隐藏展示， `noWrap` 不换行展示(仅在列为静态文本时生效) |
 
 ## 事件表
 
 当前组件会对外派发以下事件，可以通过`onEvent`来监听这些事件，并通过`actions`来配置执行的动作，在`actions`中可以通过`${事件参数名}`或`${event.data.[事件参数名]}`来获取事件产生的数据，详细查看[事件动作](../../docs/concepts/event-action)。
 
-| 事件名称       | 事件参数                                                                | 说明                 |
-| -------------- | ----------------------------------------------------------------------- | -------------------- |
-| selectedChange | `selectedItems: item[]` 已选择行<br/>`unSelectedItems: item[]` 未选择行 | 手动选择表格项时触发 |
-| columnSort     | `orderBy: string` 列排序列名<br/>`orderDir: string` 列排序值            | 点击列排序时触发     |
-| columnFilter   | `filterName: string` 列筛选列名<br/>`filterValue: string` 列筛选值      | 点击列筛选时触发     |
-| columnSearch   | `searchName: string` 列搜索列名<br/>`searchValue: string` 列搜索数据    | 点击列搜索时触发     |
-| orderChange    | `movedItems: item[]` 已排序数据                                         | 手动拖拽行排序时触发 |
-| columnToggled  | `columns: item[]` 当前显示的列配置数据                                  | 点击自定义列时触发   |
-| rowClick       | `item: object` 行点击数据<br/>`index: number` 行索引                    | 单击整行时触发       |
-| rowDbClick     | `item: object` 行点击数据<br/>`index: number` 行索引                    | 双击整行时触发       |
-| rowMouseEnter  | `item: object` 行移入数据<br/>`index: number` 行索引                    | 移入整行时触发       |
-| rowMouseLeave  | `item: object` 行移出数据<br/>`index: number` 行索引                    | 移出整行时触发       |
-| quickSaveSubmitted | `item: object` 快速编辑相关数据，包括源数据、修改后的数据、修改的行数索引、没有变动的数据 | 成功调用 `quickSaveApi` 之后触发  |
+| 事件名称           | 事件参数                                                                                  | 说明                             |
+| ------------------ | ----------------------------------------------------------------------------------------- | -------------------------------- |
+| selectedChange     | `selectedItems: item[]` 已选择行<br/>`unSelectedItems: item[]` 未选择行                   | 手动选择表格项时触发             |
+| columnSort         | `orderBy: string` 列排序列名<br/>`orderDir: string` 列排序值                              | 点击列排序时触发                 |
+| columnFilter       | `filterName: string` 列筛选列名<br/>`filterValue: string` 列筛选值                        | 点击列筛选时触发                 |
+| columnSearch       | `searchName: string` 列搜索列名<br/>`searchValue: string` 列搜索数据                      | 点击列搜索时触发                 |
+| orderChange        | `movedItems: item[]` 已排序数据                                                           | 手动拖拽行排序时触发             |
+| columnToggled      | `columns: item[]` 当前显示的列配置数据                                                    | 点击自定义列时触发               |
+| rowClick           | `item: object` 行点击数据<br/>`index: number` 行索引                                      | 单击整行时触发                   |
+| rowDbClick         | `item: object` 行点击数据<br/>`index: number` 行索引                                      | 双击整行时触发                   |
+| rowMouseEnter      | `item: object` 行移入数据<br/>`index: number` 行索引                                      | 移入整行时触发                   |
+| rowMouseLeave      | `item: object` 行移出数据<br/>`index: number` 行索引                                      | 移出整行时触发                   |
+| quickSaveSubmitted | `item: object` 快速编辑相关数据，包括源数据、修改后的数据、修改的行数索引、没有变动的数据 | 成功调用 `quickSaveApi` 之后触发 |
 
 ### selectedChange
 

--- a/packages/amis-ui/src/components/table/Row.tsx
+++ b/packages/amis-ui/src/components/table/Row.tsx
@@ -49,6 +49,7 @@ export interface Props extends ThemeProps {
   selectable: boolean;
   rowSelectionFixed?: boolean;
   rowSelectionType?: 'radio' | 'checkbox';
+  rowClickIgControl?: boolean;
   hasChildrenRow: boolean;
   hasChildrenChecked: boolean;
   expandedRowClassName: string;
@@ -90,7 +91,7 @@ class BodyRow extends React.PureComponent<Props> {
     record?: any,
     rowIndex?: number
   ) {
-    if (isClickOnInput(e)) {
+    if (isClickOnInput(e) && !this.props.rowClickIgControl) {
       return;
     }
 

--- a/packages/amis-ui/src/components/table/index.tsx
+++ b/packages/amis-ui/src/components/table/index.tsx
@@ -86,6 +86,7 @@ export interface RowSelectionOptionProps {
 export interface RowSelectionProps {
   type: string;
   rowClick?: boolean; // 点击复选框选中还是点击整行选中
+  rowClickIgControl?: boolean; // 点击行或控件，均触发Row的onClick事件
   fixed: boolean; // 只能固定在左边
   selectedRowKeys: Array<string | number>;
   keyField?: string; // 默认是key，可自定义
@@ -1060,6 +1061,7 @@ export class Table extends React.PureComponent<TableProps, TableState> {
         selectable={!!rowSelection}
         rowSelectionFixed={!!rowSelection?.fixed}
         rowSelectionType={rowSelection?.type || 'checkbox'}
+        rowClickIgControl={!!rowSelection?.rowClickIgControl}
         expandable={!!expandable}
         expandableFixed={expandable?.fixed}
         expandedRowClassName={expandedRowClassName}


### PR DESCRIPTION
### What

修复表格开启整行选择(rowSelection.rowClick)后，点击单选或复选框无响应

### Why

当前效果：

![2025-02-28 11 34 24](https://github.com/user-attachments/assets/16bcbaf4-4954-4620-a078-60a5cc254cfd)


修改后的效果：

![2025-02-28 11 42 46](https://github.com/user-attachments/assets/5aee0a54-93d4-487e-a910-c23c47104de7)

### How

Row.tsx组件中的onClick事件做了限制（修复是 在这里扩展了一个配置，不影响之前逻辑）

```javascript
// packages/amis-ui/src/components/table/Row.tsx

  onClick(
    e: React.MouseEvent<HTMLTableRowElement>,
    record?: any,
    rowIndex?: number
  ) {
    if (isClickOnInput(e)) {
      return;
    }

    const {onClick} = this.props;
    onClick && onClick(e, record, rowIndex);
  }

```

另一个原因是：

checkbox的onChange到table的onRowChange中被拦截

```javascript
// packages/amis-ui/src/components/table/index.tsx

  onRowChange(value: boolean, record: any) {
    const {rowSelection} = this.props;
    if (!(rowSelection && rowSelection.rowClick)) {
      this.selectedSingleRow(value, record);
    }
  }

```

同时isClickOnInput也影响onEvent. rowClick

![2025-02-28 11 48 18](https://github.com/user-attachments/assets/7add1666-1157-4017-862e-b8029e05280b)



