### PR TITLE
fix: 修复 combo 组件可多选按钮关闭时最多条数&最少条数未被清空

### DIFF
--- a/packages/amis-editor/src/plugin/Form/Combo.tsx
+++ b/packages/amis-editor/src/plugin/Form/Combo.tsx
@@ -375,6 +375,8 @@ export class ComboControlPlugin extends BasePlugin {
                     form.setValueByName('removable', value);
                     !value && form.setValueByName('draggable', false);
                     form.setValueByName('flat', false);
+                    form.setValueByName('maxLength', undefined);
+                    form.setValueByName('minLength', undefined);
                   }
                 }),
                 {


### PR DESCRIPTION
### What
combo 组件关闭可多选按钮时，增加对最多条数和最少条数属性的清空操作

### Why
![20250412-204541](https://github.com/user-attachments/assets/bc7b2070-fa9f-4ea4-9d3e-676ecaf4876b)


### How
每次 combo 组件可多选按钮被点击后，将 maxLength 和 minLength 属性清除