### PR TITLE
fix: 修复json请求时无法指定自定义的Content-Type

### DIFF
--- a/packages/amis-core/src/utils/api.ts
+++ b/packages/amis-core/src/utils/api.ts
@@ -605,7 +605,9 @@ export function wrapFetcher(
     ) {
       api.data = qsstringify(api.data, api.qsOptions) as any;
       api.headers = api.headers || (api.headers = {});
-      api.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+      if (!api.headers['Content-Type']) {
+        api.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+      }
     } else if (
       api.data &&
       typeof api.data !== 'string' &&
@@ -613,7 +615,10 @@ export function wrapFetcher(
     ) {
       api.data = JSON.stringify(api.data) as any;
       api.headers = api.headers || (api.headers = {});
-      api.headers['Content-Type'] = 'application/json';
+      // 避免覆盖用户自定义的Content-Type，如同为json请求，还有扩展的application/vnd.api+json
+      if (!api.headers['Content-Type']) {
+        api.headers['Content-Type'] = 'application/json';
+      }
     }
 
     // 如果发送适配器中设置了 mockResponse


### PR DESCRIPTION
同为json请求，还有扩展的Content-Type，如`application/vnd.api+json`，当遇到严格的校验的服务接口，使用`application/json`无法通过校验，所以不应遇到json请求就统一指定`Content-Type`为`application/json`