### PR TITLE
fix: 修复在无界框架中，弹出层计算了非iframe区域的高度，导致弹层被遮挡

### DIFF
--- a/packages/amis-core/src/utils/dom.tsx
+++ b/packages/amis-core/src/utils/dom.tsx
@@ -96,6 +96,7 @@ export function calculatePosition(
 
   const clip = container.getBoundingClientRect();
   const clip2 = overlayNode.getBoundingClientRect();
+  const clip3 = scrollParent.getBoundingClientRect();
   const scaleX = overlayNode.offsetWidth
     ? clip2.width / overlayNode.offsetWidth
     : 1;
@@ -202,12 +203,15 @@ export function calculatePosition(
           : myY === 'bottom'
           ? overlayHeight
           : overlayHeight / 2;
+      // 需考虑 iframe 之外的高度，并不属于可视区域
+      const scrollParentOffset =
+        positionTop < 0 && window.self !== window.top ? clip3.y : 0;
 
       // 如果还有其他可选项，则做位置判断，是否在可视区域，不完全在则继续看其他定位情况。
       if (tests.length || isAuto) {
         const transformed = {
           x: clip.x + positionLeft / scaleX,
-          y: clip.y + positionTop / scaleY,
+          y: clip.y - scrollParentOffset + positionTop / scaleY,
           width: overlayWidth,
           height: overlayHeight
         };


### PR DESCRIPTION
### What
![Pasted Graphic 1](https://github.com/user-attachments/assets/7f14dd4b-e7b9-4aff-b69d-ae85a2008def)
### Why
当嵌套在无界当中时，弹出层会把非iframe的顶层区域也当成自己的可视区域，计算出来的位置，并不是正确的。超出了iframe的区域，于是不可见。
### How
判断当前页面是否是在iframe内部，是的话减去非iframe可视区域的高度。
