### PR TITLE
feat: 优化代码支持表达式data[0]['username']==bizName, 支持'username'高亮

### DIFF
--- a/packages/amis-ui/src/components/formula/VariableList.tsx
+++ b/packages/amis-ui/src/components/formula/VariableList.tsx
@@ -287,9 +287,11 @@ function VariableList(props: VariableListProps) {
   }
 
   function handleChange(item: any) {
-    if (item.isMember || item.memberDepth !== undefined) {
-      return;
-    }
+    // 允许所有有 value 的元素被点击插入
+    // 注释掉原来的阻止逻辑，允许 isMember 元素直接点击
+    // if (item.isMember || item.memberDepth !== undefined) {
+    //   return;
+    // }
     onSelect?.(item);
   }
 


### PR DESCRIPTION
### 问题
类似表达式data[0]['username']==bizName，data是数组，username是数字对象的属性，之前不支持username高亮。
