### PR TITLE
refactor(theme): 将类方法改为箭头函数以自动绑定this  避免手动绑定this产生undefine报错，简化代码并提高可维护性

### DIFF
--- a/packages/amis-core/src/theme.tsx
+++ b/packages/amis-core/src/theme.tsx
@@ -148,14 +148,11 @@ export function themeable<
 
       constructor(props: OuterProps) {
         super(props);
-
-        this.childRef = this.childRef.bind(this);
-        this.getWrappedInstance = this.getWrappedInstance.bind(this);
       }
 
       ref: any;
 
-      childRef(ref: any) {
+      childRef = (ref: any) => {
         while (ref && ref.getWrappedInstance) {
           ref = ref.getWrappedInstance();
         }
@@ -163,7 +160,7 @@ export function themeable<
         this.ref = ref;
       }
 
-      getWrappedInstance() {
+      getWrappedInstance = () => {
         return this.ref;
       }
 


### PR DESCRIPTION
### What
CRUD 通过指定index 更新行的信息后，点击分页，无法跳转到指定页，控制台报错

### Why
<img width="1716" height="712" alt="image" src="https://github.com/user-attachments/assets/fa644353-5e62-4b71-afa4-ca59605960dc" />

### How
将手动bind this改为使用箭头函数自动绑定