### PR TITLE
input-table增加记录时，同步表信息，解决columns中设置width，在add时不生效的问题。

### DIFF
--- a/packages/amis/src/renderers/Form/InputTable.tsx
+++ b/packages/amis/src/renderers/Form/InputTable.tsx
@@ -948,7 +948,7 @@ export default class FormTable<
       if (needConfirm === false) {
         this.emitValue();
       }
-
+      this.table?.updateTableInfo?.();
       callback?.();
     });
 


### PR DESCRIPTION
https://github.com/baidu/amis/issues/10623 #10623 解决columns中设置的width，在add时不生效的问题。

### What

### Why

### How
