### PR TITLE
fix: 修复下拉选择器（Select）的自动补全（autoComplete）样式展示异常问题。

### DIFF
--- a/packages/amis-ui/scss/components/form/_select.scss
+++ b/packages/amis-ui/scss/components/form/_select.scss
@@ -453,7 +453,7 @@
 
       display: flex;
       flex-direction: row;
-      justify-content: space-between;
+      justify-content: flex-start;
       align-items: center;
     }
 


### PR DESCRIPTION
### What
修复下拉选择器（Select）的自动补全（autoComplete）样式展示异常问题。
### Why
自动补全区域原使用`justify-content: space-between`导致子元素分布不均、内容错位，表现为：  
- 候选项内容左右间距过大；  
- 输入框与候选列表的对齐不一致；  
- 视觉布局杂乱影响用户体验。

#### 修复前官方文档的样式：
<img width="1118" height="416" alt="image" src="https://github.com/user-attachments/assets/6ef81d3c-ad28-49e1-8812-464d96ffd0ce" />
<img width="1223" height="446" alt="image" src="https://github.com/user-attachments/assets/a1aac191-793f-47f9-ad23-37df81c1e16e" />
#### 修复后官方文档的样式：
<img width="1101" height="403" alt="image" src="https://github.com/user-attachments/assets/fceaa97a-21b1-49de-b889-a46ee274be55" />
<img width="1129" height="477" alt="image" src="https://github.com/user-attachments/assets/fd9dde75-2ca1-4c60-9273-bf0121a49fd7" />

### How
**调整布局对齐方式**：将自动补全容器的`justify-content`属性从`space-between`改为`flex-start`，使子元素左对齐，统一布局展示