### PR TITLE
[fix] picker组件禁用态样式

### DIFF
--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -3744,7 +3744,7 @@
   --Pick-status-focus-left-border-style: var(--borders-style-2);
   --Pick-status-focus-shadow: var(--shadows-shadow-none);
   --Pick-status-focus-bgColor: var(--colors-neutral-fill-11);
-  --Pick-status-disabled-color: var(--colors-neutral-text-2);
+  --Pick-status-disabled-color: var(--colors-neutral-line-6);
   --Pick-status-disabled-fontSize: var(--fonts-size-7);
   --Pick-status-disabled-fontWeight: var(--fonts-weight-6);
   --Pick-status-disabled-top-border-color: var(--colors-neutral-line-8);
@@ -3760,9 +3760,6 @@
   --Pick-status-disabled-left-border-width: var(--borders-width-2);
   --Pick-status-disabled-left-border-style: var(--borders-style-2);
   --Pick-status-disabled-bgColor: var(--colors-neutral-fill-10);
-  --Pick-status-disabled-color: var(--colors-neutral-line-6);
-  --Pick-status-disabled-fontSize: var(--fonts-size-7);
-  --Pick-status-disabled-fontWeight: var(--fonts-weight-6);
 
   --Status-base-fontSize: var(--fonts-size-9);
   --Status-base-icon-size: var(--sizes-size-8);

--- a/packages/amis-ui/scss/components/form/_picker.scss
+++ b/packages/amis-ui/scss/components/form/_picker.scss
@@ -39,7 +39,6 @@
 
   &.is-disabled {
     pointer-events: none;
-    opacity: var(--Button-onDisabled-opacity);
 
     .#{$ns}Picker-placeholder {
       color: var(--Pick-status-disabled-color);


### PR DESCRIPTION
### What
Picker组件禁用态样式与其他组件的边框、底色不同

### Why
picker加了一个透明度属性

### How
去掉picker的透明度，暂时不对value的透明度做特殊处理
