### PR TITLE
feat: 添加 updateOffScreen 方法并在导航点击时关闭边栏

### DIFF
--- a/packages/amis-core/src/store/app.ts
+++ b/packages/amis-core/src/store/app.ts
@@ -74,6 +74,9 @@ export const AppStore = ServiceStore.named('AppStore')
     toggleOffScreen() {
       self.offScreen = !self.offScreen;
     },
+    updateOffScreen(value: boolean) {
+      self.offScreen = value;
+    },
 
     setPages(pages: any) {
       if (pages && !Array.isArray(pages)) {

--- a/packages/amis/src/renderers/App.tsx
+++ b/packages/amis/src/renderers/App.tsx
@@ -305,8 +305,10 @@ export class App extends React.Component<AppProps, object> {
   handleNavClick(e: React.MouseEvent) {
     e.preventDefault();
 
+    const store = this.props.store;
     const env = this.props.env;
     const link = e.currentTarget.getAttribute('href')!;
+    store.updateOffScreen(false);
     env.jumpTo(link, undefined, this.props.data);
   }
 


### PR DESCRIPTION
### What
导航点击时关闭边栏

### Why
移动端，导航点击切换页面后，关闭边栏

### How
1. `AppStore` 添加 `updateOffScreen` 方法
2. `App.handleNavClick` 调用之。