### PR TITLE
fix: 解决 PopOver 中打开新页签后第一次点击无效的问题

### DIFF
--- a/packages/amis-core/src/components/PopOver.tsx
+++ b/packages/amis-core/src/components/PopOver.tsx
@@ -126,6 +126,8 @@ export class PopOver extends React.PureComponent<PopOverProps, PopOverState> {
       closeOnOutside &&
       target &&
       this.wrapperRef.current &&
+      // 要可见，不可见就不处理了，通常是打开了新页签
+      this.wrapperRef.current.offsetHeight &&
       !this.wrapperRef.current
         .getAttributeNames()
         .find(n => n.startsWith(SubPopoverDisplayedID)) &&


### PR DESCRIPTION
### What

### Why

### How
