### PR TITLE
build:  markdownPlugin中支持替换!!!include!!!语法,以便vite构建时展示expression表达式

### DIFF
--- a/scripts/markdownPlugin.ts
+++ b/scripts/markdownPlugin.ts
@@ -39,17 +39,6 @@ const renderer = new marked.Renderer();
   }
 });
 
-// renderer.table = function(header, body) {
-//   return '<table class="table table-striped">\n'
-//     + '<thead>\n'
-//     + header
-//     + '</thead>\n'
-//     + '<tbody>\n'
-//     + body
-//     + '</tbody>\n'
-//     + '</table>\n';
-// };
-
 renderer.link = function (href: string, title: string, text: string) {
   if ((this as any).options.sanitize) {
     try {
@@ -82,7 +71,7 @@ renderer.link = function (href: string, title: string, text: string) {
   return out;
 };
 
-function markdown2js(content: string, file: string) {
+function markdown2js(content: string) {
   var raw = content;
   var m = rYml.exec(content);
   var info: any = {};
@@ -130,13 +119,6 @@ function markdown2js(content: string, file: string) {
       '" aria-hidden="true"><svg aria-hidden="true" class="octicon octicon-link" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>';
 
     return '<h' + level + '>' + anchor + text + '</h' + level + '>';
-
-    // return '<h' + level + '><a name="' +
-    //   escapedText +
-    //   '" class="anchor" href="#' +
-    //   escapedText +
-    //   '"><span class="header-link"></span></a>' +
-    //   text + '</h' + level + '>';
   };
 
   const placeholder: any = {};
@@ -164,7 +146,6 @@ function markdown2js(content: string, file: string) {
             }
           });
 
-        // placeholder[index] = `<iframe class="doc-iframe" width="100%" height="${setting.height || 200}px" frameBorder="0" src="/play?code=${encodeURIComponent(code)}&scope=${encodeURIComponent(setting.scope)}"></iframe>`;
         if (lang === 'html') {
           if (~code.indexOf('<html') || ~code.indexOf('<link')) {
             return _;
@@ -196,8 +177,6 @@ function markdown2js(content: string, file: string) {
       return placeholder[id] || '';
     });
 
-  // content = global.fis ? fis.compile.partial(content, file, 'html') : content;
-  // + `\n\n<div class="m-t-lg b-l b-info b-3x wrapper bg-light dk">文档内容有误？欢迎大家一起来编写，文档地址：<i class="fa fa-github"></i><a href="https://github.com/baidu/amis/tree/master${file.subpath}">${file.subpath}</a>。</div>`;
   info.html =
     '<div class="markdown-body">' +
     content.replace(
@@ -245,33 +224,15 @@ function resolveInclude(subString: string, includePath: string) {
   return subString;
 }
 
-export default function markdownPlugin(options: {} = {}): Plugin {
+export default function markdownPlugin(): Plugin {
   return {
     name: 'markdown-as-js',
     enforce: 'pre',
     apply: 'serve',
     transform(code: string, id: string) {
-      // if (id.endsWith('.scss') && /\/_[^\/]+\.scss$/.test(id)) {
-      //   const markdowns: Array<string> = [];
-
-      //   code.replace(
-      //     /\/\*\!markdown\n([\s\S]+?)\*\//g,
-      //     (_: string, md: string) => {
-      //       markdowns.push(md.trim());
-      //       return _;
-      //     }
-      //   );
-
-      //   if (markdowns.length) {
-      //     return {code: markdown2js(markdowns.join('\n'), id) as string};
-      //   }
-
-      //   return null;
-      // }
-
       if (!id.endsWith('.md')) return null;
 
-      return {code: markdown2js(code, id) as string};
+      return {code: markdown2js(code) as string};
     }
   };
 }


### PR DESCRIPTION
### Why
目前使用npm run start和npm run build-docs时,在表达式文档中,无法看到具体的表达式


<img width="1516" height="757" alt="image" src="https://github.com/user-attachments/assets/c9924a30-32d8-424b-bd28-973482426882" />
