### PR TITLE
fix: 修复编辑器 combo 插入组件后不在子节点的情况

### DIFF
--- a/packages/amis-editor-core/src/manager.ts
+++ b/packages/amis-editor-core/src/manager.ts
@@ -1013,8 +1013,8 @@ export class EditorManager {
       // crud 和 table 等表格类容器
       regionNodeId = curActiveId;
       regionNodeRegion = 'columns';
-    } else if (node.schema.items && isLayoutPlugin(node.schema)) {
-      // 当前节点是布局类容器节点
+    } else if (node.schema.items && (isLayoutPlugin(node.schema) || node.type === 'combo')) {
+      // 当前节点是布局类容器节点或 combo 组件
       regionNodeId = curActiveId;
       regionNodeRegion = 'items';
     } else if (node.schema.body) {


### PR DESCRIPTION
### What
修改插入组件时的逻辑判断

### Why
在 combo 组件插入组件时，新增的组件会追加到 combo 后面，而不是 combo 内部。
![插入 combo](https://github.com/user-attachments/assets/e34d2ea8-c42c-446e-94ad-39523c1f622f)


### How
在插入组件时，新增对 combo 类型的判断
