### PR TITLE
fix(date): normalizeDate 在 utc 情况下没有处理 valueFormat 和 value 不匹配情况

### DIFF
--- a/packages/amis-core/src/utils/date.ts
+++ b/packages/amis-core/src/utils/date.ts
@@ -117,7 +117,7 @@ export function normalizeDate(
   }
 
   const v = options?.utc
-    ? moment.utc(value, format).local()
+    ? moment.utc(value, format, true).local()
     : moment(value, format, true);
   if (v.isValid()) {
     return v;
@@ -134,7 +134,10 @@ export function normalizeDate(
 
     while (formats.length) {
       const format = formats.shift()!;
-      const date = moment(value, format);
+
+      const date = options?.utc
+        ? moment.utc(value, format, true)
+        : moment(value, format, true);
 
       if (date.isValid()) {
         return date;


### PR DESCRIPTION
### What
`normalizeDate` 函数不够健壮，utc 情况下无法处理 valueFormat 和 value 的不匹配。
### Why
<img width="1010" height="438" alt="Screenshot 2025-08-15 at 11 46 15" src="https://github.com/user-attachments/assets/c5660477-e480-4655-873c-05ff0e133cbd" />
### How
