### PR TITLE
fix: 修复Date在极端情况下渲染错误的问题

### DIFF
--- a/packages/amis/src/renderers/Date.tsx
+++ b/packages/amis/src/renderers/Date.tsx
@@ -135,7 +135,14 @@ export class DateField extends React.Component<DateProps, DateState> {
       <span className="text-muted">{placeholder}</span>
     );
 
-    const value = getPropValue(this.props);
+    let value = getPropValue(this.props);
+
+    //时间范围格式修正
+    if (typeof value === 'string' && value.includes(',')) {
+      const values = value.split(',');
+      const firstValue = values.find(num => Number(num) > 0);
+      if (firstValue) value = firstValue;
+    }
 
     // 主要是给 fromNow 用的
     let date: any = null;

--- a/packages/amis/src/renderers/Date.tsx
+++ b/packages/amis/src/renderers/Date.tsx
@@ -140,8 +140,7 @@ export class DateField extends React.Component<DateProps, DateState> {
     //时间范围格式修正
     if (typeof value === 'string' && value.includes(',')) {
       const values = value.split(',');
-      const firstValue = values.find(num => Number(num) > 0);
-      if (firstValue) value = firstValue;
+      value = values[0];
     }
 
     // 主要是给 fromNow 用的


### PR DESCRIPTION
### What
当table配置了
`{
  "quickEdit": {
  "type": "date-range"
  },
  "name": "time",
  "label": "日期",
  "type": "date"
}`
快捷编辑时间范围
这时候Date组件便会收到如1744041600,1749139199
点击确认会显示
![image](https://github.com/user-attachments/assets/ab2ef20e-0196-40c4-9699-85faf14f0717)
![image](https://github.com/user-attachments/assets/e15e962e-c2d6-4733-817e-bad6b6293bfd)
1744-04-16
这很神奇?
### Why
因为Date组件调用normalizeDate->moment('1744041600,1749139199','YYYY-MM-DD HH:mm:ss')
神奇的事情发生了
moment尝试把17440416..转换为YYYY-MM-DD HH:mm:ss 是成功的isValid验证通过
为什么呢因为1744-04 -6 是合法的
虽然这种概率很小就是某天0点的时间戳1744041600 恰好是一个时间格式时, 时间就显示错误了
如:20240507,202550408 ... 
### How
Date组件名字已经确定他是一个日期显示器不是日期范围显示器
所以修改Date组件兼容1744041600,1749139199 值,解析value取第一个有效的时间显示
不应该错误的吧1744041600,1749139199传给moment
