### PR TITLE
fix(Actions): 为 Service 等组件的 handleAction 方法增加返回值，修复事件动作序列异常中断问题

### DIFF
--- a/packages/amis/src/renderers/Cards.tsx
+++ b/packages/amis/src/renderers/Cards.tsx
@@ -374,7 +374,7 @@ export default class Cards extends React.Component<GridProps, object> {
     const {onAction} = this.props;
 
     // 需要支持特殊事件吗？
-    onAction(e, action, ctx);
+    return onAction?.(e, action, ctx);
   }
 
   handleCheck(item: IItem) {

--- a/packages/amis/src/renderers/List.tsx
+++ b/packages/amis/src/renderers/List.tsx
@@ -547,7 +547,7 @@ export default class List extends React.Component<ListProps, ListState> {
       );
     } else {
       /** action无值代表List自身已经处理, 无需交给上层处理 */
-      action && onAction?.(e, action, ctx);
+      return action && onAction?.(e, action, ctx);
     }
   }
 

--- a/packages/amis/src/renderers/Service.tsx
+++ b/packages/amis/src/renderers/Service.tsx
@@ -737,7 +737,7 @@ export default class Service extends React.Component<ServiceProps> {
 
     if (api && action.actionType === 'ajax') {
       store.setCurrentAction(action, this.props.resolveDefinitions);
-      store
+      return store
         .saveRemote(action.api as string, data, {
           successMessage: __(action.messages && action.messages.success),
           errorMessage: __(action.messages && action.messages.failed)
@@ -764,7 +764,7 @@ export default class Service extends React.Component<ServiceProps> {
           }
         });
     } else {
-      onAction(e, action, data, throwErrors, delegate || this.context);
+      return onAction(e, action, data, throwErrors, delegate || this.context);
     }
   }
 

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -1574,7 +1574,7 @@ export default class Table2 extends React.Component<Table2Props, object> {
     const {onAction} = this.props;
 
     // todo
-    onAction && onAction(e, action, ctx);
+    return onAction?.(e, action, ctx);
   }
 
   renderActions(region: string) {

--- a/packages/amis/src/renderers/Wizard.tsx
+++ b/packages/amis/src/renderers/Wizard.tsx
@@ -657,12 +657,12 @@ export default class Wizard extends React.Component<WizardProps, WizardState> {
         targetStep <= steps.length &&
         targetStep >= 0
       ) {
-        this.gotoStep((data as any).step);
+        return this.gotoStep((data as any).step);
       }
     } else if (action.actionType === 'submit') {
-      this.finalSubmit();
+      return this.finalSubmit();
     } else if (onAction) {
-      onAction(e, action, data, throwErrors, delegate || this.context);
+      return onAction(e, action, data, throwErrors, delegate || this.context);
     }
   }
 


### PR DESCRIPTION
### What

为 Service 等组件的 handleAction 方法补上返回值。

### Why

事件动作中某些时候会因为 handleAction 没有返回值破坏逻辑引发异常，导致动作序列无法继续。

举个例子：
在 Service 中有个 button，button 的 click event 中有一个 action 是 openDialog，该 action 配置了 waitForAction。

正常情况下 DialogAction 会检查动作的返回值，提取返回值中的 confirmed 和 value。

在这个场景下这个 action 会通过 Service 的 handleAction 执行动作，而 Service 的 handleAction 没有把 onAction 的结果 return 出来，就会导致 DialogAction 会尝试 await undefined 并从中提取 confirmed 和 value；从而导致 runActions 被中断。

### How

补充 Service 中返回值逻辑，并检查其他组件中类似的情况，尝试一起修复。
