### PR TITLE
fix: 修复resolveOptionType未处理null值的问题

### DIFF
--- a/packages/amis-editor/src/util.ts
+++ b/packages/amis-editor/src/util.ts
@@ -67,7 +67,7 @@ export const resolveOptionType = (schema: any = {}) => {
 
   const value = option?.[valueField || 'value'] ?? option;
 
-  return value !== undefined ? typeof value : 'string';
+  return value !== undefined && value !== null ? typeof value : 'string';
 };
 
 /**


### PR DESCRIPTION

null值的typeof结果是object, 有特殊情况会导致无法添加事件

<img width="1490" height="583" alt="image" src="https://github.com/user-attachments/assets/bca20aa8-d8eb-4aa8-859d-6287fd99fdf6" />


复现代码:

{
  "type": "form",
  "id": "u:053682f3f0e8",
  "title": "表单",
  "mode": "flex",
  "labelAlign": "top",
  "dsType": "api",
  "feat": "View",
  "body": [
    {
      "name": "select",
      "label": "选择器",
      "type": "select",
      "id": "u:ad9b3d796e12",
      "multiple": false,
      "required": true,
      "options": [
        {
          "label": "test1",
          "value": "test1"
        }
      ],
      "valueField": "name",
      "row": null,
      "colSize": "1",
      "onEvent": {
        "change": {
          "weight": 0,
          "actions": []
        }
      }
    }
  ],
  "actions": [
    {
      "type": "button",
      "label": "提交",
      "onEvent": {
        "click": {
          "actions": [
            {
              "actionType": "submit",
              "componentId": "u:053682f3f0e8"
            }
          ]
        }
      },
      "level": "primary",
      "id": "u:4b933b4338bd"
    }
  ],
  "resetAfterSubmit": true,
  "initApi": {
    "method": "get",
    "url": "http://localhost:8888/",
    "requestAdaptor": "",
    "messages": {},
    "mockResponse": {
      "status": 0,
      "data": {
        "select": {
          "name": "123"
        }
      }
    }
  }
}


