### PR TITLE
fix: #11684 修复 CRUD filterTogglable 配置为 true 时，点击切换无效问题

### DIFF
--- a/packages/amis-core/src/store/crud.ts
+++ b/packages/amis-core/src/store/crud.ts
@@ -73,7 +73,7 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
     items: types.optional(types.array(types.frozen()), []),
     selectedItems: types.optional(types.array(types.frozen()), []),
     unSelectedItems: types.optional(types.array(types.frozen()), []),
-    filterTogggable: false,
+    filterTogglable: false,
     filterVisible: true,
     hasInnerModalOpen: false
   })
@@ -609,8 +609,11 @@ export const CRUDStore = ServiceStore.named('CRUDStore')
       }
     });
 
-    const setFilterTogglable = (toggable: boolean, filterVisible?: boolean) => {
-      self.filterTogggable = toggable;
+    const setFilterTogglable = (
+      togglable: boolean,
+      filterVisible?: boolean
+    ) => {
+      self.filterTogglable = togglable;
 
       filterVisible !== void 0 && (self.filterVisible = filterVisible);
     };

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -670,7 +670,7 @@ export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
     // 所以这里应该忽略 autoGenerateFilter 情况
     if (
       (!this.props.filter && !autoGenerateFilter) ||
-      (store.filterTogggable && !store.filterVisible)
+      (store.filterTogglable && !store.filterVisible)
     ) {
       this.handleFilterInit({});
     }
@@ -2518,7 +2518,7 @@ export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
   renderFilterToggler() {
     const {store, classnames: cx, translate: __, filterTogglable} = this.props;
 
-    if (!store.filterTogggable) {
+    if (!store.filterTogglable) {
       return null;
     }
 
@@ -2887,7 +2887,7 @@ export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
       filterCanAccessSuperData = true
     } = this.props;
 
-    if (!filter && (!store.filterTogggable || store.filterVisible)) {
+    if (!filter || (store.filterTogglable && !store.filterVisible)) {
       return null;
     }
 


### PR DESCRIPTION
### What

 1. #11684  配置filterTogglable 配置为 true 时， 点击“切换按钮”，筛选框无法正常切换
 2. #11573 filterDefaultVisible:false 属性失效

### Why

看了下之前，v6.11.0 之前，渲染CRUD filter的条件是: `filter && (!store.filterTogggable || store.filterVisible)`
![image](https://github.com/user-attachments/assets/2d05d277-2cfc-4318-94c6-50b364d55b2f)

v6.11.0 进行了改动，改为了 ：`!filter && (!store.filterTogggable || store.filterVisible)`
![image](https://github.com/user-attachments/assets/084cb1cc-41f5-4482-a6d2-e61b72840650)

此处进行了取反逻辑，但是判断有误。

### How


**改动1:**
 看了下，配置传入的  `filterTogglable `, store存储的为：`filterTogggable`, 单词拼写不一致。 顺便，对crud/Crud 两个文件中使用, `filterTogggable` 的地方，都改为了 `filterTogglable`

**改动2:**
这块修复了下 filter 渲染条件，改为：`!filter || (store.filterTogglable && !store.filterVisible)`

