### PR TITLE
fix: 修复接口报错时无法弹出预期的 msg 内容

### DIFF
--- a/packages/amis-core/src/store/crud.ts
+++ b/packages/amis-core/src/store/crud.ts
@@ -54,6 +54,7 @@ class ServerError extends Error {
   readonly response: any;
   constructor(msg: string, response?: any) {
     super(msg);
+    Object.setPrototypeOf(this, ServerError.prototype);
     this.response = response;
   }
 }

--- a/packages/amis-core/src/store/table2.ts
+++ b/packages/amis-core/src/store/table2.ts
@@ -36,6 +36,11 @@ import {filter} from '../utils/tpl';
 
 class ServerError extends Error {
   type = 'ServerError';
+
+  constructor(msg: string) {
+    super(msg);
+    Object.setPrototypeOf(this, ServerError.prototype);
+  }
 }
 
 export const Column = types

--- a/packages/amis-core/src/utils/errors.ts
+++ b/packages/amis-core/src/utils/errors.ts
@@ -6,6 +6,7 @@ export class ServerError extends Error {
 
   constructor(msg: string, response: Payload) {
     super(msg);
+    Object.setPrototypeOf(this, ServerError.prototype);
     this.response = response;
   }
 }


### PR DESCRIPTION
### What
![image](https://github.com/user-attachments/assets/36875833-0f83-4584-9edf-5053d68bd062)
![image](https://github.com/user-attachments/assets/e9790541-b270-410c-b59d-6b69df3abf14)

### Why
![image](https://github.com/user-attachments/assets/1efb45b1-162e-4545-bd13-49f4924df4e2)
result.msg 是有值的
![image](https://github.com/user-attachments/assets/699711c9-fe35-4acf-bb51-000d7e0e9d36)
最后 toast 的时候拿到的 e.message 并没有生效
本质原因如下
![image](https://github.com/user-attachments/assets/d4a9c35b-2e86-41c8-aaeb-1bdb3513b67f)

### How
解决办法参考 https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
