### PR TITLE
fix🐛: 内容贴近浏览器边缘就抖个不停amis 6.12.0 Close: #12163

### DIFF
--- a/packages/amis-core/src/utils/dom.tsx
+++ b/packages/amis-core/src/utils/dom.tsx
@@ -98,7 +98,7 @@ export function calculatePosition(
   const clip2 = overlayNode.getBoundingClientRect();
   const clip3 = scrollParent.getBoundingClientRect();
   const scaleX = overlayNode.offsetWidth
-    ? clip2.width / overlayNode.offsetWidth
+    ? Math.ceil(clip2.width) / overlayNode.offsetWidth
     : 1;
   const scaleY = overlayNode.offsetHeight
     ? clip2.height / overlayNode.offsetHeight


### PR DESCRIPTION
### What
fix https://github.com/baidu/amis/issues/12163
### Why

### How
