### PR TITLE
fix: 修复外观默认宽高配置属性名重复问题

### DIFF
--- a/packages/amis-editor/src/tpl/style.tsx
+++ b/packages/amis-editor/src/tpl/style.tsx
@@ -734,8 +734,8 @@ setSchemaTpl('style:widthHeight', (option: any = {}) => {
         ...widthSchema
       }),
       getSchemaTpl('theme:height2', {
-        name: 'width',
-        label: '宽度',
+        name: 'height',
+        label: '高度',
         ...heightSchema
       })
     ]


### PR DESCRIPTION

<img width="997" height="332" alt="image" src="https://github.com/user-attachments/assets/e95d144c-a602-4176-8088-32fe2b3fc1ee" />

