### PR TITLE
fix: 修复级联选择器组件不同的分类下子类的label不应该因为value一致就展示了一样label的问题

### DIFF
--- a/packages/amis-core/src/utils/normalizeOptions.ts
+++ b/packages/amis-core/src/utils/normalizeOptions.ts
@@ -76,9 +76,13 @@ export function normalizeOptions(
         };
 
         if (typeof option.children !== 'undefined') {
+          // 用新的 share 避免 children 内部复用全局缓存
           option.children = normalizeOptions(
             option.children,
-            share,
+            {
+              values: [],
+              options: []
+            },
             valueField
           );
         } else if (value !== undefined) {


### PR DESCRIPTION
### What

### Why

### How
