### PR TITLE
fix: 调整 dispatchEvent 流程解决 CRUD 中派送选中事件的上下文信息错误问题

### DIFF
--- a/packages/amis-core/src/RootRenderer.tsx
+++ b/packages/amis-core/src/RootRenderer.tsx
@@ -14,6 +14,7 @@ import {normalizeApi} from './utils/api';
 import {findDOMNode} from 'react-dom';
 import LazyComponent from './components/LazyComponent';
 import {hasAsyncRenderers, loadAsyncRenderersByType} from './factory';
+import {dispatchEvent} from './utils/renderer-event';
 
 export interface RootRendererProps extends RootProps {
   location?: any;
@@ -43,6 +44,7 @@ export class RootRenderer extends React.Component<RootRendererProps> {
     // 将数据里面的函数批量的绑定到 this 上
     bulkBindFunctions<RootRenderer /*为毛 this 的类型自动识别不出来？*/>(this, [
       'handleAction',
+      'dispatchEvent',
       'handleDialogConfirm',
       'handleDialogClose',
       'handleDrawerConfirm',
@@ -317,6 +319,15 @@ export class RootRenderer extends React.Component<RootRendererProps> {
     }
   }
 
+  dispatchEvent(
+    e: string | React.MouseEvent<any>,
+    data: any,
+    renderer?: React.Component<any>,
+    scoped?: IScopedContext
+  ) {
+    return dispatchEvent(e, renderer!, scoped!, data);
+  }
+
   handleDialogConfirm(
     values: object[],
     action: ActionObject,
@@ -497,7 +508,8 @@ export class RootRenderer extends React.Component<RootRendererProps> {
         onConfirm: this.handleDialogConfirm,
         onClose: this.handleDialogClose,
         show: store.dialogOpen,
-        onAction: this.handleAction
+        onAction: this.handleAction,
+        dispatchEvent: this.dispatchEvent
       }
     );
   }
@@ -521,7 +533,8 @@ export class RootRenderer extends React.Component<RootRendererProps> {
         onConfirm: this.handleDrawerConfirm,
         onClose: this.handleDrawerClose,
         show: store.drawerOpen,
-        onAction: this.handleAction
+        onAction: this.handleAction,
+        dispatchEvent: this.dispatchEvent
       }
     );
   }
@@ -544,7 +557,8 @@ export class RootRenderer extends React.Component<RootRendererProps> {
             topStore: this.store,
             data: this.store.downStream,
             context: store.context,
-            onAction: this.handleAction
+            onAction: this.handleAction,
+            dispatchEvent: this.dispatchEvent
           }) as JSX.Element
         }
 

--- a/packages/amis-core/src/SchemaRenderer.tsx
+++ b/packages/amis-core/src/SchemaRenderer.tsx
@@ -291,16 +291,17 @@ export class SchemaRenderer extends React.Component<SchemaRendererProps, any> {
     this.cRef = ref;
   }
 
-  async dispatchEvent(
+  dispatchEvent(
     e: React.MouseEvent<any>,
     data: any,
-    renderer?: React.Component<RendererProps> // for didmount
+    renderer?: React.Component<RendererProps>, // for didmount
+    scoped?: IScopedContext
   ): Promise<RendererEvent<any> | void> {
-    return await dispatchEvent(
+    return this.props.dispatchEvent(
       e,
-      this.cRef || renderer,
-      this.context as IScopedContext,
-      data
+      data,
+      renderer || this.cRef,
+      scoped || (this.context as IScopedContext)
     );
   }
 

--- a/packages/amis-core/src/factory.tsx
+++ b/packages/amis-core/src/factory.tsx
@@ -29,7 +29,7 @@ import type {RendererEnv} from './env';
 import {OnEventProps, RendererEvent} from './utils/renderer-event';
 import {Placeholder} from './renderers/Placeholder';
 import {StatusScopedProps} from './StatusScoped';
-
+import type {IScopedContext} from './Scoped';
 export interface TestFunc {
   (
     path: string,
@@ -99,9 +99,10 @@ export interface RendererProps
   };
   onBroadcast?: (type: string, rawEvent: RendererEvent<any>, ctx: any) => any;
   dispatchEvent: (
-    e: React.UIEvent<any> | React.BaseSyntheticEvent<any> | string,
+    e: string | React.MouseEvent<any>,
     data: any,
-    renderer?: React.Component<RendererProps>
+    renderer?: React.Component<RendererProps>,
+    scoped?: IScopedContext
   ) => Promise<RendererEvent<any>>;
   mobileUI?: boolean;
   [propName: string]: any;

--- a/packages/amis/__tests__/renderers/CRUD.test.tsx
+++ b/packages/amis/__tests__/renderers/CRUD.test.tsx
@@ -757,6 +757,7 @@ test('13. enderer: crud keepItemSelectionOnPageChange & maxKeepItemSelectionLeng
     ).toBe(4);
   });
   replaceReactAriaIds(container);
+  await wait(20);
   expect(container).toMatchSnapshot();
 });
 

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -596,6 +596,7 @@ export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
     this.handleFilterSubmit = this.handleFilterSubmit.bind(this);
     this.handleFilterInit = this.handleFilterInit.bind(this);
     this.handleAction = this.handleAction.bind(this);
+    this.dispatchEvent = this.dispatchEvent.bind(this);
     this.handleBulkAction = this.handleBulkAction.bind(this);
     this.handleChangePage = this.handleChangePage.bind(this);
     this.handleBulkGo = this.handleBulkGo.bind(this);
@@ -2155,6 +2156,24 @@ export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
     return this.handleAction(undefined, action, data, throwErrors);
   }
 
+  dispatchEvent(
+    e: React.MouseEvent<any> | string,
+    data: any,
+    renderer?: React.Component<RendererProps>, // for didmount
+    scoped?: IScopedContext
+  ) {
+    // 如果事件是 selectedChange 并且是当前组件触发的，
+    // 则以当前组件的选择信息为准
+    if (e === 'selectedChange' && this.control === renderer) {
+      const store = this.props.store;
+      data.selectedItems = store.selectedItems.concat();
+      data.unSelectedItems = store.unSelectedItems.concat();
+      // selectedIndexes  还不支持
+    }
+
+    return this.props.dispatchEvent(e, data, renderer, scoped);
+  }
+
   unSelectItem(item: any, index: number) {
     const {store} = this.props;
     const selected = store.selectedItems.concat();
@@ -3048,6 +3067,7 @@ export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
         orderDir: store.query.orderDir,
         popOverContainer,
         onAction: this.handleAction,
+        dispatchEvent: this.dispatchEvent,
         onItemChange: this.handleItemChange,
         onSave: this.handleSave,
         onSaveOrder: this.handleSaveOrder,

--- a/packages/amis/src/renderers/CRUD2.tsx
+++ b/packages/amis/src/renderers/CRUD2.tsx
@@ -1208,6 +1208,24 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
     }
   }
 
+  @autobind
+  dispatchEvent(
+    e: React.MouseEvent<any> | string,
+    data: any,
+    renderer?: React.Component<RendererProps>, // for didmount
+    scoped?: IScopedContext
+  ) {
+    // 如果事件是 selectedChange 并且是当前组件触发的，
+    // 则以当前组件的选择信息为准
+    if (e === 'selectedChange' && this.control === renderer) {
+      const store = this.props.store;
+      data.selectedItems = store.selectedItems.concat();
+      data.unSelectedItems = store.unSelectedItems.concat();
+    }
+
+    return this.props.dispatchEvent(e, data, renderer, scoped);
+  }
+
   unSelectItem(item: any, index: number) {
     const {store} = this.props;
     const selected = store.selectedItems.concat();
@@ -1695,6 +1713,7 @@ export default class CRUD2 extends React.Component<CRUD2Props, any> {
         onSort: this.handleQuerySearch,
         onSelect: this.handleSelect,
         onAction: this.handleAction,
+        dispatchEvent: this.dispatchEvent,
         data: store.mergedData,
         loading: store.loading,
         host: this

--- a/packages/amis/src/renderers/Form/InputDate.tsx
+++ b/packages/amis/src/renderers/Form/InputDate.tsx
@@ -556,7 +556,7 @@ export default class DateControl extends React.PureComponent<
 
   // 派发有event的事件
   @autobind
-  dispatchEvent(e: React.SyntheticEvent<HTMLElement>) {
+  dispatchEvent(e: string | React.MouseEvent<any>) {
     const {dispatchEvent, value} = this.props;
     dispatchEvent(e, resolveEventData(this.props, {value}));
   }

--- a/packages/amis/src/renderers/List.tsx
+++ b/packages/amis/src/renderers/List.tsx
@@ -554,6 +554,16 @@ export default class List extends React.Component<ListProps, ListState> {
   handleCheck(item: IItem) {
     item.toggle();
     this.syncSelected();
+
+    const {dispatchEvent, store} = this.props;
+    dispatchEvent(
+      //增删改查卡片模式选择表格项
+      'selectedChange',
+      createObject(store.data, {
+        ...store.eventContext,
+        item: item.data
+      })
+    );
   }
 
   handleCheckAll() {
@@ -561,6 +571,15 @@ export default class List extends React.Component<ListProps, ListState> {
 
     store.toggleAll();
     this.syncSelected();
+
+    const {dispatchEvent} = this.props;
+    dispatchEvent(
+      //增删改查卡片模式选择表格项
+      'selectedChange',
+      createObject(store.data, {
+        ...store.eventContext
+      })
+    );
   }
 
   syncSelected() {

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -1117,20 +1117,15 @@ export default class Table<
       // 那么用户只能通过事件动作来更新上层变量来实现选中
       item.toggle(value);
     }
+    this.syncSelected();
 
-    const rendererEvent = await dispatchEvent(
+    await dispatchEvent(
       'selectedChange',
       createObject(data, {
         ...store.eventContext,
         item: item.data
       })
     );
-
-    if (rendererEvent?.prevented) {
-      return;
-    }
-
-    this.syncSelected();
   }
 
   handleRowClick(item: IRow, index: number) {
@@ -1199,19 +1194,14 @@ export default class Table<
     const {store, data, dispatchEvent} = this.props;
 
     store.toggleAll();
+    this.syncSelected();
 
-    const rendererEvent = await dispatchEvent(
+    await dispatchEvent(
       'selectedChange',
       createObject(data, {
         ...store.eventContext
       })
     );
-
-    if (rendererEvent?.prevented) {
-      return;
-    }
-
-    this.syncSelected();
   }
 
   handleQuickChange(

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -1667,19 +1667,16 @@ export default class Table2 extends React.Component<Table2Props, object> {
   ): Promise<any> {
     const {dispatchEvent, data, store} = this.props;
 
-    const rendererEvent = await dispatchEvent(
+    store.updateSelected(selectedRowKeys);
+    this.syncSelected();
+
+    await dispatchEvent(
       'selectedChange',
       createObject(data, {
         selectedItems: selectedRows,
         unSelectedItems: unSelectedRows
       })
     );
-
-    if (rendererEvent?.prevented) {
-      return rendererEvent?.prevented;
-    }
-    store.updateSelected(selectedRowKeys);
-    this.syncSelected();
   }
 
   @autobind


### PR DESCRIPTION
### What

### Why

* Table 组件本身需要发送 `selectedChange` 事件，同时如果在 CRUD 中也要发送，目前的逻辑在 table 中，但是当 crud 中开启分页保留选择项时，派送事件的上下文不正确，只有当前页的。所以这段逻辑需要在 CRUD 中处理。之前的逻辑 dispatchEvent 无法在组件树中干预，故：调整 dispatchEvent 执行顺序，走一遍组件树，最后在 rootRenderer 中执行事件逻辑，而不是每层渲染器层直接处理了。

### How
