### PR TITLE
fix: 使用最后一行的单元格来计算列宽，提高性能

### DIFF
--- a/packages/amis-ui/src/components/table/index.tsx
+++ b/packages/amis-ui/src/components/table/index.tsx
@@ -1492,7 +1492,7 @@ export class Table extends React.PureComponent<TableProps, TableState> {
       return;
     }
     const cols = [].slice.call(
-      tbodyDom?.querySelectorAll(':scope>tr>td[data-col]')
+      tbodyDom?.querySelectorAll(':scope>tr:last-child>td[data-col]')
     );
     const colWidths: any = {};
     cols.forEach((col: HTMLElement) => {


### PR DESCRIPTION
### What
之前遍历了所有单元格，性能不好
### Why

### How
