### PR TITLE
fix: 修复动作赋值先选自定义后id后选组件不出现赋值控件问题

### DIFF
--- a/packages/amis-editor/src/renderer/event-control/actionsPanelPlugins/componentActionsPanel/setValue.tsx
+++ b/packages/amis-editor/src/renderer/event-control/actionsPanelPlugins/componentActionsPanel/setValue.tsx
@@ -186,23 +186,6 @@ registerActionPanel('setValue', {
         body: [
           {
             type: 'wrapper',
-            visibleOn: 'this.componentId === "customCmptId"',
-            className: 'p-none mb-6',
-            body: [
-              ...renderCmptActionSelect(
-                '目标组件',
-                true,
-                (value: string, oldVal: any, data: any, form: any) => {
-                  form.setValueByName('args.__containerType', 'all');
-                  form.setValueByName('args.__comboType', 'all');
-                },
-                true
-              )
-            ]
-          },
-          {
-            type: 'wrapper',
-            visibleOn: 'this.componentId !== "customCmptId"',
             className: 'p-none mb-6',
             body: [
               ...renderCmptActionSelect(


### PR DESCRIPTION
### What

### Why

### How
