### PR TITLE
fix: 表格列配置溢出显示时，mapping类型列显示出原始数据

### DIFF
--- a/packages/amis/src/renderers/PopOver.tsx
+++ b/packages/amis/src/renderers/PopOver.tsx
@@ -211,7 +211,7 @@ export const HocPopOver =
       }
 
       buildSchema() {
-        const {popOver, name, label, translate: __} = this.props;
+        const {popOver, name, label, translate: __, column} = this.props;
 
         let schema;
 
@@ -248,7 +248,7 @@ export const HocPopOver =
         } else if (this.getClassName() === 'ellipsis') {
           schema = {
             type: 'panel',
-            body: `\${${name}}`
+            body: column && column.type === 'mapping' ? column : `\${${name}}`
           };
         }
 


### PR DESCRIPTION
### What

### Why

### How
