### PR TITLE
fix: App 组件切换带参数的相同路由下的不同路径，路由参数不会更新的问题

### DIFF
--- a/packages/amis-core/src/store/app.ts
+++ b/packages/amis-core/src/store/app.ts
@@ -146,6 +146,12 @@ export const AppStore = ServiceStore.named('AppStore')
     ) {
       // 同一个页面直接返回。
       if (self.activePage?.id === page.id) {
+        if (params !== undefined) {
+          self.activePage = {
+            ...self.activePage,
+            params: params
+          };
+        }
         return;
       }
 


### PR DESCRIPTION
### What

修复App 组件切换带参数的相同路由下的不同路径，路由参数不会更新的问题 #12149

### Why

同一路由下切换路径，原代码判断相同路由后跳过了 `params` 更新。

### How

相同路由时，额外简易添加更新`params`逻辑。
