### PR TITLE
[fix amis-editor]修复block容器的最小高度问题

### DIFF
--- a/packages/amis-editor-core/scss/_variables.scss
+++ b/packages/amis-editor-core/scss/_variables.scss
@@ -46,3 +46,6 @@ $default-bg-color: #f7f7f9; // 默认背景颜色
   --button-size-md-font-size: 12px;
   --button-size-default-font-size: 12px;
 }
+
+// 空容器的占位最小高度
+$Editor-placehoder-height: 34px;

--- a/packages/amis-editor-core/scss/editor.scss
+++ b/packages/amis-editor-core/scss/editor.scss
@@ -1314,7 +1314,7 @@
 
   &.layout-content {
     height: 100%;
-    min-height: 30px;
+    min-height: $Editor-placehoder-height;
   }
 
   &.fill-placeholder {
@@ -1337,7 +1337,7 @@
 
 [data-region] {
   position: relative;
-  min-height: 34px;
+  min-height: $Editor-placehoder-height;
 
   &:empty {
     min-width: 20px;


### PR DESCRIPTION
### What
flex内，子容器默认是block情况下，编辑器的最小高度占位必须父子一致

### Why
block 父min-height，子height 100%不生效

### How
设定min-height一致