### PR TITLE
fix: 修复popOver组件内容字符过长时，弹窗中的内容闪烁

### DIFF
--- a/packages/amis-core/src/utils/resize-sensor.ts
+++ b/packages/amis-core/src/utils/resize-sensor.ts
@@ -197,20 +197,16 @@ export function resizeSensor(
       if (once) {
         observer.disconnect();
       }
-
-      if (type === 'both') {
+      const entry = entries[0];
+      const cr = entry.contentRect;
+      // 变化大于0.5px时才触发回调,允许一定的误差
+      if (
+        Math.abs(cr.width - originWidth) > 0.5 ||
+        Math.abs(cr.height - originHeight) > 0.5
+      ) {
         callback();
-      } else {
-        const entry = entries[0];
-        const cr = entry.contentRect;
-        if (
-          (type === 'width' && cr.width !== originWidth) ||
-          (type === 'height' && cr.height !== originHeight)
-        ) {
-          callback();
-          originWidth = cr.width;
-          originHeight = cr.height;
-        }
+        originWidth = cr.width;
+        originHeight = cr.height;
       }
     });
     observer.observe(element);

--- a/packages/amis-core/src/utils/resize-sensor.ts
+++ b/packages/amis-core/src/utils/resize-sensor.ts
@@ -200,11 +200,18 @@ export function resizeSensor(
       const entry = entries[0];
       const cr = entry.contentRect;
       // 变化大于0.5px时才触发回调,允许一定的误差
-      if (
-        Math.abs(cr.width - originWidth) > 0.5 ||
-        Math.abs(cr.height - originHeight) > 0.5
-      ) {
-        callback();
+      const widthChanged = Math.abs(cr.width - originWidth) > 0.5;
+      const heightChanged = Math.abs(cr.height - originHeight) > 0.5;
+
+      if (widthChanged || heightChanged) {
+        if (type === 'both') {
+          callback();
+        } else if (
+          (type === 'width' && widthChanged) ||
+          (type === 'height' && heightChanged)
+        ) {
+          callback();
+        }
         originWidth = cr.width;
         originHeight = cr.height;
       }


### PR DESCRIPTION
### What
在特定的浏览器宽度下，弹出层的位置会一直循环计算
### Why
resizeSensor所监听的弹出层元素宽度会有0.几的变化，这个变化不应该重新去计算位置
### How
