### PR TITLE
feat：按钮优化，loading时阻止事件调用

### DIFF
--- a/packages/amis-ui/scss/components/_button.scss
+++ b/packages/amis-ui/scss/components/_button.scss
@@ -735,6 +735,7 @@
   }
 
   &.is-disabled,
+  &.is-loading,
   &:disabled {
     box-shadow: none;
     cursor: not-allowed;
@@ -745,7 +746,7 @@
     }
   }
 
-  &:not(:disabled):not(.is-disabled) {
+  &:not(:disabled):not(.is-disabled):not(.is-loading) {
     cursor: pointer;
   }
 

--- a/packages/amis-ui/src/components/Button.tsx
+++ b/packages/amis-ui/src/components/Button.tsx
@@ -94,7 +94,9 @@ export class Button extends React.Component<ButtonProps> {
       <Comp
         type={Comp === 'input' || Comp === 'button' ? type : undefined}
         {...pickEventsProps(rest)}
-        onClick={rest.onClick && disabled ? () => {} : rest.onClick}
+        onClick={
+          rest.onClick && (disabled || loading) ? () => {} : rest.onClick
+        }
         href={href}
         {...testIdBuilder?.getTestId()}
         className={cx(
@@ -107,7 +109,8 @@ export class Button extends React.Component<ButtonProps> {
                 [`Button--block`]: block,
                 [`Button--iconOnly`]: iconOnly,
                 'is-disabled': disabled,
-                'is-active': active
+                'is-active': active,
+                'is-loading': loading
               },
           className
         )}


### PR DESCRIPTION
根据市面上的组件库如ant-design，按钮组件在loading时均不允许进行点击操作。
通过添加loading样式，判断loading状态阻止事件触发。