### PR TITLE
fix: 修复crud2中批量操作按钮事件混乱问题

### DIFF
--- a/docs/zh-CN/components/tabs.md
+++ b/docs/zh-CN/components/tabs.md
@@ -652,7 +652,7 @@ order: 68
   "type": "page",
   "data": {
     "defaultKey": 1,
-    "activeKey": 2
+    "key": 2
   },
   "body": [
     {

--- a/packages/amis-core/src/utils/renderer-event.ts
+++ b/packages/amis-core/src/utils/renderer-event.ts
@@ -151,7 +151,9 @@ export const bindEvent = (renderer: any) => {
     for (let key of Object.keys(listeners)) {
       const listener = rendererEventListeners.find(
         (item: RendererEventListener) =>
-          item.renderer === renderer && item.type === key
+          item.renderer === renderer &&
+          item.type === key &&
+          item.actions === listeners[key].actions
       );
       if (listener?.executing) {
         listener?.debounceInstance?.cancel?.();
@@ -322,7 +324,10 @@ export async function dispatchEvent(
     .filter(
       (item: RendererEventListener) =>
         item.type === eventName &&
-        (broadcast ? true : item.renderer === renderer)
+        (broadcast
+          ? true
+          : item.renderer === renderer &&
+            item.actions === renderer.props?.onEvent?.[eventName].actions)
     )
     .sort(
       (prev: RendererEventListener, next: RendererEventListener) =>


### PR DESCRIPTION
### What
![8613d77caf63427b05ed3c22c39b1b81](https://github.com/user-attachments/assets/03bc8f4a-fe79-435f-8567-3b15a73f29e2)
![ca28f87ed0460d12014d3cdb8f755309](https://github.com/user-attachments/assets/b6d953b9-366b-4804-a686-6b8a1b12c5bf)
### Why
点击批量发布按钮1时，执行的确是按钮2的事件。原因是：事件列表里面只判断了render和当前点击的元素是否相等。可是由于浅拷贝的原因。render其实已经发生变化，但是判断条件还是为true。 但是无法通过深拷贝来实现，深拷贝以后render永远不等于当前点击的元素的render。只能增加判断条件。
### How
