### PR TITLE
fix: table2 sticky时border未跟随导致底部文字透出

### DIFF
--- a/packages/amis-ui/scss/components/_table2.scss
+++ b/packages/amis-ui/scss/components/_table2.scss
@@ -627,6 +627,10 @@
         overflow-x: unset !important;
       }
 
+      .#{$ns}Table-table {
+        border-collapse: separate;
+      }
+
       .#{$ns}Table-row {
         z-index: 1;
       }

--- a/packages/amis-ui/scss/components/_table2.scss
+++ b/packages/amis-ui/scss/components/_table2.scss
@@ -629,6 +629,10 @@
 
       .#{$ns}Table-table {
         border-collapse: separate;
+
+        > tbody > tr > td {
+          border-top: none;
+        }
       }
 
       .#{$ns}Table-row {


### PR DESCRIPTION
### What

### Why

### How
