### PR TITLE
fix(amis): 统一crud.quickEdit处理逻辑,避免saveImmediately.api是对象时无法触发resetOnF…

### DIFF
--- a/packages/amis/__tests__/renderers/CRUD.test.tsx
+++ b/packages/amis/__tests__/renderers/CRUD.test.tsx
@@ -604,6 +604,54 @@ test('10. Renderer:crud quickSaveItemApi saveImmediately', async () => {
   expect(mockFetcher).toBeCalledTimes(3);
 });
 
+test('10.1 quickEdit.saveImmediately对象形式,能够触发接口调用', async () => {
+  const mockFetcher = jest.fn(fetcher);
+  const {container} = render(
+    amisRender(
+      {
+        type: 'page',
+        data: {
+          items: [
+            {
+              checked: true
+            }
+          ]
+        },
+        body: {
+          type: 'crud',
+          columns: [
+            {
+              name: 'checked',
+              label: 'checked',
+              quickEdit: {
+                mode: 'inline',
+                type: 'switch',
+                saveImmediately: {
+                  api: {
+                    url: '/example'
+                  }
+                },
+                resetOnFailed: true
+              }
+            }
+          ]
+        }
+      },
+      {},
+      makeEnv({fetcher: mockFetcher})
+    )
+  );
+
+  const switchBtn = container.querySelector('.cxd-Switch.is-checked')!;
+  expect(switchBtn).toBeInTheDocument();
+  fireEvent.click(switchBtn);
+
+  await waitFor(() => {
+    expect(mockFetcher).toBeCalledTimes(1);
+    expect(mockFetcher.mock.calls[0][0].url).toBe('/example');
+  });
+});
+
 test('11. Renderer:crud bulkActions', async () => {
   const {container} = render(
     amisRender(

--- a/packages/amis/__tests__/renderers/quickedit.test.tsx
+++ b/packages/amis/__tests__/renderers/quickedit.test.tsx
@@ -1,0 +1,26 @@
+/**
+ * @file QuickEdit.test.tsx
+ * @author xxx
+ * @description QuickEdit组件单元测试，主要测试getQuickEditApi函数
+ */
+
+import {getQuickEditApi} from '../../src/renderers/QuickEdit';
+
+describe('getQuickEditApi函数测试', () => {
+  test('saveImmediately为true时返回quickSaveItemApi', () => {
+    const quickSaveItemApi = '/api/save-item';
+    const result = getQuickEditApi(true, quickSaveItemApi);
+    expect(result).toBe(quickSaveItemApi);
+  });
+
+  test('saveImmediately为对象且包含api属性时返回saveImmediately.api', () => {
+    const saveImmediately = {api: '/api/custom-save'};
+    const quickSaveItemApi = '/api/save-item';
+    const result = getQuickEditApi(saveImmediately, quickSaveItemApi);
+    expect(result).toBe(saveImmediately.api);
+  });
+
+  test('saveImmediately不存在时,返回undefined', () => {
+    expect(getQuickEditApi()).toBeUndefined();
+  });
+});

--- a/packages/amis/src/renderers/CRUD.tsx
+++ b/packages/amis/src/renderers/CRUD.tsx
@@ -91,6 +91,7 @@ import isPlainObject from 'lodash/isPlainObject';
 import memoize from 'lodash/memoize';
 import {Spinner} from 'amis-ui';
 import {AutoFoldedList} from 'amis-ui';
+import {getQuickEditApi, type AMISQuickEditObject} from './QuickEdit';
 
 interface AMISLoadMoreConfig {
   /**
@@ -1753,10 +1754,7 @@ export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
     indexes: Array<string>,
     unModifiedItems?: Array<any>,
     rowsOrigin?: Array<object> | object,
-    options?: {
-      resetOnFailed?: boolean;
-      reload?: string;
-    }
+    options?: AMISQuickEditObject
   ) {
     const {
       store,
@@ -1828,7 +1826,9 @@ export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
           );
         });
     } else {
-      if (!isEffectiveApi(quickSaveItemApi)) {
+      const api = getQuickEditApi(options?.saveImmediately, quickSaveItemApi);
+
+      if (!isEffectiveApi(api)) {
         env && env.alert('CRUD quickSaveItemApi is required!');
         return;
       }
@@ -1841,7 +1841,7 @@ export default class CRUD<T extends CRUDProps> extends React.Component<T, any> {
 
       const sendData = createObject(data, rows);
       return store
-        .saveRemote(quickSaveItemApi, sendData)
+        .saveRemote(api, sendData)
         .then(async (result: any) => {
           // 如果请求 cancel 了，会来到这里
           if (!result) {

--- a/packages/amis/src/renderers/QuickEdit.tsx
+++ b/packages/amis/src/renderers/QuickEdit.tsx
@@ -22,12 +22,13 @@ import {Overlay} from 'amis-core';
 import {PopOver, AMISSchemaCollection} from 'amis-core';
 import omit from 'lodash/omit';
 import {AMISFormBase} from 'packages/amis-core/lib';
+import {SchemaApi} from '../Schema';
 
 export interface AMISQuickEditObject {
   /**
    * 是否立即保存
    */
-  saveImmediately?: boolean;
+  saveImmediately?: boolean | {api: SchemaApi};
 
   /**
    * 接口保存失败后，是否重置组件编辑状态
@@ -83,6 +84,21 @@ export interface QuickEditState {
 
 let inited: boolean = false;
 let currentOpened: any;
+
+export const getQuickEditApi = (
+  saveImmediately?: SchemaQuickEditObject['saveImmediately'],
+  quickSaveItemApi?: SchemaApi
+) => {
+  if (saveImmediately === true) {
+    return quickSaveItemApi;
+  }
+
+  if (typeof saveImmediately === 'object' && 'api' in saveImmediately) {
+    return saveImmediately.api;
+  }
+
+  return undefined;
+};
 
 export const HocQuickEdit =
   (config: Partial<QuickEditConfig> = {}) =>

--- a/packages/amis/src/renderers/Table/index.tsx
+++ b/packages/amis/src/renderers/Table/index.tsx
@@ -67,7 +67,7 @@ import {
   SchemaTpl
 } from '../../Schema';
 import {SchemaPopOver} from '../PopOver';
-import {AMISQuickEdit, SchemaQuickEdit} from '../QuickEdit';
+import {AMISQuickEdit, getQuickEditApi, SchemaQuickEdit} from '../QuickEdit';
 import {AMISCopyable, SchemaCopyable} from '../Copyable';
 import {SchemaRemark} from '../Remark';
 import ColumnToggler from './ColumnToggler';
@@ -1282,13 +1282,7 @@ export default class Table<
       return;
     }
 
-    const {
-      onSave,
-      onPristineChange,
-      saveImmediately: propsSaveImmediately,
-      primaryField,
-      onItemChange
-    } = this.props;
+    const {onSave, onPristineChange, primaryField, onItemChange} = this.props;
 
     item.change(values, savePristine);
 
@@ -1319,25 +1313,26 @@ export default class Table<
       item.path
     );
 
-    if (!saveImmediately && !propsSaveImmediately) {
-      return;
-    } else if (saveImmediately && saveImmediately.api) {
-      this.props.onAction(
-        null,
-        {
-          actionType: 'ajax',
-          api: saveImmediately.api,
-          reload: options?.reload
-        },
-        item.locals
-      );
-      return;
-    }
-
     if (!onSave) {
+      const api = getQuickEditApi(saveImmediately);
+
+      if (isEffectiveApi(api)) {
+        // 调用自身的onAction方法
+        this.props.onAction(
+          null,
+          {
+            actionType: 'ajax',
+            api,
+            reload: options?.reload
+          },
+          item.locals
+        );
+      }
+
       return;
     }
 
+    // 调用crud的onSave方法
     onSave(
       item.data,
       difference(item.data, item.pristine, ['id', primaryField]),


### PR DESCRIPTION
快速编辑接口请求失败后,列表中的switch状态却未回滚
```
 {
        type: 'page',
        data: {
          items: [
            {
              checked: true
            }
          ]
        },
        body: {
          type: 'crud',
          columns: [
            {
              name: 'checked',
              label: 'checked',
              quickEdit: {
                mode: 'inline',
                type: 'switch',
                saveImmediately: {
                  api: {
                    url: '/example'
                  }
                },
                resetOnFailed: true
              }
            }
          ]
        }
```