### PR TITLE
fix: 校验规则滚动条会与属性配置栏滚动条冲突，撑开空白底部

### DIFF
--- a/packages/amis-editor/src/renderer/ValidationControl.tsx
+++ b/packages/amis-editor/src/renderer/ValidationControl.tsx
@@ -282,6 +282,7 @@ export default class ValidationControl extends React.Component<
             closeOnOutside: true,
             hideCaret: true,
             disabled: buttons.length === 0,
+            popOverContainer: () => document.body,
             buttons
           },
           {


### PR DESCRIPTION
### What

### Why

### How
