### PR TITLE
fix: 修复树展开逻辑问题

### DIFF
--- a/packages/amis-ui/src/components/Tree.tsx
+++ b/packages/amis-ui/src/components/Tree.tsx
@@ -404,10 +404,8 @@ export class TreeSelector extends React.Component<
         } else if (foldedField && typeof node[foldedField] !== 'undefined') {
           ret = !node[foldedField];
         } else if (initial || typeof ret === 'undefined') {
-          ret = !!props.initiallyOpen;
-          if (!ret && level <= (expandLevel as number)) {
-            ret = true;
-          }
+          // initiallyOpen 为 true 时全部展开，为 false 时根据 unfoldedLevel 控制
+          ret = props.initiallyOpen ? true : level < expandLevel;
         }
         unfolded[unfoldedKey] = ret;
       }


### PR DESCRIPTION
### What
修复树组件展开逻辑问题，使 `initiallyOpen: false` 配置能够正常生效

### Why
当前代码存在的问题：
`syncUnFolded` 方法中的展开逻辑存在缺陷：即使设置 `initiallyOpen: false`，当节点层级 `level <= unfoldedLevel` 时，仍会被强制展开

这导致用户设置 `initiallyOpen: false` 时，树节点仍然会根据 `unfoldedLevel` 被展开，配置无法按预期工作

### How
修改 `syncUnFolded` 方法中的展开判断逻辑：
   - 移除 `!ret && level <= expandLevel` 的强制展开逻辑
   - 改为：当 `initiallyOpen` 为 `true` 时全部展开，为 `false` 时根据 `unfoldedLevel` 精确控制展开层级
   - 使用 `level < expandLevel` 替代 `level <= expandLevel`，确保层级判断准确