### PR TITLE
feat(amis-core): 导出 ThemeContext，支持局部主题设置

### DIFF
--- a/packages/amis-core/src/index.tsx
+++ b/packages/amis-core/src/index.tsx
@@ -71,7 +71,8 @@ import {
   getTheme,
   themeable,
   makeClassnames,
-  defaultTheme
+  defaultTheme,
+  ThemeContext
 } from './theme';
 import type {ClassNamesFn, ThemeProps} from './theme';
 const classPrefix = getClassPrefix();
@@ -213,6 +214,7 @@ export {
   setDefaultTheme,
   theme,
   themeable,
+  ThemeContext,
   ThemeProps,
   getTheme,
   classPrefix,


### PR DESCRIPTION
## 问题

此前 `ThemeContext` 仅在 `theme.ts` 模块内部定义，未从 `index.tsx` 导出。导致只用 `amis-ui` 的场景无法通过 `ThemeContext.Provider` 局部设置主题，只能依赖 `setDefaultTheme` 全局修改。

## 改动

从 `packages/amis-core/src/index.tsx` 导出 `ThemeContext`，使用方可以直接通过 Context 局部设置主题。

## 用法

```tsx
import {ThemeContext} from 'amis-core';

<ThemeContext.Provider value="antd">
  <Button>primary</Button>
  <Select options={[...]} />
</ThemeContext.Provider>
```

## 为什么需要这个改动

- `setDefaultTheme` 是全局修改，影响所有 amis-ui 组件实例
- `ThemeContext` 可以局部生效，不影响其他组件
- `render(schema, {theme: 'antd'})` 只对 amis 渲染树生效，不影响直接使用的 amis-ui 组件