### PR TITLE
feat: TooltipWrapper暗色模式下border去除

### DIFF
--- a/packages/amis-ui/scss/components/_tooltip.scss
+++ b/packages/amis-ui/scss/components/_tooltip.scss
@@ -179,7 +179,7 @@
 
   &--dark {
     background: var(--Tooltip-bg--dark);
-    border: var(--common-popover-border);
+    border: none;
     box-shadow: var(--Tooltip-boxShadow--dark);
 
     .#{$ns}Tooltip-title {


### PR DESCRIPTION
### What
TooltipWrapper组件暗色模式下去掉白色边框

### Why
![image](https://github.com/user-attachments/assets/ecf02452-6ae4-4518-b554-27d976d88a81)


### How
![image](https://github.com/user-attachments/assets/4a5491d4-c44f-407e-a4cf-45671cf15c9f)
