### PR TITLE
fix: #12218

### DIFF
--- a/packages/amis-ui/src/components/condition-builder/Item.tsx
+++ b/packages/amis-ui/src/components/condition-builder/Item.tsx
@@ -95,7 +95,7 @@ export class ConditionItem extends React.Component<ConditionItemProps> {
           : undefined) ??
         config.types[field?.type]?.defaultOp ??
         undefined,
-      right: undefined
+      right: field?.defaultValue ?? undefined
     };
     const onChange = this.props.onChange;
 


### PR DESCRIPTION
### What
修复bug: conditions组合条件组件，defaultValue 设置默认值"bb"，但是查询时，没有携带默认值，发送的是空
### Why
没有在初始化时带入defaultValue
### How
初始化时，带入defaultValue
具体bug见 #12218