### PR TITLE
fix: 修复级联选择器拿不到最新选中值+修复开启溢出隐藏后中文的第二行会露出一点

### DIFF
--- a/packages/amis-ui/scss/components/_popoverable.scss
+++ b/packages/amis-ui/scss/components/_popoverable.scss
@@ -27,6 +27,7 @@
 
     &-ellipsis {
       width: auto;
+      max-height: var(--sizes-base-15);
       overflow: hidden;
       display: -webkit-inline-box;
       -webkit-box-orient: vertical;

--- a/packages/amis/src/renderers/Form/NestedSelect.tsx
+++ b/packages/amis/src/renderers/Form/NestedSelect.tsx
@@ -307,7 +307,8 @@ export default class NestedSelectControl extends React.Component<
     }
 
     const isPrevented = await this.dispatchEvent('change', {
-      value
+      value,
+      selectedItems: option
     });
     isPrevented || onChange(value);
     isPrevented || this.handleResultClear();
@@ -432,7 +433,8 @@ export default class NestedSelectControl extends React.Component<
       ? value.map(item => item[valueField as string])
       : value;
     const isPrevented = await this.dispatchEvent('change', {
-      value: newValue
+      value: newValue,
+      selectedItems: option
     });
     isPrevented || onChange(newValue);
     isPrevented || this.handleResultClear();


### PR DESCRIPTION
### What
<img width="359" alt="image" src="https://github.com/user-attachments/assets/52d0b415-c101-4dfa-a9c8-1eba38fb1c54" />
### Why

### How
