### PR TITLE
fix(plugin/CRUD):  使用数组值前增加是否为空的判断

### DIFF
--- a/packages/amis-editor/src/plugin/CRUD.tsx
+++ b/packages/amis-editor/src/plugin/CRUD.tsx
@@ -616,7 +616,7 @@ export class CRUDPlugin extends BasePlugin {
               }
             }
 
-            if (Array.isArray(items)) {
+            if (Array.isArray(items) && items[0]) {
               Object.keys(items[0]).forEach((key: any) => {
                 const value = items[0][key];
                 autoFillKeyValues.push({


### PR DESCRIPTION
使用item[0]前先判断是否为空, 避免报错

### What

### Why

### How
