### PR TITLE
fix(amis): 显式计算column的className,解决table组件中单元格className无法使用表达式的问题

### DIFF
--- a/packages/amis/__tests__/renderers/Table/Cell.test.tsx
+++ b/packages/amis/__tests__/renderers/Table/Cell.test.tsx
@@ -79,6 +79,35 @@ const renderTable = () =>
     )
   );
 
+const renderTableWithClassName = (className: any) =>
+  render(
+    amisRender(
+      {
+        type: 'page',
+        data: {
+          items: [
+            {
+              id: 1
+            }
+          ]
+        },
+        body: {
+          type: 'crud',
+          source: '${items}',
+          columns: [
+            {
+              name: 'id',
+              label: 'id',
+              className: className
+            }
+          ]
+        }
+      },
+      {},
+      makeEnv({})
+    )
+  );
+
 describe('层级选择', () => {
   it('选择根节点,所有后代节点都会自动选中', async () => {
     renderTable();
@@ -173,5 +202,19 @@ describe('层级选择', () => {
     expect(checkMeFirst.parentElement!.classList).not.toContain(
       'cxd-Checkbox--partial checked'
     );
+  });
+});
+
+describe('column className', () => {
+  it('对象形式的className, 能够正确计算表达式的值', async () => {
+    const {container} = renderTableWithClassName({
+      primary: '${id > 0}', // 应该为true，因为id=1
+      danger: '${id < 0}'
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.primary')).toBeInTheDocument();
+      expect(container.querySelector('.danger')).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/amis/src/renderers/Table/Cell.tsx
+++ b/packages/amis/src/renderers/Table/Cell.tsx
@@ -8,7 +8,8 @@ import {
   resolveVariable,
   buildTrackExpression,
   evalTrackExpression,
-  TestIdBuilder
+  TestIdBuilder,
+  filterClassNameObject
 } from 'amis-core';
 import {BadgeObject, Checkbox, Icon, Spinner} from 'amis-ui';
 import React from 'react';
@@ -173,6 +174,12 @@ export default function Cell({
 
   const finalCanAccessSuperData =
     column.pristine.canAccessSuperData ?? canAccessSuperData;
+  const columnClassName = filterClassNameObject(
+    column.pristine.className,
+    data
+  );
+  const tdClassName = cx(columnClassName, stickyClassName);
+
   const subProps: any = {
     ...props,
     // 操作列不下发loading，否则会导致操作栏里面的所有按钮都出现loading
@@ -204,22 +211,14 @@ export default function Cell({
       store.firstToggledColumnIndex === props.colIndex,
     onQuery: undefined,
     style,
-    className: cx(
-      column.pristine.className,
-      stickyClassName,
-      addtionalClassName
-    ),
+    className: cx(tdClassName, addtionalClassName),
     testIdBuilder: testIdBuilder?.getChild(column.name || column.value)
   };
   delete subProps.label;
 
   if (column.type === '__checkme') {
     return (
-      <td
-        style={style}
-        className={cx(column.pristine.className, stickyClassName)}
-        {...testIdBuilder?.getTestId()}
-      >
+      <td style={style} className={tdClassName} {...testIdBuilder?.getTestId()}>
         <Checkbox
           classPrefix={ns}
           type={multiple ? 'checkbox' : 'radio'}
@@ -235,7 +234,7 @@ export default function Cell({
     return (
       <td
         style={style}
-        className={cx(column.pristine.className, stickyClassName, {
+        className={cx(tdClassName, {
           'is-dragDisabled': !item.draggable
         })}
         {...testIdBuilder?.getChild('drag').getTestId()}
@@ -245,10 +244,7 @@ export default function Cell({
     );
   } else if (column.type === '__expandme') {
     return (
-      <td
-        style={style}
-        className={cx(column.pristine.className, stickyClassName)}
-      >
+      <td style={style} className={tdClassName}>
         {item.expandable ? (
           <a
             className={cx('Table-expandBtn', item.expanded ? 'is-active' : '')}
@@ -266,10 +262,7 @@ export default function Cell({
     );
   } else if (column.type === '__index') {
     return (
-      <td
-        style={style}
-        className={cx(column.pristine.className, stickyClassName)}
-      >
+      <td style={style} className={tdClassName}>
         {`${filterItemIndex ? filterItemIndex(item.path, item) : item.path}`
           .split('.')
           .map(a => parseInt(a, 10) + 1 + (offset || 0))

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -44,7 +44,8 @@ import {
   getTree,
   resolveVariableAndFilterForAsync,
   getMatchedEventTargets,
-  loopTooMuch
+  loopTooMuch,
+  filterClassNameObject
 } from 'amis-core';
 import {
   Button,
@@ -2045,15 +2046,15 @@ export default class Table<
     }
 
     const {key, ...restProps} = props;
+    const columnClassName = filterClassNameObject(
+      column.pristine.className,
+      data
+    );
+    const thClassName = cx(columnClassName, stickyClassName);
 
     if (column.type === '__checkme') {
       return (
-        <th
-          {...restProps}
-          key={key}
-          style={style}
-          className={cx(column.pristine.className, stickyClassName)}
-        >
+        <th {...restProps} key={key} style={style} className={thClassName}>
           {store.rows.length && store.multiple ? (
             <Checkbox
               classPrefix={ns}
@@ -2071,21 +2072,11 @@ export default class Table<
       );
     } else if (column.type === '__dragme') {
       return (
-        <th
-          {...restProps}
-          key={key}
-          style={style}
-          className={cx(column.pristine.className, stickyClassName)}
-        />
+        <th {...restProps} key={key} style={style} className={thClassName} />
       );
     } else if (column.type === '__expandme') {
       return (
-        <th
-          {...restProps}
-          key={key}
-          style={style}
-          className={cx(column.pristine.className, stickyClassName)}
-        >
+        <th {...restProps} key={key} style={style} className={thClassName}>
           {(store.footable &&
             (store.footable.expandAll === false || store.footable.accordion)) ||
           (store.expandConfig &&
@@ -2109,12 +2100,7 @@ export default class Table<
       );
     } else if (column.type === '__index') {
       return (
-        <th
-          {...restProps}
-          key={key}
-          style={style}
-          className={cx(column.pristine.className, stickyClassName)}
-        >
+        <th {...restProps} key={key} style={style} className={thClassName}>
           {__('Table.index')}
 
           {resizable === false ? null : resizeLine}
@@ -2272,7 +2258,7 @@ export default class Table<
           key="content"
           className={cx(
             `TableCell--title`,
-            column.pristine.className,
+            columnClassName,
             column.pristine.labelClassName
           )}
           style={props.style}


### PR DESCRIPTION
期望在单元格上渲染primary类名,但实际上danger也被渲染了
```
{
        type: 'page',
        data: {
          items: [
            {
              id: 1
            }
          ]
        },
        body: {
          type: 'crud',
          source: '${items}',
          columns: [
            {
              name: 'id',
              label: 'id',
              className: {
                primary: '${id > 0}',
               danger: '${id < 0}'
              }
            }
          ]
        }
      }
```