### PR TITLE
fix: 解决当 drawer 中嵌入iframe 时，拖动不了的问题

### DIFF
--- a/packages/amis-core/src/store/modal.ts
+++ b/packages/amis-core/src/store/modal.ts
@@ -6,6 +6,7 @@ export const ModalStore = ServiceStore.named('ModalStore')
   .props({
     form: types.frozen(),
     entered: false,
+    dragging: false,
     resizeCoord: 0,
     schema: types.frozen(),
     isFullscreen: false
@@ -14,6 +15,9 @@ export const ModalStore = ServiceStore.named('ModalStore')
     return {
       get formData() {
         return createObject(self.data, self.form);
+      },
+      get inDragging() {
+        return self.dragging;
       }
     };
   })
@@ -22,7 +26,9 @@ export const ModalStore = ServiceStore.named('ModalStore')
       setEntered(value: boolean) {
         self.entered = value;
       },
-
+      setDragging(value: boolean) {
+        self.dragging = value;
+      },
       setFormData(obj: any) {
         self.form = obj;
       },

--- a/packages/amis-ui/src/components/Drawer.tsx
+++ b/packages/amis-ui/src/components/Drawer.tsx
@@ -45,14 +45,18 @@ export interface DrawerProps {
   drawerClassName?: string;
   drawerMaskClassName?: string;
   mobileUI?: boolean;
+  onDragging?: (value: boolean) => void;
 }
+
 export interface DrawerState {}
+
 const fadeStyles: {
   [propName: string]: string;
 } = {
   [ENTERING]: 'in',
   [ENTERED]: 'in'
 };
+
 export class Drawer extends React.Component<DrawerProps, DrawerState> {
   static defaultProps: Pick<
     DrawerProps,
@@ -223,7 +227,8 @@ export class Drawer extends React.Component<DrawerProps, DrawerState> {
 
   @autobind
   resizeMouseDown(e: React.MouseEvent<any>) {
-    const {position, classPrefix: ns} = this.props;
+    const {position, classPrefix: ns, onDragging} = this.props;
+    onDragging && onDragging(true);
     const drawer = this.contentDom;
     const resizer = this.resizer.current!;
 
@@ -282,6 +287,8 @@ export class Drawer extends React.Component<DrawerProps, DrawerState> {
 
   @autobind
   removeResize() {
+    const {onDragging} = this.props;
+    onDragging && onDragging(false);
     document.body.removeEventListener('mousemove', this.bindResize);
     document.body.removeEventListener('mouseup', this.removeResize);
   }

--- a/packages/amis/src/renderers/Drawer.tsx
+++ b/packages/amis/src/renderers/Drawer.tsx
@@ -181,6 +181,7 @@ export interface DrawerProps
 export interface DrawerState {
   entered: boolean;
   resizeCoord: number;
+
   [propName: string]: any;
 }
 
@@ -229,6 +230,7 @@ export default class Drawer extends React.Component<DrawerProps> {
   $$id: string = guid();
   drawer: any;
   clearErrorTimer: ReturnType<typeof setTimeout> | undefined;
+
   constructor(props: DrawerProps) {
     super(props);
 
@@ -497,6 +499,7 @@ export default class Drawer extends React.Component<DrawerProps> {
       onSaved: this.handleFormSaved,
       onActionSensor: this.handleActionSensor,
       btnDisabled: store.loading,
+      inDragging: store.inDragging,
       syncLocation: false
     };
 
@@ -655,6 +658,7 @@ export default class Drawer extends React.Component<DrawerProps> {
         overlay={overlay}
         onEntered={this.handleEntered}
         onExited={this.handleExited}
+        onDragging={store.setDragging}
         closeOnEsc={closeOnEsc}
         closeOnOutside={
           !store.drawerOpen && !store.dialogOpen && closeOnOutside

--- a/packages/amis/src/renderers/IFrame.tsx
+++ b/packages/amis/src/renderers/IFrame.tsx
@@ -60,7 +60,9 @@ export interface IFrameSchema extends BaseSchema {
 
 export interface IFrameProps
   extends RendererProps,
-    Omit<IFrameSchema, 'type' | 'className'> {}
+    Omit<IFrameSchema, 'type' | 'className'> {
+  inDragging?: boolean;
+}
 
 export default class IFrame extends React.Component<IFrameProps, object> {
   IFrameRef: React.RefObject<HTMLIFrameElement> = React.createRef();
@@ -229,6 +231,7 @@ export default class IFrame extends React.Component<IFrameProps, object> {
       env,
       themeCss,
       baseControlClassName,
+      inDragging,
       classnames: cx
     } = this.props;
 
@@ -241,7 +244,12 @@ export default class IFrame extends React.Component<IFrameProps, object> {
       ...tempStyle,
       ...style
     };
-
+    if (inDragging) {
+      style = {
+        ...style,
+        pointerEvents: 'none'
+      };
+    }
     const finalSrc = src
       ? resolveVariableAndFilter(src, data, '| raw')
       : undefined;


### PR DESCRIPTION
```
{
  "type": "page",
  "body": [
    {
      "label": "弹出",
      "type": "button",
      "actionType": "drawer",
      "drawer": {
        "title": "抽屉标题",
        "body": {
          "type": "iframe",
          "src": "https://www.baidu.com"
        },
        "resizable": true
      },
      "id": "u:dc6bdfb36551"
    }
  ],
  "id": "u:2c910152a738",
  "regions": [
    "body"
  ],
  "asideResizor": false,
  "pullRefresh": {
    "disabled": true
  }
}
```

主要原因是拖动的时候，iframe 抢走了鼠标