### PR TITLE
fix(theme): 修复默认主题设置问题, 使用defaultTheme作为默认值而不是硬编码的'cxd'

### DIFF
--- a/packages/amis-core/src/index.tsx
+++ b/packages/amis-core/src/index.tsx
@@ -69,7 +69,8 @@ import {
   theme,
   getTheme,
   themeable,
-  makeClassnames
+  makeClassnames,
+  defaultTheme
 } from './theme';
 import type {ClassNamesFn, ThemeProps} from './theme';
 const classPrefix = getClassPrefix();
@@ -350,9 +351,9 @@ function AMISRenderer({
   }, Object.keys(options).concat(Object.values(options)).concat(locale));
 
   const env = getEnv(store);
-  let theme = props.theme || options.theme || 'cxd';
+  let theme = props.theme || options.theme || defaultTheme;
   if (theme === 'default') {
-    theme = 'cxd';
+    theme = defaultTheme;
   }
   env.theme = getTheme(theme);
 


### PR DESCRIPTION
amis-editor中使用render的地方没有传theme, 导致render渲染出来是cxd的类名, 在AMISRenderer使用defaultTheme, 可以通过设置defaultTheme固定主题