### PR TITLE
fix: 优化开启千分符后，带默认值的情况下，输入时小数末尾零被格式掉

### DIFF
--- a/packages/amis-core/src/utils/math.ts
+++ b/packages/amis-core/src/utils/math.ts
@@ -45,6 +45,22 @@ export function numberFormatter(num: number | string, precision?: number) {
   return ZERO.toFixed(finalP);
 }
 
+// 还原千分符格式化的值，并保留小数点后的精度
+export function numberReverter(value: string | number | undefined) {
+  if (!value) return '';
+  const stringValue = value.toString();
+  const withoutCommas = stringValue.replace(/,/g, '');
+
+  // 如果原始字符串有小数点，保留小数部分的精度
+  if (stringValue.includes('.')) {
+    const decimalPlaces = stringValue.split('.')[1].length;
+    return Number(withoutCommas).toFixed(decimalPlaces);
+  }
+
+  // 对于整数，直接返回转换后的数字
+  return withoutCommas;
+}
+
 /**
  * 判断一个数字是否为整数，且在给定范围内
  *

--- a/packages/amis/src/renderers/Form/InputNumber.tsx
+++ b/packages/amis/src/renderers/Form/InputNumber.tsx
@@ -18,6 +18,7 @@ import {
   autobind,
   createObject,
   numberFormatter,
+  numberReverter,
   safeSub,
   normalizeOptions,
   Option,
@@ -499,8 +500,11 @@ export default class NumberControl extends React.Component<
           ) => {
             // 增加千分分隔
             if (kilobitSeparator && value) {
-              if (userTyping || this.input === document.activeElement) {
-                // 如果是用户输入状态，则只进行千分隔处理，避免光标乱跳
+              if (
+                (userTyping || this.input === document.activeElement) &&
+                numberReverter(value) === numberReverter(this.input?.value)
+              ) {
+                // 如果是用户输入状态，且value与输入框内值相同，则只进行千分隔处理，避免光标乱跳
                 let parts = value.toString().split('.');
                 parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
                 value = parts.join('.');


### PR DESCRIPTION
### What

### Why

### How
