### PR TITLE
修复虚拟滚动的 scrollTop 计算问题

### DIFF
--- a/packages/amis/src/renderers/Table/VirtualTableBody.tsx
+++ b/packages/amis/src/renderers/Table/VirtualTableBody.tsx
@@ -99,19 +99,28 @@ function VirtualTableBody(props: VirtualTableBodyProps) {
     const wrap = table.parentElement!;
     const rootDom = wrap.closest(`.${classPrefix}Table`)!;
 
-    const header =
-      rootDom?.querySelector(`:scope > .${classPrefix}Table-fixedTop`) ||
-      table.querySelector(':scope > thead')!;
+    const fixedHeader = rootDom?.querySelector(`:scope > .${classPrefix}Table-fixedTop`);
+    const header = fixedHeader || table.querySelector(':scope > thead')!;
     const firstRow = leadingPlaceholderRef.current!;
     const isAutoFill = rootDom.classList.contains(
       `${classPrefix}Table--autoFillHeight`
     );
     const toDispose: Array<() => void> = [];
-
     const check = () => {
-      const rect = header.getBoundingClientRect();
-      const rect2 = firstRow.getBoundingClientRect();
-      const scrollTop = rect.bottom - rect2.top;
+      let scrollTop = 0;
+      // 判断 header 是否是固定表头
+      if (fixedHeader) {
+        // 固定表头：用 getBoundingClientRect 计算
+        const rect = header.getBoundingClientRect();
+        const rect2 = firstRow.getBoundingClientRect();
+        scrollTop = rect.bottom - rect2.top;
+      } else {
+        // 普通 thead：直接读取滚动容器的 scrollTop
+        const scrollContainer: any = isAutoFill ? wrap : 
+          (getScrollParent(rootDom as HTMLElement) === document.body ? 
+            document.documentElement : getScrollParent(rootDom as HTMLElement));
+        scrollTop = scrollContainer.scrollTop || 0;
+      }
       setScrollTop(scrollTop);
       if (scrollTop && store.tableLayout !== 'fixed') {
         store.switchToFixedLayout();


### PR DESCRIPTION
### What
修复 input-table 组件在懒加载场景下，使用非固定表头时虚拟滚动失效的问题。
### Why
当表格编辑框启用懒加载时，如果表头不是 fixed 定位（即普通的 `<thead>` 元素），虚拟滚动的 scrollTop 计算逻辑存在缺陷：

- 原逻辑使用 `header.getBoundingClientRect().bottom - firstRow.getBoundingClientRect().top` 计算滚动距离
- 当 header 是普通 `<thead>` 时，它和 firstRow 都在同一个滚动容器内，一起滚动，导致计算结果始终为 0
- scrollTop 始终为 0 导致 `store.switchToFixedLayout()` 永远不会触发
- 虚拟滚动机制失效，只渲染初始的部分数据，后续数据无法加载

而固定表头场景能正常工作，是因为固定表头位置不变，可以正确计算出与滚动内容的相对距离。
### How
- 在 useEffect 初始化时判断表头类型，判断 header 是否是固定表头
- 针对两种表头类型使用不同的 scrollTop 计算方式：
  - **固定表头**：保持原逻辑，使用 `getBoundingClientRect()` 计算相对位置
  - **普通表头**：直接读取滚动容器的 `scrollTop` 属性，获取真实滚动距离
- 确保虚拟滚动在两种场景下都能正确触发布局切换和数据加载