### PR TITLE
fix: #11791 修复wizard/InputTable 同时使用时内置按钮异常问题

### DIFF
--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -39,6 +39,7 @@ import {TableSchema} from '../Table';
 import {SchemaApi, SchemaCollection, SchemaClassName} from '../../Schema';
 import find from 'lodash/find';
 import debounce from 'lodash/debounce';
+import cloneDeep from 'lodash/cloneDeep';
 import moment from 'moment';
 import {sortArray, str2function} from 'amis-core';
 
@@ -1302,7 +1303,7 @@ export default class FormTable<
   ): Array<any> {
     const {env, mobileUI, testIdBuilder} = this.props;
     let columns: Array<any> = Array.isArray(props.columns)
-      ? props.columns.concat()
+      ? cloneDeep(props.columns)
       : [];
     const ns = this.props.classPrefix;
     const __ = this.props.translate;


### PR DESCRIPTION
### What
 #11791 

### Why
报错代码：
<img width="959" alt="image" src="https://github.com/user-attachments/assets/210089f8-3aea-4fc7-957b-e656a8e29a6b" />
  
columns被frozen：
<img width="817" alt="image" src="https://github.com/user-attachments/assets/f7cabeec-5e6e-4ce0-9ab8-a9ef423df1b9" />
<img width="940" alt="image" src="https://github.com/user-attachments/assets/05a20d85-9d33-4596-841a-38544b1b2c2d" />


### How
InputTable接收props中的columns时深拷贝，这样每次frozen对象就不会影响了
