### PR TITLE
feat: 折叠边栏时，对齐 logo 和页面菜单图标

### DIFF
--- a/packages/amis-ui/scss/layout/_layout.scss
+++ b/packages/amis-ui/scss/layout/_layout.scss
@@ -426,6 +426,7 @@ body {
 
       .#{$ns}Layout-brandBar {
         position: static;
+        padding-right: 17px;
       }
 
       .#{$ns}Layout-asideWrap {


### PR DESCRIPTION
### What
折叠边栏时，对齐 logo 和页面菜单图标

### Why
折叠边栏时，菜单右侧有 `17px` padding，但品牌区域没有该 padding，导致图标不对齐

### How

添加 `Layout--folded Layout-brandBar` 的 `padding-right: 17px;`