### PR TITLE
fix(amis): 统一quickEdit处理逻辑,避免saveImmediately.api是对象时无法触发resetOnFailed的问题 Closes:#14362

### DIFF
--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -73,6 +73,7 @@ import isPlainObject from 'lodash/isPlainObject';
 import memoize from 'lodash/memoize';
 import {Spinner} from 'amis-ui';
 import {AutoFoldedList} from 'amis-ui';
+import {getQuickEditApi, type SchemaQuickEditObject} from './QuickEdit';
 
 interface LoadMoreConfig {
   showIcon?: boolean;
@@ -940,8 +941,8 @@ export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
           action.reload
             ? this.reloadTarget(filterTarget(action.reload, data), data)
             : redirect
-            ? null
-            : this.search(undefined, undefined, true, true);
+              ? null
+              : this.search(undefined, undefined, true, true);
           action.close && this.closeTarget(action.close);
         })
         .catch(e => {
@@ -1481,7 +1482,7 @@ export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
         const rendererEvent = await dispatchEvent?.(
           'fetchInited',
           createObject(this.props.data, {
-            responseData: value?.ok ? store.data ?? {} : value,
+            responseData: value?.ok ? (store.data ?? {}) : value,
             responseStatus:
               value?.status === undefined ? (error ? 1 : 0) : value?.status,
             responseMsg: msg
@@ -1496,7 +1497,7 @@ export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
         const rendererEvent = await dispatchEvent?.(
           'research',
           createObject(this.props.data, {
-            responseData: value?.ok ? store.data ?? {} : value,
+            responseData: value?.ok ? (store.data ?? {}) : value,
             responseStatus:
               value?.status === undefined ? (error ? 1 : 0) : value?.status,
             responseMsg: msg
@@ -1675,10 +1676,7 @@ export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
     indexes: Array<string>,
     unModifiedItems?: Array<any>,
     rowsOrigin?: Array<object> | object,
-    options?: {
-      resetOnFailed?: boolean;
-      reload?: string;
-    }
+    options?: SchemaQuickEditObject
   ) {
     const {
       store,
@@ -1750,7 +1748,9 @@ export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
           );
         });
     } else {
-      if (!isEffectiveApi(quickSaveItemApi)) {
+      const api = getQuickEditApi(options?.saveImmediately, quickSaveItemApi);
+
+      if (!isEffectiveApi(api)) {
         env && env.alert('CRUD quickSaveItemApi is required!');
         return;
       }
@@ -1763,7 +1763,7 @@ export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
 
       const sendData = createObject(data, rows);
       return store
-        .saveRemote(quickSaveItemApi, sendData)
+        .saveRemote(api, sendData)
         .then(async (result: any) => {
           // 如果请求 cancel 了，会来到这里
           if (!result) {
@@ -2594,8 +2594,8 @@ export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
             {isLoading
               ? contentText.contentrefresh
               : isNoMore
-              ? contentText.contentnomore
-              : contentText.contentdown}
+                ? contentText.contentnomore
+                : contentText.contentdown}
           </span>
         )}
       </div>

--- a/packages/amis/src/renderers/QuickEdit.tsx
+++ b/packages/amis/src/renderers/QuickEdit.tsx
@@ -20,7 +20,7 @@ import {Overlay} from 'amis-core';
 import {PopOver} from 'amis-core';
 import omit from 'lodash/omit';
 import {Icon} from 'amis-ui';
-import {SchemaCollection, SchemaObject} from '../Schema';
+import {SchemaApi, SchemaCollection, SchemaObject} from '../Schema';
 
 export type SchemaQuickEditObject =
   /**
@@ -30,7 +30,7 @@ export type SchemaQuickEditObject =
       /**
        * 是否立即保存
        */
-      saveImmediately?: boolean;
+      saveImmediately?: boolean | {api: SchemaApi};
 
       /**
        * 接口保存失败后，是否重置组件编辑状态
@@ -115,6 +115,20 @@ export interface QuickEditState {
 let inited: boolean = false;
 let currentOpened: any;
 
+export const getQuickEditApi = (
+  saveImmediately?: SchemaQuickEditObject['saveImmediately'],
+  quickSaveItemApi?: SchemaApi
+) => {
+  if (saveImmediately === true) {
+    return quickSaveItemApi;
+  }
+
+  if (typeof saveImmediately === 'object' && 'api' in saveImmediately) {
+    return saveImmediately.api;
+  }
+
+  return undefined;
+};
 export const HocQuickEdit =
   (config: Partial<QuickEditConfig> = {}) =>
   (Component: React.ComponentType<any>): any => {

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -1297,21 +1297,6 @@ export default class Table<
       item.path
     );
 
-    if (!saveImmediately && !propsSaveImmediately) {
-      return;
-    } else if (saveImmediately && saveImmediately.api) {
-      this.props.onAction(
-        null,
-        {
-          actionType: 'ajax',
-          api: saveImmediately.api,
-          reload: options?.reload
-        },
-        item.locals
-      );
-      return;
-    }
-
     if (!onSave) {
       return;
     }
@@ -1757,13 +1742,13 @@ export default class Table<
           title: column.enlargeTitle
             ? filter(column.enlargeTitle, row.data)
             : column.title
-            ? filter(column.title, row.data)
-            : undefined,
+              ? filter(column.title, row.data)
+              : undefined,
           caption: column.enlargeCaption
             ? filter(column.enlargeCaption, row.data)
             : column.caption
-            ? filter(column.caption, row.data)
-            : undefined
+              ? filter(column.caption, row.data)
+              : undefined
         }))
       );
     });
@@ -2255,7 +2240,7 @@ export default class Table<
           )}
           style={props.style}
         >
-          {props.label ?? column.label
+          {(props.label ?? column.label)
             ? render('tpl', props.label ?? column.label)
             : null}
 


### PR DESCRIPTION
https://github.com/baidu/amis/issues/14362

