### PR TITLE
fix: 当表格列配置溢出显示 mapping等类型列显示出原始数据

### DIFF
--- a/packages/amis/src/renderers/PopOver.tsx
+++ b/packages/amis/src/renderers/PopOver.tsx
@@ -211,14 +211,14 @@ export const HocPopOver =
       }
 
       buildSchema() {
-        const {popOver, name, label, translate: __} = this.props;
+        const {popOver, name, label, translate: __, column} = this.props;
 
         let schema;
 
         if (popOver === true) {
           schema = {
             type: 'panel',
-            body: `\${${name}}`
+            body: column ?? `\${${name}}`
           };
         } else if (
           popOver &&
@@ -248,7 +248,7 @@ export const HocPopOver =
         } else if (this.getClassName() === 'ellipsis') {
           schema = {
             type: 'panel',
-            body: `\${${name}}`
+            body: column ?? `\${${name}}`
           };
         }
 


### PR DESCRIPTION
### What

### Why

### How
