### PR TITLE
fix: 修复前导零数字公式解析问题

### DIFF
--- a/packages/amis-formula/src/lexer.ts
+++ b/packages/amis-formula/src/lexer.ts
@@ -644,6 +644,9 @@ export function lexer(input: string, options: LexerOptions = {}) {
             state = numberStates.POINT;
           } else if (isExp(char)) {
             state = numberStates.EXP;
+          } else if (isDigit(char)) {  // 添加这个条件
+            passedValueIndex = i + 1;
+            state = numberStates.DIGIT; // 转换到DIGIT状态
           } else {
             break iterator;
           }


### PR DESCRIPTION
## 问题描述
在解析以0开头的数字时，词法分析器会将连续的数字拆分为多个独立的数字token。
例如：`[001]` 会被解析为 `[0, 0, 1]` 而不是预期的 `[1]`。

## 问题原因
在 [numberLiteral](\packages\amis-formula\src\lexer.ts#L618-L705) 函数的 [numberStates.ZERO](\packages\amis-formula\src\lexer.ts#L60-L60) 状态中，当遇到后续数字字符时没有正确处理，直接跳出循环导致数字被拆分。

## 修复方案
修改 [numberStates.ZERO](file://D:\Work\LowCode\zc_amis\packages\amis-formula\src\lexer.ts#L60-L60) 状态的处理逻辑，当遇到数字字符时，将其视为连续数字的一部分，转换到 [numberStates.DIGIT](file://D:\Work\LowCode\zc_amis\packages\amis-formula\src\lexer.ts#L61-L61) 状态继续处理。

## 测试结果
- `[001]` → `[1]` ✓
- `[0123]` → `[123]` ✓
- `[0]` → `[0]` ✓
- 其他数字格式保持不变 ✓
