### PR TITLE
chore: ajaxAction api 配置 sendOn 空字符串 api 执行会被拦截问题调整

### DIFF
--- a/packages/amis-core/src/actions/AjaxAction.ts
+++ b/packages/amis-core/src/actions/AjaxAction.ts
@@ -61,7 +61,7 @@ export class AjaxAction implements RendererAction {
     const messages = (action?.api as ApiObject)?.messages;
     let api = normalizeApi(action.api);
 
-    if (api.sendOn !== undefined) {
+    if (api.sendOn) {
       // 发送请求前，判断是否需要发送
       const sendOn = await evalExpressionWithConditionBuilderAsync(
         api.sendOn,


### PR DESCRIPTION
### What

### Why

### How
