### PR TITLE
[fix] 删除多余的props,只传递必要的,避免static定制情况下读到非预期的数据

### DIFF
--- a/packages/amis/src/renderers/Form/StaticHoc.tsx
+++ b/packages/amis/src/renderers/Form/StaticHoc.tsx
@@ -126,7 +126,7 @@ let supportStatic = <T extends FormControlProps>() => {
             [props.type || '', 'form-static-schema'].join('-'),
             staticSchema,
             {
-              ...omit(props, ['onEvent']),
+              selectedOptions: props.selectedOptions,
               ...(props.selectedOptions
                 ? {
                     data: createObject(


### PR DESCRIPTION

### What
picker设定静态展示使用其他组件，如each时，会读取picker的value，而不是解析name数据
### Why

### How
