### PR TITLE
fix: 修复 input-tag 组件配置面板无法配置 joinValues 和 extractValue 属性

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,7 @@
       "type": "node",
       "request": "launch",
       "name": "Jest: current file",
+      //"env": { "NODE_ENV": "test" },
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": ["${fileBasenameNoExtension}"],
       "console": "integratedTerminal",


### PR DESCRIPTION
### What
修复 input-tag 组件配置面板无法配置 joinValues 和 extractValue 属性的情况

### Why
修复前
![image](https://github.com/user-attachments/assets/6538bcfe-61f8-4cfd-bdd3-774d24c3f9fc)
修复后
![image](https://github.com/user-attachments/assets/77960be2-8aa0-4450-983c-65f1f944a2a5)

### How
getSchemaTpl('joinValues') 和 getSchemaTpl('extractValue') 内部的 visibleOn 判断依赖了 multiple 字段，但是 input-tag 组件里没有该字段，修改相关逻辑
