### PR TITLE
fix: 修复crud2 存在隐藏列时切换问题 #12258

### DIFF
--- a/packages/amis/src/renderers/CRUD2.tsx
+++ b/packages/amis/src/renderers/CRUD2.tsx
@@ -1264,14 +1264,15 @@ export default class CRUD2<T extends CRUD2Props> extends React.Component<
   }
 
   @autobind
-  toggleToggle(index: number) {
+  toggleToggle(id: string) {
     const {store} = this.props;
-    const column = store.columns[index];
+    const column = store.columns.find((c: any) => c.id === id);
+    if (!column) return;
     const toggled = column.toggled ?? true;
     store.updateColumns(
-      store.columns.map((c: any, i: number) => ({
+      store.columns.map((c: any) => ({
         ...c,
-        toggled: index === i ? !toggled : c.toggled !== false
+        toggled: c.id === id ? !toggled : c.toggled !== false
       }))
     );
   }

--- a/packages/amis/src/renderers/Table2/ColumnToggler.tsx
+++ b/packages/amis/src/renderers/Table2/ColumnToggler.tsx
@@ -105,9 +105,9 @@ export class ColumnTogglerRenderer extends React.Component<ColumnTogglerRenderer
         {toggableColumns?.map((column: any, index: number) => (
           <li
             className={cx('ColumnToggler-menuItem')}
-            key={'item' + (column.index || index)}
+            key={'item' + (column.id || index)}
             onClick={() => {
-              toggleToggle && toggleToggle(index);
+              toggleToggle && toggleToggle(column.id);
             }}
           >
             <Checkbox

--- a/packages/amis/src/renderers/Table2/index.tsx
+++ b/packages/amis/src/renderers/Table2/index.tsx
@@ -1629,9 +1629,11 @@ export default class Table2 extends React.Component<Table2Props, object> {
                 })
               );
             },
-            toggleToggle: (index: number) => {
-              const column = store.columnsData[index];
-              column.toggleToggle();
+            toggleToggle: (id: string) => {
+              const column = store.columnsData.find(
+                (col: any) => col?.id === id
+              );
+              column?.toggleToggle();
 
               dispatchEvent(
                 'columnToggled',


### PR DESCRIPTION
### What
crud2 存在隐藏列时切换问题，例如第一列隐藏，在切换列显示时，点击隐藏会出现点击无效和点击第二列却隐藏第一列

### Why
代码中基于index处理显示隐藏

### How
基于列的id隐藏/显示