### PR TITLE
fix: 修复horizontalScroll组件没有从amis ui导出导致被摇树优化的问题

### DIFF
--- a/packages/amis-ui/src/components/index.tsx
+++ b/packages/amis-ui/src/components/index.tsx
@@ -146,6 +146,9 @@ import Shape from './Shape';
 import type {IShapeType} from './Shape';
 import MobileDevTool from './MobileDevTool';
 import DropdownContextMenus from './DropdownContextMenus';
+import {HorizontalScroll} from './HorizontalScroll';
+import type {HorizontalScrollProps} from './HorizontalScroll';
+
 export {
   NotFound,
   Alert as AlertComponent,
@@ -290,5 +293,7 @@ export {
   IShapeType,
   MobileDevTool,
   DropdownContextMenus,
-  Slider
+  Slider,
+  HorizontalScroll,
+  HorizontalScrollProps
 };


### PR DESCRIPTION
### What
修复horizontalScroll组件没有从amis ui导出导致被摇树优化的问题
### Why

### How
