### PR TITLE
fix: 悬浮容器首次加入工作区无法拖动

### DIFF
--- a/packages/amis-editor-core/src/component/HighlightBox.tsx
+++ b/packages/amis-editor-core/src/component/HighlightBox.tsx
@@ -225,16 +225,22 @@ export default observer(function ({
     (isActive && !store.activeElement) || ~store.selections.indexOf(id);
 
   React.useLayoutEffect(() => {
-    if (!node.draggable || !isSelected || !isAlive(node)) {
-      return;
-    }
-    const dom = node.getTarget() as HTMLElement;
-    const targets = Array.isArray(dom) ? dom : dom ? [dom] : [];
-    targets.forEach(item => {
-      item.setAttribute('draggable', 'true');
-      item.addEventListener('dragstart', handleDragStart as any);
-    });
+    let targets: HTMLElement[] = [];
+
+    const timer = setTimeout(() => {
+      if (!node.draggable || !isSelected || !isAlive(node)) {
+        return;
+      }
+      const dom = node.getTarget() as HTMLElement;
+      targets = Array.isArray(dom) ? dom : dom ? [dom] : [];
+      targets.forEach(item => {
+        item.setAttribute('draggable', 'true');
+        item.addEventListener('dragstart', handleDragStart as any);
+      });
+    }, 150);
+
     return () => {
+      clearTimeout(timer);
       targets.forEach(item => {
         item.removeAttribute('draggable');
         item.removeEventListener('dragstart', handleDragStart as any);


### PR DESCRIPTION
### What
悬浮容器首次加入内容区时候虽然悬浮容器看是选中了，但是无法拖拽，需要点击其他组件以后再次选中回来才能拖拽。

### Why
因为执行useLayoutEffect 时候 node.getTarget() 返回的空数组，amis渲染器还未完成Dom的渲染，此处无法获取到。
<img width="647" height="1100" alt="image" src="https://github.com/user-attachments/assets/1132a9c3-cb47-4301-9dc9-1905869baf8f" />


### How
添加150ms延迟来确保node.getTarget()拿得到。

