### PR TITLE
fix: 修复 validateFormItem 类型在 actionConfigInitFormatterHoc 中被遗漏的问题

### DIFF
--- a/packages/amis-editor/src/renderer/event-control/eventControlConfigHelper.ts
+++ b/packages/amis-editor/src/renderer/event-control/eventControlConfigHelper.ts
@@ -377,7 +377,8 @@ export const actionConfigInitFormatterHoc =
         'submit',
         'clear',
         'reset',
-        'validate'
+        'validate',
+        'validateFormItem'
       ].includes(action.actionType)
     ) {
       const node = findTree(
@@ -608,7 +609,8 @@ export const actionConfigSubmitFormatterHoc =
         'submit',
         'clear',
         'reset',
-        'validate'
+        'validate',
+        'validateFormItem'
       ].includes(action.actionType)
     ) {
       // 处理一下自行输入组件id的转换


### PR DESCRIPTION
在 eventControlConfigHelper.ts 文件中，actionConfigInitFormatterHoc 函数中的动作类型数组缺少了 'validateFormItem' 类型， 导致该类型的动作在初始化时无法正确处理组件ID相关的配置。这与 actionConfigSubmitFormatterHoc 函数中的处理不一致， 统一两个函数中的动作类型数组，确保 'validateFormItem' 动作能够正确处理组件ID转换逻辑。

- 在 actionConfigInitFormatterHoc 中的类型检查数组中添加 'validateFormItem'
- 保持与 actionConfigSubmitFormatterHoc 中相同逻辑的一致性
