### PR TITLE
fix: form reset的时候父级数据也被还原

### DIFF
--- a/packages/amis-core/src/store/form.ts
+++ b/packages/amis-core/src/store/form.ts
@@ -765,7 +765,8 @@ export const FormStore = ServiceStore.named('FormStore')
 
     function reset(cb?: (data: any) => void, resetData: boolean = true) {
       if (resetData) {
-        self.data = self.pristine;
+        // 父级的数据可能已经被修改，__super不应该被修改
+        self.data = createObject(self.data.__super, self.pristine);
       }
 
       // 值可能变了，重新验证一次。


### PR DESCRIPTION
### What
如题，表单还原的时候，会导致父级数据被还原。如果表单项中有数据请求等依赖父级数据，会导致数据错误
### Why

### How
