### PR TITLE
fix:修复checkbox的标签对齐

### DIFF
--- a/packages/amis-ui/scss/_components.scss
+++ b/packages/amis-ui/scss/_components.scss
@@ -1664,7 +1664,7 @@
   --Form-item-color: var(--colors-neutral-text-4);
   --Form-item-fontSize: var(--fonts-size-7);
   --Form-item-fontWeight: var(--fonts-weight-6);
-  --Form-item-lineHeight: var(--fonts-lineHeight-1);
+  --Form-item-lineHeight: var(--fonts-lineHeight-2);
   --Form-item-star-color: var(--colors-error-5);
   --Form-item-star-size: var(--sizes-size-7);
   --Form-description-color: var(--colors-neutral-text-5);


### PR DESCRIPTION
### What

### Why

### How
