### PR TITLE
fix: 修复 placeholder 点击无法聚焦的问题

### DIFF
--- a/packages/amis/src/renderers/Form/InputText.tsx
+++ b/packages/amis/src/renderers/Form/InputText.tsx
@@ -406,7 +406,8 @@ export default class TextControl extends React.PureComponent<
     // 修复 placeholder 点击无法聚焦的问题
     const isClickedOnInput =
       event.target === this.input ||
-      (this.input?.parentElement?.contains(event.target) ?? false);
+      (this.input?.parentElement?.contains(event.target as HTMLElement) ??
+        false);
 
     if (multiple || isClickedOnInput) {
       // 已经 focus 的就不重复执行，否则总重新定位光标


### PR DESCRIPTION
### What
1.  修复了 `input-text` 组件因 `autoComplete`、`creatable` 属性配置导致弹框点击外部后仍不消失的 Bug（关联 Issue #10972）；
2.  修复了上述修复过程中引入的「点击 placeholder 元素时组件无法聚焦、无任何响应」的回归问题；
3.  优化了组件点击区域的判断逻辑，确保输入框自身及所有子元素（含 placeholder）点击时均可正常触发聚焦并保持弹框开启。
### Why
1.  原始问题（Issue #10972）：当组件启用 `autoComplete` 或 `creatable` 属性时，点击输入框内部区域后弹框正常显示，但存在点击输入框内部分子元素（如 placeholder）时无法聚焦，无法弹出下拉选择；
2.  回归问题：已有代码判断`multiple || event.target === this.input`，导致 placeholder 等输入框子元素点击时无法被识别，进而无法触发组件聚焦，用户操作受阻；
3.  需求本质：用户点击 `input-text` 组件的任意可交互区域（输入框自身、内部 placeholder、子元素）都应正常聚焦，并保持 autoComplete/creatable 弹框开启，点击组件外部时弹框关闭，需兼顾功能完整性和用户体验。
### How
优化点击区域判断逻辑

采用「输入框自身判断 + 输入框父容器后代判断」的组合逻辑：event.target === this.input || (this.input?.parentElement?.contains(event.target) ?? false)，既覆盖输入框自身点击场景，也覆盖父容器下所有子元素（含 placeholder、关联图标等）的点击场景，完整识别组件可交互区域；
使用 this.input?.parentElement?.contains 安全判断父容器是否包含点击目标，通过 ?? false 设定默认值，保证代码在 DOM 元素未挂载时的健壮性