### PR TITLE
fix: make some fields optional in InputText props

### DIFF
--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -139,7 +139,7 @@ export type InputTextRendererEvent =
   | 'enter';
 
 export interface TextProps extends OptionsControlProps, SpinnerExtraProps {
-  placeholder?: string;
+  placeholder?: string | { [propName: string]: string; };
   addOn?: ActionObject & {
     position?: 'left' | 'right';
     label?: string;


### PR DESCRIPTION
### What

在外部尝试重新封装 InputText 时类型出错

```typescript
import * as React from 'react';
import {FormItem, OptionsControl} from 'amis';
import TextControl from 'amis/lib/renderers/Form/InputText';

class MyFormItem extends React.Component {
  render() {
    const {value, onChange} = this.props;

    return (
      <div>
        <p>这个是个自定义组件</p>
        <p>当前值：{value}</p>
        <a
          className="btn btn-default"
          onClick={() => onChange(Math.round(Math.random() * 10000))}
        >
          随机修改
        </a>
      </div>
    );
  }
}
export const MyFormItemRenderer = FormItem({
  type: 'custom'
})(MyFormItem)

export class TextControlRenderer extends TextControl {}

OptionsControl({
  type: 'input-text',
  alias: ['input-password', 'native-date', 'native-time', 'native-number']
})(TextControlRenderer);
```

报错

```
Argument of type 'typeof TextControlRenderer' is not assignable to parameter of type 'ComponentType<OptionsControlProps>'.
  Type 'typeof TextControlRenderer' is not assignable to type 'ComponentClass<OptionsControlProps, any>'.
    Types of parameters 'props' and 'props' are incompatible.
      Property 'spinnerClassName' is missing in type 'OptionsControlProps' but required in type 'TextProps'.ts(2345)
```

### Why

spinnerClassName 应该是 optional 的

### How
