### PR TITLE
fix: range类开启双字段保存时,影响默认值配置中结束字段的值回显

### DIFF
--- a/packages/amis-editor/src/renderer/FormulaControl.tsx
+++ b/packages/amis-editor/src/renderer/FormulaControl.tsx
@@ -522,7 +522,8 @@ export default class FormulaControl extends React.Component<
         'validateApi',
         'themeCss',
         'onEvent',
-        'embed'
+        'embed',
+        'extraName'
       ];
 
       // 当前组件要剔除的字段


### PR DESCRIPTION
### What

### Why

### How
