### PR TITLE
fix: crud2 init fetch with default form value

### DIFF
--- a/packages/amis/src/renderers/CRUD2.tsx
+++ b/packages/amis/src/renderers/CRUD2.tsx
@@ -1390,6 +1390,9 @@ export default class CRUD2<T extends CRUD2Props> extends React.Component<
             resetPage: true
           });
         },
+        onInit: (data: any) => {
+          this.initQuery(data);
+        },
         // 移动端的查询表单支持折叠
         ...(this.props.mobileUI
           ? {


### PR DESCRIPTION
### What
BUG:crud2.0表格组件查询组件的默认值，初始化请求的时候没有携带默认值，手动点击查询才会携带
修复问题： #12070
### Why

### How
