### PR TITLE
feat: 折叠状态导航菜单优化

### DIFF
--- a/examples/components/App.tsx
+++ b/examples/components/App.tsx
@@ -440,6 +440,7 @@ export class App extends React.PureComponent<{
 
     return (
       <AsideNav
+        folded={this.state.folded}
         navigations={this.state.navigations.map((item: any) => ({
           ...item,
           children: item.children

--- a/packages/amis-ui/scss/layout/_aside.scss
+++ b/packages/amis-ui/scss/layout/_aside.scss
@@ -340,10 +340,20 @@ img.#{$ns}AsideNav-itemIcon {
       height: 0 !important;
       position: absolute;
       left: 100%;
-      top: 0 !important;
+      top: 0;
       z-index: 1050;
       width: var(--Layout-aside-width);
       box-shadow: 0 px2rem(2px) px2rem(6px) rgba(0, 0, 0, 0.1);
+
+      &[data-pop-direction="left"] {
+        left: auto !important;
+        right: 100% !important;
+      }
+
+      &[data-pop-vertical="up"] {
+        top: auto !important;
+        bottom: 0 !important;
+      }
     }
 
     &.#{$ns}Layout--sm .#{$ns}AsideNav-subList {

--- a/packages/amis-ui/scss/layout/_aside.scss
+++ b/packages/amis-ui/scss/layout/_aside.scss
@@ -104,6 +104,9 @@
     overflow: hidden;
     margin-left: calc(var(--gap-md) * -1);
     transition: all var(--animation-duration) ease-in-out 0s;
+    .#{$ns}Layout--folded & {
+      transition: none !important;
+    }
     background: var(--Layout-aside-subList-bg);
 
     .#{$ns}Layout--folded .#{$ns}AsideNav-item > & {

--- a/packages/amis-ui/src/components/AsideNav.tsx
+++ b/packages/amis-ui/src/components/AsideNav.tsx
@@ -394,9 +394,33 @@ export class AsideNav extends React.Component<AsideNavProps, AsideNavState> {
       subMenuElement.setAttribute('data-pop-direction', 'left');
     }
 
+    const viewportMargin = 20;
     // 设置垂直方向
     if (shouldExpandUp) {
       subMenuElement.setAttribute('data-pop-vertical', 'up');
+      const willOverflowAbove = spaceAbove < subMenuHeight;
+      if (willOverflowAbove) {
+        // 如果仍会溢出，适当下移
+        const offsetHeight = parentRect.bottom - rect.height - viewportMargin;
+        subMenuElement.style.setProperty(
+          'bottom',
+          `${offsetHeight}px`,
+          'important'
+        );
+      }
+    } else if (spaceBelow < subMenuHeight) {
+      // 如果仍会溢出，适当上移
+      const offsetHeightRequired = parentRect.top + rect.height - viewportHeight + viewportMargin;
+      const offsetHeightAvailable = spaceAbove - viewportMargin;
+      const offsetHeight = Math.min(
+        offsetHeightRequired,
+        offsetHeightAvailable
+      );
+      subMenuElement.style.setProperty(
+        'top',
+        `${-offsetHeight}px`,
+        'important'
+      );
     }
   }
 
@@ -407,6 +431,8 @@ export class AsideNav extends React.Component<AsideNavProps, AsideNavState> {
     // 清除所有调整属性
     subMenuElement.removeAttribute('data-pop-direction');
     subMenuElement.removeAttribute('data-pop-vertical');
+    subMenuElement.style.removeProperty('top');
+    subMenuElement.style.removeProperty('bottom');
   }
 }
 

--- a/packages/amis-ui/src/components/AsideNav.tsx
+++ b/packages/amis-ui/src/components/AsideNav.tsx
@@ -207,6 +207,7 @@ export class AsideNav extends React.Component<AsideNavProps, AsideNavState> {
     depth = 1
   ): React.ReactNode {
     const {
+      folded,
       renderLink,
       isActive,
       renderSubLinks,
@@ -241,6 +242,24 @@ export class AsideNav extends React.Component<AsideNavProps, AsideNavState> {
           [`is-open`]: link.open,
           [`is-active`]: link.active
         })}
+        onMouseEnter={
+          !folded || !link.children || !link.children.length
+            ? undefined
+            : e => {
+              if (!link.open) {
+                this.toggleExpand(link, e);
+              }
+            }
+        }
+        onMouseLeave={
+          !folded || !link.children || !link.children.length
+            ? undefined
+            : e => {
+              if (link.open) {
+                this.toggleExpand(link, e);
+              }
+            }
+        }
       >
         {dom}
         {renderSubLinks(link, this.renderLink, depth, this.props)}

--- a/packages/amis/src/renderers/App.tsx
+++ b/packages/amis/src/renderers/App.tsx
@@ -376,6 +376,7 @@ export class App extends React.Component<AppProps, object> {
       <>
         {asideBefore ? render('aside-before', asideBefore) : null}
         <AsideNav
+          folded={store.folded}
           navigations={store.navigations}
           renderLink={(
             {link, active, toggleExpand, classnames: cx, depth, subHeader}: any,


### PR DESCRIPTION
### What
折叠状态导航菜单优化

### How

对应4个commits，分别：

1. 点击弹出导航菜单项时关闭无关项，避免菜单层叠遮挡
1. 一级菜单是 hover，二三级菜单需要点击，比较不协调。调整为移动切换子菜单。
1. 优化菜单展开方向，比如，位于屏幕下沿的菜单项，很多时候向上展开即可避免溢出
    <img width="407" height="351" alt="image" src="https://github.com/user-attachments/assets/9e559dc8-7b3d-4f94-8822-6ce000e78e4b" />

1. 选择展开方向后若仍溢出，充分利用剩余空间：向上展开时的底部空间；向下展开时的顶部空间
    <img width="403" height="354" alt="image" src="https://github.com/user-attachments/assets/836a5c2b-48e1-4118-9ef8-ad2023bf5ea1" />

只要子菜单高度不超过屏幕高度都能完整展示，这应该能适应绝大多数场合了。否则仍会溢出，能力有限没解决。